### PR TITLE
Implements basic actor type

### DIFF
--- a/vm/src/actor/code.rs
+++ b/vm/src/actor/code.rs
@@ -1,0 +1,72 @@
+use cid::Cid;
+
+/// CodeID is the reference to the code which is attached to the Actor state.
+/// There are builtin IDs and the option for custom code with a Cid
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum CodeID {
+    Init,
+    Cron,
+    Account,
+    PaymentChannel,
+    StoragePower,
+    StorageMiner,
+    StorageMarket,
+    CustomCode(Cid),
+}
+
+// TODO define builtin Cids
+
+impl CodeID {
+    /// Returns true if cid is builtin Actor
+    pub fn is_builtin(&self) -> bool {
+        match *self {
+            CodeID::CustomCode(_) => false,
+            _ => true,
+        }
+    }
+    /// Returns true if cid is singleton Actor
+    pub fn is_singleton(&self) -> bool {
+        match *self {
+            CodeID::StorageMarket | CodeID::Init | CodeID::StoragePower => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cid::{Cid, Codec, Version};
+
+    #[test]
+    fn builtin_checks() {
+        // Tests all builtins will return true
+        assert!(CodeID::Init.is_builtin());
+        assert!(CodeID::StorageMarket.is_builtin());
+        assert!(CodeID::StoragePower.is_builtin());
+        assert!(CodeID::Cron.is_builtin());
+        assert!(CodeID::Account.is_builtin());
+        assert!(CodeID::PaymentChannel.is_builtin());
+        assert!(CodeID::StorageMiner.is_builtin());
+
+        assert!(
+            !CodeID::CustomCode(Cid::new(Codec::DagProtobuf, Version::V1, &[0u8])).is_builtin()
+        );
+    }
+
+    #[test]
+    fn singleton_checks() {
+        // singletons
+        assert!(CodeID::Init.is_singleton());
+        assert!(CodeID::StorageMarket.is_singleton());
+        assert!(CodeID::StoragePower.is_singleton());
+        // non-singletons
+        assert!(!CodeID::Cron.is_singleton());
+        assert!(!CodeID::Account.is_singleton());
+        assert!(!CodeID::PaymentChannel.is_singleton());
+        assert!(!CodeID::StorageMiner.is_singleton());
+        assert!(
+            !CodeID::CustomCode(Cid::new(Codec::DagProtobuf, Version::V1, &[0u8])).is_singleton()
+        );
+    }
+}

--- a/vm/src/actor/mod.rs
+++ b/vm/src/actor/mod.rs
@@ -1,10 +1,23 @@
+mod code;
+
+pub use self::code::*;
+
 use cid::Cid;
 use num_bigint::BigUint;
 
+/// State of all actor implementations
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub struct Actor {
-    code_cid: Cid,
+pub struct ActorState {
+    code_id: CodeID,
     state: Cid,
     balance: BigUint,
     sequence: u64,
+}
+
+/// Actor trait which defines the common functionality of system Actors
+pub trait Actor {
+    /// Returns Actor Cid
+    fn cid(&self) -> Cid;
+    /// Actor public key, if it exists
+    fn public_key(&self) -> Vec<u8>;
 }


### PR DESCRIPTION
- Finishes #12 
- Based on spec (where applicable, a lot of useless and unnecessary info and they apply it to go implementation)

Will expand and tweak when building out the runtime and interpreter, but wanted to PR this in so people don't use types that will not remain but also to split up the PRs to keep them small