### PR TITLE
Fix makefile clean and phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,16 @@ clean-all:
 	cargo clean
 
 clean:
-	cargo clean -p node
-	cargo clean -p ferret-libp2p
-	cargo clean -p network
-	cargo clean -p blockchain
-	cargo clean -p vm
-	cargo clean -p address
-	cargo clean -p crypto
-	cargo clean -p encoding
+	@echo "Cleaning local packages..."
+	@cargo clean -p node
+	@cargo clean -p ferret-libp2p
+	@cargo clean -p network
+	@cargo clean -p blockchain
+	@cargo clean -p vm
+	@cargo clean -p address
+	@cargo clean -p crypto
+	@cargo clean -p encoding
+	@echo "Done cleaning."
 
 lint: clean
 	cargo fmt


### PR DESCRIPTION
Sorry I forgot to comment on the PR that the encoding package was missing, so I added it and also included phony target definitions (makefile uses file system over definitions in file, so defines that the commands are referencing the other targets and not a file target) and a test command while I was here