### PR TITLE
Initial Structures for Message - Manager Communication

### DIFF
--- a/blockchain/src/blocks/mod.rs
+++ b/blockchain/src/blocks/mod.rs
@@ -1,10 +1,8 @@
 mod block;
-mod block_msg;
 mod errors;
 mod ticket;
 mod tipset;
 
 pub use block::*;
-pub use block_msg::*;
 pub use errors::*;
 pub use tipset::*;

--- a/blockchain/src/chain_sync/block_msg.rs
+++ b/blockchain/src/chain_sync/block_msg.rs
@@ -1,8 +1,9 @@
-use super::TipSetKeys;
+use crate::blocks::TipSetKeys;
 use libp2p::PeerId;
 use std::fmt;
 
 /// BlockMsg is a container used to decode pubsub messages into prior to validation and propagation
+/// see https://github.com/filecoin-project/go-filecoin/blob/master/internal/pkg/block/chain_info.go for reference
 pub struct BlockMsg {
     // the originator of the TipSetKey propagation wave
     _source: PeerId,

--- a/blockchain/src/chain_sync/block_proposer.rs
+++ b/blockchain/src/chain_sync/block_proposer.rs
@@ -1,4 +1,4 @@
-use crate::blocks::BlockMsg;
+use super::BlockMsg;
 use std::io;
 /// BlockProposer allows callers to propose new blocks for inclusion in the chain
 pub trait BlockProposer {

--- a/blockchain/src/chain_sync/mod.rs
+++ b/blockchain/src/chain_sync/mod.rs
@@ -1,1 +1,4 @@
+mod block_msg;
 mod block_proposer;
+
+pub use block_msg::*;


### PR DESCRIPTION
This is a small PR but steps towards setting up the necessary structures for receiving and proposing block data from libp2p. Specifically, this PR contains a struct used to place pubsub message data to be sent to the manager for validation and the `BlockProposer` trait with `send_gossip_block`, `send_own_block`, `send_hello` to be used for communication between receiving/adding blocks and the `ChainManager`. For background, the manager in the context of the PR deals with incoming blocks and semantic validation as per the spec and go implementation.

Below is further detail and context of the discussion I had with @ec2 and my interpretation of how [go-filecoin](https://github.com/filecoin-project/go-filecoin) handles incoming/outgoing data as it related to the `ChainManager`.

**For `SendGossipBlock`:**

See [ProcessBlock](https://github.com/filecoin-project/go-filecoin/blob/master/internal/app/go-filecoin/node/block.go) for additional details.

Upon receiving a `pubsub message` to process a block for inclusion into the chain, the data contained within the `pubsub message` is decoded, expanded on and placed in a struct for validation prior to propagation. 

The pubsub message should contain the following fields:
- `Source peerId`
- `Sender peerId`
- `Block Data` in bytes

From Block Data you can derive the `head tipset keys` (CIDS), and `height`. These fields are placed inside `BlockMsg` struct (as per PR), to be sent to the manager for semantic validation. 

**For `SendOwnBlock`:**

See [AddNewBlock](https://github.com/filecoin-project/go-filecoin/blob/master/internal/app/go-filecoin/node/block.go) for additional details.

While publishing a new block on the block topic, the fields required for validation are derived from the block and node and are placed in the `BlockMsg` struct to be sent to the manager for semantic validation.