### PR TITLE
Fix libp2p revision

### DIFF
--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 [dependencies]
 vm = {path = "../vm"}
 address = {path = "../vm/address"}
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "cdd5251d29e21a01aa2ffed8cb577a37a0f9e2eb" }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "3f9b030e29c9b31f9fe6f2ed27be4a813e2b3701" }
 cid = "0.3.1"
 multihash = "0.8.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -11,7 +11,7 @@ network = { path = "network" }
 ferret-libp2p = { path = "ferret-libp2p"}
 
 
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "cdd5251d29e21a01aa2ffed8cb577a37a0f9e2eb" }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "3f9b030e29c9b31f9fe6f2ed27be4a813e2b3701" }
 tokio = "0.1.22"
 futures = "0.1.29"
 clap = "2.33.0"

--- a/node/ferret-libp2p/Cargo.toml
+++ b/node/ferret-libp2p/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "cdd5251d29e21a01aa2ffed8cb577a37a0f9e2eb" }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "3f9b030e29c9b31f9fe6f2ed27be4a813e2b3701" }
 tokio = "0.1.22"
 futures = "0.1.29"
 log = "0.4.8"

--- a/node/network/Cargo.toml
+++ b/node/network/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2018"
 ferret-libp2p = { path = "../ferret-libp2p" }
 futures = "0.1.29"
 tokio = "0.1.22"
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "cdd5251d29e21a01aa2ffed8cb577a37a0f9e2eb" }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "3f9b030e29c9b31f9fe6f2ed27be4a813e2b3701" }
 log = "0.4.8"
 slog = "2.5.2"


### PR DESCRIPTION
Whatever revision was chosen before is out of date, switches to version used by Lighthouse