### PR TITLE
CI cleanup

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -82,3 +82,22 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  publish_docs:
+      name: Publish Documentation
+      needs: [clippy, test]
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@master
+        - name: Install Rust
+          run: rustup update beta && rustup default beta
+        - name: Build documentation
+          run: cargo doc --no-deps --all-features
+        - name: Publish documentation
+          run: |
+            cd target/doc
+            git init
+            git add .
+            git -c user.name='ci' -c user.email='ci' commit -m 'Deploy documentation'
+            git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages
+          if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'


### PR DESCRIPTION
#117 Cleaning up CI build

- Implements cache on the clippy job (test job can't be cached because it is over the github limit of 400mb)
  - Cache is overwritten every time the build passes, which is somewhat inefficient but there is no other way to invalidate old caches without either committing the cargo lock or something hacky
- Adds a build for pushes to master (so the requirement of all jobs to pass on PRs not required and build status can be seen on master)
- Publishes cargo docs to gh-pages branch on push to master (will probably require configuring in settings, tested on other repo)