### PR TITLE
Remove TODO rename old file to keypair.old(?)

### DIFF
--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -1,77 +1,6 @@
-// Copyright 2020 ChainSafe Systems
-// SPDX-License-Identifier: Apache-2.0, MIT
-
-use dirs::home_dir;
-use std::fs::{create_dir_all, read_dir, File};
-use std::io::{prelude::*, Result};
-use std::path::Path;
-use toml;
-
-/// Writes a string to a specified file. Creates the desired path if it does not exist.
-/// Note: `path` and `filename` are appended to produce the resulting file path.
-pub fn write_to_file(message: &[u8], path: &str, file_name: &str) -> Result<()> {
-    // Create path if it doesn't exist
-    create_dir_all(Path::new(path))?;
-    let join = format!("{}{}", path, file_name);
-    let mut file = File::create(join)?;
-    file.write_all(message)?;
-    Ok(())
-}
-
-/// Read file as a `Vec<u8>`
-pub fn read_file_to_vec(path: &str) -> Result<Vec<u8>> {
-    let mut file = File::open(path)?;
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer)?;
-    Ok(buffer)
-}
-
-/// Read file as a `String`.
-pub fn read_file_to_string(path: &str) -> Result<String> {
-    let mut file = File::open(path)?;
-    let mut string = String::new();
-    file.read_to_string(&mut string)?;
-    Ok(string)
-}
-
-/// Gets the home directory of the current system.
-/// Will return correct path for windows, linux, and osx.
-///
-/// # Panics
-/// We will panic if we cannot determine a home directory.
-pub fn get_home_dir() -> String {
-    home_dir().unwrap().to_str().unwrap().to_owned()
-}
-
-/// Converts a toml file represented as a string to `S`
-///
-/// # Example
-/// ```
-/// use serde::Deserialize;
-/// use utils::read_toml;
-///
-/// #[derive(Deserialize)]
-/// struct Config {
-///     name: String
-/// };
-///
-/// let toml_string = "name = \"forest\"\n";
-/// let config: Config = read_toml(toml_string).unwrap();
-/// assert_eq!(config.name, "forest");
-/// ```
-pub fn read_toml<S>(toml_string: &str) -> Result<S>
-where
-    for<'de> S: serde::de::Deserialize<'de>,
-{
-    let new_struct: S = toml::from_str(toml_string)?;
-    Ok(new_struct)
-}
-
 /// Get file count in a certain directory
 /// Will return the number of files in the directory
 ///
-/// 
-/// # Error
 /// Error will be logged if:
 /// - The provided path doesn't exist.
 /// - The process lacks permissions to view the contents.
@@ -98,4 +27,9 @@ where
 /// ```
 pub fn count_files(dir: &str) -> Result<usize> {
     Ok(read_dir(dir)?.enumerate().count())
+}
+
+pub fn rename_file(from: &str, to: &str) -> Result<()> {
+    rename(from, to)?;
+    Ok(())
 }

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use dirs::home_dir;
-use std::fs::{create_dir_all, File};
+use std::fs::{create_dir_all, read_dir, File};
 use std::io::{prelude::*, Result};
 use std::path::Path;
 use toml;
@@ -65,4 +65,30 @@ where
 {
     let new_struct: S = toml::from_str(toml_string)?;
     Ok(new_struct)
+}
+
+/// Get file count in a certain directory
+/// Will return the number of files in the directory
+///
+/// # Panics
+/// It will panic if:
+/// - The provided path doesn't exist.
+/// - The process lacks permissions to view the contents.
+/// - The path points at a non-directory file.
+///
+/// # Example
+/// ```
+/// use utils::count_files;
+/// use utils::get_home_dir;
+///
+/// let path_to_keystore = get_home_dir() + "/.forest/libp2p/keypair";
+/// let file_count = count_files(path_to_keystore[0..path_to_keystore.len()-8].to_string());
+/// assert_eq!(file_count, 1);
+/// ```
+pub fn count_files(dir: String) -> Result<u32> {
+    let mut file_count = 0;
+    for _i in read_dir(dir).expect("read files in the directory") {
+        file_count += 1;
+    }
+    Ok(file_count)
 }

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -70,25 +70,32 @@ where
 /// Get file count in a certain directory
 /// Will return the number of files in the directory
 ///
-/// # Panics
-/// It will panic if:
+/// 
+/// # Error
+/// Error will be logged if:
 /// - The provided path doesn't exist.
 /// - The process lacks permissions to view the contents.
 /// - The path points at a non-directory file.
 ///
 /// # Example
-/// ```no_run
+/// ```
 /// use utils::count_files;
 /// use utils::get_home_dir;
 ///
 /// let path_to_keystore = get_home_dir() + "/.forest/libp2p/keypair";
-/// let file_count = count_files(path_to_keystore[0..path_to_keystore.len()-8].to_string());
-/// assert_eq!(file_count, 1);
+/// let dir_to_keystore = path_to_keystore.replace("/keypair", "");
+/// match count_files(&dir_to_keystore) {
+///     Err(e) => {
+///         info!(log, "Error {:?}", &e);
+///     }
+///     Ok(v) => {
+///     fs::rename(
+///             path_to_keystore.clone(),
+///             path_to_keystore.clone() + &format!(".old({:})", v),
+///         );
+///     }
+/// }
 /// ```
-pub fn count_files(dir: String) -> Result<u32> {
-    let mut file_count = 0;
-    for _i in read_dir(dir).expect("read files in the directory") {
-        file_count += 1;
-    }
-    Ok(file_count)
+pub fn count_files(dir: &str) -> Result<usize> {
+    Ok(read_dir(dir)?.enumerate().count())
 }

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -77,7 +77,7 @@ where
 /// - The path points at a non-directory file.
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// use utils::count_files;
 /// use utils::get_home_dir;
 ///

--- a/node/utils/tests/files.rs
+++ b/node/utils/tests/files.rs
@@ -122,10 +122,8 @@ fn count_files_in_a_dir() {
     let msg = "Hello World!";
     let path = "./test_string_read_file/";
     let file_name = "out.keystore";
-    if let Err(e) = write_to_file(&msg.as_bytes().to_vec(), &path, file_name) {
-        panic!(e);
-    }
-    match count_files(path.to_string()) {
+    write_to_file(msg.as_bytes(), &path, file_name).unwrap();
+    match count_files(path) {
         Ok(file_count) => {
             cleanup_file(path);
             assert_eq!(1, file_count);

--- a/node/utils/tests/files.rs
+++ b/node/utils/tests/files.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use utils::{read_file_to_string, read_file_to_vec, read_toml, write_to_file};
+use utils::{count_files, read_file_to_string, read_file_to_vec, read_toml, write_to_file};
 
 use serde_derive::Deserialize;
 use std::fs::remove_dir_all;
@@ -115,4 +115,24 @@ fn read_from_toml() {
     assert_eq!(config.port, None);
     assert_eq!(config.keys.github, "xxxxxxxxxxxxxxxxx");
     assert_eq!(config.keys.travis.as_ref().unwrap(), "yyyyyyyyyyyyyyyyy");
+}
+
+#[test]
+fn count_files_in_a_dir() {
+    let msg = "Hello World!";
+    let path = "./test_string_read_file/";
+    let file_name = "out.keystore";
+    if let Err(e) = write_to_file(&msg.as_bytes().to_vec(), &path, file_name) {
+        panic!(e);
+    }
+    match count_files(path.to_string()) {
+        Ok(file_count) => {
+            cleanup_file(path);
+            assert_eq!(1, file_count);
+        }
+        Err(e) => {
+            cleanup_file(path);
+            panic!("{:?}", e);
+        }
+    }
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- I add a utility function `count_files` to count files in a directory
- ? willl be the number of old keystore files in the libp2p directory
- when the key does not work, the program will label the old keystore file and make new one


<!-- Thank you 🔥 -->