### PR TITLE
Refactor keypair retrieval and saving

### DIFF
--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use forest_libp2p::config::Libp2pConfig;
+use forest_libp2p::Libp2pConfig;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Default)]

--- a/forest/src/main.rs
+++ b/forest/src/main.rs
@@ -6,8 +6,10 @@ mod log;
 
 use self::cli::cli;
 use async_std::task;
-use forest_libp2p::service::Libp2pService;
-use slog::info;
+use forest_libp2p::{get_keypair, Libp2pService};
+use libp2p::identity::{ed25519, Keypair};
+use slog::{info, trace};
+use utils::write_to_file;
 
 #[async_std::main]
 async fn main() {
@@ -19,7 +21,22 @@ async fn main() {
 
     let logger = log.clone();
 
-    let lp2p_service = Libp2pService::new(logger, &config.network);
+    let net_keypair = match get_keypair(&log, &"/.forest/libp2p/keypair") {
+        Some(kp) => kp,
+        None => {
+            // Keypair not found, generate and save generated keypair
+            let gen_keypair = ed25519::Keypair::generate();
+            // Save Ed25519 keypair to file
+            // TODO rename old file to keypair.old(?)
+            if let Err(e) = write_to_file(&gen_keypair.encode(), &"/.forest/libp2p/", "keypair") {
+                info!(log, "Could not write keystore to disk!");
+                trace!(log, "Error {:?}", e);
+            };
+            Keypair::Ed25519(gen_keypair)
+        }
+    };
+
+    let lp2p_service = Libp2pService::new(logger, &config.network, net_keypair);
 
     task::block_on(async move {
         lp2p_service.run().await;

--- a/node/forest_libp2p/src/lib.rs
+++ b/node/forest_libp2p/src/lib.rs
@@ -3,6 +3,10 @@
 
 #![recursion_limit = "1024"]
 
-pub mod behaviour;
-pub mod config;
-pub mod service;
+mod behaviour;
+mod config;
+mod service;
+
+pub use self::behaviour::*;
+pub use self::config::*;
+pub use self::service::*;

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -167,27 +167,25 @@ pub fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox), Er
         .boxed()
 }
 
-/// Fetch keypair from disk, or generate a new one if its not available
+/// Fetch keypair from disk, returning none if it cannot be decoded
 pub fn get_keypair(log: &Logger, path: &str) -> Option<Keypair> {
     let path_to_keystore = get_home_dir() + path;
-    let local_keypair = match read_file_to_vec(&path_to_keystore) {
+    match read_file_to_vec(&path_to_keystore) {
         Err(e) => {
             info!(log, "Networking keystore not found!");
             trace!(log, "Error {:?}", e);
-            return None;
+            None
         }
         Ok(mut vec) => match ed25519::Keypair::decode(&mut vec) {
             Ok(kp) => {
                 info!(log, "Recovered keystore from {:?}", &path_to_keystore);
-                kp
+                Some(Keypair::Ed25519(kp))
             }
             Err(e) => {
                 info!(log, "Could not decode networking keystore!");
                 trace!(log, "Error {:?}", e);
-                return None;
+                None
             }
         },
-    };
-
-    Some(Keypair::Ed25519(local_keypair))
+    }
 }

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -18,7 +18,7 @@ use libp2p::{
 use slog::{debug, error, info, trace, Logger};
 use std::io::{Error, ErrorKind};
 use std::time::Duration;
-use utils::{get_home_dir, read_file_to_vec, write_to_file};
+use utils::{get_home_dir, read_file_to_vec};
 
 type Libp2pStream = Boxed<(PeerId, StreamMuxerBox), Error>;
 type Libp2pBehaviour = ForestBehaviour<Substream<StreamMuxerBox>>;
@@ -53,8 +53,7 @@ pub struct Libp2pService {
 
 impl Libp2pService {
     /// Constructs a Libp2pService
-    pub fn new(log: Logger, config: &Libp2pConfig) -> Self {
-        let net_keypair = get_keypair(&log);
+    pub fn new(log: Logger, config: &Libp2pConfig, net_keypair: Keypair) -> Self {
         let peer_id = PeerId::from(net_keypair.public());
 
         info!(log, "Local peer id: {:?}", peer_id);
@@ -169,46 +168,26 @@ pub fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox), Er
 }
 
 /// Fetch keypair from disk, or generate a new one if its not available
-fn get_keypair(log: &Logger) -> Keypair {
-    let path_to_keystore = get_home_dir() + "/.forest/libp2p/keypair";
+pub fn get_keypair(log: &Logger, path: &str) -> Option<Keypair> {
+    let path_to_keystore = get_home_dir() + path;
     let local_keypair = match read_file_to_vec(&path_to_keystore) {
         Err(e) => {
             info!(log, "Networking keystore not found!");
             trace!(log, "Error {:?}", e);
-            return generate_new_peer_id(log);
+            return None;
         }
-        Ok(mut vec) => {
-            // If decoding fails, generate new peer id
-            // TODO rename old file to keypair.old(?)
-            match ed25519::Keypair::decode(&mut vec) {
-                Ok(kp) => {
-                    info!(log, "Recovered keystore from {:?}", &path_to_keystore);
-                    kp
-                }
-                Err(e) => {
-                    info!(log, "Could not decode networking keystore!");
-                    trace!(log, "Error {:?}", e);
-                    return generate_new_peer_id(log);
-                }
+        Ok(mut vec) => match ed25519::Keypair::decode(&mut vec) {
+            Ok(kp) => {
+                info!(log, "Recovered keystore from {:?}", &path_to_keystore);
+                kp
             }
-        }
+            Err(e) => {
+                info!(log, "Could not decode networking keystore!");
+                trace!(log, "Error {:?}", e);
+                return None;
+            }
+        },
     };
 
-    Keypair::Ed25519(local_keypair)
-}
-
-/// Generates a new libp2p keypair and saves to disk
-fn generate_new_peer_id(log: &Logger) -> Keypair {
-    let path_to_keystore = get_home_dir() + "/.forest/libp2p/";
-    let generated_keypair = Keypair::generate_ed25519();
-    info!(log, "Generated new keystore!");
-
-    if let Keypair::Ed25519(key) = generated_keypair.clone() {
-        if let Err(e) = write_to_file(&key.encode(), &path_to_keystore, "keypair") {
-            info!(log, "Could not write keystore to disk!");
-            trace!(log, "Error {:?}", e);
-        };
-    }
-
-    generated_keypair
+    Some(Keypair::Ed25519(local_keypair))
 }

--- a/node/utils/tests/files.rs
+++ b/node/utils/tests/files.rs
@@ -8,47 +8,43 @@ use std::fs::remove_dir_all;
 
 // Please use with caution, remove_dir_all will completely delete a directory
 fn cleanup_file(path: &str) {
-    if let Err(e) = remove_dir_all(path) {
-        panic!("cleanup_file() path: {:?} failed: {:?}", path, e);
-    }
+    remove_dir_all(path).expect("cleanup_file() path: {:?} failed: {:?}");
 }
 
 #[test]
 fn write_to_file_to_path() {
-    let msg = "Hello World!".as_bytes().to_vec();
+    let msg = "Hello World!".as_bytes();
     let path = "./test-write/";
     let file = "test.txt";
     match write_to_file(&msg, &path, file) {
         Ok(_) => cleanup_file(path),
         Err(e) => {
             cleanup_file(path);
-            panic!("{:?}", e);
+            panic!("{}", e);
         }
     }
 }
 
 #[test]
 fn write_to_file_nested_dir() {
-    let msg = "Hello World!".as_bytes().to_vec();
+    let msg = "Hello World!".as_bytes();
     let root = "./test_missing";
     let path = format!("{}{}", root, "/test_write_string/");
     match write_to_file(&msg, &path, "test-file") {
         Ok(_) => cleanup_file(root),
         Err(e) => {
             cleanup_file(root);
-            panic!("{:?}", e);
+            panic!("{}", e);
         }
     }
 }
 
 #[test]
 fn read_from_file_vec() {
-    let msg = "Hello World!".as_bytes().to_vec();
+    let msg = "Hello World!".as_bytes();
     let path = "./test_read_file/";
     let file_name = "out.keystore";
-    if let Err(e) = write_to_file(&msg, &path, file_name) {
-        panic!(e);
-    }
+    write_to_file(&msg, &path, file_name).unwrap();
     match read_file_to_vec(&format!("{}{}", path, file_name)) {
         Ok(contents) => {
             cleanup_file(path);
@@ -56,7 +52,7 @@ fn read_from_file_vec() {
         }
         Err(e) => {
             cleanup_file(path);
-            panic!("{:?}", e);
+            panic!("{}", e);
         }
     }
 }
@@ -66,9 +62,7 @@ fn read_from_file_string() {
     let msg = "Hello World!";
     let path = "./test_string_read_file/";
     let file_name = "out.keystore";
-    if let Err(e) = write_to_file(&msg.as_bytes().to_vec(), &path, file_name) {
-        panic!(e);
-    }
+    write_to_file(&msg.as_bytes(), &path, file_name).unwrap();
     match read_file_to_string(&format!("{}{}", path, file_name)) {
         Ok(contents) => {
             cleanup_file(path);
@@ -76,7 +70,7 @@ fn read_from_file_string() {
         }
         Err(e) => {
             cleanup_file(path);
-            panic!("{:?}", e);
+            panic!("{}", e);
         }
     }
 }
@@ -106,10 +100,7 @@ fn read_from_toml() {
         github = 'xxxxxxxxxxxxxxxxx'
         travis = 'yyyyyyyyyyyyyyyyy'
     "#;
-    let config: Config = match read_toml(toml_str) {
-        Ok(contents) => contents,
-        Err(e) => panic!(e),
-    };
+    let config: Config = read_toml(toml_str).unwrap();
 
     assert_eq!(config.ip, "127.0.0.1");
     assert_eq!(config.port, None);


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Issues found when working with network tests, keypair should not be automatically persisted when a keypair is not found. There was some janky logic that I wanted to clean up as well.
  - Essentially the problem is that a keypair is automatically pulled from keystore and used when generating new Libp2pService
- Cleaned up tests that unnecessarily heap allocated bytes and handled errors specifically in the test (found in #217) 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->