### PR TITLE
Fix cbor serialization formats and cleanup

### DIFF
--- a/blockchain/blocks/Cargo.toml
+++ b/blockchain/blocks/Cargo.toml
@@ -10,7 +10,6 @@ crypto = { path = "../../crypto" }
 message = { package = "forest_message", path = "../../vm/message" }
 clock = { path = "../../node/clock" }
 cid = { package = "forest_cid", path = "../../ipld/cid" }
-multihash = "0.9.4"
 derive_builder = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 encoding = { package = "forest_encoding", path = "../../encoding" }

--- a/blockchain/blocks/src/block.rs
+++ b/blockchain/blocks/src/block.rs
@@ -47,10 +47,9 @@ impl Block {
 }
 
 /// Tracks the merkleroots of both secp and bls messages separately
-#[derive(Clone, Debug, PartialEq, Default)]
 pub struct TxMeta {
-    pub bls_messages: Cid,
-    pub secp_messages: Cid,
+    pub bls_message_root: Cid,
+    pub secp_message_root: Cid,
 }
 
 impl Serialize for TxMeta {
@@ -58,7 +57,10 @@ impl Serialize for TxMeta {
     where
         S: Serializer,
     {
-        let value = (self.bls_messages.clone(), self.secp_messages.clone());
+        let value = (
+            self.bls_message_root.clone(),
+            self.secp_message_root.clone(),
+        );
         Serialize::serialize(&value, serializer)
     }
 }
@@ -68,10 +70,10 @@ impl<'de> Deserialize<'de> for TxMeta {
     where
         D: Deserializer<'de>,
     {
-        let (bls_messages, secp_messages) = Deserialize::deserialize(deserializer)?;
+        let (bls_message_root, secp_message_root) = Deserialize::deserialize(deserializer)?;
         Ok(TxMeta {
-            bls_messages,
-            secp_messages,
+            bls_message_root,
+            secp_message_root,
         })
     }
 }

--- a/blockchain/blocks/src/block.rs
+++ b/blockchain/blocks/src/block.rs
@@ -1,23 +1,11 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-#![allow(dead_code)]
-
 use super::BlockHeader;
 use cid::Cid;
 use encoding::{de::Deserializer, ser::Serializer};
 use message::{SignedMessage, UnsignedMessage};
-use multihash::Hash;
 use serde::{Deserialize, Serialize};
-
-// DefaultHashFunction represents the default hashing function to use
-// TODO SHOULD BE BLAKE2B256 (256 hashing not implemented)
-const DEFAULT_HASH_FUNCTION: Hash = Hash::Blake2b512;
-// TODO determine the purpose for these structures, currently spec includes them but with no definition
-struct ChallengeTicketsCommitment {}
-struct PoStCandidate {}
-struct PoStRandomness {}
-struct PoStProof {}
 
 /// A complete block
 #[derive(Clone, Debug, PartialEq)]
@@ -76,13 +64,4 @@ impl<'de> Deserialize<'de> for TxMeta {
             secp_message_root,
         })
     }
-}
-
-/// ElectionPoStVerifyInfo seems to be connected to VRF
-/// see https://github.com/filecoin-project/lotus/blob/master/chain/sync.go#L1099
-struct ElectionPoStVerifyInfo {
-    candidates: PoStCandidate,
-    randomness: PoStRandomness,
-    proof: PoStProof,
-    messages: Vec<UnsignedMessage>,
 }

--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -22,9 +22,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 ///
 /// Usage:
 /// ```
-/// use forest_blocks::{BlockHeader, TipSetKeys, Ticket, TxMeta};
+/// use forest_blocks::{BlockHeader, TipSetKeys, Ticket};
 /// use address::Address;
-/// use cid::{Cid, Codec, Prefix, Version};
+/// use cid::Cid;
 /// use clock::ChainEpoch;
 /// use num_bigint::BigUint;
 /// use crypto::Signature;
@@ -68,8 +68,6 @@ pub struct BlockHeader {
 
     // STATE
     /// messages contains the Cid to the merkle links for bls_messages and secp_messages
-    /// The spec shows that messages is a TxMeta, but Lotus has it as a Cid to a TxMeta.
-    /// TODO: Need to figure out how to convert TxMeta to a Cid
     #[builder(default)]
     messages: Cid,
 
@@ -183,7 +181,6 @@ impl<'de> de::Deserialize<'de> for BlockHeader {
 impl RawBlock for BlockHeader {
     /// returns the block raw contents as a byte array
     fn raw_data(&self) -> Result<Vec<u8>, EncodingError> {
-        // TODO should serialize block header using CBOR encoding
         self.marshal_cbor()
     }
     /// returns the content identifier of the block

--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -112,9 +112,6 @@ pub struct BlockHeader {
     cached_bytes: Vec<u8>,
 }
 
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
-
 impl Cbor for BlockHeader {}
 
 #[derive(Serialize, Deserialize)]

--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -14,7 +14,7 @@ use encoding::{
 };
 use num_bigint::BigUint;
 use raw_block::RawBlock;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -114,29 +114,12 @@ pub struct BlockHeader {
 
 impl Cbor for BlockHeader {}
 
-#[derive(Serialize, Deserialize)]
-struct CborBlockHeader(
-    Address,    // miner_address
-    Ticket,     // ticket
-    EPostProof, // epost_verify
-    TipSetKeys, // parents []cid
-    BigUint,    // weight
-    ChainEpoch, // epoch
-    Cid,        // state_root
-    Cid,        // message_receipts
-    Cid,        // messages
-    Signature,  // bls_aggregate
-    u64,        // timestamp
-    Signature,  // signature
-    u64,        // fork_signal
-);
-
 impl ser::Serialize for BlockHeader {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        CborBlockHeader(
+        (
             self.miner_address.clone(),
             self.ticket.clone(),
             self.epost_verify.clone(),
@@ -151,7 +134,7 @@ impl ser::Serialize for BlockHeader {
             self.signature.clone(),
             self.fork_signal,
         )
-        .serialize(serializer)
+            .serialize(serializer)
     }
 }
 

--- a/blockchain/blocks/src/ticket.rs
+++ b/blockchain/blocks/src/ticket.rs
@@ -18,9 +18,6 @@ pub struct Ticket {
     pub vrfproof: VRFResult,
 }
 
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
-
 impl Ticket {
     /// Ticket constructor
     pub fn new(vrfproof: VRFResult) -> Self {

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -21,9 +21,6 @@ pub struct TipSetKeys {
     pub cids: Vec<Cid>,
 }
 
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
-
 impl TipSetKeys {
     /// constructor
     pub fn new(cids: Vec<Cid>) -> Self {
@@ -150,7 +147,7 @@ impl Tipset {
         })
     }
     /// Returns all blocks in tipset
-    pub fn blocks(&self) -> &Vec<BlockHeader> {
+    pub fn blocks(&self) -> &[BlockHeader] {
         &self.blocks
     }
     /// Returns the smallest ticket of all blocks in the tipset
@@ -210,7 +207,7 @@ impl FullTipset {
         Self { blocks: blks }
     }
     /// Returns all blocks in a full tipset
-    pub fn blocks(&self) -> &Vec<Block> {
+    pub fn blocks(&self) -> &[Block] {
         &self.blocks
     }
     /// Returns a Tipset
@@ -218,7 +215,7 @@ impl FullTipset {
         let mut headers = Vec::new();
 
         for block in self.blocks() {
-            headers.push(block.to_header().clone())
+            headers.push(block.header().clone())
         }
         let tip: Tipset = Tipset::new(headers)?;
         Ok(tip)

--- a/blockchain/sync_manager/src/sync.rs
+++ b/blockchain/sync_manager/src/sync.rs
@@ -59,7 +59,7 @@ impl<'a> Syncer<'a> {
 
         // compare target_weight to heaviest weight stored; ignore otherwise
         let best_weight = self.chain_store.heaviest_tipset().blocks()[0].weight();
-        let target_weight = fts.blocks()[0].to_header().weight();
+        let target_weight = fts.blocks()[0].header().weight();
 
         if !target_weight.lt(&best_weight) {
             // Store incoming block header
@@ -74,7 +74,7 @@ impl<'a> Syncer<'a> {
     /// bls and secp messages contained in the passed in block and stores them in a key-value store
     fn validate_msg_data(&self, block: &Block) -> Result<(), Error> {
         let sm_root = self.compute_msg_data(block)?;
-        if block.to_header().messages() != &sm_root {
+        if block.header().messages() != &sm_root {
             return Err(Error::InvalidRoots);
         }
 
@@ -204,7 +204,7 @@ impl<'a> Syncer<'a> {
         }
         // validate message root from header matches message root
         let sm_root = self.compute_msg_data(&block)?;
-        if block.to_header().messages() != &sm_root {
+        if block.header().messages() != &sm_root {
             return Err(Error::InvalidRoots);
         }
 
@@ -214,7 +214,7 @@ impl<'a> Syncer<'a> {
     /// Validates block semantically according to https://github.com/filecoin-project/specs/blob/6ab401c0b92efb6420c6e198ec387cf56dc86057/validation.md
     pub fn validate(&self, block: Block) -> Result<(), Error> {
         // get header from full block
-        let header = block.to_header();
+        let header = block.header();
 
         // check if block has been signed
         if header.signature().bytes().is_empty() {

--- a/blockchain/sync_manager/src/sync.rs
+++ b/blockchain/sync_manager/src/sync.rs
@@ -7,12 +7,12 @@ use super::errors::Error;
 use super::manager::SyncManager;
 use address::Address;
 use amt::{BlockStore, AMT};
-use blocks::{Block, FullTipset, TipSetKeys, Tipset};
+use blocks::{Block, FullTipset, TipSetKeys, Tipset, TxMeta};
 use chain::ChainStore;
 use cid::{Cid, Error as CidError};
 use crypto::is_valid_signature;
 use libp2p::core::PeerId;
-use message::{Message, MsgMeta};
+use message::Message;
 use num_bigint::BigUint;
 use raw_block::RawBlock;
 use state::{HamtStateTree, StateTree};
@@ -92,7 +92,7 @@ impl<'a> Syncer<'a> {
         let bls_root = AMT::new_from_slice(self.chain_store.blockstore(), &bls_cids)?;
         let secp_root = AMT::new_from_slice(self.chain_store.blockstore(), &secp_cids)?;
 
-        let meta = MsgMeta {
+        let meta = TxMeta {
             bls_message_root: bls_root,
             secp_message_root: secp_root,
         };

--- a/crypto/src/vrf.rs
+++ b/crypto/src/vrf.rs
@@ -19,9 +19,6 @@ impl VRFPublicKey {
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Default, Serialize, Deserialize)]
 pub struct VRFResult(#[serde(with = "serde_bytes")] Vec<u8>);
 
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
-
 impl VRFResult {
     /// Creates a VRFResult from a raw vector
     pub fn new(output: Vec<u8>) -> Self {
@@ -47,9 +44,6 @@ impl VRFResult {
         }
     }
 }
-
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
 
 #[cfg(test)]
 mod tests {

--- a/node/clock/src/lib.rs
+++ b/node/clock/src/lib.rs
@@ -34,9 +34,6 @@ impl<'de> de::Deserialize<'de> for ChainEpoch {
     }
 }
 
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
-
 /// ChainEpochClock is used by the system node to assume weak clock synchrony amongst the other
 /// systems.
 pub struct ChainEpochClock {

--- a/vm/actor/src/lib.rs
+++ b/vm/actor/src/lib.rs
@@ -16,9 +16,6 @@ use serde::{Deserialize, Serialize};
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ActorID(u64);
 
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
-
 impl Cbor for ActorID {}
 
 /// State of all actor implementations

--- a/vm/message/src/lib.rs
+++ b/vm/message/src/lib.rs
@@ -10,11 +10,6 @@ pub use signed_message::*;
 pub use unsigned_message::*;
 
 use address::Address;
-use cid::Cid;
-use encoding::{
-    de::{self, Deserialize, Deserializer},
-    ser::{self, Serializer},
-};
 use num_bigint::BigUint;
 use vm::{MethodNum, Serialized, TokenAmount};
 
@@ -37,35 +32,4 @@ pub trait Message {
     fn gas_limit(&self) -> &BigUint;
     /// Returns the required funds for the message
     fn required_funds(&self) -> BigUint;
-}
-
-pub struct MsgMeta {
-    pub bls_message_root: Cid,
-    pub secp_message_root: Cid,
-}
-
-impl ser::Serialize for MsgMeta {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        (
-            self.bls_message_root.clone(),
-            self.secp_message_root.clone(),
-        )
-            .serialize(serializer)
-    }
-}
-
-impl<'de> de::Deserialize<'de> for MsgMeta {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let (bls_message_root, secp_message_root) = Deserialize::deserialize(deserializer)?;
-        Ok(Self {
-            bls_message_root,
-            secp_message_root,
-        })
-    }
 }

--- a/vm/message/src/signed_message.rs
+++ b/vm/message/src/signed_message.rs
@@ -5,20 +5,38 @@ use super::{Message, UnsignedMessage};
 use address::Address;
 use crypto::{Error as CryptoError, Signature, Signer};
 use encoding::Cbor;
+use encoding::{de::Deserializer, ser::Serializer};
 use num_bigint::BigUint;
 use raw_block::RawBlock;
 use serde::{Deserialize, Serialize};
 use vm::{MethodNum, Serialized, TokenAmount};
 
 /// Represents a wrapped message with signature bytes
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct SignedMessage {
     message: UnsignedMessage,
     signature: Signature,
 }
 
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
+impl Serialize for SignedMessage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = (self.message.clone(), self.signature.clone());
+        Serialize::serialize(&value, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SignedMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let (message, signature) = Deserialize::deserialize(deserializer)?;
+        Ok(SignedMessage { message, signature })
+    }
+}
 
 impl SignedMessage {
     pub fn new<S: Signer>(msg: &UnsignedMessage, signer: &S) -> Result<Self, CryptoError> {

--- a/vm/src/method.rs
+++ b/vm/src/method.rs
@@ -9,9 +9,6 @@ use std::ops::Deref;
 #[derive(Default, Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
 pub struct MethodNum(u64); // TODO: add constraints to this
 
-// TODO verify format or implement custom serialize/deserialize function (if necessary):
-// https://github.com/ChainSafe/forest/issues/143
-
 impl MethodNum {
     /// Constructor for new MethodNum
     pub fn new(num: u64) -> Self {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Implement/ fix TxMeta (or message root) serialization to tuple serialization
- Implement serialization of signed messages (will be important for signatures soon)
- Cleaned up usages of a few small things for consistency
- Adds cid function from block to access cid for block easier from header

These things were bugging me a bit and wanted to do now as we would need soon


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes #143

**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->