### PR TITLE
Fix cid serde feature reference

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -88,6 +88,12 @@ jobs:
           command: clippy
           args: -- -D warnings
 
+      - name: Check forest binary
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -p forest
+
   publish_docs:
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     name: Publish Documentation

--- a/blockchain/blocks/Cargo.toml
+++ b/blockchain/blocks/Cargo.toml
@@ -9,7 +9,7 @@ address = { package = "forest_address", path = "../../vm/address" }
 crypto = { path = "../../crypto" }
 message = { package = "forest_message", path = "../../vm/message" }
 clock = { path = "../../node/clock" }
-cid = { package = "forest_cid", path = "../../ipld/cid" }
+cid = { package = "forest_cid", path = "../../ipld/cid", features = ["serde_derive"] }
 derive_builder = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 encoding = { package = "forest_encoding", path = "../../encoding" }

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -57,7 +57,7 @@ impl Default for Cid {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_derive")]
 impl ser::Serialize for Cid {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
@@ -74,7 +74,7 @@ impl ser::Serialize for Cid {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_derive")]
 impl<'de> de::Deserialize<'de> for Cid {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Somehow this was not caught in the cargo check, build, or lint but is caught when running with `cargo run -p forest`. Might be worth adding `cargo c -p forest` to the CI since it works when compiling workspace as a whole because the serde feature gets compiled since the IPLD crate defines the serde_derive feature on Cid but the forest binary does not currently connect with IPLD yet.
- Made `serde_derive` feature config more explicit on the serde implementations in Cid

Edit: Added `cargo check -p forest` to the CI so this doesn't happen again

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->