### PR TITLE
Refactor SyncManager to have ownership over tipsets

### DIFF
--- a/blockchain/sync_manager/src/manager.rs
+++ b/blockchain/sync_manager/src/manager.rs
@@ -4,18 +4,19 @@
 use super::bucket::SyncBucketSet;
 use blocks::Tipset;
 use libp2p::core::PeerId;
+use std::rc::Rc;
 
 #[derive(Default)]
-pub struct SyncManager<'a> {
-    sync_queue: SyncBucketSet<'a>,
+pub struct SyncManager {
+    sync_queue: SyncBucketSet,
 }
 
-impl<'a> SyncManager<'a> {
-    pub fn schedule_tipset(&mut self, tipset: &'a Tipset) {
+impl SyncManager {
+    pub fn schedule_tipset(&mut self, tipset: Rc<Tipset>) {
         // TODO implement interactions for syncing state when SyncManager built out
         self.sync_queue.insert(tipset);
     }
-    pub fn select_sync_target(&self) -> Option<&'a Tipset> {
+    pub fn select_sync_target(&self) -> Option<Rc<Tipset>> {
         self.sync_queue.heaviest()
     }
     pub fn set_peer_head(&self, _peer: PeerId, _ts: Tipset) {

--- a/blockchain/sync_manager/src/sync.rs
+++ b/blockchain/sync_manager/src/sync.rs
@@ -25,7 +25,7 @@ pub struct Syncer<'a> {
     // TODO add block sync
 
     // manages sync buckets
-    sync_manager: SyncManager<'a>,
+    sync_manager: SyncManager,
     // access and store tipsets / blocks / messages
     chain_store: ChainStore<'a>,
     // the known genesis tipset

--- a/blockchain/sync_manager/tests/manager_test.rs
+++ b/blockchain/sync_manager/tests/manager_test.rs
@@ -4,6 +4,7 @@
 use blocks::{BlockHeader, Tipset};
 use cid::{multihash::Hash::Blake2b256, Cid};
 use num_bigint::BigUint;
+use std::rc::Rc;
 use sync_manager::SyncManager;
 
 fn create_header(weight: u64, parent_bz: &[u8], cached_bytes: &[u8]) -> BlockHeader {
@@ -19,25 +20,25 @@ fn create_header(weight: u64, parent_bz: &[u8], cached_bytes: &[u8]) -> BlockHea
 #[test]
 fn schedule_tipset() {
     let header = create_header(0, b"", b"");
-    let tipset = Tipset::new(vec![header]).unwrap();
+    let tipset = Rc::new(Tipset::new(vec![header]).unwrap());
     let mut manager = SyncManager::default();
-    manager.schedule_tipset(&tipset);
+    manager.schedule_tipset(tipset.clone());
     {
         // Test scheduling inside different scope
-        manager.schedule_tipset(&tipset);
+        manager.schedule_tipset(tipset.clone());
     }
-    manager.schedule_tipset(&tipset);
+    manager.schedule_tipset(tipset);
 }
 
 #[test]
 fn heaviest_different_chain() {
-    let l_tipset = Tipset::new(vec![create_header(1, b"1", b"1")]).unwrap();
-    let m_tipset = Tipset::new(vec![create_header(2, b"2", b"2")]).unwrap();
-    let h_tipset = Tipset::new(vec![create_header(3, b"1", b"1")]).unwrap();
+    let l_tipset = Rc::new(Tipset::new(vec![create_header(1, b"1", b"1")]).unwrap());
+    let m_tipset = Rc::new(Tipset::new(vec![create_header(2, b"2", b"2")]).unwrap());
+    let h_tipset = Rc::new(Tipset::new(vec![create_header(3, b"1", b"1")]).unwrap());
     let mut manager = SyncManager::default();
-    manager.schedule_tipset(&l_tipset);
-    manager.schedule_tipset(&m_tipset);
-    manager.schedule_tipset(&h_tipset);
-    assert_eq!(manager.select_sync_target().unwrap(), &h_tipset);
-    assert_ne!(manager.select_sync_target().unwrap(), &l_tipset);
+    manager.schedule_tipset(l_tipset.clone());
+    manager.schedule_tipset(m_tipset.clone());
+    manager.schedule_tipset(h_tipset.clone());
+    assert_eq!(manager.select_sync_target().unwrap(), h_tipset);
+    assert_ne!(manager.select_sync_target().unwrap(), l_tipset);
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- I wrote the syncmanager assuming that it would just use references to the tipsets kept in memory (optimistic thinking, I know) but in fact how it needs to happen is tipsets will be pulled from the network and kept in memory only for the sync manager. Because of this, the tipsets need to be heap allocated using an Rc (https://doc.rust-lang.org/std/rc/struct.Rc.html) and clone references to it to use in the sync manager.

Don't be worried about the clone, it only creates a new pointer to the heap allocated tipset and increments the reference count. Also don't need to use the non-associative `Rc::clone(&other)` in my usages here because the type in enforced by the function usage, but be careful when cloning a tipset into the sync manager not to create a duplicate of it.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->