### PR TITLE
Update multibase dependency for lowercase base32 support

### DIFF
--- a/ipld/cid/Cargo.toml
+++ b/ipld/cid/Cargo.toml
@@ -9,7 +9,7 @@ features = ["serde_derive"]
 
 [dependencies]
 multihash = "0.9.4"
-multibase = "0.7.0"
+multibase = { git = "https://github.com/multiformats/rust-multibase", rev = "4220b42bd422b940d46fd05589c2672e861f63a1" }
 integer-encoding = "1.0.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_cbor = { version = "0.11.0", features = ["tags"], optional = true }

--- a/ipld/cid/Cargo.toml
+++ b/ipld/cid/Cargo.toml
@@ -9,7 +9,7 @@ features = ["serde_derive"]
 
 [dependencies]
 multihash = "0.9.4"
-multibase = { git = "https://github.com/multiformats/rust-multibase", rev = "4220b42bd422b940d46fd05589c2672e861f63a1" }
+multibase = "0.8.0"
 integer-encoding = "1.0.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_cbor = { version = "0.11.0", features = ["tags"], optional = true }

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -135,7 +135,7 @@ impl Cid {
     fn to_string_v0(&self) -> String {
         use multibase::{encode, Base};
 
-        let mut string = encode(Base::Base58btc, self.hash.clone());
+        let mut string = encode(Base::Base58Btc, self.hash.clone());
 
         // Drop the first character as v0 does not know
         // about multibase
@@ -147,7 +147,7 @@ impl Cid {
     fn to_string_v1(&self) -> String {
         use multibase::{encode, Base};
 
-        encode(Base::Base58btc, self.to_bytes().as_slice())
+        encode(Base::Base58Btc, self.to_bytes().as_slice())
     }
 
     fn to_bytes_v0(&self) -> Vec<u8> {

--- a/ipld/cid/src/to_cid.rs
+++ b/ipld/cid/src/to_cid.rs
@@ -86,7 +86,7 @@ fn decode_str(cid_str: &str) -> Result<Vec<u8>, Error> {
     let (_, decoded) = if Version::is_v0_str(hash) {
         // TODO: could avoid the roundtrip here and just use underlying
         // base-x base58btc decoder here.
-        let hash = multibase::Base::Base58btc.code().to_string() + hash;
+        let hash = multibase::Base::Base58Btc.code().to_string() + hash;
 
         multibase::decode(hash)
     } else {

--- a/ipld/cid/src/to_cid.rs
+++ b/ipld/cid/src/to_cid.rs
@@ -113,8 +113,6 @@ mod tests {
         assert_eq!(hash.algorithm(), Hash::Blake2b256);
     }
     #[test]
-    #[should_panic]
-    // TODO remove should_panic once lowercase base32 implemented in multibase
     fn verify_base32_lower() {
         let t_str = "bafy2bzaced2esi3bximo7jezgdjxkwpiu4vom3rvg44cienfsdgllheuiphee";
         let decoded = &decode_str(&t_str).unwrap();


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Update multibase dependency for lowercase base32 support

Really annoying having to manually convert lowercase base32 from outputs of Lotus to uppercase in testing so just getting this ready. 

Support in multibase was added with https://github.com/multiformats/rust-multibase/pull/16 but ~hasn't been released so will probably leave as draft until it is~.

Edit: Released now, good to come in

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->