### PR TITLE
Update multihash dependency and Blockstore interface

### DIFF
--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -279,7 +279,7 @@ impl BlockHeader {
     fn update_cache(&mut self) -> Result<(), String> {
         self.cached_bytes = self.marshal_cbor().map_err(|e| e.to_string())?;
         self.cached_cid =
-            Cid::from_bytes(&self.cached_bytes, Blake2b256).map_err(|e| e.to_string())?;
+            Cid::new_from_cbor(&self.cached_bytes, Blake2b256).map_err(|e| e.to_string())?;
         Ok(())
     }
     /// Check to ensure block signature is valid

--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -3,7 +3,7 @@
 
 use super::{EPostProof, Error, FullTipset, Ticket, TipSetKeys};
 use address::Address;
-use cid::{multihash::Hash::Blake2b256, Cid};
+use cid::{multihash::Blake2b256, Cid};
 use clock::ChainEpoch;
 use crypto::{is_valid_signature, Signature};
 use derive_builder::Builder;

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -239,7 +239,7 @@ mod tests {
     const CACHED_BYTES: [u8; 1] = [0];
 
     fn template_key(data: &[u8]) -> Cid {
-        Cid::from_bytes(data, Blake2b256).unwrap()
+        Cid::new_from_cbor(data, Blake2b256).unwrap()
     }
 
     // key_setup returns a vec of 4 distinct CIDs

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -231,7 +231,7 @@ impl FullTipset {
 mod tests {
     use super::*;
     use address::Address;
-    use cid::{multihash::Hash::Blake2b256, Cid};
+    use cid::{multihash::Blake2b256, Cid};
     use crypto::VRFResult;
     use num_bigint::BigUint;
 

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -18,4 +18,4 @@ ipld_blockstore = { path = "../../ipld/blockstore" }
 [dev-dependencies]
 address = { package = "forest_address", path = "../../vm/address" }
 crypto = { path = "../../crypto" }
-multihash = "0.9.4"
+multihash = "0.10.0"

--- a/blockchain/chain/src/store/tip_index.rs
+++ b/blockchain/chain/src/store/tip_index.rs
@@ -93,7 +93,7 @@ impl TipIndex {
 mod tests {
     use super::*;
     use blocks::{BlockHeader, Ticket, Tipset};
-    use cid::{multihash::Hash::Blake2b256, Cid};
+    use cid::{multihash::Blake2b256, Cid};
     use crypto::VRFResult;
 
     fn template_key(data: &[u8]) -> Cid {

--- a/blockchain/chain/src/store/tip_index.rs
+++ b/blockchain/chain/src/store/tip_index.rs
@@ -97,7 +97,7 @@ mod tests {
     use crypto::VRFResult;
 
     fn template_key(data: &[u8]) -> Cid {
-        Cid::from_bytes(data, Blake2b256).unwrap()
+        Cid::new_from_cbor(data, Blake2b256).unwrap()
     }
 
     // key_setup returns a vec of distinct CIDs

--- a/blockchain/chain_sync/src/bucket.rs
+++ b/blockchain/chain_sync/src/bucket.rs
@@ -74,7 +74,7 @@ impl SyncBucketSet {
 mod tests {
     use super::*;
     use blocks::BlockHeader;
-    use cid::{multihash::Hash::Blake2b256, Cid};
+    use cid::{multihash::Blake2b256, Cid};
     use num_bigint::BigUint;
 
     fn create_header(weight: u64, parent_bz: &[u8], cached_bytes: &[u8]) -> BlockHeader {

--- a/blockchain/chain_sync/src/bucket.rs
+++ b/blockchain/chain_sync/src/bucket.rs
@@ -81,7 +81,7 @@ mod tests {
         let header = BlockHeader::builder()
             .weight(BigUint::from(weight))
             .cached_bytes(cached_bytes.to_vec())
-            .cached_cid(Cid::from_bytes(parent_bz, Blake2b256).unwrap())
+            .cached_cid(Cid::new_from_cbor(parent_bz, Blake2b256).unwrap())
             .build()
             .unwrap();
         header

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -13,7 +13,7 @@ use async_std::sync::{channel, Receiver, Sender};
 use async_std::task;
 use blocks::{Block, BlockHeader, FullTipset, TipSetKeys, Tipset, TxMeta};
 use chain::ChainStore;
-use cid::Cid;
+use cid::{multihash::Blake2b256, Cid};
 use core::time::Duration;
 use crypto::is_valid_signature;
 use db::Error as DBError;
@@ -226,7 +226,7 @@ where
             secp_message_root: secp_root,
         };
         // store message roots and receive meta_root
-        let meta_root = self.chain_store.blockstore().put(&meta)?;
+        let meta_root = self.chain_store.blockstore().put(&meta, Blake2b256)?;
 
         Ok(meta_root)
     }

--- a/blockchain/chain_sync/tests/manager_test.rs
+++ b/blockchain/chain_sync/tests/manager_test.rs
@@ -3,7 +3,7 @@
 
 use blocks::{BlockHeader, Tipset};
 use chain_sync::SyncManager;
-use cid::{multihash::Hash::Blake2b256, Cid};
+use cid::{multihash::Blake2b256, Cid};
 use num_bigint::BigUint;
 use std::sync::Arc;
 

--- a/blockchain/chain_sync/tests/manager_test.rs
+++ b/blockchain/chain_sync/tests/manager_test.rs
@@ -11,7 +11,7 @@ fn create_header(weight: u64, parent_bz: &[u8], cached_bytes: &[u8]) -> BlockHea
     let header = BlockHeader::builder()
         .weight(BigUint::from(weight))
         .cached_bytes(cached_bytes.to_vec())
-        .cached_cid(Cid::from_bytes(parent_bz, Blake2b256).unwrap())
+        .cached_cid(Cid::new_from_cbor(parent_bz, Blake2b256).unwrap())
         .build()
         .unwrap();
     header

--- a/encoding/src/cbor.rs
+++ b/encoding/src/cbor.rs
@@ -20,6 +20,6 @@ pub trait Cbor: Serialize + DeserializeOwned {
     /// Returns the content identifier of the raw block of data
     /// Default is Blake2b256 hash
     fn cid(&self) -> Result<Cid, Error> {
-        Ok(Cid::from_bytes(&self.marshal_cbor()?, Blake2b256)?)
+        Ok(Cid::new_from_cbor(&self.marshal_cbor()?, Blake2b256)?)
     }
 }

--- a/encoding/src/cbor.rs
+++ b/encoding/src/cbor.rs
@@ -3,7 +3,7 @@
 
 use super::errors::Error;
 use crate::{de::DeserializeOwned, from_slice, ser::Serialize, to_vec};
-use cid::{multihash::Hash::Blake2b256, Cid};
+use cid::{multihash::Blake2b256, Cid};
 
 /// Cbor utility functions for serializable objects
 pub trait Cbor: Serialize + DeserializeOwned {

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{node::Link, nodes_for_height, BitMap, Error, Node, Root, MAX_INDEX, WIDTH};
-use cid::Cid;
+use cid::{multihash::Blake2b256, Cid};
 use encoding::{de::DeserializeOwned, ser::Serialize};
 use ipld_blockstore::BlockStore;
 
@@ -103,7 +103,7 @@ where
                 self.root.node.flush(self.block_store)?;
 
                 // Get cid from storing root node
-                let cid = self.block_store.put(&self.root.node)?;
+                let cid = self.block_store.put(&self.root.node, Blake2b256)?;
 
                 // Set links node with first index as cid
                 let mut new_links: [Option<Link<V>>; WIDTH] = Default::default();
@@ -186,6 +186,6 @@ where
     /// flush root and return Cid used as key in block store
     pub fn flush(&mut self) -> Result<Cid, Error> {
         self.root.node.flush(self.block_store)?;
-        Ok(self.block_store.put(&self.root)?)
+        Ok(self.block_store.put(&self.root, Blake2b256)?)
     }
 }

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{nodes_for_height, BitMap, Error, WIDTH};
-use cid::Cid;
+use cid::{multihash::Blake2b256, Cid};
 use encoding::{
     de::{self, Deserialize, DeserializeOwned},
     ser::{self, Serialize},
@@ -150,7 +150,7 @@ where
                     n.flush(bs)?;
 
                     // Puts node in blockstore and and retrieves it's CID
-                    let cid = bs.put(n)?;
+                    let cid = bs.put(n, Blake2b256)?;
 
                     // Turn cached node into a Cid link
                     *link = Some(Link::Cid(cid));

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::{multihash::Hash, Cid};
+use cid::{multihash::Blake2b256, Cid};
 use db::{Error, MemoryDB, Read, RocksDb, Write};
 use encoding::{de::DeserializeOwned, from_slice, ser::Serialize, to_vec};
 
@@ -25,13 +25,14 @@ pub trait BlockStore: Read + Write {
         }
     }
 
+    // TODO allow put function to set hash type of Cid with multihash::MultihashDigest trait
     /// Put an object in the block store and return the Cid identifier
     fn put<S>(&self, obj: &S) -> Result<Cid, Error>
     where
         S: Serialize,
     {
         let bz = to_vec(obj).map_err(|e| Error::new(e.to_string()))?;
-        let cid = Cid::from_bytes(&bz, Hash::Blake2b256).map_err(|e| Error::new(e.to_string()))?;
+        let cid = Cid::from_bytes(&bz, Blake2b256).map_err(|e| Error::new(e.to_string()))?;
         self.write(cid.to_bytes(), bz)?;
         Ok(cid)
     }

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::{multihash::Blake2b256, Cid};
+use cid::{multihash::MultihashDigest, Cid};
 use db::{Error, MemoryDB, Read, RocksDb, Write};
 use encoding::{de::DeserializeOwned, from_slice, ser::Serialize, to_vec};
 
@@ -25,14 +25,14 @@ pub trait BlockStore: Read + Write {
         }
     }
 
-    // TODO allow put function to set hash type of Cid with multihash::MultihashDigest trait
     /// Put an object in the block store and return the Cid identifier
-    fn put<S>(&self, obj: &S) -> Result<Cid, Error>
+    fn put<S, T>(&self, obj: &S, hash: T) -> Result<Cid, Error>
     where
         S: Serialize,
+        T: MultihashDigest,
     {
         let bz = to_vec(obj).map_err(|e| Error::new(e.to_string()))?;
-        let cid = Cid::new_from_cbor(&bz, Blake2b256).map_err(|e| Error::new(e.to_string()))?;
+        let cid = Cid::new_from_cbor(&bz, hash).map_err(|e| Error::new(e.to_string()))?;
         self.write(cid.to_bytes(), bz)?;
         Ok(cid)
     }

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -32,7 +32,7 @@ pub trait BlockStore: Read + Write {
         S: Serialize,
     {
         let bz = to_vec(obj).map_err(|e| Error::new(e.to_string()))?;
-        let cid = Cid::from_bytes(&bz, Blake2b256).map_err(|e| Error::new(e.to_string()))?;
+        let cid = Cid::new_from_cbor(&bz, Blake2b256).map_err(|e| Error::new(e.to_string()))?;
         self.write(cid.to_bytes(), bz)?;
         Ok(cid)
     }

--- a/ipld/cid/Cargo.toml
+++ b/ipld/cid/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 features = ["serde_derive"]
 
 [dependencies]
-multihash = "0.9.4"
+multihash = "0.10.0"
 multibase = "0.8.0"
 integer-encoding = "1.0.3"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -102,7 +102,7 @@ impl Cid {
     }
 
     /// Constructs a cid with bytes using default version and codec
-    pub fn from_bytes<T: MultihashDigest>(bz: &[u8], hash: T) -> Result<Self, Error> {
+    pub fn new_from_cbor<T: MultihashDigest>(bz: &[u8], hash: T) -> Result<Self, Error> {
         let hash = hash.digest(bz);
         Ok(Cid {
             version: Version::V1,
@@ -121,7 +121,7 @@ impl Cid {
         let hash = prefix
             .mh_type
             .hasher()
-            .ok_or(Error::Other("Prefix must use builtin hasher".to_owned()))?
+            .ok_or_else(|| Error::Other("Prefix must use builtin hasher".to_owned()))?
             .digest(data);
         Ok(Cid {
             version: prefix.version,

--- a/ipld/cid/src/to_cid.rs
+++ b/ipld/cid/src/to_cid.rs
@@ -99,7 +99,7 @@ fn decode_str(cid_str: &str) -> Result<Vec<u8>, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use multihash::Hash;
+    use multihash::Code::Blake2b256;
 
     #[test]
     fn verify_base32_upper() {
@@ -110,7 +110,7 @@ mod tests {
         assert_eq!(version, Version::V1, "failed version check");
         assert_eq!(codec, Codec::DagCBOR, "failed codec check");
         let hash = Multihash::from_bytes(hash.to_vec()).unwrap();
-        assert_eq!(hash.algorithm(), Hash::Blake2b256);
+        assert_eq!(hash.algorithm(), Blake2b256);
     }
     #[test]
     fn verify_base32_lower() {
@@ -121,6 +121,6 @@ mod tests {
         assert_eq!(version, Version::V1, "failed version check");
         assert_eq!(codec, Codec::DagCBOR, "failed codec check");
         let hash = Multihash::from_bytes(hash.to_vec()).unwrap();
-        assert_eq!(hash.algorithm(), Hash::Blake2b256);
+        assert_eq!(hash.algorithm(), Blake2b256);
     }
 }

--- a/ipld/cid/tests/base_cid_tests.rs
+++ b/ipld/cid/tests/base_cid_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_cid::{Cid, Codec, Error, Prefix, Version};
-use multihash::{self, Sha2_256};
+use multihash::{self, Code, Sha2_256};
 use std::collections::HashMap;
 
 #[test]
@@ -54,6 +54,24 @@ fn v0_error() {
 }
 
 #[test]
+fn prefix_roundtrip() {
+    let data = b"awesome test content";
+    let h = Sha2_256::digest(data);
+
+    let cid = Cid::new(Codec::DagProtobuf, Version::V1, h);
+    let prefix = cid.prefix();
+
+    let cid2 = Cid::new_from_prefix(&prefix, data).unwrap();
+
+    assert_eq!(cid, cid2);
+
+    let prefix_bytes = prefix.as_bytes();
+    let prefix2 = Prefix::new_from_bytes(&prefix_bytes).unwrap();
+
+    assert_eq!(prefix, prefix2);
+}
+
+#[test]
 fn from() {
     let the_hash = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n";
 
@@ -76,7 +94,7 @@ fn test_hash() {
     let prefix = Prefix {
         version: Version::V0,
         codec: Codec::DagProtobuf,
-        mh_type: Sha2_256,
+        mh_type: Code::Sha2_256,
     };
     let mut map = HashMap::new();
     let cid = Cid::new_from_prefix(&prefix, &data).unwrap();

--- a/ipld/cid/tests/base_cid_tests.rs
+++ b/ipld/cid/tests/base_cid_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_cid::{Cid, Codec, Error, Prefix, Version};
-use multihash::{self, Code, Sha2_256};
+use multihash::{self, Blake2b256, Code, Sha2_256};
 use std::collections::HashMap;
 
 #[test]
@@ -100,4 +100,16 @@ fn test_hash() {
     let cid = Cid::new_from_prefix(&prefix, &data).unwrap();
     map.insert(cid.clone(), data.clone());
     assert_eq!(&data, map.get(&cid).unwrap());
+}
+
+#[test]
+fn test_prefix_retrieval() {
+    let data: Vec<u8> = vec![1, 2, 3];
+
+    let cid = Cid::new_from_cbor(&data, Blake2b256).unwrap();
+
+    let prefix = cid.prefix();
+    assert_eq!(prefix.version, Version::V1);
+    assert_eq!(prefix.codec, Codec::DagCBOR);
+    assert_eq!(prefix.mh_type, Code::Blake2b256);
 }

--- a/ipld/cid/tests/serde_tests.rs
+++ b/ipld/cid/tests/serde_tests.rs
@@ -11,9 +11,9 @@ use serde_cbor::{from_slice, to_vec};
 #[test]
 fn vector_cid_serialize_round() {
     let cids = vec![
-        Cid::from_bytes(&[0, 1], Blake2b256).unwrap(),
-        Cid::from_bytes(&[1, 2], Blake2b256).unwrap(),
-        Cid::from_bytes(&[3, 2], Blake2b256).unwrap(),
+        Cid::new_from_cbor(&[0, 1], Blake2b256).unwrap(),
+        Cid::new_from_cbor(&[1, 2], Blake2b256).unwrap(),
+        Cid::new_from_cbor(&[3, 2], Blake2b256).unwrap(),
     ];
 
     // Serialize cids with cbor

--- a/ipld/cid/tests/serde_tests.rs
+++ b/ipld/cid/tests/serde_tests.rs
@@ -5,7 +5,7 @@
 
 use forest_cid::Cid;
 use multihash;
-use multihash::Hash::Blake2b256;
+use multihash::Blake2b256;
 use serde_cbor::{from_slice, to_vec};
 
 #[test]

--- a/ipld/tests/ipld_test.rs
+++ b/ipld/tests/ipld_test.rs
@@ -15,7 +15,7 @@ struct TestStruct {
 
 #[test]
 fn encode_new_type() {
-    let details = Cid::from_bytes(&[1, 2, 3], Blake2b256).unwrap();
+    let details = Cid::new_from_cbor(&[1, 2, 3], Blake2b256).unwrap();
     let name = "Test".to_string();
     let t_struct = TestStruct {
         name: name.clone(),

--- a/ipld/tests/ipld_test.rs
+++ b/ipld/tests/ipld_test.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::{multihash::Hash::Blake2b256, Cid};
+use cid::{multihash::Blake2b256, Cid};
 use encoding::{from_slice, to_vec};
 use forest_ipld::Ipld;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Updates to completely new API of multihash
- Update function name which generates Cid from cbor encoded bytes 
  - `Cid::from_bytes()` is kinda misleading as it insinuates it is just deserializing a Cid, when it is in fact generating a new one
- Updates blockstore put to pass in the hash type to allow using other hash types for Cid generation (needed by Erlich)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->