### PR TITLE
Implement multimap

### DIFF
--- a/blockchain/chain_sync/src/errors.rs
+++ b/blockchain/chain_sync/src/errors.rs
@@ -26,7 +26,7 @@ pub enum Error {
     /// Error originating from key-value store
     KeyValueStore(String),
     /// Error originating from the AMT
-    AMT(String),
+    Amt(String),
     /// Error originating from state
     State(String),
     /// Error in validating arbitrary data
@@ -45,7 +45,7 @@ impl fmt::Display for Error {
             Error::Encoding(msg) => write!(f, "{}", msg),
             Error::InvalidCid(msg) => write!(f, "{}", msg),
             Error::Store(msg) => write!(f, "{}", msg),
-            Error::AMT(msg) => write!(f, "{}", msg),
+            Error::Amt(msg) => write!(f, "{}", msg),
             Error::State(msg) => write!(f, "{}", msg),
             Error::Validation(msg) => write!(f, "{}", msg),
             Error::Other(msg) => write!(f, "chain_sync error: {}", msg),
@@ -91,7 +91,7 @@ impl From<StoreErr> for Error {
 
 impl From<AmtErr> for Error {
     fn from(e: AmtErr) -> Error {
-        Error::AMT(e.to_string())
+        Error::Amt(e.to_string())
     }
 }
 

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -8,7 +8,7 @@ use super::network_handler::NetworkHandler;
 use super::peer_manager::PeerManager;
 use super::{Error, SyncManager, SyncNetworkContext};
 use address::Address;
-use amt::AMT;
+use amt::Amt;
 use async_std::sync::{channel, Receiver, Sender};
 use async_std::task;
 use blocks::{Block, BlockHeader, FullTipset, TipSetKeys, Tipset, TxMeta};
@@ -215,9 +215,9 @@ where
         // collect bls and secp cids
         let bls_cids = cids_from_messages(block.bls_msgs())?;
         let secp_cids = cids_from_messages(block.secp_msgs())?;
-        // generate AMT and batch set message values
-        let bls_root = AMT::new_from_slice(self.chain_store.blockstore(), &bls_cids)?;
-        let secp_root = AMT::new_from_slice(self.chain_store.blockstore(), &secp_cids)?;
+        // generate Amt and batch set message values
+        let bls_root = Amt::new_from_slice(self.chain_store.blockstore(), &bls_cids)?;
+        let secp_root = Amt::new_from_slice(self.chain_store.blockstore(), &secp_cids)?;
 
         let meta = TxMeta {
             bls_message_root: bls_root,

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -184,4 +184,38 @@ where
         self.root.node.flush(self.block_store)?;
         Ok(self.block_store.put(&self.root, Blake2b256)?)
     }
+
+    /// Iterates over each value in the Amt and runs a function on the values.
+    ///
+    /// The index in the amt is a `u64` and the value is the generic parameter `V` as defined
+    /// in the Amt.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ipld_amt::Amt;
+    ///
+    /// let store = db::MemoryDB::default();
+    ///
+    /// let mut map: Amt<String, _> = Amt::new(&store);
+    /// map.set(1, "One".to_owned()).unwrap();
+    /// map.set(4, "Four".to_owned()).unwrap();
+    ///
+    /// let mut values: Vec<(u64, String)> = Vec::new();
+    /// map.for_each(&mut |i, v| {
+    ///    values.push((i, v));
+    ///    Ok(())
+    /// }).unwrap();
+    /// assert_eq!(&values, &[(1, "One".to_owned()), (4, "Four".to_owned())]);
+    /// ```
+    #[inline]
+    pub fn for_each<F>(&self, f: &mut F) -> Result<(), String>
+    where
+        V: DeserializeOwned,
+        F: FnMut(u64, V) -> Result<(), String>,
+    {
+        self.root
+            .node
+            .for_each(self.block_store, self.height(), 0, f)
+    }
 }

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -31,6 +31,12 @@ pub struct Amt<'db, V, BS> {
     block_store: &'db BS,
 }
 
+impl<'a, V: PartialEq, BS: BlockStore> PartialEq for Amt<'a, V, BS> {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root
+    }
+}
+
 impl<'db, V, BS> Amt<'db, V, BS>
 where
     V: Clone + DeserializeOwned + Serialize,

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     /// Error when trying to serialize an AMT without a flushed cache
     Cached,
     /// Custom AMT error
-    Custom(String),
+    Custom(&'static str),
 }
 
 impl fmt::Display for Error {
@@ -32,10 +32,16 @@ impl fmt::Display for Error {
             Error::Db(msg) => write!(f, "{}", msg),
             Error::Cached => write!(
                 f,
-                "Tried to serialize without saving cache, run flush() on AMT before serializing"
+                "Tried to serialize without saving cache, run flush() on Amt before serializing"
             ),
-            Error::Custom(msg) => write!(f, "Custom AMT error: {}", msg),
+            Error::Custom(msg) => write!(f, "Amt error: {}", msg),
         }
+    }
+}
+
+impl From<Error> for String {
+    fn from(e: Error) -> Self {
+        e.to_string()
     }
 }
 

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 mod node;
 mod root;
 
-pub use self::amt::AMT;
+pub use self::amt::Amt;
 pub use self::bitmap::BitMap;
 pub use self::error::Error;
 pub(crate) use self::node::Node;

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -74,7 +74,7 @@ where
         if bmap.get_bit(i as u64) {
             let value = v_iter
                 .next()
-                .ok_or_else(|| Error::Custom("Vector length does not match bitmap".to_owned()))?;
+                .ok_or_else(|| Error::Custom("Vector length does not match bitmap"))?;
             *e = Some(<T>::from(value.clone()));
         }
     }
@@ -173,7 +173,7 @@ where
         self.bitmap().is_empty()
     }
 
-    /// Gets value at given index of AMT given height
+    /// Gets value at given index of Amt given height
     pub(super) fn get<DB: BlockStore>(
         &self,
         bs: &DB,
@@ -253,7 +253,7 @@ where
                 unreachable!("Value is set as cached")
             }
         } else {
-            unreachable!("Non zero height in AMT is always Links type")
+            unreachable!("Non zero height in Amt is always Links type")
         }
     }
 
@@ -270,7 +270,7 @@ where
         }
     }
 
-    /// Delete value in AMT by index
+    /// Delete value in Amt by index
     pub(super) fn delete<DB: BlockStore>(
         &mut self,
         bs: &DB,
@@ -280,7 +280,7 @@ where
         let sub_i = i / nodes_for_height(height);
 
         if !self.bitmap().get_bit(sub_i) {
-            // Value does not exist in AMT
+            // Value does not exist in Amt
             return Ok(false);
         }
 

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -47,7 +47,7 @@ impl<V> Default for Node<V> {
 }
 
 /// Turns the WIDTH length array into a vector for serialization
-fn values_to_vec<T>(bmap: BitMap, values: &[Option<T>; WIDTH]) -> Vec<T>
+fn values_to_vec<T>(bmap: &BitMap, values: &[Option<T>; WIDTH]) -> Vec<T>
 where
     T: Clone,
 {
@@ -103,7 +103,7 @@ where
         S: ser::Serializer,
     {
         match &self {
-            Node::Leaf { bmap, vals } => (bmap, [0u8; 0], values_to_vec(*bmap, &vals)).serialize(s),
+            Node::Leaf { bmap, vals } => (bmap, [0u8; 0], values_to_vec(bmap, &vals)).serialize(s),
             Node::Link { bmap, links } => {
                 let cids = cids_from_links(links).map_err(|e| ser::Error::custom(e.to_string()))?;
                 (bmap, cids, [0u8; 0]).serialize(s)
@@ -321,6 +321,49 @@ where
                 Ok(true)
             }
         }
+    }
+
+    pub(super) fn for_each<S, F>(
+        &self,
+        store: &S,
+        height: u32,
+        offset: u64,
+        f: &mut F,
+    ) -> Result<(), String>
+    where
+        F: FnMut(u64, V) -> Result<(), String>,
+        S: BlockStore,
+    {
+        match self {
+            Node::Leaf { bmap, vals } => {
+                for i in 0..WIDTH {
+                    if bmap.get_bit(i as u64) {
+                        f(
+                            offset + i as u64,
+                            vals[i].clone().expect("set bit should contain value"),
+                        )?;
+                    }
+                }
+            }
+            Node::Link { bmap, links } => {
+                for i in 0..WIDTH {
+                    if bmap.get_bit(i as u64) {
+                        let offs = offset + (i as u64 * nodes_for_height(height));
+                        match links[i].as_ref().expect("bit set at index") {
+                            Link::Cached(sub) => sub.for_each(store, height - 1, offs, f)?,
+                            Link::Cid(cid) => {
+                                let node = store.get::<Node<V>>(cid)?.ok_or_else(|| {
+                                    Error::Cid("Cid did not match any in database".to_owned())
+                                })?;
+
+                                node.for_each(store, height - 1, offs, f)?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -5,7 +5,7 @@ use cid::{multihash::MultihashDigest, Cid};
 use db::{Error, MemoryDB, RocksDb, Store};
 use encoding::{de::DeserializeOwned, from_slice, ser::Serialize, to_vec};
 
-/// Wrapper for database to handle inserting and retrieving data from AMT with Cids
+/// Wrapper for database to handle inserting and retrieving ipld data with Cids
 pub trait BlockStore: Store {
     /// Get bytes from block store by Cid
     fn get_bytes(&self, cid: &Cid) -> Result<Option<Vec<u8>>, Error> {

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -97,7 +97,7 @@ where
     }
 
     /// Returns a reference to the underlying store of the Hamt.
-    pub fn store(&self) -> &BS {
+    pub fn store(&self) -> &'a BS {
         self.store
     }
 

--- a/vm/actor/Cargo.toml
+++ b/vm/actor/Cargo.toml
@@ -19,6 +19,7 @@ libp2p = "0.15.0"
 lazy_static = "1.4.0"
 ipld_blockstore = { path = "../../ipld/blockstore" }
 ipld_hamt = { path = "../../ipld/hamt" }
+ipld_amt = { path = "../../ipld/amt" }
 forest_ipld = { path = "../../ipld" }
 message = { package = "forest_message", path = "../message" }
 

--- a/vm/actor/src/util/balance_table.rs
+++ b/vm/actor/src/util/balance_table.rs
@@ -16,7 +16,7 @@ where
     BS: BlockStore,
 {
     /// Initializes a new empty balance table
-    pub fn new_empty(bs: &'a BS) -> Self {
+    pub fn new(bs: &'a BS) -> Self {
         Self(Hamt::new_with_bit_width(bs, HAMT_BIT_WIDTH))
     }
 

--- a/vm/actor/src/util/mod.rs
+++ b/vm/actor/src/util/mod.rs
@@ -2,5 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod balance_table;
+mod multimap;
 
 pub use self::balance_table::BalanceTable;
+pub use self::multimap::*;

--- a/vm/actor/src/util/multimap.rs
+++ b/vm/actor/src/util/multimap.rs
@@ -16,7 +16,7 @@ where
     BS: BlockStore,
 {
     /// Initializes a new empty multimap.
-    pub fn new_empty(bs: &'a BS) -> Self {
+    pub fn new(bs: &'a BS) -> Self {
         Self(Hamt::new_with_bit_width(bs, HAMT_BIT_WIDTH))
     }
 

--- a/vm/actor/src/util/multimap.rs
+++ b/vm/actor/src/util/multimap.rs
@@ -1,0 +1,78 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::HAMT_BIT_WIDTH;
+use cid::Cid;
+use encoding::Cbor;
+use ipld_amt::Amt;
+use ipld_blockstore::BlockStore;
+use ipld_hamt::{Error, Hamt};
+use vm::TokenAmount;
+
+/// Multimap stores multiple values per key in a Hamt of Amts.
+/// The order of insertion of values for each key is retained.
+pub struct Multimap<'a, BS>(Hamt<'a, String, BS>);
+impl<'a, BS> Multimap<'a, BS>
+where
+    BS: BlockStore,
+{
+    /// Initializes a new empty multimap.
+    pub fn new_empty(bs: &'a BS) -> Self {
+        Self(Hamt::new_with_bit_width(bs, HAMT_BIT_WIDTH))
+    }
+
+    /// Initializes a multimap from a root Cid
+    pub fn from_root(bs: &'a BS, cid: &Cid) -> Result<Self, Error> {
+        Ok(Self(Hamt::load_with_bit_width(cid, bs, HAMT_BIT_WIDTH)?))
+    }
+
+    /// Retrieve root from multimap
+    #[inline]
+    pub fn root(&mut self) -> Result<Cid, Error> {
+        self.0.flush()
+    }
+
+    /// Adds a value for a key.
+    pub fn add<V>(&mut self, key: &String, _value: &V) -> Result<(), String>
+    where
+        V: Cbor + Clone,
+    {
+        let _prev = self
+            .get::<V>(key)?
+            .ok_or(format!("Array for key: {} does not exist", key))?;
+        todo!()
+    }
+
+    /// Gets token amount for given address in multimap
+    #[inline]
+    pub fn get<V>(&self, key: &String) -> Result<Option<Amt<'a, V, BS>>, String>
+    where
+        V: Cbor + Clone,
+    {
+        match self.0.get(key)? {
+            Some(cid) => Ok(Some(Amt::load(&cid, self.0.store())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Removes all values for a key.
+    #[inline]
+    pub fn remove_all<C: Cbor>(&mut self, key: String) -> Result<(), String> {
+        // Remove entry from table
+        self.0.delete(&key)?;
+
+        Ok(())
+    }
+
+    /// Returns total balance held by this multimap
+    pub fn for_each(&self) -> Result<TokenAmount, String> {
+        let mut total = TokenAmount::default();
+
+        self.0.for_each(&mut |_, v| {
+            total += v;
+            Ok(())
+        })?;
+
+        Ok(total)
+    }
+}

--- a/vm/actor/src/util/multimap.rs
+++ b/vm/actor/src/util/multimap.rs
@@ -37,7 +37,9 @@ where
         V: Serialize + DeserializeOwned + Clone,
     {
         // Get construct amt from retrieved cid or create new
-        let mut arr = self.get::<V>(&key)?.unwrap_or(Amt::new(self.0.store()));
+        let mut arr = self
+            .get::<V>(&key)?
+            .unwrap_or_else(|| Amt::new(self.0.store()));
 
         // Set value at next index
         arr.set(arr.count(), value)?;
@@ -51,7 +53,7 @@ where
 
     /// Gets the Array of value type `V` using the multimap store.
     #[inline]
-    pub fn get<V>(&self, key: &String) -> Result<Option<Amt<'a, V, BS>>, String>
+    pub fn get<V>(&self, key: &str) -> Result<Option<Amt<'a, V, BS>>, String>
     where
         V: DeserializeOwned + Serialize + Clone,
     {
@@ -71,7 +73,7 @@ where
     }
 
     /// Iterates through all values in the array at a given key.
-    pub fn for_each<F, V>(&self, key: &String, mut f: F) -> Result<(), String>
+    pub fn for_each<F, V>(&self, key: &str, mut f: F) -> Result<(), String>
     where
         V: Serialize + DeserializeOwned + Clone,
         F: FnMut(u64, V) -> Result<(), String>,

--- a/vm/actor/tests/balance_table_test.rs
+++ b/vm/actor/tests/balance_table_test.rs
@@ -10,7 +10,7 @@ use vm::TokenAmount;
 fn add_create() {
     let addr = Address::new_id(100).unwrap();
     let store = db::MemoryDB::default();
-    let mut bt = BalanceTable::new_empty(&store);
+    let mut bt = BalanceTable::new(&store);
 
     assert_eq!(bt.has(&addr), Ok(false));
 
@@ -27,7 +27,7 @@ fn total() {
     let addr1 = Address::new_id(100).unwrap();
     let addr2 = Address::new_id(101).unwrap();
     let store = db::MemoryDB::default();
-    let mut bt = BalanceTable::new_empty(&store);
+    let mut bt = BalanceTable::new(&store);
 
     assert_eq!(bt.total(), Ok(TokenAmount::new(0)));
 
@@ -70,7 +70,7 @@ fn total() {
 fn balance_subtracts() {
     let addr = Address::new_id(100).unwrap();
     let store = db::MemoryDB::default();
-    let mut bt = BalanceTable::new_empty(&store);
+    let mut bt = BalanceTable::new(&store);
 
     bt.set(&addr, TokenAmount::new(80)).unwrap();
     assert_eq!(bt.get(&addr), Ok(TokenAmount::new(80)));
@@ -100,7 +100,7 @@ fn balance_subtracts() {
 fn remove() {
     let addr = Address::new_id(100).unwrap();
     let store = db::MemoryDB::default();
-    let mut bt = BalanceTable::new_empty(&store);
+    let mut bt = BalanceTable::new(&store);
 
     bt.set(&addr, TokenAmount::new(1)).unwrap();
     assert_eq!(bt.get(&addr), Ok(TokenAmount::new(1)));

--- a/vm/actor/tests/multimap_test.rs
+++ b/vm/actor/tests/multimap_test.rs
@@ -8,7 +8,7 @@ use ipld_amt::Amt;
 #[test]
 fn basic_add() {
     let store = db::MemoryDB::default();
-    let mut mm = Multimap::new_empty(&store);
+    let mut mm = Multimap::new(&store);
 
     let addr = Address::new_id(100).unwrap();
     assert_eq!(mm.get::<u64>(&addr.hash_key()), Ok(None));
@@ -24,7 +24,7 @@ fn basic_add() {
 #[test]
 fn for_each() {
     let store = db::MemoryDB::default();
-    let mut mm = Multimap::new_empty(&store);
+    let mut mm = Multimap::new(&store);
 
     let addr = Address::new_id(100).unwrap();
     assert_eq!(mm.get::<u64>(&addr.hash_key()), Ok(None));
@@ -47,7 +47,7 @@ fn for_each() {
 #[test]
 fn remove_all() {
     let store = db::MemoryDB::default();
-    let mut mm = Multimap::new_empty(&store);
+    let mut mm = Multimap::new(&store);
 
     let addr1 = Address::new_id(100).unwrap();
     let addr2 = Address::new_id(101).unwrap();

--- a/vm/actor/tests/multimap_test.rs
+++ b/vm/actor/tests/multimap_test.rs
@@ -1,0 +1,68 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use actor::Multimap;
+use address::Address;
+use ipld_amt::Amt;
+
+#[test]
+fn basic_add() {
+    let store = db::MemoryDB::default();
+    let mut mm = Multimap::new_empty(&store);
+
+    let addr = Address::new_id(100).unwrap();
+    assert_eq!(mm.get::<u64>(&addr.hash_key()), Ok(None));
+
+    mm.add(addr.hash_key(), 8).unwrap();
+    let arr: Amt<u64, _> = mm.get(&addr.hash_key()).unwrap().unwrap();
+    assert_eq!(arr.get(0), Ok(Some(8)));
+
+    mm.add(addr.hash_key(), 2).unwrap();
+    mm.add(addr.hash_key(), 78).unwrap();
+}
+
+#[test]
+fn for_each() {
+    let store = db::MemoryDB::default();
+    let mut mm = Multimap::new_empty(&store);
+
+    let addr = Address::new_id(100).unwrap();
+    assert_eq!(mm.get::<u64>(&addr.hash_key()), Ok(None));
+
+    mm.add(addr.hash_key(), 8).unwrap();
+    mm.add(addr.hash_key(), 2).unwrap();
+    mm.add(addr.hash_key(), 3).unwrap();
+    mm.add("Some other string".to_owned(), 7).unwrap();
+
+    let mut vals: Vec<(u64, u64)> = Vec::new();
+    mm.for_each(&addr.hash_key(), |i, v| {
+        vals.push((i, v));
+        Ok(())
+    })
+    .unwrap();
+
+    assert_eq!(&vals, &[(0, 8), (1, 2), (2, 3)])
+}
+
+#[test]
+fn remove_all() {
+    let store = db::MemoryDB::default();
+    let mut mm = Multimap::new_empty(&store);
+
+    let addr1 = Address::new_id(100).unwrap();
+    let addr2 = Address::new_id(101).unwrap();
+
+    mm.add(addr1.hash_key(), 8).unwrap();
+    mm.add(addr1.hash_key(), 88).unwrap();
+    mm.add(addr2.hash_key(), 1).unwrap();
+
+    let arr: Amt<u64, _> = mm.get(&addr1.hash_key()).unwrap().unwrap();
+    assert_eq!(arr.get(1), Ok(Some(88)));
+
+    mm.remove_all(addr1.hash_key()).unwrap();
+    assert_eq!(mm.get::<u64>(&addr1.hash_key()), Ok(None));
+
+    assert!(mm.get::<u64>(&addr2.hash_key()).unwrap().is_some());
+    mm.remove_all(addr2.hash_key()).unwrap();
+    assert_eq!(mm.get::<u64>(&addr2.hash_key()), Ok(None));
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- It's a hamt where the values are amts
  - Used for indexing addresses and epochs and saving an ordered set of values
- Refactors Amt to get it closer in line with the Hamt for more consistent usage

Note: the array value type must be inferred when retrieving since only a cid is saved at the nodes of the Hamt, so still have to be careful on usage to make sure the Amts get deserialized correctly


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes #280 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->