### PR TITLE
Improve actors serialization handling

### DIFF
--- a/vm/actor/src/builtin/account/mod.rs
+++ b/vm/actor/src/builtin/account/mod.rs
@@ -4,7 +4,7 @@
 mod state;
 
 pub use self::state::State;
-use crate::{assert_empty_params, empty_return};
+use crate::check_empty_params;
 use address::{Address, Protocol};
 use ipld_blockstore::BlockStore;
 use num_derive::FromPrimitive;
@@ -74,13 +74,13 @@ impl ActorCode for Actor {
     {
         match Method::from_method_num(method) {
             Some(Method::Constructor) => {
-                Self::constructor(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::constructor(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::PubkeyAddress) => {
-                assert_empty_params(params);
+                check_empty_params(params)?;
                 Self::pubkey_address(rt)?;
-                Ok(empty_return())
+                Ok(Serialized::default())
             }
             _ => Err(rt.abort(ExitCode::SysErrInvalidMethod, "Invalid method")),
         }

--- a/vm/actor/src/builtin/cron/mod.rs
+++ b/vm/actor/src/builtin/cron/mod.rs
@@ -4,7 +4,7 @@
 mod state;
 
 pub use self::state::{Entry, State};
-use crate::{assert_empty_params, empty_return, SYSTEM_ACTOR_ADDR};
+use crate::{check_empty_params, SYSTEM_ACTOR_ADDR};
 use address::Address;
 use ipld_blockstore::BlockStore;
 use num_derive::FromPrimitive;
@@ -107,13 +107,13 @@ impl ActorCode for Actor {
     {
         match Method::from_method_num(method) {
             Some(Method::Constructor) => {
-                Self::constructor(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::constructor(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::EpochTick) => {
-                assert_empty_params(params);
+                check_empty_params(params)?;
                 Self::epoch_tick(rt)?;
-                Ok(empty_return())
+                Ok(Serialized::default())
             }
             _ => Err(rt.abort(ExitCode::SysErrInvalidMethod, "Invalid method")),
         }

--- a/vm/actor/src/builtin/init/mod.rs
+++ b/vm/actor/src/builtin/init/mod.rs
@@ -7,8 +7,8 @@ mod state;
 pub use self::params::*;
 pub use self::state::State;
 use crate::{
-    empty_return, make_map, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID, MARKET_ACTOR_CODE_ID,
-    MINER_ACTOR_CODE_ID, POWER_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR,
+    make_map, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID, MARKET_ACTOR_CODE_ID, MINER_ACTOR_CODE_ID,
+    POWER_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR,
 };
 use address::Address;
 use cid::Cid;
@@ -128,12 +128,12 @@ impl ActorCode for Actor {
     {
         match Method::from_method_num(method) {
             Some(Method::Constructor) => {
-                Self::constructor(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::constructor(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::Exec) => {
-                let res = Self::exec(rt, params.deserialize().unwrap())?;
-                Ok(Serialized::serialize(res).unwrap())
+                let res = Self::exec(rt, params.deserialize()?)?;
+                Ok(Serialized::serialize(res)?)
             }
             _ => {
                 // Method number does not match available, abort in runtime

--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -6,7 +6,7 @@ mod types;
 
 pub use self::state::State;
 pub use self::types::*;
-use crate::{empty_return, make_map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR};
+use crate::{make_map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR};
 use address::Address;
 use ipld_blockstore::BlockStore;
 use message::Message;
@@ -396,36 +396,36 @@ impl ActorCode for Actor {
     {
         match Method::from_method_num(method) {
             Some(Method::Constructor) => {
-                Self::constructor(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::constructor(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::Propose) => {
-                let res = Self::propose(rt, params.deserialize().unwrap())?;
-                Ok(Serialized::serialize(res).unwrap())
+                let res = Self::propose(rt, params.deserialize()?)?;
+                Ok(Serialized::serialize(res)?)
             }
             Some(Method::Approve) => {
-                Self::approve(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::approve(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::Cancel) => {
-                Self::cancel(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::cancel(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::AddSigner) => {
-                Self::add_signer(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::add_signer(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::RemoveSigner) => {
-                Self::remove_signer(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::remove_signer(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::SwapSigner) => {
-                Self::swap_signer(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::swap_signer(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             Some(Method::ChangeNumApprovalsThreshold) => {
-                Self::change_num_approvals_threshold(rt, params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::change_num_approvals_threshold(rt, params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             _ => Err(rt.abort(ExitCode::SysErrInvalidMethod, "Invalid method".to_owned())),
         }

--- a/vm/actor/src/builtin/power/mod.rs
+++ b/vm/actor/src/builtin/power/mod.rs
@@ -4,7 +4,7 @@
 mod state;
 
 pub use self::state::State;
-use crate::{assert_empty_params, empty_return};
+use crate::check_empty_params;
 use ipld_blockstore::BlockStore;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -67,9 +67,9 @@ impl ActorCode for Actor {
     {
         match Method::from_method_num(method) {
             Some(Method::Constructor) => {
-                assert_empty_params(params);
+                check_empty_params(params)?;
                 Self::constructor(rt)?;
-                Ok(empty_return())
+                Ok(Serialized::default())
             }
             // TODO handle other methods available
             _ => Err(rt.abort(ExitCode::SysErrInvalidMethod, "Invalid method")),

--- a/vm/actor/src/builtin/reward/mod.rs
+++ b/vm/actor/src/builtin/reward/mod.rs
@@ -4,7 +4,7 @@
 mod state;
 
 pub use self::state::{Reward, State};
-use crate::{assert_empty_params, empty_return};
+use crate::check_empty_params;
 use address::Address;
 use ipld_blockstore::BlockStore;
 use num_derive::FromPrimitive;
@@ -72,18 +72,18 @@ impl ActorCode for Actor {
     {
         match Method::from_method_num(method) {
             Some(Method::Constructor) => {
-                assert_empty_params(params);
+                check_empty_params(params)?;
                 Self::constructor(rt)?;
-                Ok(empty_return())
+                Ok(Serialized::default())
             }
             Some(Method::AwardBlockReward) => {
-                assert_empty_params(params);
+                check_empty_params(params)?;
                 Self::award_block_reward(rt)?;
-                Ok(empty_return())
+                Ok(Serialized::default())
             }
             Some(Method::WithdrawReward) => {
-                Self::withdraw_reward(rt, &params.deserialize().unwrap())?;
-                Ok(empty_return())
+                Self::withdraw_reward(rt, &params.deserialize()?)?;
+                Ok(Serialized::default())
             }
             _ => Err(rt.abort(ExitCode::SysErrInvalidMethod, "Invalid method")),
         }

--- a/vm/actor/src/builtin/system/mod.rs
+++ b/vm/actor/src/builtin/system/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::{assert_empty_params, empty_return, SYSTEM_ACTOR_ADDR};
+use crate::{check_empty_params, SYSTEM_ACTOR_ADDR};
 
 use address::Address;
 use ipld_blockstore::BlockStore;
@@ -52,9 +52,9 @@ impl ActorCode for Actor {
     {
         match Method::from_method_num(method) {
             Some(Method::Constructor) => {
-                assert_empty_params(params);
+                check_empty_params(params)?;
                 Self::constructor(rt)?;
-                Ok(empty_return())
+                Ok(Serialized::default())
             }
             _ => {
                 // Method number does not match available, abort in runtime

--- a/vm/actor/src/lib.rs
+++ b/vm/actor/src/lib.rs
@@ -11,6 +11,7 @@ pub use self::builtin::*;
 pub use self::util::*;
 pub use vm::{ActorID, ActorState, DealID, Serialized};
 
+use encoding::Error as EncodingError;
 use ipld_blockstore::BlockStore;
 use ipld_hamt::Hamt;
 use unsigned_varint::decode::Error as UVarintError;
@@ -19,14 +20,8 @@ const HAMT_BIT_WIDTH: u8 = 5;
 
 /// Used when invocation requires parameters to be an empty array of bytes
 #[inline]
-fn assert_empty_params(params: &Serialized) {
-    params.deserialize::<[u8; 0]>().unwrap();
-}
-
-/// Empty return is an empty serialized array
-#[inline]
-fn empty_return() -> Serialized {
-    Serialized::serialize::<[u8; 0]>([]).unwrap()
+fn check_empty_params(params: &Serialized) -> Result<(), EncodingError> {
+    params.deserialize::<[u8; 0]>().map(|_| ())
 }
 
 /// Create a map

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use encoding::Error as EncodingError;
 use thiserror::Error;
 
 use crate::ExitCode;
@@ -28,5 +29,15 @@ impl ActorError {
 
     pub fn msg(&self) -> &str {
         &self.msg
+    }
+}
+
+impl From<EncodingError> for ActorError {
+    fn from(e: EncodingError) -> Self {
+        Self {
+            fatal: true,
+            exit_code: ExitCode::ErrSerialization,
+            msg: e.to_string(),
+        }
     }
 }

--- a/vm/src/method.rs
+++ b/vm/src/method.rs
@@ -28,9 +28,17 @@ pub const METHOD_SEND: isize = 0;
 pub const METHOD_CONSTRUCTOR: isize = 1;
 
 /// Serialized bytes to be used as parameters into actor methods
-#[derive(Default, Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Serialized {
     bytes: Vec<u8>,
+}
+
+impl Default for Serialized {
+    /// Default serialized bytes is an empty array serialized
+    #[inline]
+    fn default() -> Self {
+        Self::serialize::<[u8; 0]>([]).unwrap()
+    }
 }
 
 impl ser::Serialize for Serialized {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Handles serialization errors from message serialized bytes now that #289 is in
- Change serialized default to serializing empty array, as it is too easy to misuse the default that exists now (will just be empty bytes which will fail the empty serialize check)
  - Also removes the `empty_return` function as this is just the serialized default



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->