### PR TITLE
Switch MethodNum and ActorID to aliases

### DIFF
--- a/tests/serialization_tests/tests/u_message_ser.rs
+++ b/tests/serialization_tests/tests/u_message_ser.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use std::fs::File;
 use std::io::prelude::*;
 use std::str::FromStr;
-use vm::{MethodNum, Serialized};
+use vm::Serialized;
 
 #[derive(Debug, Deserialize)]
 struct MessageVector {
@@ -41,7 +41,7 @@ impl From<MessageVector> for UnsignedMessage {
             .from(Address::from_str(&vector.from).unwrap())
             .sequence(vector.nonce)
             .value(vector.value.parse().unwrap())
-            .method_num(MethodNum::new(vector.method))
+            .method_num(vector.method)
             .params(Serialized::new(base64::decode(&vector.params).unwrap()))
             .gas_limit(vector.gas_limit)
             .gas_price(vector.gas_price.parse().unwrap())

--- a/vm/actor/src/builtin/account/mod.rs
+++ b/vm/actor/src/builtin/account/mod.rs
@@ -14,6 +14,7 @@ use vm::{ActorError, ExitCode, MethodNum, Serialized, METHOD_CONSTRUCTOR};
 
 /// Account actor methods available
 #[derive(FromPrimitive)]
+#[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     PubkeyAddress = 2,
@@ -22,7 +23,7 @@ pub enum Method {
 impl Method {
     /// Converts a method number into a Method enum
     fn from_method_num(m: MethodNum) -> Option<Method> {
-        FromPrimitive::from_u64(u64::from(m))
+        FromPrimitive::from_u64(m)
     }
 }
 

--- a/vm/actor/src/builtin/cron/mod.rs
+++ b/vm/actor/src/builtin/cron/mod.rs
@@ -16,6 +16,7 @@ use vm::{ActorError, ExitCode, MethodNum, Serialized, TokenAmount, METHOD_CONSTR
 
 /// Cron actor methods available
 #[derive(FromPrimitive)]
+#[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     EpochTick = 2,
@@ -24,7 +25,7 @@ pub enum Method {
 impl Method {
     /// Converts a method number into an Method enum
     fn from_method_num(m: MethodNum) -> Option<Method> {
-        FromPrimitive::from_u64(u64::from(m))
+        FromPrimitive::from_u64(m)
     }
 }
 

--- a/vm/actor/src/builtin/init/mod.rs
+++ b/vm/actor/src/builtin/init/mod.rs
@@ -22,6 +22,7 @@ use vm::{ActorError, ExitCode, MethodNum, Serialized, METHOD_CONSTRUCTOR};
 
 /// Init actor methods available
 #[derive(FromPrimitive)]
+#[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     Exec = 2,
@@ -30,7 +31,7 @@ pub enum Method {
 impl Method {
     /// Converts a method number into an Method enum
     fn from_method_num(m: MethodNum) -> Option<Method> {
-        FromPrimitive::from_u64(u64::from(m))
+        FromPrimitive::from_u64(m)
     }
 }
 
@@ -102,7 +103,7 @@ impl Actor {
         // Invoke constructor
         rt.send::<Ipld>(
             &id_address,
-            MethodNum::new(METHOD_CONSTRUCTOR as u64),
+            METHOD_CONSTRUCTOR,
             &params.constructor_params,
             rt.message().value(),
         )

--- a/vm/actor/src/builtin/init/state.rs
+++ b/vm/actor/src/builtin/init/state.rs
@@ -41,7 +41,7 @@ impl State {
         map.set(addr.hash_key(), id)?;
         self.address_map = map.flush()?;
 
-        Ok(Address::new_id(id.0).expect("Id Address should be created without Error"))
+        Ok(Address::new_id(id).expect("Id Address should be created without Error"))
     }
 
     /// ResolveAddress resolves an address to an ID-address, if possible.
@@ -66,7 +66,7 @@ impl State {
             .get(&addr.hash_key())?
             .ok_or_else(|| "Address not found".to_owned())?;
 
-        Ok(Address::new_id(actor_id.0).map_err(|e| e.to_string())?)
+        Ok(Address::new_id(actor_id).map_err(|e| e.to_string())?)
     }
 }
 

--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -18,6 +18,7 @@ use vm::{ActorError, ExitCode, MethodNum, Serialized, TokenAmount, METHOD_CONSTR
 
 /// Multisig actor methods available
 #[derive(FromPrimitive)]
+#[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     Propose = 2,
@@ -34,7 +35,7 @@ pub enum Method {
 impl Method {
     /// Converts a method number into a Method enum
     fn from_method_num(m: MethodNum) -> Option<Method> {
-        FromPrimitive::from_u64(u64::from(m))
+        FromPrimitive::from_u64(m)
     }
 }
 

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -23,6 +23,7 @@ use vm::{
 
 /// Payment Channel actor methods available
 #[derive(FromPrimitive)]
+#[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     UpdateChannelState = 2,
@@ -33,7 +34,7 @@ pub enum Method {
 impl Method {
     /// Converts a method number into an Method enum
     fn from_method_num(m: MethodNum) -> Option<Method> {
-        FromPrimitive::from_u64(u64::from(m))
+        FromPrimitive::from_u64(m)
     }
 }
 
@@ -299,20 +300,10 @@ impl Actor {
             })?;
 
         // send remaining balance to `from`
-        rt.send::<Ipld>(
-            &st.from,
-            MethodNum(METHOD_SEND as u64),
-            &Serialized::default(),
-            &rem_bal,
-        )?;
+        rt.send::<Ipld>(&st.from, METHOD_SEND, &Serialized::default(), &rem_bal)?;
 
         // send ToSend to `to`
-        rt.send::<Ipld>(
-            &st.to,
-            MethodNum(METHOD_SEND as u64),
-            &Serialized::default(),
-            &st.to_send,
-        )?;
+        rt.send::<Ipld>(&st.to, METHOD_SEND, &Serialized::default(), &st.to_send)?;
 
         rt.transaction(|st: &mut State| {
             st.to_send = TokenAmount::from(0u8);

--- a/vm/actor/src/builtin/power/mod.rs
+++ b/vm/actor/src/builtin/power/mod.rs
@@ -13,6 +13,7 @@ use vm::{ActorError, ExitCode, MethodNum, Serialized, METHOD_CONSTRUCTOR};
 
 /// Storage power actor methods available
 #[derive(FromPrimitive)]
+#[repr(u64)]
 pub enum Method {
     /// Constructor for Storage Power Actor
     Constructor = METHOD_CONSTRUCTOR,
@@ -35,7 +36,7 @@ pub enum Method {
 impl Method {
     /// Converts a method number into an Method enum
     fn from_method_num(m: MethodNum) -> Option<Method> {
-        FromPrimitive::from_u64(u64::from(m))
+        FromPrimitive::from_u64(m)
     }
 }
 

--- a/vm/actor/src/builtin/reward/mod.rs
+++ b/vm/actor/src/builtin/reward/mod.rs
@@ -14,6 +14,7 @@ use vm::{ActorError, ExitCode, MethodNum, Serialized, METHOD_CONSTRUCTOR};
 
 /// Reward actor methods available
 #[derive(FromPrimitive)]
+#[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     AwardBlockReward = 2,
@@ -23,7 +24,7 @@ pub enum Method {
 impl Method {
     /// Converts a method number into an Method enum
     fn from_method_num(m: MethodNum) -> Option<Method> {
-        FromPrimitive::from_u64(u64::from(m))
+        FromPrimitive::from_u64(m)
     }
 }
 

--- a/vm/actor/src/builtin/singletons.rs
+++ b/vm/actor/src/builtin/singletons.rs
@@ -16,4 +16,4 @@ lazy_static! {
 }
 
 /// Defines first available ID address after builtin actors
-pub const FIRST_NON_SINGLETON_ADDR: ActorID = ActorID(100);
+pub const FIRST_NON_SINGLETON_ADDR: ActorID = 100;

--- a/vm/actor/src/builtin/system/mod.rs
+++ b/vm/actor/src/builtin/system/mod.rs
@@ -12,6 +12,7 @@ use vm::{ActorError, ExitCode, MethodNum, Serialized, METHOD_CONSTRUCTOR};
 
 /// Init actor methods available
 #[derive(FromPrimitive)]
+#[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
 }
@@ -19,7 +20,7 @@ pub enum Method {
 impl Method {
     /// Converts a method number into a Method enum
     fn from_method_num(m: MethodNum) -> Option<Method> {
-        FromPrimitive::from_u64(u64::from(m))
+        FromPrimitive::from_u64(m)
     }
 }
 

--- a/vm/actor/src/lib.rs
+++ b/vm/actor/src/lib.rs
@@ -9,7 +9,7 @@ mod util;
 
 pub use self::builtin::*;
 pub use self::util::*;
-pub use vm::{ActorID, ActorState, DealID, Serialized};
+pub use vm::{ActorState, DealID, Serialized};
 
 use encoding::Error as EncodingError;
 use ipld_blockstore::BlockStore;

--- a/vm/src/actor_state.rs
+++ b/vm/src/actor_state.rs
@@ -3,22 +3,11 @@
 
 use crate::TokenAmount;
 use cid::Cid;
-use encoding::Cbor;
 use num_bigint::biguint_ser::{BigUintDe, BigUintSer};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::ops::AddAssign;
 
 /// Identifier for Actors, includes builtin and initialized actors
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Serialize, Deserialize, Default)]
-pub struct ActorID(pub u64);
-
-impl AddAssign<u64> for ActorID {
-    fn add_assign(&mut self, other: u64) {
-        self.0 += other
-    }
-}
-
-impl Cbor for ActorID {}
+pub type ActorID = u64;
 
 /// State of all actor implementations
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/vm/src/method.rs
+++ b/vm/src/method.rs
@@ -2,30 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::{de, from_slice, ser, serde_bytes, to_vec, Cbor, Error as EncodingError};
-use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
 /// Method number indicator for calling actor methods
-#[derive(Default, Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
-pub struct MethodNum(pub u64); // TODO: add constraints to this
-
-impl MethodNum {
-    /// Constructor for new MethodNum
-    pub fn new(num: u64) -> Self {
-        Self(num)
-    }
-}
-
-impl From<MethodNum> for u64 {
-    fn from(method_num: MethodNum) -> u64 {
-        method_num.0
-    }
-}
+pub type MethodNum = u64;
 
 /// Base actor send method
-pub const METHOD_SEND: isize = 0;
+pub const METHOD_SEND: MethodNum = 0;
 /// Base actor constructor method
-pub const METHOD_CONSTRUCTOR: isize = 1;
+pub const METHOD_CONSTRUCTOR: MethodNum = 1;
 
 /// Serialized bytes to be used as parameters into actor methods
 #[derive(Clone, PartialEq, Debug)]

--- a/vm/tests/params_test.rs
+++ b/vm/tests/params_test.rs
@@ -3,7 +3,7 @@
 
 use address::Address;
 use encoding::{from_slice, to_vec};
-use vm::{MethodNum, Serialized};
+use vm::Serialized;
 
 #[test]
 fn serialized_deserialize() {
@@ -37,11 +37,4 @@ fn cbor_params() {
     let addr = Address::new_id(1).unwrap();
     let params = Serialized::serialize(addr.clone()).unwrap();
     assert_eq!(from_slice::<Address>(&params).unwrap(), addr);
-}
-
-#[test]
-fn method_num() {
-    // Test constructor available publicly
-    let method = MethodNum::new(1);
-    assert_eq!(1 as u64, u64::from(method));
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- extension from #309 there are some types that are starting to be used in Actors that don't yet have a reason to be their own type, and switching because it shouldn't be until there is an actual need. Makes referencing other actor's methods and calling much cleaner as well as comparisons/conversions.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->