### PR TITLE
Logging level config with RUST_LOG env variable

### DIFF
--- a/forest/src/logger/mod.rs
+++ b/forest/src/logger/mod.rs
@@ -1,11 +1,21 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use log::LevelFilter;
+
 pub(crate) fn setup_logger() {
-    let logger = pretty_env_logger::formatted_timed_builder()
-        .filter(None, log::LevelFilter::Info)
-        .build();
+    let mut logger_builder = pretty_env_logger::formatted_timed_builder();
+    if let Ok(s) = ::std::env::var("RUST_LOG") {
+        // Set log level based on filters if set
+        logger_builder.parse_filters(&s);
+    } else {
+        // If no ENV variable specified, default to info
+        logger_builder.filter(None, LevelFilter::Info);
+    }
+    let logger = logger_builder.build();
+
+    // Wrap Logger in async_log
     async_log::Logger::wrap(logger, || 0)
-        .start(log::LevelFilter::Info)
+        .start(LevelFilter::Trace)
         .unwrap();
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Enables env filter configuration with our logger
  - Was previously statically set, but using the underlying builder type we can achieve what we actually want with #237 
  - Can use with `RUST_LOG=trace ...` and more configurable options following https://doc.rust-lang.org/1.1.0/log/index.html with something useful like: `RUST_LOG="info,chain_sync::sync=trace"` to trace specific modules



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes #237


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->