### PR TITLE
Refactor error handling

### DIFF
--- a/blockchain/blocks/Cargo.toml
+++ b/blockchain/blocks/Cargo.toml
@@ -14,6 +14,7 @@ derive_builder = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 encoding = { package = "forest_encoding", path = "../../encoding" }
 num-bigint = { path = "../../utils/bigint", package = "forest_bigint" }
+thiserror = "1.0"
 
 [dev-dependencies]
 base64 = "0.12.0"

--- a/blockchain/blocks/src/errors.rs
+++ b/blockchain/blocks/src/errors.rs
@@ -1,29 +1,24 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::{fmt, time::SystemTimeError as TimeErr};
+use std::time::SystemTimeError as TimeErr;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+/// Blockchain blocks error
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
     /// Tipset contains invalid data, as described by the string parameter.
+    #[error("Invalid tipset: {0}")]
     InvalidTipSet(String),
     /// The given tipset has no blocks
+    #[error("No blocks for tipset")]
     NoBlocks,
     /// Invalid signature
+    #[error("Invalid signature: {0}")]
     InvalidSignature(String),
     /// Error in validating arbitrary data
+    #[error("Error validating data: {0}")]
     Validation(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::InvalidTipSet(msg) => write!(f, "Invalid tipset: {}", msg),
-            Error::NoBlocks => write!(f, "No blocks for tipset"),
-            Error::InvalidSignature(msg) => write!(f, "Invalid signature: {}", msg),
-            Error::Validation(msg) => write!(f, "Error validating data: {}", msg),
-        }
-    }
 }
 
 impl From<TimeErr> for Error {

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -15,9 +15,12 @@ num-bigint = { path = "../../utils/bigint", package = "forest_bigint" }
 message = { package = "forest_message", path = "../../vm/message" }
 ipld_blockstore = { path = "../../ipld/blockstore" }
 ipld_amt = { path = "../../ipld/amt/" }
+thiserror = "1.0"
 
 [dev-dependencies]
 address = { package = "forest_address", path = "../../vm/address" }
 crypto = { path = "../../crypto" }
 multihash = "0.10.0"
-test_utils = { version = "0.1.0", path = "../../utils/test_utils/", features = ["test_constructors"] }
+test_utils = { version = "0.1.0", path = "../../utils/test_utils/", features = [
+    "test_constructors"
+] }

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -92,7 +92,7 @@ where
             let key = m.cid()?.key();
             let value = &m.marshal_cbor()?;
             if self.db.exists(&key)? {
-                return Err(Error::KeyValueStore("Keys exist".to_string()));
+                return Ok(());
             }
             self.db.write(&key, value)?
         }
@@ -127,9 +127,7 @@ where
                 let bh = BlockHeader::unmarshal_cbor(&x)?;
                 block_headers.push(bh);
             } else {
-                return Err(Error::KeyValueStore(
-                    "Key for header does not exist".to_string(),
-                ));
+                return Err(Error::NotFound("Key for header"));
             }
         }
         // construct new Tipset to return
@@ -187,7 +185,8 @@ where
                 let bytes = value.ok_or_else(|| Error::UndefinedKey(k.to_string()))?;
 
                 // Decode bytes into type T
-                from_slice(&bytes)?
+                let t = from_slice(&bytes)?;
+                Ok(t)
             })
             .collect()
     }

--- a/blockchain/chain/src/store/errors.rs
+++ b/blockchain/chain/src/store/errors.rs
@@ -8,6 +8,7 @@ use encoding::{error::Error as SerdeErr, Error as EncErr};
 use ipld_amt::Error as AmtErr;
 use thiserror::Error;
 
+/// Chain error
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {
     /// Key was not found
@@ -20,19 +21,19 @@ pub enum Error {
     #[error("{0} not found")]
     NotFound(&'static str),
     /// Error originating from key-value store
-    #[error("{0}")]
+    #[error(transparent)]
     DB(#[from] DbErr),
     /// Error originating constructing blockchain structures
-    #[error("{0}")]
+    #[error(transparent)]
     Blockchain(#[from] BlkErr),
     /// Error originating from encoding arbitrary data
     #[error("{0}")]
     Encoding(String),
     /// Error originating from Cid creation
-    #[error("{0}")]
+    #[error(transparent)]
     Cid(#[from] CidErr),
     /// Amt error
-    #[error("{0}")]
+    #[error(transparent)]
     Amt(#[from] AmtErr),
 }
 

--- a/blockchain/chain/src/store/errors.rs
+++ b/blockchain/chain/src/store/errors.rs
@@ -6,57 +6,34 @@ use cid::Error as CidErr;
 use db::Error as DbErr;
 use encoding::{error::Error as SerdeErr, Error as EncErr};
 use ipld_amt::Error as AmtErr;
-use serde::Deserialize;
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Error, PartialEq)]
 pub enum Error {
     /// Key was not found
+    #[error("Invalid tipset: {0}")]
     UndefinedKey(String),
     /// Tipset contains no blocks
+    #[error("No blocks for tipset")]
     NoBlocks,
+    /// Key not found in database
+    #[error("{0} not found")]
+    NotFound(&'static str),
     /// Error originating from key-value store
-    KeyValueStore(String),
+    #[error("{0}")]
+    DB(#[from] DbErr),
     /// Error originating constructing blockchain structures
-    Blockchain(String),
+    #[error("{0}")]
+    Blockchain(#[from] BlkErr),
     /// Error originating from encoding arbitrary data
+    #[error("{0}")]
     Encoding(String),
     /// Error originating from Cid creation
-    Cid(String),
+    #[error("{0}")]
+    Cid(#[from] CidErr),
     /// Amt error
-    Amt(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::UndefinedKey(msg) => write!(f, "Invalid key: {}", msg),
-            Error::NoBlocks => write!(f, "No blocks for tipset"),
-            Error::KeyValueStore(msg) => {
-                write!(f, "Error originating from Key-Value store: {}", msg)
-            }
-            Error::Blockchain(msg) => write!(
-                f,
-                "Error originating from construction of blockchain structures: {}",
-                msg
-            ),
-            Error::Amt(msg) => write!(f, "Error originating from AMT: {}", msg),
-            Error::Encoding(msg) => write!(f, "Error originating from Encoding type: {}", msg),
-            Error::Cid(msg) => write!(f, "Error originating from from Cid creation: {}", msg),
-        }
-    }
-}
-
-impl From<DbErr> for Error {
-    fn from(e: DbErr) -> Error {
-        Error::KeyValueStore(e.to_string())
-    }
-}
-
-impl From<BlkErr> for Error {
-    fn from(e: BlkErr) -> Error {
-        Error::Blockchain(e.to_string())
-    }
+    #[error("{0}")]
+    Amt(#[from] AmtErr),
 }
 
 impl From<EncErr> for Error {
@@ -68,17 +45,5 @@ impl From<EncErr> for Error {
 impl From<SerdeErr> for Error {
     fn from(e: SerdeErr) -> Error {
         Error::Encoding(e.to_string())
-    }
-}
-
-impl From<CidErr> for Error {
-    fn from(e: CidErr) -> Error {
-        Error::Cid(e.to_string())
-    }
-}
-
-impl From<AmtErr> for Error {
-    fn from(e: AmtErr) -> Error {
-        Error::Amt(e.to_string())
     }
 }

--- a/blockchain/chain_sync/Cargo.toml
+++ b/blockchain/chain_sync/Cargo.toml
@@ -25,6 +25,7 @@ async-std = { version = "1.4.0", features = ["unstable"] }
 forest_libp2p = { path = "../../node/forest_libp2p" }
 futures = "0.3.2"
 lru = "0.4.3"
+thiserror = "1.0"
 
 [dev-dependencies]
 test_utils = { version = "0.1.0", path = "../../utils/test_utils/", features = ["test_constructors"] }

--- a/blockchain/chain_sync/src/errors.rs
+++ b/blockchain/chain_sync/src/errors.rs
@@ -10,29 +10,28 @@ use encoding::{error::Error as SerdeErr, Error as EncErr};
 use state_manager::Error as StErr;
 use thiserror::Error;
 
+/// ChainSync error
 #[derive(Debug, PartialEq, Error)]
 pub enum Error {
     #[error("No blocks for tipset")]
     NoBlocks,
     /// Error originating constructing blockchain structures
-    #[error("{0}")]
+    #[error(transparent)]
     Blockchain(#[from] BlkErr),
     /// Error originating from encoding arbitrary data
     #[error("{0}")]
     Encoding(String),
     /// Error originating from CID construction
-    #[error("{0}")]
+    #[error(transparent)]
     InvalidCid(#[from] CidErr),
     /// Error indicating an invalid root
     #[error("Invalid root detected")]
     InvalidRoots,
     /// Error indicating a chain store error
-    #[error("{0}")]
+    #[error(transparent)]
     Store(#[from] StoreErr),
-    // /// Error originating from key-value store
-    // KeyValueStore(String),
     /// Error originating from state
-    #[error("{0}")]
+    #[error(transparent)]
     State(#[from] StErr),
     /// Error in validating arbitrary data
     #[error("{0}")]

--- a/blockchain/chain_sync/src/errors.rs
+++ b/blockchain/chain_sync/src/errors.rs
@@ -8,57 +8,43 @@ use cid::Error as CidErr;
 use db::Error as DbErr;
 use encoding::{error::Error as SerdeErr, Error as EncErr};
 use state_manager::Error as StErr;
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
+    #[error("No blocks for tipset")]
     NoBlocks,
     /// Error originating constructing blockchain structures
-    Blockchain(String),
+    #[error("{0}")]
+    Blockchain(#[from] BlkErr),
     /// Error originating from encoding arbitrary data
+    #[error("{0}")]
     Encoding(String),
     /// Error originating from CID construction
-    InvalidCid(String),
+    #[error("{0}")]
+    InvalidCid(#[from] CidErr),
     /// Error indicating an invalid root
+    #[error("Invalid root detected")]
     InvalidRoots,
     /// Error indicating a chain store error
-    Store(String),
-    /// Error originating from key-value store
-    KeyValueStore(String),
+    #[error("{0}")]
+    Store(#[from] StoreErr),
+    // /// Error originating from key-value store
+    // KeyValueStore(String),
     /// Error originating from state
-    State(String),
+    #[error("{0}")]
+    State(#[from] StErr),
     /// Error in validating arbitrary data
-    Validation(String),
+    #[error("{0}")]
+    Validation(&'static str),
     /// Any other error that does not need to be specifically handled
+    #[error("{0}")]
     Other(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::NoBlocks => write!(f, "No blocks for tipset"),
-            Error::InvalidRoots => write!(f, "Invalid root detected"),
-            Error::Blockchain(msg) => write!(f, "{}", msg),
-            Error::KeyValueStore(msg) => write!(f, "{}", msg),
-            Error::Encoding(msg) => write!(f, "{}", msg),
-            Error::InvalidCid(msg) => write!(f, "{}", msg),
-            Error::Store(msg) => write!(f, "{}", msg),
-            Error::State(msg) => write!(f, "{}", msg),
-            Error::Validation(msg) => write!(f, "{}", msg),
-            Error::Other(msg) => write!(f, "chain_sync error: {}", msg),
-        }
-    }
-}
-
-impl From<BlkErr> for Error {
-    fn from(e: BlkErr) -> Error {
-        Error::Blockchain(e.to_string())
-    }
 }
 
 impl From<DbErr> for Error {
     fn from(e: DbErr) -> Error {
-        Error::KeyValueStore(e.to_string())
+        Error::Store(e.into())
     }
 }
 
@@ -74,27 +60,9 @@ impl From<SerdeErr> for Error {
     }
 }
 
-impl From<CidErr> for Error {
-    fn from(e: CidErr) -> Error {
-        Error::InvalidCid(e.to_string())
-    }
-}
-
-impl From<StoreErr> for Error {
-    fn from(e: StoreErr) -> Error {
-        Error::Store(e.to_string())
-    }
-}
-
 impl From<AmtErr> for Error {
     fn from(e: AmtErr) -> Error {
         Error::Other(e.to_string())
-    }
-}
-
-impl From<StErr> for Error {
-    fn from(e: StErr) -> Error {
-        Error::State(e.to_string())
     }
 }
 

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -504,13 +504,13 @@ where
                 Some(MsgMetaData { sequence, balance }) => {
                     // sequence equality check
                     if *sequence != msg.sequence() {
-                        return Err(Error::Validation("Sequences are not equal".to_string()));
+                        return Err(Error::Validation("Sequences are not equal"));
                     }
 
                     // sufficient funds check
                     if *balance < msg.required_funds() {
                         return Err(Error::Validation(
-                            "Insufficient funds for message execution".to_string(),
+                            "Insufficient funds for message execution",
                         ));
                     }
                     // update balance and increment sequence by 1
@@ -523,9 +523,9 @@ where
                 None => {
                     let actor = tree
                         .get_actor(msg.from())
-                        .map_err(Error::Blockchain)?
+                        .map_err(Error::Other)?
                         .ok_or_else(|| {
-                            Error::State("Could not retrieve actor from state tree".to_owned())
+                            Error::Other("Could not retrieve actor from state tree".to_owned())
                         })?;
 
                     MsgMetaData {
@@ -551,9 +551,7 @@ where
             check_msg(m, &mut msg_meta_data, &tree)?;
             // signature validation
             if !is_valid_signature(&m.cid()?.to_bytes(), m.from(), m.signature()) {
-                return Err(Error::Validation(
-                    "Message signature is not valid".to_string(),
-                ));
+                return Err(Error::Validation("Message signature is not valid"));
             }
         }
         // validate message root from header matches message root
@@ -572,7 +570,7 @@ where
 
         // check if block has been signed
         if header.signature().bytes().is_empty() {
-            return Err(Error::Validation("Signature is nil in header".to_string()));
+            return Err(Error::Validation("Signature is nil in header"));
         }
 
         let base_tipset = self.load_fts(&TipSetKeys::new(header.parents().cids.clone()))?;
@@ -634,11 +632,7 @@ where
 
         let mut return_set = vec![head];
 
-        let to_epoch = to
-            .blocks()
-            .get(0)
-            .ok_or_else(|| Error::Blockchain("Tipset must not be empty".to_owned()))?
-            .epoch();
+        let to_epoch = to.blocks().get(0).expect("Tipset cannot be empty").epoch();
 
         // Loop until most recent tipset height is less than to tipset height
         'sync: while let Some(cur_ts) = return_set.last() {

--- a/blockchain/state_manager/Cargo.toml
+++ b/blockchain/state_manager/Cargo.toml
@@ -13,3 +13,4 @@ state_tree = { path = "../../vm/state_tree/" }
 vm = { path = "../../vm" }
 blockstore = { package = "ipld_blockstore", path = "../../ipld/blockstore/" }
 forest_blocks = { path = "../../blockchain/blocks" }
+thiserror = "1.0"

--- a/blockchain/state_manager/src/errors.rs
+++ b/blockchain/state_manager/src/errors.rs
@@ -4,6 +4,7 @@
 use db::Error as DbErr;
 use thiserror::Error;
 
+/// State manager error
 #[derive(Debug, PartialEq, Error)]
 pub enum Error {
     /// Error orginating from state
@@ -16,6 +17,6 @@ pub enum Error {
     #[error("Actor state with cid {0} not found")]
     ActorStateNotFound(String),
     /// Error originating from key-value store
-    #[error("{0}")]
+    #[error(transparent)]
     DB(#[from] DbErr),
 }

--- a/blockchain/state_manager/src/errors.rs
+++ b/blockchain/state_manager/src/errors.rs
@@ -2,29 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use db::Error as DbErr;
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
     /// Error orginating from state
+    #[error("{0}")]
     State(String),
+    /// Actor for given address not found
+    #[error("Actor for address: {0} does not exist")]
+    ActorNotFound(String),
+    /// Actor state not found at given cid
+    #[error("Actor state with cid {0} not found")]
+    ActorStateNotFound(String),
     /// Error originating from key-value store
-    KeyValueStore(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::State(msg) => write!(f, "{}", msg),
-            Error::KeyValueStore(msg) => {
-                write!(f, "Error originating from Key-Value store: {}", msg)
-            }
-        }
-    }
-}
-
-impl From<DbErr> for Error {
-    fn from(e: DbErr) -> Error {
-        Error::KeyValueStore(e.to_string())
-    }
+    #[error("{0}")]
+    DB(#[from] DbErr),
 }

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -33,10 +33,11 @@ where
     {
         let actor = self
             .get_actor(addr, ts)?
-            .ok_or_else(|| Error::State(format!("Actor for address: {} does not exist", addr)))?;
-        let act: D = self.bs.get(&actor.state)?.ok_or_else(|| {
-            Error::State("Could not retrieve actor state from IPLD store".to_owned())
-        })?;
+            .ok_or_else(|| Error::ActorNotFound(addr.to_string()))?;
+        let act: D = self
+            .bs
+            .get(&actor.state)?
+            .ok_or_else(|| Error::ActorStateNotFound(actor.state.to_string()))?;
         Ok(act)
     }
     /// Returns the epoch at which the miner was slashed at

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -12,6 +12,7 @@ bls-signatures = "0.5.0"
 serde = { version = "1.0", features = ["derive"] }
 num-traits = "0.2"
 num-derive = "0.3.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/crypto/src/errors.rs
+++ b/crypto/src/errors.rs
@@ -5,43 +5,26 @@ use address::Error as AddressError;
 use encoding::Error as EncodingError;
 use secp256k1::Error as SecpError;
 use std::error;
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+/// Crypto error
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
     /// Failed to produce a signature
+    #[error("Failed to sign data {0}")]
     SigningError(String),
     /// Unable to perform ecrecover with the given params
+    #[error("Could not recover public key from signature: {0}")]
     InvalidRecovery(String),
     /// Provided public key is not understood
-    InvalidPubKey(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::SigningError(s) => write!(f, "Could not sign data: {}", s),
-            Error::InvalidRecovery(s) => {
-                write!(f, "Could not recover public key from signature: {}", s)
-            }
-            Error::InvalidPubKey(s) => {
-                write!(f, "Invalid generated pub key to create address: {}", s)
-            }
-        }
-    }
+    #[error("Invalid generated pub key to create address: {0}")]
+    InvalidPubKey(#[from] AddressError),
 }
 
 impl From<Box<dyn error::Error>> for Error {
     fn from(err: Box<dyn error::Error>) -> Error {
         // Pass error encountered in signer trait as module error type
         Error::SigningError(err.to_string())
-    }
-}
-
-impl From<AddressError> for Error {
-    fn from(err: AddressError) -> Error {
-        // convert error from generating address
-        Error::InvalidPubKey(err.to_string())
     }
 }
 

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -10,3 +10,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.3"
 serde_cbor = { version = "0.11.0", features = ["tags"] }
 cid = { package = "forest_cid", path = "../ipld/cid" }
+thiserror = "1.0"

--- a/encoding/src/errors.rs
+++ b/encoding/src/errors.rs
@@ -4,6 +4,7 @@
 use cid::Error as CidError;
 use serde_cbor::error::Error as CborError;
 use std::fmt;
+use thiserror::Error;
 
 /// Error type for encoding and decoding data through any Forest supported protocol
 ///
@@ -23,39 +24,18 @@ use std::fmt;
 ///     protocol: CodecProtocol::Cbor,
 /// };
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
+    #[error("Could not decode in format {protocol}: {description}")]
     Unmarshalling {
         description: String,
         protocol: CodecProtocol,
     },
+    #[error("Could not encode in format {protocol}: {description}")]
     Marshalling {
         description: String,
         protocol: CodecProtocol,
     },
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::Unmarshalling {
-                description,
-                protocol,
-            } => write!(
-                f,
-                "Could not decode in format {}: {}",
-                protocol, description
-            ),
-            Error::Marshalling {
-                description,
-                protocol,
-            } => write!(
-                f,
-                "Could not encode in format {}: {}",
-                protocol, description
-            ),
-        }
-    }
 }
 
 impl From<CborError> for Error {

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 encoding = { package = "forest_encoding", path = "../encoding" }
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
 
 [dependencies.cid]
 package = "forest_cid"

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -10,6 +10,7 @@ db = { path = "../../node/db" }
 encoding = { package = "forest_encoding", path = "../../encoding" }
 serde = { version = "1.0", features = ["derive"] }
 ipld_blockstore = { path = "../blockstore" }
+thiserror = "1.0"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -55,7 +55,7 @@ where
         // Load root bytes from database
         let root: Root<V> = block_store
             .get(cid)?
-            .ok_or_else(|| Error::Db("Root not found in database".to_owned()))?;
+            .ok_or_else(|| Error::Custom("Root not found in database"))?;
 
         Ok(Self { root, block_store })
     }
@@ -170,9 +170,10 @@ where
             let sub_node: Node<V> = match &self.root.node {
                 Node::Link { links, .. } => match &links[0] {
                     Some(Link::Cached(node)) => *node.clone(),
-                    Some(Link::Cid(cid)) => self.block_store.get(cid)?.ok_or_else(|| {
-                        Error::Cid("Cid did not match any in database".to_owned())
-                    })?,
+                    Some(Link::Cid(cid)) => self
+                        .block_store
+                        .get(cid)?
+                        .ok_or_else(|| Error::Custom("Cid did not match any in database"))?,
                     _ => unreachable!("Link index should match bitmap"),
                 },
                 Node::Leaf { .. } => unreachable!("Non zero height cannot be a leaf node"),

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -4,37 +4,43 @@
 use cid::Error as CidError;
 use db::Error as DBError;
 use encoding::error::Error as EncodingError;
-use std::fmt;
+use thiserror::Error;
 
 /// AMT Error
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// Index referenced it above arbitrary max set
+    #[error("index {0} out of range for the amt")]
     OutOfRange(u64),
     /// Cbor encoding error
-    Cbor(String),
+    #[error("{0}")]
+    Encoding(#[from] EncodingError),
     /// Error generating a Cid for data
-    Cid(String),
+    #[error("{0}")]
+    Cid(#[from] CidError),
     /// Error interacting with underlying database
-    Db(String),
+    #[error("{0}")]
+    DB(#[from] DBError),
     /// Error when trying to serialize an AMT without a flushed cache
+    #[error("Tried to serialize without saving cache, run flush() on Amt before serializing")]
     Cached,
     /// Custom AMT error
+    #[error("{0}")]
     Custom(&'static str),
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::OutOfRange(v) => write!(f, "index {} out of range for the amt", v),
-            Error::Cbor(msg) => write!(f, "{}", msg),
-            Error::Cid(msg) => write!(f, "{}", msg),
-            Error::Db(msg) => write!(f, "{}", msg),
-            Error::Cached => write!(
-                f,
-                "Tried to serialize without saving cache, run flush() on Amt before serializing"
-            ),
-            Error::Custom(msg) => write!(f, "Amt error: {}", msg),
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        use Error::*;
+
+        match (self, other) {
+            (&OutOfRange(a), &OutOfRange(b)) => a == b,
+            (&Encoding(_), &Encoding(_)) => true,
+            (&Cid(ref a), &Cid(ref b)) => a == b,
+            (&DB(ref a), &DB(ref b)) => a == b,
+            (&Cached, &Cached) => true,
+            (&Custom(ref a), &Custom(ref b)) => a == b,
+            _ => false,
         }
     }
 }
@@ -42,23 +48,5 @@ impl fmt::Display for Error {
 impl From<Error> for String {
     fn from(e: Error) -> Self {
         e.to_string()
-    }
-}
-
-impl From<DBError> for Error {
-    fn from(e: DBError) -> Error {
-        Error::Db(e.to_string())
-    }
-}
-
-impl From<CidError> for Error {
-    fn from(e: CidError) -> Error {
-        Error::Cid(e.to_string())
-    }
-}
-
-impl From<EncodingError> for Error {
-    fn from(e: EncodingError) -> Error {
-        Error::Cbor(e.to_string())
     }
 }

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -13,13 +13,13 @@ pub enum Error {
     #[error("index {0} out of range for the amt")]
     OutOfRange(u64),
     /// Cbor encoding error
-    #[error("{0}")]
+    #[error(transparent)]
     Encoding(#[from] EncodingError),
     /// Error generating a Cid for data
-    #[error("{0}")]
+    #[error(transparent)]
     Cid(#[from] CidError),
     /// Error interacting with underlying database
-    #[error("{0}")]
+    #[error(transparent)]
     DB(#[from] DBError),
     /// Error when trying to serialize an AMT without a flushed cache
     #[error("Tried to serialize without saving cache, run flush() on Amt before serializing")]

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -190,9 +190,9 @@ where
             Node::Link { links, .. } => match &links[sub_i as usize] {
                 Some(Link::Cid(cid)) => {
                     // TODO after benchmarking check if cache should be updated from get
-                    let node: Node<V> = bs.get::<Node<V>>(cid)?.ok_or_else(|| {
-                        Error::Cid("Cid did not match any in database".to_owned())
-                    })?;
+                    let node: Node<V> = bs
+                        .get::<Node<V>>(cid)?
+                        .ok_or_else(|| Error::Custom("Cid did not match any in database"))?;
 
                     // Get from node pulled into memory from Cid
                     node.get(bs, height - 1, i % nodes_for_height(height))
@@ -224,9 +224,9 @@ where
         if let Node::Link { links, bmap } = self {
             links[idx] = match &mut links[idx] {
                 Some(Link::Cid(cid)) => {
-                    let node = bs.get::<Node<V>>(cid)?.ok_or_else(|| {
-                        Error::Cid("Cid did not match any in database".to_owned())
-                    })?;
+                    let node = bs
+                        .get::<Node<V>>(cid)?
+                        .ok_or_else(|| Error::Custom("Cid did not match any in database"))?;
 
                     Some(Link::Cached(Box::new(node)))
                 }
@@ -298,9 +298,9 @@ where
             Self::Link { links, bmap } => {
                 let mut sub_node: Node<V> = match &links[sub_i as usize] {
                     Some(Link::Cached(n)) => *n.clone(),
-                    Some(Link::Cid(cid)) => bs.get(cid)?.ok_or_else(|| {
-                        Error::Cid("Cid did not match any in database".to_owned())
-                    })?,
+                    Some(Link::Cid(cid)) => bs
+                        .get(cid)?
+                        .ok_or_else(|| Error::Custom("Cid did not match any in database"))?,
                     None => unreachable!("Bitmap value for index is set"),
                 };
 
@@ -353,7 +353,7 @@ where
                             Link::Cached(sub) => sub.for_each(store, height - 1, offs, f)?,
                             Link::Cid(cid) => {
                                 let node = store.get::<Node<V>>(cid)?.ok_or_else(|| {
-                                    Error::Cid("Cid did not match any in database".to_owned())
+                                    Error::Custom("Cid did not match any in database")
                                 })?;
 
                                 node.for_each(store, height - 1, offs, f)?;

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -30,7 +30,7 @@ pub trait BlockStore: Store {
         T: MultihashDigest,
     {
         let bz = to_vec(obj)?;
-        let cid = Cid::new_from_cbor(&bz, hash).map_err(|e| Error::Encoding(e.to_string()))?;
+        let cid = Cid::new_from_cbor(&bz, hash).map_err(|e| Error::Other(e.to_string()))?;
         self.write(cid.to_bytes(), bz)?;
         Ok(cid)
     }

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2018"
 [dependencies]
 unsigned-varint = "0.3.1"
 cid = { package = "forest_cid", path = "../cid", features = ["serde_derive"] }
-forest_encoding = { path = "../../encoding"}
-blockstore = { package = "ipld_blockstore", path = "../blockstore"}
+forest_encoding = { path = "../../encoding" }
+blockstore = { package = "ipld_blockstore", path = "../blockstore" }
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
 
 [dev-dependencies]
-db = { path = "../../node/db"}
+db = { path = "../../node/db" }

--- a/ipld/car/src/error.rs
+++ b/ipld/car/src/error.rs
@@ -2,23 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::multihash::DecodeOwnedError;
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug)]
+/// Car utility error
+#[derive(Debug, Error)]
 pub enum Error {
+    #[error("Failed to parse CAR file: {0}")]
     ParsingError(String),
+    #[error("Invalid CAR file: {0}")]
     InvalidFile(String),
+    #[error("CAR error: {0}")]
     Other(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::ParsingError(err) => write!(f, "Failed to parse CAR file: {}", err.clone()),
-            Error::InvalidFile(err) => write!(f, "Invalid CAR file: {}", err.clone()),
-            Error::Other(err) => write!(f, "CAR Error: {}", err.clone()),
-        }
-    }
 }
 
 impl From<cid::Error> for Error {

--- a/ipld/cid/Cargo.toml
+++ b/ipld/cid/Cargo.toml
@@ -14,6 +14,7 @@ integer-encoding = "1.0.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_cbor = { version = "0.11.0", features = ["tags"], optional = true }
 serde_bytes = { version = "0.11.3", optional = true }
+thiserror = "1.0"
 
 [features]
 serde_derive = ["serde", "serde_bytes", "serde_cbor"]

--- a/ipld/cid/src/error.rs
+++ b/ipld/cid/src/error.rs
@@ -1,41 +1,22 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::{error, fmt, io};
-/// Error types
-#[derive(PartialEq, Eq, Clone, Debug)]
+use std::io;
+use thiserror::Error;
+
+/// Cid Error
+#[derive(PartialEq, Eq, Clone, Debug, Error)]
 pub enum Error {
+    #[error("Unknown codec")]
     UnknownCodec,
+    #[error("Input too short")]
     InputTooShort,
+    #[error("Failed to parse multihash")]
     ParsingError,
+    #[error("Unrecognized CID version")]
     InvalidCidVersion,
+    #[error("Other cid Error: {0}")]
     Other(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::UnknownCodec => write!(f, "Unknown codec"),
-            Error::InputTooShort => write!(f, "Input too short"),
-            Error::ParsingError => write!(f, "Failed to parse multihash"),
-            Error::InvalidCidVersion => write!(f, "Unrecognized CID version"),
-            Error::Other(err) => write!(f, "Other cid Error: {}", err.clone()),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        use self::Error::*;
-
-        match self {
-            UnknownCodec => "Unknown codec",
-            InputTooShort => "Input too short",
-            ParsingError => "Failed to parse multihash",
-            InvalidCidVersion => "Unrecognized CID version",
-            Other(_) => "Other Cid Error",
-        }
-    }
 }
 
 impl From<io::Error> for Error {
@@ -65,11 +46,5 @@ impl From<multihash::EncodeError> for Error {
 impl From<multihash::DecodeError> for Error {
     fn from(_: multihash::DecodeError) -> Error {
         Error::ParsingError
-    }
-}
-
-impl From<Error> for fmt::Error {
-    fn from(_: Error) -> fmt::Error {
-        fmt::Error {}
     }
 }

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -13,6 +13,7 @@ db = { path = "../../node/db" }
 ipld_blockstore = { path = "../blockstore" }
 forest_ipld = { path = "../" }
 serde_bytes = "0.11.3"
+thiserror = "1.0"
 
 # TODO replace fork with updated fork or make PR into https://github.com/stusmall/murmur3
 [dependencies.murmur3]

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -4,41 +4,28 @@
 use db::Error as DBError;
 use forest_encoding::error::Error as CborError;
 use forest_ipld::Error as IpldError;
-use std::fmt;
+use thiserror::Error;
 
 /// HAMT Error
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
     /// Maximum depth error
+    #[error("Maximum depth reached")]
     MaxDepth,
     /// Error interacting with underlying database
-    Db(String),
+    #[error("{0}")]
+    Db(#[from] DBError),
     /// Error encoding/ decoding values in store
+    #[error("{0}")]
     Encoding(String),
     /// Custom HAMT error
+    #[error("{0}")]
     Custom(&'static str),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::MaxDepth => write!(f, "Maximum depth reached"),
-            Error::Db(msg) => write!(f, "Database Error: {}", msg),
-            Error::Encoding(msg) => write!(f, "Encoding Error: {}", msg),
-            Error::Custom(msg) => write!(f, "HAMT error: {}", msg),
-        }
-    }
 }
 
 impl From<Error> for String {
     fn from(e: Error) -> Self {
         e.to_string()
-    }
-}
-
-impl From<DBError> for Error {
-    fn from(e: DBError) -> Error {
-        Error::Db(e.to_string())
     }
 }
 

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -13,7 +13,7 @@ pub enum Error {
     #[error("Maximum depth reached")]
     MaxDepth,
     /// Error interacting with underlying database
-    #[error("{0}")]
+    #[error(transparent)]
     Db(#[from] DBError),
     /// Error encoding/ decoding values in store
     #[error("{0}")]

--- a/ipld/src/error.rs
+++ b/ipld/src/error.rs
@@ -3,31 +3,18 @@
 
 use serde::ser;
 use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
+    #[error("{0}")]
     Encoding(String),
+    #[error("{0}")]
     Other(&'static str),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::Encoding(msg) => write!(f, "{}", msg),
-            Error::Other(msg) => write!(f, "{}", msg),
-        }
-    }
 }
 
 impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Error {
         Error::Encoding(msg.to_string())
-    }
-}
-
-// TODO rework to handle low level source through io
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
     }
 }

--- a/ipld/src/error.rs
+++ b/ipld/src/error.rs
@@ -5,6 +5,7 @@ use serde::ser;
 use std::fmt;
 use thiserror::Error;
 
+/// Ipld error
 #[derive(Debug, PartialEq, Error)]
 pub enum Error {
     #[error("{0}")]

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 [dependencies]
 rocksdb = "0.13.0"
 parking_lot = "0.10.0"
-encoding = { package = "forest_encoding", path = "../../encoding"}
+encoding = { package = "forest_encoding", path = "../../encoding" }
+thiserror = "1.0"

--- a/node/db/src/errors.rs
+++ b/node/db/src/errors.rs
@@ -2,21 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::error::Error as CborError;
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Error)]
 pub enum Error {
+    #[error("Invalid bulk write kv lengths, must be equal")]
     InvalidBulkLen,
-    Database(String),
-    Encoding(String),
+    #[error("Cannot use unopened database")]
+    Unopened,
+    #[error("{0}")]
+    Database(#[from] rocksdb::Error),
+    #[error("{0}")]
+    Encoding(#[from] CborError),
+    #[error("{0}")]
+    Other(String),
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::InvalidBulkLen => write!(f, "Invalid bulk write kv lengths, must be equal"),
-            Error::Database(msg) => write!(f, "{}", msg),
-            Error::Encoding(msg) => write!(f, "{}", msg),
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        use Error::*;
+
+        match (self, other) {
+            (&InvalidBulkLen, &InvalidBulkLen) => true,
+            (&Unopened, &Unopened) => true,
+            (&Database(_), &Database(_)) => true,
+            (&Encoding(_), &Encoding(_)) => true,
+            (&Other(ref a), &Other(ref b)) => a == b,
+            _ => false,
         }
     }
 }
@@ -24,17 +36,5 @@ impl fmt::Display for Error {
 impl From<Error> for String {
     fn from(e: Error) -> Self {
         e.to_string()
-    }
-}
-
-impl From<rocksdb::Error> for Error {
-    fn from(e: rocksdb::Error) -> Error {
-        Error::Database(String::from(e))
-    }
-}
-
-impl From<CborError> for Error {
-    fn from(e: CborError) -> Error {
-        Error::Encoding(e.to_string())
     }
 }

--- a/node/db/src/errors.rs
+++ b/node/db/src/errors.rs
@@ -4,15 +4,16 @@
 use encoding::error::Error as CborError;
 use thiserror::Error;
 
+/// Database error
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Invalid bulk write kv lengths, must be equal")]
     InvalidBulkLen,
     #[error("Cannot use unopened database")]
     Unopened,
-    #[error("{0}")]
+    #[error(transparent)]
     Database(#[from] rocksdb::Error),
-    #[error("{0}")]
+    #[error(transparent)]
     Encoding(#[from] CborError),
     #[error("{0}")]
     Other(String),

--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -59,7 +59,7 @@ impl RocksDb {
     /// Returns reference to db as long as it is initialized
     pub fn db(&self) -> Result<&DB, Error> {
         match &self.status {
-            DbStatus::Unopened(_) => Err(Error::Database("Unopened database used".to_string())),
+            DbStatus::Unopened(_) => Err(Error::Unopened),
             DbStatus::Open(db) => Ok(db),
         }
     }

--- a/vm/address/Cargo.toml
+++ b/vm/address/Cargo.toml
@@ -11,3 +11,4 @@ data-encoding = "2.1.2"
 data-encoding-macro = "0.1.7"
 leb128 = "0.2.1"
 encoding = { package = "forest_encoding", path = "../../encoding" }
+thiserror = "1.0"

--- a/vm/address/src/errors.rs
+++ b/vm/address/src/errors.rs
@@ -6,6 +6,7 @@ use data_encoding::DecodeError;
 use std::{io, num};
 use thiserror::Error;
 
+/// Address error
 #[derive(Debug, PartialEq, Error)]
 pub enum Error {
     #[error("Unknown address network")]

--- a/vm/address/src/errors.rs
+++ b/vm/address/src/errors.rs
@@ -3,47 +3,27 @@
 
 use super::{BLS_PUB_LEN, PAYLOAD_HASH_LEN};
 use data_encoding::DecodeError;
-use std::{fmt, io, num};
+use std::{io, num};
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
+    #[error("Unknown address network")]
     UnknownNetwork,
+    #[error("Unknown address protocol")]
     UnknownProtocol,
+    #[error("Invalid address payload")]
     InvalidPayload,
+    #[error("Invalid address length")]
     InvalidLength,
+    #[error("Invalid payload length, wanted: {} got: {0}", PAYLOAD_HASH_LEN)]
     InvalidPayloadLength(usize),
+    #[error("Invalid BLS pub key length, wanted: {} got: {0}", BLS_PUB_LEN)]
     InvalidBLSLength(usize),
+    #[error("Invalid address checksum")]
     InvalidChecksum,
-    Base32Decoding(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::UnknownNetwork => write!(f, "Unknown address network"),
-            Error::UnknownProtocol => write!(f, "Unknown address protocol"),
-            Error::InvalidPayload => write!(f, "Invalid address payload"),
-            Error::InvalidLength => write!(f, "Invalid address length"),
-            Error::InvalidPayloadLength(len) => write!(
-                f,
-                "Invalid payload length, wanted: {} got: {}",
-                PAYLOAD_HASH_LEN, len
-            ),
-            Error::InvalidBLSLength(len) => write!(
-                f,
-                "Invalid BLS pub key length, wanted: {} got: {}",
-                BLS_PUB_LEN, len
-            ),
-            Error::InvalidChecksum => write!(f, "Invalid address checksum"),
-            Error::Base32Decoding(err) => write!(f, "Decoding error: {}", err),
-        }
-    }
-}
-
-impl From<DecodeError> for Error {
-    fn from(e: DecodeError) -> Error {
-        Error::Base32Decoding(e.to_string())
-    }
+    #[error("Decoding for address failed: {0}")]
+    Base32Decoding(#[from] DecodeError),
 }
 
 impl From<num::ParseIntError> for Error {

--- a/vm/address/tests/address_test.rs
+++ b/vm/address/tests/address_test.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use data_encoding::{DecodeError, DecodeKind};
 use encoding::{from_slice, Cbor};
 use forest_address::{
     checksum, validate_checksum, Address, Error, Network, Protocol, BLS_PUB_LEN, PAYLOAD_HASH_LEN,
@@ -290,11 +291,17 @@ fn invalid_string_addresses() {
         },
         StringAddrVec {
             input: "t2gfvuyh7v2sx3patm1k23wdzmhyhtmqctasbr24y",
-            expected: Error::Base32Decoding("invalid symbol at 16".to_owned()),
+            expected: Error::Base32Decoding(DecodeError {
+                position: 16,
+                kind: DecodeKind::Symbol,
+            }),
         },
         StringAddrVec {
             input: "t2gfvuyh7v2sx3paTm1k23wdzmhyhtmqctasbr24y",
-            expected: Error::Base32Decoding("invalid symbol at 14".to_owned()),
+            expected: Error::Base32Decoding(DecodeError {
+                position: 14,
+                kind: DecodeKind::Symbol,
+            }),
         },
         StringAddrVec {
             input: "t2",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Been bugging me for a while now, and now seemed like a good time to change because less conflicts
  - Switches all errors to derive std::error::Error through the `thiserror` crate (https://github.com/dtolnay/thiserror) which makes it more extensible and clean/quick to use

There are still things I think could be improved, but I tried to keep these changes unopinionated without making any functional changes.

Only functional changes are two things I suspect to be bugs [here](https://github.com/ChainSafe/forest/compare/austin/errorrefactor?expand=1#diff-84b58b922d122fcf1338a9609b10fb68R95) if that doesn't resolve, the change(s) in `chain_store.rs` @dutterbutter can you confirm there isn't a specific reason it should not change


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->
#216 

**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->