### PR TITLE
Implement verify signature syscall and cleanup

### DIFF
--- a/blockchain/blocks/src/errors.rs
+++ b/blockchain/blocks/src/errors.rs
@@ -15,7 +15,7 @@ pub enum Error {
     NoBlocks,
     /// Invalid signature
     #[error("Invalid signature: {0}")]
-    InvalidSignature(&'static str),
+    InvalidSignature(String),
     /// Error in validating arbitrary data
     #[error("Error validating data: {0}")]
     Validation(String),

--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -265,9 +265,10 @@ impl BlockHeader {
     }
     /// Check to ensure block signature is valid
     pub fn check_block_signature(&self, addr: &Address) -> Result<(), Error> {
-        let signature = self.signature().as_ref().ok_or(Error::InvalidSignature(
-            "Signature is nil in header".to_owned(),
-        ))?;
+        let signature = self
+            .signature()
+            .as_ref()
+            .ok_or_else(|| Error::InvalidSignature("Signature is nil in header".to_owned()))?;
 
         signature
             .verify(&self.cid().to_bytes(), addr)

--- a/blockchain/blocks/src/ticket.rs
+++ b/blockchain/blocks/src/ticket.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crypto::VRFResult;
+use crypto::VRFProof;
 use encoding::{BytesDe, BytesSer};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vm::PoStProof;
@@ -12,12 +12,12 @@ use vm::PoStProof;
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Default)]
 pub struct Ticket {
     /// A proof output by running a VRF on the VDFResult of the parent ticket
-    pub vrfproof: VRFResult,
+    pub vrfproof: VRFProof,
 }
 
 impl Ticket {
     /// Ticket constructor
-    pub fn new(vrfproof: VRFResult) -> Self {
+    pub fn new(vrfproof: VRFProof) -> Self {
         Self { vrfproof }
     }
 }
@@ -36,7 +36,7 @@ impl<'de> Deserialize<'de> for Ticket {
     where
         D: Deserializer<'de>,
     {
-        let [cm]: [VRFResult; 1] = Deserialize::deserialize(deserializer)?;
+        let [cm]: [VRFProof; 1] = Deserialize::deserialize(deserializer)?;
         Ok(Self { vrfproof: cm })
     }
 }

--- a/blockchain/chain_sync/src/errors.rs
+++ b/blockchain/chain_sync/src/errors.rs
@@ -35,7 +35,7 @@ pub enum Error {
     State(#[from] StErr),
     /// Error in validating arbitrary data
     #[error("{0}")]
-    Validation(&'static str),
+    Validation(String),
     /// Any other error that does not need to be specifically handled
     #[error("{0}")]
     Other(String),

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -102,40 +102,52 @@ impl Signature {
     pub fn signature_type(&self) -> SignatureType {
         self.sig_type
     }
-}
-
-/// Checks if a signature is valid given data and address
-pub fn is_valid_signature(data: &[u8], addr: &Address, sig: &Signature) -> bool {
-    match addr.protocol() {
-        Protocol::BLS => verify_bls_sig(data, addr.payload(), sig),
-        Protocol::Secp256k1 => verify_secp256k1_sig(data, addr, sig),
-        _ => false,
-    }
-}
-
-/// Returns true if a bls signature is valid
-pub(crate) fn verify_bls_sig(data: &[u8], pub_k: &[u8], sig: &Signature) -> bool {
-    if pub_k.len() != BLS_PUB_LEN || sig.bytes().len() != BLS_SIG_LEN {
-        // validates pubkey length and signature length for protocol
-        return false;
+    /// Checks if a signature is valid given data and address
+    pub fn verify(&self, data: &[u8], addr: &Address) -> Result<(), String> {
+        match addr.protocol() {
+            Protocol::BLS => self.verify_bls_sig(data, addr),
+            Protocol::Secp256k1 => self.verify_secp256k1_sig(data, addr),
+            _ => Err("Address must be resolved to verify a signature".to_owned()),
+        }
     }
 
-    // hash data to be verified
-    let hashed = bls_hash(data);
+    /// Returns true if a bls signature is valid
+    pub(crate) fn verify_bls_sig(&self, data: &[u8], addr: &Address) -> Result<(), String> {
+        let pub_k = addr.payload();
 
-    // generate public key object from bytes
-    let pk = match BlsPubKey::from_bytes(&pub_k) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    // generate signature struct from bytes
-    let sig = match BlsSignature::from_bytes(sig.bytes()) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
+        // hash data to be verified
+        let hashed = bls_hash(data);
 
-    // BLS verify hash against key
-    verify(&sig, &[hashed], &[pk])
+        // generate public key object from bytes
+        let pk = BlsPubKey::from_bytes(&pub_k).map_err(|e| e.to_string())?;
+
+        // generate signature struct from bytes
+        let sig = BlsSignature::from_bytes(self.bytes()).map_err(|e| e.to_string())?;
+
+        // BLS verify hash against key
+        match verify(&sig, &[hashed], &[pk]) {
+            true => Ok(()),
+            false => Err("bls signature verification failed".to_owned()),
+        }
+    }
+
+    /// Returns true if a secp256k1 signature is valid
+    fn verify_secp256k1_sig(&self, data: &[u8], addr: &Address) -> Result<(), String> {
+        // blake2b 256 hash
+        let hash = blake2b_256(data);
+
+        // Ecrecover with hash and signature
+        let mut signature = [0u8; 65];
+        signature[..].clone_from_slice(self.bytes());
+        let rec_addr = ecrecover(&hash, &signature).map_err(|e| e.to_string())?;
+
+        // check address against recovered address
+        if &rec_addr == addr {
+            Ok(())
+        } else {
+            Err("Secp signature verification failed".to_owned())
+        }
+    }
 }
 
 pub fn verify_bls_aggregate(data: &[&[u8]], pub_keys: &[&[u8]], aggregate_sig: &Signature) -> bool {
@@ -161,23 +173,6 @@ pub fn verify_bls_aggregate(data: &[&[u8]], pub_keys: &[&[u8]], aggregate_sig: &
 
     // DOes the aggregate verification
     verify(&sig, &hashed_data[..], &pks[..])
-}
-
-/// Returns true if a secp256k1 signature is valid
-fn verify_secp256k1_sig(data: &[u8], addr: &Address, sig: &Signature) -> bool {
-    // blake2b 256 hash
-    let hash = blake2b_256(data);
-
-    // Ecrecover with hash and signature
-    let mut signature = [0u8; 65];
-    signature[..].clone_from_slice(sig.bytes());
-    let rec_addr = ecrecover(&hash, &signature);
-
-    // check address against recovered address
-    match rec_addr {
-        Ok(r) => addr == &r,
-        Err(_) => false,
-    }
 }
 
 // TODO: verify signature data format after signing implemented
@@ -229,18 +224,12 @@ mod tests {
         let pk = sk.public_key();
         let addr = Address::new_bls(pk.as_bytes()).unwrap();
 
-        assert_eq!(
-            is_valid_signature(&msg, &addr, &Signature::new_bls(signature_bytes.clone())),
-            true
-        );
-        assert_eq!(
-            verify_bls_sig(
-                &msg,
-                &pk.as_bytes(),
-                &Signature::new_bls(signature_bytes.clone())
-            ),
-            true
-        );
+        Signature::new_bls(signature_bytes.clone())
+            .verify(&msg, &addr)
+            .unwrap();
+        Signature::new_bls(signature_bytes.clone())
+            .verify_bls_sig(&msg, &addr)
+            .unwrap();
     }
     #[test]
     fn bls_agg_verify() {

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -125,9 +125,10 @@ impl Signature {
         let sig = BlsSignature::from_bytes(self.bytes()).map_err(|e| e.to_string())?;
 
         // BLS verify hash against key
-        match verify(&sig, &[hashed], &[pk]) {
-            true => Ok(()),
-            false => Err("bls signature verification failed".to_owned()),
+        if verify(&sig, &[hashed], &[pk]) {
+            Ok(())
+        } else {
+            Err("bls signature verification failed".to_owned())
         }
     }
 

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -102,6 +102,7 @@ impl Signature {
     pub fn signature_type(&self) -> SignatureType {
         self.sig_type
     }
+
     /// Checks if a signature is valid given data and address
     pub fn verify(&self, data: &[u8], addr: &Address) -> Result<(), String> {
         match addr.protocol() {
@@ -111,7 +112,7 @@ impl Signature {
         }
     }
 
-    /// Returns true if a bls signature is valid
+    /// Returns `String` error if a bls signature is invalid
     pub(crate) fn verify_bls_sig(&self, data: &[u8], addr: &Address) -> Result<(), String> {
         let pub_k = addr.payload();
 
@@ -132,7 +133,7 @@ impl Signature {
         }
     }
 
-    /// Returns true if a secp256k1 signature is valid
+    /// Returns `String` error if a secp256k1 signature is invalid
     fn verify_secp256k1_sig(&self, data: &[u8], addr: &Address) -> Result<(), String> {
         // blake2b 256 hash
         let hash = blake2b_256(data);

--- a/crypto/src/vrf.rs
+++ b/crypto/src/vrf.rs
@@ -1,73 +1,34 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::signature::{verify_bls_sig, Signature, BLS_SIG_LEN};
-use bls_signatures::{Serialize as BlsSerialize, Signature as BLSSignature};
-use encoding::serde_bytes;
+use crate::signature::BLS_SIG_LEN;
+use encoding::{blake2b_256, serde_bytes};
 use serde::{Deserialize, Serialize};
-
-pub struct VRFPublicKey(Vec<u8>);
-
-/// Contains some public key type to be used for VRF verification
-impl VRFPublicKey {
-    pub fn new(input: Vec<u8>) -> Self {
-        Self(input)
-    }
-}
 
 /// The output from running a VRF
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Default, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct VRFResult(#[serde(with = "serde_bytes")] Vec<u8>);
+pub struct VRFProof(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
-impl VRFResult {
-    /// Creates a VRFResult from a raw vector
+impl VRFProof {
+    /// Creates a VRFProof from a raw vector
     pub fn new(output: Vec<u8>) -> Self {
         Self(output)
     }
+
     /// Returns reference to underlying vector
     pub fn bytes(&self) -> &[u8] {
         &self.0
     }
+
+    /// Compute the blake2b256 digest of the proof
+    pub fn digest(&self) -> [u8; 32] {
+        blake2b_256(&self.0)
+    }
+
     /// Returns max value based on [BLS_SIG_LEN](constant.BLS_SIG_LEN.html)
     pub fn max_value() -> Self {
+        // TODO revisit if this is necessary
         Self::new([std::u8::MAX; BLS_SIG_LEN].to_vec())
-    }
-    /// Validates syntax...
-    pub fn validate_syntax(&self) -> bool {
-        unimplemented!()
-    }
-    /// Asserts whether `input` was used with `pk` to produce this VRFOutput
-    pub fn verify(&self, input: &[u8], pk: &VRFPublicKey) -> bool {
-        match BLSSignature::from_bytes(&self.0) {
-            Ok(sig) => verify_bls_sig(input, &pk.0, &Signature::new_bls(sig.as_bytes())),
-            Err(_) => false,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bls_signatures::{PrivateKey, Serialize};
-    use rand::rngs::mock::StepRng;
-    use rand::Rng;
-
-    #[test]
-    fn verify() {
-        let rng = &mut StepRng::new(4, 3);
-        let privk = PrivateKey::generate(rng);
-
-        let init_input = (0..64).map(|_| rng.gen()).collect::<Vec<u8>>();
-        let input = privk.sign(&init_input);
-
-        let genesis = VRFResult::new(input.as_bytes());
-
-        let sig = privk.sign(genesis.bytes());
-        let res = VRFResult::new(sig.as_bytes());
-
-        let pubk = VRFPublicKey::new(privk.public_key().as_bytes());
-
-        assert!(res.verify(genesis.bytes(), &pubk));
     }
 }

--- a/tests/serialization_tests/tests/block_header_ser.rs
+++ b/tests/serialization_tests/tests/block_header_ser.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "serde_tests")]
 
 use cid::Cid;
-use crypto::VRFResult;
+use crypto::VRFProof;
 use encoding::{from_slice, to_vec};
 use forest_blocks::{BlockHeader, EPostProof, EPostTicket, Ticket, TipSetKeys};
 use hex::encode;
@@ -24,7 +24,7 @@ struct TicketVector {
 impl From<TicketVector> for Ticket {
     fn from(v: TicketVector) -> Self {
         Self {
-            vrfproof: VRFResult::new(base64::decode(&v.proof).unwrap()),
+            vrfproof: VRFProof::new(base64::decode(&v.proof).unwrap()),
         }
     }
 }

--- a/utils/test_utils/src/chain_structures.rs
+++ b/utils/test_utils/src/chain_structures.rs
@@ -4,13 +4,12 @@
 #![cfg(feature = "test_constructors")]
 
 use address::Address;
-use base64;
 use blocks::{
     Block, BlockHeader, EPostProof, EPostTicket, FullTipset, Ticket, TipSetKeys, Tipset, TxMeta,
 };
 use chain::TipSetMetadata;
 use cid::{multihash::Blake2b256, Cid};
-use crypto::{Signature, Signer, VRFResult};
+use crypto::{Signature, Signer, VRFProof};
 use encoding::{from_slice, to_vec};
 use forest_libp2p::blocksync::{BlockSyncResponse, TipSetBundle};
 use forest_libp2p::rpc::RPCResponse;
@@ -41,7 +40,7 @@ fn template_header(
         .miner_address(Address::new_secp256k1(&ticket_p).unwrap())
         .timestamp(timestamp)
         .ticket(Ticket {
-            vrfproof: VRFResult::new(ticket_p),
+            vrfproof: VRFProof::new(ticket_p),
         })
         .messages(msg_root)
         .signature(Some(Signature::new_bls(vec![1, 4, 3, 6, 7, 1, 2])))
@@ -91,7 +90,7 @@ pub fn construct_header(epoch: u64, weight: u64) -> Vec<BlockHeader> {
 
 /// Returns a Ticket to be used for testing
 pub fn construct_ticket() -> Ticket {
-    let vrf_result = VRFResult::new(base64::decode("lmRJLzDpuVA7cUELHTguK9SFf+IVOaySG8t/0IbVeHHm3VwxzSNhi1JStix7REw6Apu6rcJQV1aBBkd39gQGxP8Abzj8YXH+RdSD5RV50OJHi35f3ixR0uhkY6+G08vV").unwrap());
+    let vrf_result = VRFProof::new(base64::decode("lmRJLzDpuVA7cUELHTguK9SFf+IVOaySG8t/0IbVeHHm3VwxzSNhi1JStix7REw6Apu6rcJQV1aBBkd39gQGxP8Abzj8YXH+RdSD5RV50OJHi35f3ixR0uhkY6+G08vV").unwrap());
     Ticket::new(vrf_result)
 }
 

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -474,7 +474,7 @@ impl Actor {
             .map_err(|e| {
                 ActorError::new(
                     ExitCode::SysErrorIllegalArgument,
-                    format!("failed to compute unsealed sector CID: {}", e),
+                    format!("failed to compute unsealed sector CID: {}", e.msg()),
                 )
             })?;
 
@@ -609,9 +609,9 @@ where
             &sv_bz,
         )
         .map_err(|e| {
-            rt.abort(
+            ActorError::new(
                 ExitCode::ErrIllegalArgument,
-                format!("signature proposal invalid: {}", e),
+                format!("signature proposal invalid: {}", e.msg()),
             )
         })?;
 

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -113,9 +113,9 @@ impl Actor {
         rt.syscalls()
             .verify_signature(&sig, &signer, &sv_bz)
             .map_err(|e| {
-                rt.abort(
+                ActorError::new(
                     ExitCode::ErrIllegalArgument,
-                    format!("voucher signature invalid: {}", e),
+                    format!("voucher signature invalid: {}", e.msg()),
                 )
             })?;
 
@@ -130,7 +130,10 @@ impl Actor {
         if !sv.secret_pre_image.is_empty() {
             let hashed_secret: &[u8] = &rt.syscalls().hash_blake2b(&params.secret)?;
             if hashed_secret != sv.secret_pre_image.as_slice() {
-                return Err(rt.abort(ExitCode::ErrIllegalArgument, "incorrect secret"));
+                return Err(ActorError::new(
+                    ExitCode::ErrIllegalArgument,
+                    "incorrect secret".to_owned(),
+                ));
             }
         }
 

--- a/vm/actor/src/builtin/power/mod.rs
+++ b/vm/actor/src/builtin/power/mod.rs
@@ -482,7 +482,7 @@ impl Actor {
             .map_err(|e| {
                 ActorError::new(
                     ExitCode::ErrIllegalArgument,
-                    format!("fault not verified: {}", e),
+                    format!("fault not verified: {}", e.msg()),
                 )
             })?;
 

--- a/vm/runtime/src/lib.rs
+++ b/vm/runtime/src/lib.rs
@@ -135,12 +135,13 @@ pub trait Syscalls {
     /// Verifies that a signature is valid for an address and plaintext.
     fn verify_signature(
         &self,
-        _signature: &Signature,
-        _signer: &Address,
-        _plaintext: &[u8],
+        signature: &Signature,
+        signer: &Address,
+        plaintext: &[u8],
     ) -> Result<(), ActorError> {
-        // TODO
-        todo!()
+        signature
+            .verify(plaintext, signer)
+            .map_err(|e| ActorError::new(ExitCode::ErrPlaceholder, e.to_string()))
     }
     /// Hashes input data using blake2b with 256 bit output.
     fn hash_blake2b(&self, _data: &[u8]) -> Result<[u8; 32], ActorError> {

--- a/vm/runtime/src/lib.rs
+++ b/vm/runtime/src/lib.rs
@@ -141,7 +141,7 @@ pub trait Syscalls {
     ) -> Result<(), ActorError> {
         signature
             .verify(plaintext, signer)
-            .map_err(|e| ActorError::new(ExitCode::ErrPlaceholder, e.to_string()))
+            .map_err(|e| ActorError::new(ExitCode::ErrPlaceholder, e))
     }
     /// Hashes input data using blake2b with 256 bit output.
     fn hash_blake2b(&self, _data: &[u8]) -> Result<[u8; 32], ActorError> {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Implements verify sig syscall #301 
  - Removes duplicate error when syscalls are called in actors
    - (I don't actually think the out of gas exit code can be hit within the actors and maybe that is intentional)
- Crypto crate cleanup
  - A lot was setup to try to match spec 1:1 and old implementation when possible, so now more closely matches impls and cleaner interface in rust
  - Signature verification now also returns result instead of just a boolean, for better error reporting



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->
#301


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->