### PR TITLE
Disallow default Cid and Address serialization

### DIFF
--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -27,19 +27,19 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// ```
 /// use forest_blocks::{BlockHeader, TipSetKeys, Ticket};
 /// use address::Address;
-/// use cid::Cid;
+/// use cid::{Cid, multihash::Identity};
 /// use num_bigint::BigUint;
 /// use crypto::Signature;
 ///
 /// BlockHeader::builder()
+///     .messages(Cid::new_from_cbor(&[], Identity)) // required
+///     .message_receipts(Cid::new_from_cbor(&[], Identity)) // required
+///     .state_root(Cid::new_from_cbor(&[], Identity)) // required
 ///     .miner_address(Address::new_id(0).unwrap()) // optional
 ///     .bls_aggregate(None) // optional
 ///     .parents(TipSetKeys::default()) // optional
 ///     .weight(BigUint::from(0u8)) // optional
 ///     .epoch(0) // optional
-///     .messages(Cid::default()) // optional
-///     .message_receipts(Cid::default()) // optional
-///     .state_root(Cid::default()) // optional
 ///     .timestamp(0) // optional
 ///     .ticket(Ticket::default()) // optional
 ///     .build_and_validate()

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -215,6 +215,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use address::Address;
     use cid::multihash::Identity;
 
     #[test]
@@ -228,6 +229,7 @@ mod tests {
             .messages(Cid::new_from_cbor(&[], Identity))
             .message_receipts(Cid::new_from_cbor(&[], Identity))
             .state_root(Cid::new_from_cbor(&[], Identity))
+            .miner_address(Address::new_id(0).unwrap())
             .build_and_validate()
             .unwrap();
 

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -215,6 +215,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cid::multihash::Identity;
 
     #[test]
     fn genesis_test() {
@@ -224,6 +225,9 @@ mod tests {
         let gen_block = BlockHeader::builder()
             .epoch(1)
             .weight((2 as u32).into())
+            .messages(Cid::new_from_cbor(&[], Identity))
+            .message_receipts(Cid::new_from_cbor(&[], Identity))
+            .state_root(Cid::new_from_cbor(&[], Identity))
             .build_and_validate()
             .unwrap();
 

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -11,7 +11,7 @@ pub use self::error::Error;
 pub use self::version::Version;
 use integer_encoding::{VarIntReader, VarIntWriter};
 pub use multihash;
-use multihash::{Blake2b256, Code, Multihash, MultihashDigest};
+use multihash::{Code, Identity, Multihash, MultihashDigest};
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::fmt;
@@ -49,7 +49,7 @@ pub struct Cid {
 
 impl Default for Cid {
     fn default() -> Self {
-        Self::new(Codec::Raw, Version::V1, Blake2b256.digest(&[]))
+        Self::new(Codec::Raw, Version::V1, Identity.digest(&[]))
     }
 }
 
@@ -59,9 +59,14 @@ impl ser::Serialize for Cid {
     where
         S: ser::Serializer,
     {
+        if self == &Cid::default() {
+            // TODO remove if intended to use outside of Forest
+            // Only used for convenience of having Cid implement default
+            return Err(ser::Error::custom("Cannot serialize a default Cid"));
+        }
+
         let mut cid_bytes = self.to_bytes();
 
-        // TODO determine if identity multibase prefix should just be included for IPLD links
         // or for all Cid bytes (byte is irrelevant and redundant)
         cid_bytes.insert(0, MULTIBASE_IDENTITY);
 

--- a/node/forest_libp2p/src/hello/message.rs
+++ b/node/forest_libp2p/src/hello/message.rs
@@ -86,12 +86,17 @@ impl<'de> Deserialize<'de> for HelloResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use forest_cid::multihash::Identity;
     use forest_encoding::*;
 
     #[test]
     fn hello_default_ser() {
-        let bz = to_vec(&HelloMessage::default()).unwrap();
+        let orig_msg = HelloMessage {
+            genesis_hash: Cid::new_from_cbor(&[], Identity),
+            ..Default::default()
+        };
+        let bz = to_vec(&orig_msg).unwrap();
         let msg: HelloMessage = from_slice(&bz).unwrap();
-        assert_eq!(msg, HelloMessage::default());
+        assert_eq!(msg, orig_msg);
     }
 }

--- a/node/forest_libp2p/tests/hello_test.rs
+++ b/node/forest_libp2p/tests/hello_test.rs
@@ -4,21 +4,25 @@
 mod rpc_test_utils;
 
 use self::rpc_test_utils::*;
-use forest_cid::Cid;
+use forest_cid::{multihash::Identity, Cid};
 use forest_libp2p::hello::{HelloMessage, HelloResponse};
 use forest_libp2p::rpc::{RPCEvent, RPCMessage, RPCRequest, RPCResponse};
 use futures::future;
 use num_bigint::BigInt;
+
+fn empty_cid() -> Cid {
+    Cid::new_from_cbor(&[], Identity)
+}
 
 #[test]
 fn test_empty_rpc() {
     let (mut sender, mut receiver) = build_node_pair();
 
     let rpc_request = RPCRequest::Hello(HelloMessage {
-        heaviest_tip_set: vec![Cid::default()],
+        heaviest_tip_set: vec![empty_cid()],
         heaviest_tipset_weight: BigInt::from(1),
         heaviest_tipset_height: 2,
-        genesis_hash: Cid::default(),
+        genesis_hash: empty_cid(),
     });
 
     let c_request = rpc_request.clone();

--- a/vm/address/src/lib.rs
+++ b/vm/address/src/lib.rs
@@ -205,11 +205,10 @@ impl ser::Serialize for Address {
     where
         S: ser::Serializer,
     {
-        // if self == &Cid::default() {
-        //     // TODO remove if intended to use outside of Forest
-        //     // Only used for convenience of having Cid implement default
-        //     return Err(ser::Error::custom("Cannot serialize a default Cid"));
-        // }
+        if self == &Address::default() {
+            // Just a sanity check to disallow serialization of invalid address
+            return Err(ser::Error::custom("Cannot serialize a default Address"));
+        }
 
         let address_bytes = self.to_bytes();
         serde_bytes::Serialize::serialize(&address_bytes, s)

--- a/vm/address/src/lib.rs
+++ b/vm/address/src/lib.rs
@@ -205,6 +205,12 @@ impl ser::Serialize for Address {
     where
         S: ser::Serializer,
     {
+        // if self == &Cid::default() {
+        //     // TODO remove if intended to use outside of Forest
+        //     // Only used for convenience of having Cid implement default
+        //     return Err(ser::Error::custom("Cannot serialize a default Cid"));
+        // }
+
         let address_bytes = self.to_bytes();
         serde_bytes::Serialize::serialize(&address_bytes, s)
     }

--- a/vm/default_runtime/tests/transfer_test.rs
+++ b/vm/default_runtime/tests/transfer_test.rs
@@ -3,10 +3,7 @@
 
 use actor::{init, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_ADDR};
 use address::Address;
-use cid::{
-    multihash::{Blake2b256, Identity},
-    Cid,
-};
+use cid::multihash::{Blake2b256, Identity};
 use db::MemoryDB;
 use default_runtime::{internal_send, DefaultRuntime};
 use ipld_blockstore::BlockStore;
@@ -35,7 +32,12 @@ fn transfer_test() {
         .map_err(|e| e.to_string())
         .unwrap();
 
-    let act_s = ActorState::new(Cid::default(), state_cid.clone(), Default::default(), 1);
+    let act_s = ActorState::new(
+        ACCOUNT_ACTOR_CODE_ID.clone(),
+        state_cid.clone(),
+        Default::default(),
+        1,
+    );
     state.set_actor(&INIT_ACTOR_ADDR, act_s.clone()).unwrap();
 
     let actor_addr_1 = Address::new_id(100).unwrap();

--- a/vm/src/sector/serde.rs
+++ b/vm/src/sector/serde.rs
@@ -230,17 +230,29 @@ impl<'de> Deserialize<'de> for OnChainElectionPoStVerifyInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cid::{multihash::Identity, Cid};
     use encoding::{from_slice, to_vec};
+
+    fn empty_cid() -> Cid {
+        Cid::new_from_cbor(&[], Identity)
+    }
 
     #[test]
     fn default_serializations() {
-        let s = SealVerifyInfo::default();
+        let ocs = OnChainSealVerifyInfo {
+            sealed_cid: empty_cid(),
+            ..Default::default()
+        };
+        let bz = to_vec(&ocs).unwrap();
+        assert_eq!(from_slice::<OnChainSealVerifyInfo>(&bz).unwrap(), ocs);
+
+        let s = SealVerifyInfo {
+            unsealed_cid: empty_cid(),
+            on_chain: ocs,
+            ..Default::default()
+        };
         let bz = to_vec(&s).unwrap();
         assert_eq!(from_slice::<SealVerifyInfo>(&bz).unwrap(), s);
-
-        let s = OnChainSealVerifyInfo::default();
-        let bz = to_vec(&s).unwrap();
-        assert_eq!(from_slice::<OnChainSealVerifyInfo>(&bz).unwrap(), s);
 
         let s = PoStCandidate::default();
         let bz = to_vec(&s).unwrap();

--- a/vm/state_tree/tests/state_tree_tests.rs
+++ b/vm/state_tree/tests/state_tree_tests.rs
@@ -3,15 +3,19 @@
 
 use actor::{init, ActorState, INIT_ACTOR_ADDR};
 use address::Address;
-use cid::{multihash::Blake2b256, Cid};
+use cid::{multihash::Identity, Cid};
 use ipld_blockstore::BlockStore;
 use ipld_hamt::Hamt;
 use state_tree::*;
 
+fn empty_cid() -> Cid {
+    Cid::new_from_cbor(&[], Identity)
+}
+
 #[test]
 fn get_set_cache() {
-    let act_s = ActorState::new(Cid::default(), Cid::default(), Default::default(), 1);
-    let act_a = ActorState::new(Cid::default(), Cid::default(), Default::default(), 2);
+    let act_s = ActorState::new(empty_cid(), empty_cid(), Default::default(), 1);
+    let act_a = ActorState::new(empty_cid(), empty_cid(), Default::default(), 2);
     let addr = Address::new_id(1).unwrap();
     let store = db::MemoryDB::default();
     let mut tree = HamtStateTree::new(&store);
@@ -34,7 +38,7 @@ fn delete_actor() {
     let mut tree = HamtStateTree::new(&store);
 
     let addr = Address::new_id(3).unwrap();
-    let act_s = ActorState::new(Cid::default(), Cid::default(), Default::default(), 1);
+    let act_s = ActorState::new(empty_cid(), empty_cid(), Default::default(), 1);
     tree.set_actor(&addr, act_s.clone()).unwrap();
     assert_eq!(tree.get_actor(&addr).unwrap(), Some(act_s));
     tree.delete_actor(&addr).unwrap();
@@ -54,11 +58,11 @@ fn get_set_non_id() {
     let init_state = init::State::new(e_cid.clone(), "test".to_owned());
     let state_cid = tree
         .store()
-        .put(&init_state, Blake2b256)
+        .put(&init_state, Identity)
         .map_err(|e| e.to_string())
         .unwrap();
 
-    let act_s = ActorState::new(Cid::default(), state_cid.clone(), Default::default(), 1);
+    let act_s = ActorState::new(empty_cid(), state_cid.clone(), Default::default(), 1);
 
     // Test snapshot
     let snapshot = tree.snapshot().unwrap();
@@ -75,7 +79,7 @@ fn get_set_non_id() {
     assert_eq!(
         new_init_s,
         Some(ActorState {
-            code: Cid::default(),
+            code: empty_cid(),
             state: state_cid,
             balance: Default::default(),
             sequence: 2


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Just a sanity check as we get to the point of running a node
  - Default is only really needed out of convenience and for testing, but erroring on attempting to serialize either enforces that this default structs do not get used in any meaningful way.
  - Just makes debugging any potential bug relating to this easier as it will silently allow using the defaults currently



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->