### PR TITLE
Implement buffered blockstore cache

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -15,14 +15,19 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Pull serialization vectors
-        run: git submodule update --init
+      # TODO revisit this, workaround for now
+      - name: Install OpenCL
+        run: sudo apt install ocl-icd-opencl-dev	
 
-      - name: Build CI docker image
-        run: docker build -t forest/rust:latest -f ./Dockerfile-ci .
+      - name: Toolchain setup
+        uses: actions-rs/toolchain@v1
+        with:	
+          profile: minimal	
+          toolchain: stable	
+          override: true	
 
-      - name: Test all
-        run: docker run forest/rust cargo test --all-features
+      - name: Cargo test all
+        run: make test-all
 
   fmt:
     name: rustfmt

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -8,7 +8,5 @@ edition = "2018"
 cid = { package = "forest_cid", path = "../cid" }
 db = { path = "../../node/db" }
 encoding = { package = "forest_encoding", path = "../../encoding" }
-
-[dev-dependencies]
 forest_ipld = { path = "../" }
 commcid = { path = "../../utils/commcid" }

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2018"
 cid = { package = "forest_cid", path = "../cid" }
 db = { path = "../../node/db" }
 encoding = { package = "forest_encoding", path = "../../encoding" }
+
+[dev-dependencies]
+forest_ipld = { path = "../" }
+commcid = { path = "../../utils/commcid" }

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::BlockStore;
-use cid::{multihash::MultihashDigest, Cid};
+use cid::{
+    multihash::{Code, MultihashDigest},
+    Cid,
+};
+use commcid::FilecoinMultihashCode;
 use db::{Error, Store};
-use encoding::{ser::Serialize, to_vec};
+use encoding::{from_slice, ser::Serialize, to_vec};
+use forest_ipld::Ipld;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::error::Error as StdError;
@@ -27,21 +32,78 @@ where
             write: Default::default(),
         }
     }
-    /// Flushes the buffered cache based on the root node
-    pub fn flush(&mut self, _root: &Cid) -> Result<(), Box<dyn StdError>> {
-        // TODO update this to only write over values connected to the root
-        // This will be done by querying root in `self.write` and writing all values connected
-        // through links from that root that doesn't exist in `self.base`
-        for (k, v) in self.write.borrow().iter() {
-            self.base.write(k.to_bytes(), v)?;
-        }
+    /// Flushes the buffered cache based on the root node.
+    /// This will recursively traverse the cache and write all data connected by links to this
+    /// root Cid.
+    pub fn flush(&mut self, root: &Cid) -> Result<(), Box<dyn StdError>> {
+        write_recursive(self.base, &self.write.borrow(), root)?;
 
         self.write = Default::default();
         Ok(())
     }
-    fn write_recursive(&self, cid: &Cid) -> Result<(), Box<dyn StdError>> {
-        todo!()
+}
+
+// Recursively traverses cache through Cid links.
+fn write_recursive<BS>(
+    base: &BS,
+    cache: &HashMap<Cid, Vec<u8>>,
+    cid: &Cid,
+) -> Result<(), Box<dyn StdError>>
+where
+    BS: BlockStore,
+{
+    // Skip identity and Filecoin commitment Cids
+    let ch = cid.hash.algorithm();
+    if ch == Code::Identity
+        || ch == Code::Custom(FilecoinMultihashCode::SealedV1 as u64)
+        || ch == Code::Custom(FilecoinMultihashCode::UnsealedV1 as u64)
+    {
+        return Ok(());
     }
+
+    let raw_cid_bz = cid.to_bytes();
+    let raw_bz = cache
+        .get(cid)
+        .ok_or("Invalid link in flushing buffered store".to_owned())?;
+
+    // If root exists in base store already, can skip
+    if base.exists(&raw_cid_bz)? {
+        return Ok(());
+    }
+
+    // Deserialize the bytes to Ipld to traverse links.
+    // This is safer than finding links in place,
+    // but slightly slower to copy and potentially allocate non Cid data.
+    let block: Ipld = from_slice(raw_bz)?;
+
+    // Traverse and write linked data recursively
+    for_each_link(&block, &|c| write_recursive(base, cache, c))?;
+
+    // Write the root node to base storage
+    base.write(&raw_cid_bz, raw_bz)?;
+    Ok(())
+}
+
+// Recursively explores Ipld for links and calls a function with a reference to the Cid.
+fn for_each_link<F>(ipld: &Ipld, cb: &F) -> Result<(), Box<dyn StdError>>
+where
+    F: Fn(&Cid) -> Result<(), Box<dyn StdError>>,
+{
+    match ipld {
+        Ipld::Link(c) => cb(&c)?,
+        Ipld::List(arr) => {
+            for item in arr {
+                for_each_link(item, cb)?
+            }
+        }
+        Ipld::Map(map) => {
+            for (_, v) in map {
+                for_each_link(v, cb)?
+            }
+        }
+        _ => (),
+    }
+    Ok(())
 }
 
 impl<BS> BlockStore for BufferedBlockStore<'_, BS>
@@ -131,7 +193,7 @@ mod tests {
         let mem = db::MemoryDB::default();
         let mut buf_store = BufferedBlockStore::new(&mem);
 
-        let cid = buf_store.put(&8, Identity).unwrap();
+        let cid = buf_store.put(&8, Blake2b256).unwrap();
         assert_eq!(mem.get::<u8>(&cid).unwrap(), None);
         assert_eq!(buf_store.get::<u8>(&cid).unwrap(), Some(8));
 
@@ -153,28 +215,38 @@ mod tests {
         let mut map: BTreeMap<String, Ipld> = Default::default();
         map.insert("array".to_owned(), Ipld::Link(arr_cid.clone()));
         let sealed_comm_cid = commitment_to_cid(&[7u8; 32], FilecoinMultihashCode::SealedV1);
-        map.insert("sealed".to_owned(), Ipld::Link(sealed_comm_cid));
+        map.insert("sealed".to_owned(), Ipld::Link(sealed_comm_cid.clone()));
         let unsealed_comm_cid = commitment_to_cid(&[5u8; 32], FilecoinMultihashCode::UnsealedV1);
-        map.insert("unsealed".to_owned(), Ipld::Link(unsealed_comm_cid));
-        map.insert("identity".to_owned(), Ipld::Link(identity_cid));
+        map.insert("unsealed".to_owned(), Ipld::Link(unsealed_comm_cid.clone()));
+        map.insert("identity".to_owned(), Ipld::Link(identity_cid.clone()));
         map.insert("value".to_owned(), Ipld::String(str_val.to_owned()));
+        let map_cid = buf_store.put(&map, Blake2b256).unwrap();
+
+        let root_cid = buf_store.put(&(map_cid.clone(), 1u8), Blake2b256).unwrap();
 
         // Make sure a block not connected to the root does not get written
         let unconnected = buf_store.put(&27u8, Blake2b256).unwrap();
 
-        let map_cid = buf_store.put(&map, Blake2b256).unwrap();
-        assert_eq!(mem.get::<(String, u8)>(&arr_cid).unwrap(), None);
         assert_eq!(mem.get::<Ipld>(&map_cid).unwrap(), None);
+        assert_eq!(mem.get::<Ipld>(&root_cid).unwrap(), None);
+        assert_eq!(mem.get::<(String, u8)>(&arr_cid).unwrap(), None);
         assert_eq!(buf_store.get::<u8>(&unconnected).unwrap(), Some(27u8));
 
         // Flush and assert changes
-        buf_store.flush(&map_cid).unwrap();
-        assert_eq!(mem.get::<Ipld>(&map_cid).unwrap(), Some(Ipld::Map(map)));
+        buf_store.flush(&root_cid).unwrap();
         assert_eq!(
             mem.get::<(String, u8)>(&arr_cid).unwrap(),
             Some((str_val.to_owned(), value))
         );
-        // assert_eq!(mem.get::<u8>(&unconnected).unwrap(), None);
-        // assert_eq!(buf_store.get::<u8>(&unconnected).unwrap(), None);
+        assert_eq!(mem.get::<Ipld>(&map_cid).unwrap(), Some(Ipld::Map(map)));
+        assert_eq!(
+            mem.get::<Ipld>(&root_cid).unwrap(),
+            Some(Ipld::List(vec![Ipld::Link(map_cid), Ipld::Integer(1)]))
+        );
+        assert_eq!(buf_store.get::<u8>(&identity_cid).unwrap(), None);
+        assert_eq!(buf_store.get::<Ipld>(&unsealed_comm_cid).unwrap(), None);
+        assert_eq!(buf_store.get::<Ipld>(&sealed_comm_cid).unwrap(), None);
+        assert_eq!(mem.get::<u8>(&unconnected).unwrap(), None);
+        assert_eq!(buf_store.get::<u8>(&unconnected).unwrap(), None);
     }
 }

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -64,7 +64,7 @@ where
     let raw_cid_bz = cid.to_bytes();
     let raw_bz = cache
         .get(cid)
-        .ok_or("Invalid link in flushing buffered store".to_owned())?;
+        .ok_or_else(|| "Invalid link in flushing buffered store".to_owned())?;
 
     // If root exists in base store already, can skip
     if base.exists(&raw_cid_bz)? {
@@ -97,7 +97,7 @@ where
             }
         }
         Ipld::Map(map) => {
-            for (_, v) in map {
+            for v in map.values() {
                 for_each_link(v, cb)?
             }
         }

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -43,7 +43,7 @@ where
     }
 }
 
-// Recursively traverses cache through Cid links.
+/// Recursively traverses cache through Cid links.
 fn write_recursive<BS>(
     base: &BS,
     cache: &HashMap<Cid, Vec<u8>>,
@@ -84,7 +84,7 @@ where
     Ok(())
 }
 
-// Recursively explores Ipld for links and calls a function with a reference to the Cid.
+/// Recursively explores Ipld for links and calls a function with a reference to the Cid.
 fn for_each_link<F>(ipld: &Ipld, cb: &F) -> Result<(), Box<dyn StdError>>
 where
     F: Fn(&Cid) -> Result<(), Box<dyn StdError>>,

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -27,6 +27,7 @@ where
             write: Default::default(),
         }
     }
+    /// Flushes the buffered cache based on the root node
     pub fn flush(&mut self, _root: &Cid) -> Result<(), Box<dyn StdError>> {
         // TODO update this to only write over values connected to the root
         // This will be done by querying root in `self.write` and writing all values connected
@@ -37,6 +38,9 @@ where
 
         self.write = Default::default();
         Ok(())
+    }
+    fn write_recursive(&self, cid: &Cid) -> Result<(), Box<dyn StdError>> {
+        todo!()
     }
 }
 
@@ -117,15 +121,60 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cid::multihash::Identity;
+    use cid::multihash::{Blake2b256, Identity};
+    use commcid::{commitment_to_cid, FilecoinMultihashCode};
+    use forest_ipld::Ipld;
+    use std::collections::BTreeMap;
 
     #[test]
     fn basic_buffered_store() {
         let mem = db::MemoryDB::default();
-        let buf_store = BufferedBlockStore::new(&mem);
+        let mut buf_store = BufferedBlockStore::new(&mem);
 
         let cid = buf_store.put(&8, Identity).unwrap();
         assert_eq!(mem.get::<u8>(&cid).unwrap(), None);
         assert_eq!(buf_store.get::<u8>(&cid).unwrap(), Some(8));
+
+        buf_store.flush(&cid).unwrap();
+        assert_eq!(buf_store.get::<u8>(&cid).unwrap(), Some(8));
+        assert_eq!(mem.get::<u8>(&cid).unwrap(), Some(8));
+    }
+
+    #[test]
+    fn buffered_store_with_links() {
+        let mem = db::MemoryDB::default();
+        let mut buf_store = BufferedBlockStore::new(&mem);
+        let str_val = "value";
+        let value = 8u8;
+        let arr_cid = buf_store.put(&(str_val, value), Blake2b256).unwrap();
+        let identity_cid = buf_store.put(&0u8, Identity).unwrap();
+
+        // Create map to insert into store
+        let mut map: BTreeMap<String, Ipld> = Default::default();
+        map.insert("array".to_owned(), Ipld::Link(arr_cid.clone()));
+        let sealed_comm_cid = commitment_to_cid(&[7u8; 32], FilecoinMultihashCode::SealedV1);
+        map.insert("sealed".to_owned(), Ipld::Link(sealed_comm_cid));
+        let unsealed_comm_cid = commitment_to_cid(&[5u8; 32], FilecoinMultihashCode::UnsealedV1);
+        map.insert("unsealed".to_owned(), Ipld::Link(unsealed_comm_cid));
+        map.insert("identity".to_owned(), Ipld::Link(identity_cid));
+        map.insert("value".to_owned(), Ipld::String(str_val.to_owned()));
+
+        // Make sure a block not connected to the root does not get written
+        let unconnected = buf_store.put(&27u8, Blake2b256).unwrap();
+
+        let map_cid = buf_store.put(&map, Blake2b256).unwrap();
+        assert_eq!(mem.get::<(String, u8)>(&arr_cid).unwrap(), None);
+        assert_eq!(mem.get::<Ipld>(&map_cid).unwrap(), None);
+        assert_eq!(buf_store.get::<u8>(&unconnected).unwrap(), Some(27u8));
+
+        // Flush and assert changes
+        buf_store.flush(&map_cid).unwrap();
+        assert_eq!(mem.get::<Ipld>(&map_cid).unwrap(), Some(Ipld::Map(map)));
+        assert_eq!(
+            mem.get::<(String, u8)>(&arr_cid).unwrap(),
+            Some((str_val.to_owned(), value))
+        );
+        // assert_eq!(mem.get::<u8>(&unconnected).unwrap(), None);
+        // assert_eq!(buf_store.get::<u8>(&unconnected).unwrap(), None);
     }
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Was just setup to copy everything from cache in previous PR #374 but now changed to traverse Ipld links through the cache to only write values that are connected to the root node `AND` have not been written to the base store

This is important to not cause database bloat and write unnecessary intermediate values. (Only need data connected to the root used in blockheaders)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->
#377 

**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->