### PR TITLE
DAGJson support for Ipld

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean:
 
 lint: license clean
 	cargo fmt --all
-	cargo clippy -- -D warnings
+	cargo clippy --all-features -- -D warnings
 
 build:
 	cargo build --bin forest

--- a/blockchain/blocks/Cargo.toml
+++ b/blockchain/blocks/Cargo.toml
@@ -10,7 +10,7 @@ beacon = { package = "beacon", path = "../beacon" }
 crypto = { path = "../../crypto" }
 message = { package = "forest_message", path = "../../vm/message" }
 clock = { path = "../../node/clock" }
-cid = { package = "forest_cid", path = "../../ipld/cid", features = ["serde_derive"] }
+cid = { package = "forest_cid", path = "../../ipld/cid", features = ["cbor"] }
 derive_builder = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 encoding = { package = "forest_encoding", path = "../../encoding" }

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -12,7 +12,7 @@ encoding = { package = "forest_encoding", path = "../encoding" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde_json = { version = "1.0", optional = true }
-base64 = "0.12.0"
+base64 = { version = "0.12.0", optional = true }
 
 [dependencies.cid]
 package = "forest_cid"
@@ -20,4 +20,4 @@ path = "../ipld/cid"
 features = ["cbor"]
 
 [features]
-json = ["serde_json"]
+json = ["serde_json", "base64"]

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 encoding = { package = "forest_encoding", path = "../encoding" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+serde_json = "1.0"
+base64 = "0.12.0"
 
 [dependencies.cid]
 package = "forest_cid"

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -12,7 +12,7 @@ encoding = { package = "forest_encoding", path = "../encoding" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde_json = { version = "1.0", optional = true }
-base64 = { version = "0.12.0", optional = true }
+multibase = { version = "0.8.0", optional = true }
 
 [dependencies.cid]
 package = "forest_cid"
@@ -20,4 +20,4 @@ path = "../ipld/cid"
 features = ["cbor"]
 
 [features]
-json = ["serde_json", "base64"]
+json = ["serde_json", "multibase"]

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -4,14 +4,20 @@ version = "0.1.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+features = ["json"]
+
 [dependencies]
 encoding = { package = "forest_encoding", path = "../encoding" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-serde_json = "1.0"
+serde_json = { version = "1.0", optional = true }
 base64 = "0.12.0"
 
 [dependencies.cid]
 package = "forest_cid"
 path = "../ipld/cid"
 features = ["cbor"]
+
+[features]
+json = ["serde_json"]

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -12,4 +12,4 @@ thiserror = "1.0"
 [dependencies.cid]
 package = "forest_cid"
 path = "../ipld/cid"
-features = ["serde_derive"]
+features = ["cbor"]

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 unsigned-varint = "0.3.1"
-cid = { package = "forest_cid", path = "../cid", features = ["serde_derive"] }
+cid = { package = "forest_cid", path = "../cid", features = ["cbor"] }
 forest_encoding = { path = "../../encoding" }
 blockstore = { package = "ipld_blockstore", path = "../blockstore" }
 serde = { version = "1.0", features = ["derive"] }

--- a/ipld/cid/Cargo.toml
+++ b/ipld/cid/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["cbor"]
+features = ["cbor", "json"]
 
 [dependencies]
 multihash = "0.10.0"
@@ -16,5 +16,9 @@ serde_cbor = { version = "0.11.0", features = ["tags"], optional = true }
 serde_bytes = { version = "0.11.3", optional = true }
 thiserror = "1.0"
 
+[dev-dependencies]
+serde_json = "1.0"
+
 [features]
 cbor = ["serde", "serde_bytes", "serde_cbor"]
+json = ["serde"]

--- a/ipld/cid/Cargo.toml
+++ b/ipld/cid/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["serde_derive"]
+features = ["cbor"]
 
 [dependencies]
 multihash = "0.10.0"
@@ -17,4 +17,4 @@ serde_bytes = { version = "0.11.3", optional = true }
 thiserror = "1.0"
 
 [features]
-serde_derive = ["serde", "serde_bytes", "serde_cbor"]
+cbor = ["serde", "serde_bytes", "serde_cbor"]

--- a/ipld/cid/src/json.rs
+++ b/ipld/cid/src/json.rs
@@ -1,0 +1,37 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::Cid;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+/// Wrapper for serializing and deserializing a Cid from JSON.
+#[derive(Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct CidJson(#[serde(with = "self")] pub Cid);
+
+/// Wrapper for serializing a cid reference to JSON.
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct CidJsonRef<'a>(#[serde(with = "self")] pub &'a Cid);
+
+pub fn serialize<S>(c: &Cid, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    CidMap { cid: c.to_string() }.serialize(serializer)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Cid, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let CidMap { cid } = Deserialize::deserialize(deserializer)?;
+    cid.parse().map_err(de::Error::custom)
+}
+
+/// Struct just used as a helper to serialize a cid into a map with key "/"
+#[derive(Serialize, Deserialize)]
+struct CidMap {
+    #[serde(rename = "/")]
+    cid: String,
+}

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -31,6 +31,9 @@ const CBOR_TAG_CID: u64 = 42;
 #[cfg(feature = "cbor")]
 const MULTIBASE_IDENTITY: u8 = 0;
 
+#[cfg(feature = "json")]
+pub mod json;
+
 /// Prefix represents all metadata of a CID, without the actual content.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Prefix {

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -17,18 +17,18 @@ use std::convert::TryInto;
 use std::fmt;
 use std::io::Cursor;
 
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "cbor")]
 use serde::{de, ser};
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "cbor")]
 use serde_cbor::tags::Tagged;
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "cbor")]
 use std::convert::TryFrom;
 
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "cbor")]
 const CBOR_TAG_CID: u64 = 42;
 /// multibase identity prefix
 /// https://github.com/ipld/specs/blob/master/block-layer/codecs/dag-cbor.md#link-format
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "cbor")]
 const MULTIBASE_IDENTITY: u8 = 0;
 
 /// Prefix represents all metadata of a CID, without the actual content.
@@ -53,7 +53,7 @@ impl Default for Cid {
     }
 }
 
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "cbor")]
 impl ser::Serialize for Cid {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
@@ -75,7 +75,7 @@ impl ser::Serialize for Cid {
     }
 }
 
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "cbor")]
 impl<'de> de::Deserialize<'de> for Cid {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/ipld/cid/tests/json_tests.rs
+++ b/ipld/cid/tests/json_tests.rs
@@ -1,0 +1,61 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+#![cfg(feature = "json")]
+
+use forest_cid::{
+    json::{self, CidJson, CidJsonRef},
+    Cid,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{from_str, to_string};
+
+#[test]
+fn symmetric_json_serialization() {
+    let cid: Cid = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
+        .parse()
+        .unwrap();
+    let cid_json = r#"{"/":"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"}"#;
+
+    // Deserialize
+    let CidJson(cid_d) = from_str(cid_json).unwrap();
+    assert_eq!(&cid_d, &cid, "Deserialized cid does not match");
+
+    // Serialize
+    let ser_cid = to_string(&CidJsonRef(&cid_d)).unwrap();
+    assert_eq!(ser_cid, cid_json);
+}
+
+#[test]
+fn annotating_struct_json() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct TestStruct {
+        #[serde(with = "json")]
+        cid_one: Cid,
+        #[serde(with = "json")]
+        cid_two: Cid,
+        other: String,
+    }
+    let test_json = r#"
+            {
+                "cid_one": {
+                    "/": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
+                },
+                "cid_two": {
+                    "/": "bafy2bzaceaa466o2jfc4g4ggrmtf55ygigvkmxvkr5mvhy4qbwlxetbmlkqjk"
+                },
+                "other": "Some data"
+            }
+        "#;
+    let expected = TestStruct {
+        cid_one: "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
+            .parse()
+            .unwrap(),
+        cid_two: "bafy2bzaceaa466o2jfc4g4ggrmtf55ygigvkmxvkr5mvhy4qbwlxetbmlkqjk"
+            .parse()
+            .unwrap(),
+        other: "Some data".to_owned(),
+    };
+
+    assert_eq!(from_str::<TestStruct>(test_json).unwrap(), expected);
+}

--- a/ipld/cid/tests/serde_tests.rs
+++ b/ipld/cid/tests/serde_tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-#![cfg(feature = "serde_derive")]
+#![cfg(feature = "cbor")]
 
 use forest_cid::Cid;
 use multihash::Blake2b256;

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -255,7 +255,7 @@ where
             Pointer::Values(vals) => {
                 // Update, if the key already exists.
                 if let Some(i) = vals.iter().position(|p| p.key() == &key) {
-                    std::mem::replace(&mut vals[i].1, value);
+                    vals[i].1 = value;
                     return Ok(());
                 }
 

--- a/ipld/src/error.rs
+++ b/ipld/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use encoding::error::Error as CborError;
 use serde::ser;
 use std::fmt;
 use thiserror::Error;
@@ -17,5 +18,11 @@ pub enum Error {
 impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Error {
         Error::Encoding(msg.to_string())
+    }
+}
+
+impl From<CborError> for Error {
+    fn from(e: CborError) -> Error {
+        Error::Encoding(e.to_string())
     }
 }

--- a/ipld/src/json.rs
+++ b/ipld/src/json.rs
@@ -169,12 +169,12 @@ impl<'de> de::Visitor<'de> for JSONVisitor {
             if let Some(v) = map.get("/") {
                 match v {
                     Ipld::String(s) => {
-                        // Json block is a Cid
+                        // { "/": ".." } Json block is a Cid
                         return Ok(Ipld::Link(s.parse().map_err(de::Error::custom)?));
                     }
                     Ipld::Map(obj) => {
-                        // Are other bytes encoding types supported?
                         if let Some(Ipld::String(s)) = obj.get(BYTES_JSON_KEY) {
+                            // { "/": { "bytes": "<multibase>" } } Json block are bytes encoded
                             let (_, bz) = multibase::decode(s)
                                 .map_err(|e| de::Error::custom(e.to_string()))?;
                             return Ok(Ipld::Bytes(bz));

--- a/ipld/src/json.rs
+++ b/ipld/src/json.rs
@@ -62,13 +62,13 @@ impl TryFrom<&Ipld> for JsonValue {
             Ipld::Bytes(bz) => json!({ "/": { "base64": base64::encode(bz) } }),
             Ipld::Link(cid) => json!({ "/": cid.to_string() }),
             Ipld::List(list) => JsonValue::Array(
-                list.into_iter()
+                list.iter()
                     .map(JsonValue::try_from)
                     .collect::<Result<_, _>>()?,
             ),
             Ipld::Map(map) => {
                 let mut new = Map::new();
-                for (k, v) in map.into_iter() {
+                for (k, v) in map.iter() {
                     new.insert(k.to_string(), JsonValue::try_from(v)?);
                 }
                 JsonValue::Object(new)

--- a/ipld/src/json.rs
+++ b/ipld/src/json.rs
@@ -1,0 +1,140 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::Ipld;
+use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{json, Map, Number, Value as JsonValue};
+use std::collections::BTreeMap;
+use std::convert::{TryFrom, TryInto};
+
+/// Wrapper for serializing and deserializing a Ipld from JSON.
+#[derive(Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct IpldJson(#[serde(with = "self")] pub Ipld);
+
+/// Wrapper for serializing a ipld reference to JSON.
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct IpldJsonRef<'a>(#[serde(with = "self")] pub &'a Ipld);
+
+// TODO serialize and deserialize should not have to go through a Json value buffer
+// (unnecessary clones and copies) but the efficiency for JSON shouldn't matter too much
+
+pub fn serialize<S>(ipld: &Ipld, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    JsonValue::try_from(ipld)
+        .map_err(ser::Error::custom)?
+        .serialize(serializer)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Ipld, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(JsonValue::deserialize(deserializer)?
+        .try_into()
+        .map_err(de::Error::custom)?)
+}
+
+impl TryFrom<&Ipld> for JsonValue {
+    type Error = &'static str;
+
+    fn try_from(ipld: &Ipld) -> Result<Self, Self::Error> {
+        let val = match ipld {
+            Ipld::Null => JsonValue::Null,
+            Ipld::Bool(b) => JsonValue::Bool(*b),
+            Ipld::Integer(i) => {
+                let i = *i;
+                if i < 0 {
+                    let c = i64::try_from(i).map_err(|_| "Invalid precision for json number")?;
+                    JsonValue::Number(c.into())
+                } else {
+                    let c = u64::try_from(i).map_err(|_| "Invalid precision for json number")?;
+                    JsonValue::Number(c.into())
+                }
+            }
+            Ipld::Float(f) => JsonValue::Number(
+                Number::from_f64(*f).ok_or("Float does not have finite precision")?,
+            ),
+            Ipld::String(s) => JsonValue::String(s.clone()),
+            Ipld::Bytes(bz) => json!({ "/": { "base64": base64::encode(bz) } }),
+            Ipld::Link(cid) => json!({ "/": cid.to_string() }),
+            Ipld::List(list) => JsonValue::Array(
+                list.into_iter()
+                    .map(JsonValue::try_from)
+                    .collect::<Result<_, _>>()?,
+            ),
+            Ipld::Map(map) => {
+                let mut new = Map::new();
+                for (k, v) in map.into_iter() {
+                    new.insert(k.to_string(), JsonValue::try_from(v)?);
+                }
+                JsonValue::Object(new)
+            }
+        };
+        Ok(val)
+    }
+}
+
+impl TryFrom<JsonValue> for Ipld {
+    type Error = &'static str;
+
+    fn try_from(json: JsonValue) -> Result<Self, Self::Error> {
+        let val = match json {
+            JsonValue::Null => Ipld::Null,
+            JsonValue::Bool(b) => Ipld::Bool(b),
+            JsonValue::Number(n) => {
+                if let Some(v) = n.as_u64() {
+                    Ipld::Integer(v.into())
+                } else if let Some(v) = n.as_i64() {
+                    Ipld::Integer(v.into())
+                } else if let Some(v) = n.as_f64() {
+                    Ipld::Float(v)
+                } else {
+                    // Json number can only be one of those three types
+                    unreachable!()
+                }
+            }
+            JsonValue::String(s) => Ipld::String(s),
+            JsonValue::Array(values) => Ipld::List(
+                values
+                    .into_iter()
+                    .map(Ipld::try_from)
+                    .collect::<Result<_, _>>()?,
+            ),
+            JsonValue::Object(map) => {
+                // Check for escaped values (Bytes and Cids)
+                if map.len() == 1 {
+                    if let Some(v) = map.get("/") {
+                        match v {
+                            JsonValue::String(s) => {
+                                // Json block is a Cid
+                                return Ok(Ipld::Link(
+                                    s.parse().map_err(|_| "Failed not parse cid string")?,
+                                ));
+                            }
+                            JsonValue::Object(obj) => {
+                                // Are other bytes encoding types supported?
+                                if let Some(JsonValue::String(bz)) = obj.get("base64") {
+                                    return Ok(Ipld::Bytes(
+                                        base64::decode(bz)
+                                            .map_err(|_| "Failed to parse base64 bytes")?,
+                                    ));
+                                }
+                            }
+                            _ => (),
+                        }
+                    }
+                }
+                let mut new = BTreeMap::new();
+                for (k, v) in map.into_iter() {
+                    new.insert(k, Ipld::try_from(v)?);
+                }
+                Ipld::Map(new)
+            }
+        };
+        Ok(val)
+    }
+}

--- a/ipld/src/json.rs
+++ b/ipld/src/json.rs
@@ -3,7 +3,7 @@
 
 use super::{ipld, Ipld};
 use multibase::Base;
-use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
 use std::fmt;
 
@@ -170,7 +170,7 @@ impl<'de> de::Visitor<'de> for JSONVisitor {
                 match v {
                     Ipld::String(s) => {
                         // Json block is a Cid
-                        return Ok(Ipld::Link(s.parse().map_err(|e| de::Error::custom(e))?));
+                        return Ok(Ipld::Link(s.parse().map_err(de::Error::custom)?));
                     }
                     Ipld::Map(obj) => {
                         // Are other bytes encoding types supported?

--- a/ipld/src/lib.rs
+++ b/ipld/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod de;
 mod error;
+pub mod json;
 mod ser;
 
 pub use self::error::Error;

--- a/ipld/src/lib.rs
+++ b/ipld/src/lib.rs
@@ -8,6 +8,9 @@ mod ser;
 #[cfg(feature = "json")]
 pub mod json;
 
+#[macro_use]
+mod macros;
+
 pub use self::error::Error;
 
 use cid::Cid;

--- a/ipld/src/lib.rs
+++ b/ipld/src/lib.rs
@@ -113,7 +113,10 @@ pub fn from_ipld<T>(value: &Ipld) -> Result<T, String>
 where
     T: DeserializeOwned,
 {
-    // TODO find a way to convert without going through byte buffer
+    // TODO update to not go through byte buffer to convert
+    // There is a good amount of overhead for this (having to implement serde::Deserializer)
+    // for Ipld, but possible. The benefit isn't worth changing yet since if the value is not
+    // passed by reference as needed by HAMT, then the values will have to be cloned.
     let buf = to_vec(value).map_err(|e| e.to_string())?;
     from_slice(buf.as_slice()).map_err(|e| e.to_string())
 }

--- a/ipld/src/lib.rs
+++ b/ipld/src/lib.rs
@@ -88,11 +88,15 @@ pub enum Ipld {
     Map(BTreeMap<String, Ipld>),
 
     /// Represents a link to another piece of data through a content identifier (`Cid`).
+    /// Using `ipld` macro, can wrap Cid with Link to be explicit of Link type, or let it resolve.
     ///
     /// ```
     /// # use forest_ipld::ipld;
     /// # use cid::Cid;
-    /// let v = ipld!(Link(Cid::default()));
+    /// let cid: Cid = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n".parse().unwrap();
+    /// let v1 = ipld!(Link(cid.clone()));
+    /// let v2 = ipld!(cid);
+    /// assert_eq!(v1, v2);
     /// ```
     Link(Cid),
 }

--- a/ipld/src/lib.rs
+++ b/ipld/src/lib.rs
@@ -25,7 +25,7 @@ use std::collections::BTreeMap;
 pub enum Ipld {
     /// Represents a null value.
     ///
-    /// ```
+    /// ```no_run
     /// # use forest_ipld::ipld;
     /// let v = ipld!(null);
     /// ```
@@ -33,7 +33,7 @@ pub enum Ipld {
 
     /// Represents a boolean value.
     ///
-    /// ```
+    /// ```no_run
     /// # use forest_ipld::ipld;
     /// let v = ipld!(true);
     /// ```
@@ -41,7 +41,7 @@ pub enum Ipld {
 
     /// Represents a signed integer value.
     ///
-    /// ```
+    /// ```no_run
     /// # use forest_ipld::ipld;
     /// let v = ipld!(28);
     /// ```
@@ -49,7 +49,7 @@ pub enum Ipld {
 
     /// Represents a floating point value.
     ///
-    /// ```
+    /// ```no_run
     /// # use forest_ipld::ipld;
     /// let v = ipld!(8.5);
     /// ```
@@ -57,7 +57,7 @@ pub enum Ipld {
 
     /// Represents a String.
     ///
-    /// ```
+    /// ```no_run
     /// # use forest_ipld::ipld;
     /// let v = ipld!("string");
     /// ```
@@ -65,7 +65,7 @@ pub enum Ipld {
 
     /// Represents Bytes.
     ///
-    /// ```
+    /// ```no_run
     /// # use forest_ipld::ipld;
     /// let v = ipld!(Bytes(vec![0x98, 0x8, 0x2a, 0xff]));
     /// ```
@@ -73,7 +73,7 @@ pub enum Ipld {
 
     /// Represents List of IPLD objects.
     ///
-    /// ```
+    /// ```no_run
     /// # use forest_ipld::ipld;
     /// let v = ipld!([1, "string", null]);
     /// ```
@@ -81,7 +81,7 @@ pub enum Ipld {
 
     /// Represents a map of strings to Ipld objects.
     ///
-    /// ```
+    /// ```no_run
     /// # use forest_ipld::ipld;
     /// let v = ipld!({"key": "value", "bool": true});
     /// ```

--- a/ipld/src/lib.rs
+++ b/ipld/src/lib.rs
@@ -20,17 +20,80 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::BTreeMap;
 
-/// Represents IPLD data structure used when serializing and deserializing data
+/// Represents IPLD data structure used when serializing and deserializing data.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Ipld {
+    /// Represents a null value.
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// let v = ipld!(null);
+    /// ```
     Null,
+
+    /// Represents a boolean value.
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// let v = ipld!(true);
+    /// ```
     Bool(bool),
+
+    /// Represents a signed integer value.
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// let v = ipld!(28);
+    /// ```
     Integer(i128),
+
+    /// Represents a floating point value.
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// let v = ipld!(8.5);
+    /// ```
     Float(f64),
+
+    /// Represents a String.
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// let v = ipld!("string");
+    /// ```
     String(String),
+
+    /// Represents Bytes.
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// let v = ipld!(Bytes(vec![0x98, 0x8, 0x2a, 0xff]));
+    /// ```
     Bytes(Vec<u8>),
+
+    /// Represents List of IPLD objects.
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// let v = ipld!([1, "string", null]);
+    /// ```
     List(Vec<Ipld>),
+
+    /// Represents a map of strings to Ipld objects.
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// let v = ipld!({"key": "value", "bool": true});
+    /// ```
     Map(BTreeMap<String, Ipld>),
+
+    /// Represents a link to another piece of data through a content identifier (`Cid`).
+    ///
+    /// ```
+    /// # use forest_ipld::ipld;
+    /// # use cid::Cid;
+    /// let v = ipld!(Link(Cid::default()));
+    /// ```
     Link(Cid),
 }
 

--- a/ipld/src/lib.rs
+++ b/ipld/src/lib.rs
@@ -3,8 +3,10 @@
 
 mod de;
 mod error;
-pub mod json;
 mod ser;
+
+#[cfg(feature = "json")]
+pub mod json;
 
 pub use self::error::Error;
 

--- a/ipld/src/macros.rs
+++ b/ipld/src/macros.rs
@@ -13,8 +13,8 @@
 /// let value = ipld!({
 ///     "code": 200,
 ///     "success": true,
-///     "link": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n".parse::<Cid>().unwrap(),
-///     "bytes": vec![0x1, 0xfa, 0x8b],
+///     "link": Link("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n".parse().unwrap()),
+///     "bytes": Bytes(vec![0x1, 0xfa, 0x8b]),
 ///     "payload": {
 ///         "features": [
 ///             "serde",

--- a/ipld/src/macros.rs
+++ b/ipld/src/macros.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 /// Construct a `forest_ipld::Ipld` roughly matching JSON format. This code is a modified version
 /// of `serde_json::json` macro, with extensions for being able to indicate links and bytes.
 /// These two matterns can be matched by wrapping `Cid` link in `Link(..)` or the `Vec<u8>` in

--- a/ipld/src/macros.rs
+++ b/ipld/src/macros.rs
@@ -1,0 +1,321 @@
+/// Construct a `forest_ipld::Ipld` roughly matching JSON format. This code is a modified version
+/// of `serde_json::json` macro, with extensions for being able to indicate links and bytes.
+/// These two matterns can be matched by wrapping `Cid` link in `Link(..)` or the `Vec<u8>` in
+/// `Bytes()`.
+///
+/// ```
+/// # use forest_ipld::ipld;
+/// # use cid::Cid;
+/// #
+/// let value = ipld!({
+///     "code": 200,
+///     "success": true,
+///     "link": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n".parse::<Cid>().unwrap(),
+///     "bytes": vec![0x1, 0xfa, 0x8b],
+///     "payload": {
+///         "features": [
+///             "serde",
+///             "ipld"
+///         ]
+///     }
+/// });
+/// ```
+///
+/// Variables or expressions can be interpolated into the JSON literal. Any type
+/// interpolated into an array element or object value must implement Serde's
+/// `Serialize` trait, while any type interpolated into a object key must
+/// implement `Into<String>`. If the `Serialize` implementation of the
+/// interpolated type decides to fail, or if the interpolated type contains a
+/// map with non-string keys, the `ipld!` macro will panic.
+///
+/// ```
+/// # use forest_ipld::ipld;
+/// #
+/// let code = 200;
+/// let features = vec!["serde", "ipld"];
+///
+/// let value = ipld!({
+///     "code": code,
+///     "success": code == 200,
+///     "payload": {
+///         features[0]: features[1]
+///     }
+/// });
+/// ```
+///
+/// Trailing commas are allowed inside both arrays and objects.
+///
+/// ```
+/// # use forest_ipld::ipld;
+/// #
+/// let value = ipld!([
+///     "notice",
+///     "the",
+///     "trailing",
+///     "comma -->",
+/// ]);
+/// ```
+#[macro_export(local_inner_macros)]
+macro_rules! ipld {
+    // Hide distracting implementation details from the generated rustdoc.
+    ($($ipld:tt)+) => {
+        ipld_internal!($($ipld)+)
+    };
+}
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! ipld_internal {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: ipld_internal!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        ipld_internal_vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        ipld_internal_vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!(false)] $($rest)*)
+    };
+
+    // * Next element is a `Link`.
+    (@array [$($elems:expr,)*] Link($cid:expr) $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!(Link($cid))] $($rest)*)
+    };
+
+    // * Next element is `Bytes`.
+    (@array [$($elems:expr,)*] Bytes($bz:expr) $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!(Bytes($bz))] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        ipld_internal!(@array [$($elems,)* ipld_internal!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        ipld_internal!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        ipld_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: ipld_internal!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        ipld_internal!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        ipld_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!(false)) $($rest)*);
+    };
+
+    // * Next value is a `Link`.
+    (@object $object:ident ($($key:tt)+) (: Link($cid:expr) $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!(Link($cid))) $($rest)*);
+    };
+
+    // * Next value is `Bytes`
+    (@object $object:ident ($($key:tt)+) (: Bytes($bz:expr) $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!(Bytes($bz))) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        ipld_internal!(@object $object [$($key)+] (ipld_internal!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        ipld_internal!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        ipld_internal!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        ipld_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        ipld_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        ipld_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: ipld_internal!($($ipld)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        $crate::Ipld::Null
+    };
+
+    (true) => {
+        $crate::Ipld::Bool(true)
+    };
+
+    (false) => {
+        $crate::Ipld::Bool(false)
+    };
+
+    // * Cid link pattern
+    (Link($cid:expr)) => {
+        $crate::Ipld::Link($cid)
+    };
+
+    // * Bytes pattern
+    (Bytes($bz:expr)) => {
+        $crate::Ipld::Bytes($bz)
+    };
+
+    ([]) => {
+        $crate::Ipld::List(ipld_internal_vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::Ipld::List(ipld_internal!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        $crate::Ipld::Map(::std::collections::BTreeMap::new())
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::Ipld::Map({
+            let mut object = ::std::collections::BTreeMap::new();
+            ipld_internal!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {
+        $crate::to_ipld(&$other).unwrap()
+    };
+}
+
+// The ipld_internal macro above cannot invoke vec directly because it uses
+// local_inner_macros. A vec invocation there would resolve to $crate::vec.
+// Instead invoke vec here outside of local_inner_macros.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! ipld_internal_vec {
+    ($($content:tt)*) => {
+        vec![$($content)*]
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! ipld_unexpected {
+    () => {};
+}

--- a/ipld/tests/cbor_test.rs
+++ b/ipld/tests/cbor_test.rs
@@ -3,9 +3,8 @@
 
 use cid::{multihash::Blake2b256, Cid};
 use encoding::{from_slice, to_vec};
-use forest_ipld::Ipld;
+use forest_ipld::{ipld, Ipld};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Clone)]
 struct TestStruct {
@@ -30,8 +29,8 @@ fn encode_new_type() {
 
     // Test ipld decoding
     let ipld_decoded: Ipld = from_slice(&struct_encoded).unwrap();
-    let mut e_map = BTreeMap::<String, Ipld>::new();
-    e_map.insert("details".to_string(), Ipld::Link(details));
-    e_map.insert("name".to_string(), Ipld::String(name));
-    assert_eq!(&ipld_decoded, &Ipld::Map(e_map));
+    assert_eq!(
+        &ipld_decoded,
+        &ipld!({"details": Link(details), "name": "Test"})
+    );
 }

--- a/ipld/tests/json_tests.rs
+++ b/ipld/tests/json_tests.rs
@@ -4,13 +4,12 @@
 #![cfg(feature = "json")]
 
 use forest_ipld::{
+    ipld,
     json::{self, IpldJson, IpldJsonRef},
     Ipld,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{from_str, to_string};
-use std::collections::BTreeMap;
-use std::iter::FromIterator;
 
 #[test]
 fn deserialize_json_symmetric() {
@@ -30,41 +29,20 @@ fn deserialize_json_symmetric() {
         "list": [null, { "/": "bafy2bzaceaa466o2jfc4g4ggrmtf55ygigvkmxvkr5mvhy4qbwlxetbmlkqjk" }, 1]
     }
     "#;
-    let expected = Ipld::Map(BTreeMap::from_iter(
-        [
-            (
-                "link".to_owned(),
-                Ipld::Link(
-                    "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
-                        .parse()
-                        .unwrap(),
-                ),
-            ),
-            (
-                "bytes".to_owned(),
-                Ipld::Bytes([0x54, 0x68, 0x65, 0x20, 0x71, 0x75, 0x69].to_vec()),
-            ),
-            ("string".to_owned(), Ipld::String("Some data".to_owned())),
-            ("float".to_owned(), Ipld::Float(10.5)),
-            ("integer".to_owned(), Ipld::Integer(8)),
-            ("neg_integer".to_owned(), Ipld::Integer(-20)),
-            ("null".to_owned(), Ipld::Null),
-            (
-                "list".to_owned(),
-                Ipld::List(vec![
-                    Ipld::Null,
-                    Ipld::Link(
-                        "bafy2bzaceaa466o2jfc4g4ggrmtf55ygigvkmxvkr5mvhy4qbwlxetbmlkqjk"
-                            .parse()
-                            .unwrap(),
-                    ),
-                    Ipld::Integer(1),
-                ]),
-            ),
-        ]
-        .to_vec()
-        .into_iter(),
-    ));
+    let expected = ipld!({
+        "link": Link("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n".parse().unwrap()),
+        "bytes": Bytes(vec![0x54, 0x68, 0x65, 0x20, 0x71, 0x75, 0x69]),
+        "string": "Some data",
+        "float": 10.5,
+        "integer": 8,
+        "neg_integer": -20,
+        "null": null,
+        "list": [
+            null,
+            Link("bafy2bzaceaa466o2jfc4g4ggrmtf55ygigvkmxvkr5mvhy4qbwlxetbmlkqjk".parse().unwrap()),
+            1,
+        ],
+    });
 
     // Assert deserializing into expected Ipld
     let IpldJson(ipld_d) = from_str(test_json).unwrap();
@@ -91,14 +69,14 @@ fn annotating_struct_json() {
             }
         "#;
     let expected = TestStruct {
-        one: Ipld::List(vec![
-            Ipld::Link(
+        one: ipld!([
+            Link(
                 "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
                     .parse()
-                    .unwrap(),
+                    .unwrap()
             ),
-            Ipld::Null,
-            Ipld::Integer(8),
+            null,
+            8
         ]),
         other: "Some data".to_owned(),
     };
@@ -110,17 +88,8 @@ fn annotating_struct_json() {
 fn link_edge_case() {
     // Test ported from go-ipld-prime (making sure edge case is handled)
     let test_json = r#"{"/":{"/":"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"}}"#;
-    let expected = Ipld::Map(BTreeMap::from_iter(
-        [(
-            "/".to_owned(),
-            Ipld::Link(
-                "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
-                    .parse()
-                    .unwrap(),
-            ),
-        )]
-        .to_vec(),
-    ));
+    let expected =
+        ipld!({"/": Link("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n".parse().unwrap())});
 
     let IpldJson(ipld_d) = from_str(test_json).unwrap();
     assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");

--- a/ipld/tests/json_tests.rs
+++ b/ipld/tests/json_tests.rs
@@ -103,3 +103,24 @@ fn annotating_struct_json() {
 
     assert_eq!(from_str::<TestStruct>(test_json).unwrap(), expected);
 }
+
+#[test]
+fn link_edge_case() {
+    // Test ported from go-ipld-prime (making sure edge case is handled)
+    let test_json = r#"{"/":{"/":"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"}}"#;
+    let expected = Ipld::Map(BTreeMap::from_iter(
+        [(
+            "/".to_owned(),
+            Ipld::Link(
+                "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
+                    .parse()
+                    .unwrap(),
+            ),
+        )]
+        .to_vec(),
+    ));
+
+    let IpldJson(ipld_d) = from_str(test_json).unwrap();
+    assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
+}
+

--- a/ipld/tests/json_tests.rs
+++ b/ipld/tests/json_tests.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+#![cfg(feature = "json")]
+
 use forest_ipld::{
     json::{self, IpldJson, IpldJsonRef},
     Ipld,
@@ -123,4 +125,3 @@ fn link_edge_case() {
     let IpldJson(ipld_d) = from_str(test_json).unwrap();
     assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
 }
-

--- a/ipld/tests/json_tests.rs
+++ b/ipld/tests/json_tests.rs
@@ -46,7 +46,7 @@ fn deserialize_json_symmetric() {
 
     // Assert deserializing into expected Ipld
     let IpldJson(ipld_d) = from_str(test_json).unwrap();
-    // assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
+    assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
 
     // Symmetric tests
     let ser_json = to_string(&IpldJsonRef(&expected)).unwrap();

--- a/ipld/tests/json_tests.rs
+++ b/ipld/tests/json_tests.rs
@@ -19,7 +19,7 @@ fn deserialize_json_symmetric() {
             "/": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
         },
         "bytes": {
-            "/": { "base64": "VGhlIHF1aQ==" }
+            "/": { "bytes": "VGhlIHF1aQ==" }
         },
         "string": "Some data",
         "float": 10.5,
@@ -50,6 +50,7 @@ fn deserialize_json_symmetric() {
 
     // Symmetric tests
     let ser_json = to_string(&IpldJsonRef(&expected)).unwrap();
+    println!("{}", ser_json);
     let IpldJson(ipld_d) = from_str(&ser_json).unwrap();
     assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
 }

--- a/ipld/tests/json_tests.rs
+++ b/ipld/tests/json_tests.rs
@@ -1,0 +1,104 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use forest_ipld::{
+    json::{self, IpldJson, IpldJsonRef},
+    Ipld,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{from_str, to_string, Value};
+use std::collections::BTreeMap;
+use std::iter::FromIterator;
+
+#[test]
+fn deserialize_json_symmetric() {
+    let test_json = r#"
+    {
+        "link": {
+            "/": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
+        },
+        "bytes": {
+            "/": { "base64": "VGhlIHF1aQ==" }
+        },
+        "string": "Some data",
+        "float": 10.5,
+        "integer": 8,
+        "neg_integer": -20,
+        "null": null,
+        "list": [null, { "/": "bafy2bzaceaa466o2jfc4g4ggrmtf55ygigvkmxvkr5mvhy4qbwlxetbmlkqjk" }, 1]
+    }
+    "#;
+    let expected = Ipld::Map(BTreeMap::from_iter(
+        [
+            (
+                "link".to_owned(),
+                Ipld::Link(
+                    "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
+                        .parse()
+                        .unwrap(),
+                ),
+            ),
+            (
+                "bytes".to_owned(),
+                Ipld::Bytes([0x54, 0x68, 0x65, 0x20, 0x71, 0x75, 0x69].to_vec()),
+            ),
+            ("string".to_owned(), Ipld::String("Some data".to_owned())),
+            ("float".to_owned(), Ipld::Float(10.5)),
+            ("integer".to_owned(), Ipld::Integer(8)),
+            ("neg_integer".to_owned(), Ipld::Integer(-20)),
+            ("null".to_owned(), Ipld::Null),
+            (
+                "list".to_owned(),
+                Ipld::List(vec![
+                    Ipld::Null,
+                    Ipld::Link(
+                        "bafy2bzaceaa466o2jfc4g4ggrmtf55ygigvkmxvkr5mvhy4qbwlxetbmlkqjk"
+                            .parse()
+                            .unwrap(),
+                    ),
+                    Ipld::Integer(1),
+                ]),
+            ),
+        ]
+        .to_vec()
+        .into_iter(),
+    ));
+
+    // Assert deserializing into expected Ipld
+    let IpldJson(ipld_d) = from_str(test_json).unwrap();
+    assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
+
+    // Symmetric tests
+    let ser_json = to_string(&IpldJsonRef(&expected)).unwrap();
+    let IpldJson(ipld_d) = from_str(&ser_json).unwrap();
+    assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
+}
+
+// #[derive(Serialize, Deserialize, Clone)]
+// struct TestStruct {
+//     name: String,
+//     details: Cid,
+// }
+
+// #[test]
+// fn encode_new_type() {
+//     let details = Cid::new_from_cbor(&[1, 2, 3], Blake2b256);
+//     let name = "Test".to_string();
+//     let t_struct = TestStruct {
+//         name: name.clone(),
+//         details: details.clone(),
+//     };
+//     let struct_encoded = to_vec(&t_struct).unwrap();
+
+//     // Test to make sure struct can be encoded and decoded without IPLD
+//     let struct_decoded: TestStruct = from_slice(&struct_encoded).unwrap();
+//     assert_eq!(&struct_decoded.name, &name);
+//     assert_eq!(&struct_decoded.details, &details.clone());
+
+//     // Test ipld decoding
+//     let ipld_decoded: Ipld = from_slice(&struct_encoded).unwrap();
+//     let mut e_map = BTreeMap::<String, Ipld>::new();
+//     e_map.insert("details".to_string(), Ipld::Link(details));
+//     e_map.insert("name".to_string(), Ipld::String(name));
+//     assert_eq!(&ipld_decoded, &Ipld::Map(e_map));
+// }

--- a/ipld/tests/json_tests.rs
+++ b/ipld/tests/json_tests.rs
@@ -19,7 +19,7 @@ fn deserialize_json_symmetric() {
             "/": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
         },
         "bytes": {
-            "/": { "bytes": "VGhlIHF1aQ==" }
+            "/": { "bytes": "mVGhlIHF1aQ" }
         },
         "string": "Some data",
         "float": 10.5,
@@ -46,11 +46,10 @@ fn deserialize_json_symmetric() {
 
     // Assert deserializing into expected Ipld
     let IpldJson(ipld_d) = from_str(test_json).unwrap();
-    assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
+    // assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
 
     // Symmetric tests
     let ser_json = to_string(&IpldJsonRef(&expected)).unwrap();
-    println!("{}", ser_json);
     let IpldJson(ipld_d) = from_str(&ser_json).unwrap();
     assert_eq!(&ipld_d, &expected, "Deserialized ipld does not match");
 }

--- a/tests/serialization_tests/Cargo.toml
+++ b/tests/serialization_tests/Cargo.toml
@@ -9,7 +9,7 @@ serde_tests = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-cid = { package = "forest_cid", path = "../../ipld/cid", features = ["serde_derive"] }
+cid = { package = "forest_cid", path = "../../ipld/cid", features = ["cbor"] }
 crypto = { path = "../../crypto" }
 base64 = "0.12.0"
 

--- a/tests/serialization_tests/Cargo.toml
+++ b/tests/serialization_tests/Cargo.toml
@@ -5,15 +5,15 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
 [features]
-serde_tests = []
+serde_tests = ["serde", "crypto", "base64"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-cid = { package = "forest_cid", path = "../../ipld/cid", features = ["cbor"] }
-crypto = { path = "../../crypto" }
-base64 = "0.12.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
+crypto = { path = "../../crypto", optional = true }
+base64 = { version = "0.12.0", optional = true }
 
 [dev-dependencies]
+cid = { package = "forest_cid", path = "../../ipld/cid", features = ["cbor", "json"] }
 serde_json = "1.0"
 hex = "0.4.2"
 vm = { path = "../../vm" }

--- a/tests/serialization_tests/src/lib.rs
+++ b/tests/serialization_tests/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![cfg(feature = "serde_tests")]
 
-use cid::Cid;
 use crypto::Signature;
 use serde::Deserialize;
 
@@ -22,17 +21,5 @@ impl From<SignatureVector> for Signature {
             2 => Signature::new_bls(base64::decode(&v.data).unwrap()),
             _ => panic!("unsupported signature type"),
         }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub struct CidVector {
-    #[serde(alias = "/")]
-    c_str: String,
-}
-
-impl From<CidVector> for Cid {
-    fn from(c: CidVector) -> Self {
-        c.c_str.parse().unwrap()
     }
 }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -9,7 +9,7 @@ num-bigint = { path = "../utils/bigint", package = "forest_bigint" }
 address = { package = "forest_address", path = "./address" }
 encoding = { package = "forest_encoding", path = "../encoding" }
 serde = { version = "1.0", features = ["derive"] }
-cid = { package = "forest_cid", path = "../ipld/cid", features = ["serde_derive"] }
+cid = { package = "forest_cid", path = "../ipld/cid", features = ["cbor"] }
 num-traits = "0.2"
 num-derive = "0.3.0"
 clock = { path = "../node/clock" }

--- a/vm/actor/Cargo.toml
+++ b/vm/actor/Cargo.toml
@@ -13,7 +13,7 @@ encoding = { package = "forest_encoding", path = "../../encoding" }
 num-traits = "0.2"
 num-derive = "0.3.0"
 clock = { path = "../../node/clock" }
-cid = { package = "forest_cid", path = "../../ipld/cid", features = ["serde_derive"] }
+cid = { package = "forest_cid", path = "../../ipld/cid", features = ["cbor"] }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4.0"
 ipld_blockstore = { path = "../../ipld/blockstore" }

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -296,7 +296,7 @@ where
         value: &TokenAmount,
     ) -> Result<Serialized, ActorError> {
         let msg = UnsignedMessage::builder()
-            .to(to.clone())
+            .to(*to)
             .from(*self.message.from())
             .method_num(method)
             .value(value.clone())

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -117,8 +117,8 @@ where
                 .ok_or_else(|| "Failed to query system actor".to_string())?;
 
             let rew_msg = UnsignedMessage::builder()
-                .from(SYSTEM_ACTOR_ADDR.clone())
-                .to(REWARD_ACTOR_ADDR.clone())
+                .from(*SYSTEM_ACTOR_ADDR)
+                .to(*REWARD_ACTOR_ADDR)
                 .sequence(sys_act.sequence)
                 .value(BigUint::zero())
                 .gas_price(BigUint::zero())
@@ -148,8 +148,8 @@ where
             .ok_or_else(|| "Failed to query system actor".to_string())?;
 
         let cron_msg = UnsignedMessage::builder()
-            .from(SYSTEM_ACTOR_ADDR.clone())
-            .to(CRON_ACTOR_ADDR.clone())
+            .from(*SYSTEM_ACTOR_ADDR)
+            .to(*CRON_ACTOR_ADDR)
             .sequence(sys_act.sequence)
             .value(BigUint::zero())
             .gas_price(BigUint::zero())

--- a/vm/runtime/Cargo.toml
+++ b/vm/runtime/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 vm = { path = "../../vm" }
-blocks = { package = "forest_blocks", path = "../../blockchain/blocks/" }
 crypto = { path = "../../crypto" }
 address = { package = "forest_address", path = "../address" }
 message = { package = "forest_message", path = "../message" }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Useful going forward for selectors and testing, implementation is not efficient since the serialization and deserialization requires some theoretically unnecessary clones/copies, but it doesn't matter because this is just JSON and I don't want to fork serde_json or reimplement
  - Added json support for Cids with this (for obvious reasons) but did not for anything outside of IPLD because I don't think it'll be necessary yet
- Updates serialization tests to use Cid json and cleaned up a few other small things

Also added the ipld! macro for fun (makes things a lot easier)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->