### PR TITLE
Clean up tipsets

### DIFF
--- a/blockchain/blocks/src/errors.rs
+++ b/blockchain/blocks/src/errors.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum Error {
     /// Tipset contains invalid data, as described by the string parameter.
     #[error("Invalid tipset: {0}")]
-    InvalidTipSet(String),
+    InvalidTipset(String),
     /// The given tipset has no blocks
     #[error("No blocks for tipset")]
     NoBlocks,

--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -318,8 +318,7 @@ impl BlockHeader {
         const FIXED_BLOCK_DELAY: u64 = 45;
         // check that it is appropriately delayed from its parents including null blocks
         if self.timestamp()
-            < base_tipset.min_timestamp()?
-                + FIXED_BLOCK_DELAY * (self.epoch() - base_tipset.epoch())
+            < base_tipset.min_timestamp() + FIXED_BLOCK_DELAY * (self.epoch() - base_tipset.epoch())
         {
             return Err(Error::Validation(
                 "Header was generated too soon".to_string(),

--- a/blockchain/blocks/src/header.rs
+++ b/blockchain/blocks/src/header.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::{Error, Ticket, TipSetKeys, Tipset};
+use super::{Error, Ticket, Tipset, TipsetKeys};
 use address::Address;
 use beacon::BeaconEntry;
 use cid::{multihash::Blake2b256, Cid};
@@ -30,7 +30,7 @@ const BLOCKS_PER_EPOCH: u64 = 5;
 ///
 /// Usage:
 /// ```
-/// use forest_blocks::{BlockHeader, TipSetKeys, Ticket};
+/// use forest_blocks::{BlockHeader, TipsetKeys, Ticket};
 /// use address::Address;
 /// use cid::{Cid, multihash::Identity};
 /// use num_bigint::BigUint;
@@ -42,7 +42,7 @@ const BLOCKS_PER_EPOCH: u64 = 5;
 ///     .state_root(Cid::new_from_cbor(&[], Identity)) // required
 ///     .miner_address(Address::new_id(0)) // optional
 ///     .bls_aggregate(None) // optional
-///     .parents(TipSetKeys::default()) // optional
+///     .parents(TipsetKeys::default()) // optional
 ///     .weight(BigUint::from(0u8)) // optional
 ///     .epoch(0) // optional
 ///     .timestamp(0) // optional
@@ -58,7 +58,7 @@ pub struct BlockHeader {
     /// but can be several in the case where there were multiple winning ticket-
     /// holders for an epoch
     #[builder(default)]
-    parents: TipSetKeys,
+    parents: TipsetKeys,
 
     /// weight is the aggregate chain weight of the parent set
     #[builder(default)]
@@ -220,7 +220,7 @@ impl BlockHeader {
         BlockHeaderBuilder::default()
     }
     /// Getter for BlockHeader parents
-    pub fn parents(&self) -> &TipSetKeys {
+    pub fn parents(&self) -> &TipsetKeys {
         &self.parents
     }
     /// Getter for BlockHeader weight

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -75,6 +75,7 @@ pub struct Tipset {
     key: TipsetKeys,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl Tipset {
     /// Builds a new Tipset from a collection of blocks.
     /// A valid tipset contains a non-empty collection of blocks that have distinct miners and all
@@ -184,10 +185,6 @@ impl Tipset {
     /// Returns the number of blocks in the tipset
     pub fn len(&self) -> usize {
         self.blocks.len()
-    }
-    /// Returns true if no blocks present in tipset
-    pub fn is_empty(&self) -> bool {
-        self.blocks.is_empty()
     }
     /// Returns a key for the tipset.
     pub fn key(&self) -> &TipsetKeys {

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -14,21 +14,21 @@ use encoding::{
 use num_bigint::BigUint;
 use serde::Deserialize;
 
-/// A set of CIDs forming a unique key for a TipSet.
+/// A set of CIDs forming a unique key for a Tipset.
 /// Equal keys will have equivalent iteration order, but note that the CIDs are *not* maintained in
 /// the same order as the canonical iteration order of blocks in a tipset (which is by ticket)
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default, Ord, PartialOrd)]
-pub struct TipSetKeys {
+pub struct TipsetKeys {
     pub cids: Vec<Cid>,
 }
 
-impl TipSetKeys {
+impl TipsetKeys {
     pub fn new(cids: Vec<Cid>) -> Self {
         Self { cids }
     }
 
     /// checks whether the set contains exactly the same CIDs as another.
-    pub fn equals(&self, key: &TipSetKeys) -> bool {
+    pub fn equals(&self, key: &TipsetKeys) -> bool {
         if self.cids.len() != key.cids.len() {
             return false;
         }
@@ -46,7 +46,7 @@ impl TipSetKeys {
     }
 }
 
-impl ser::Serialize for TipSetKeys {
+impl ser::Serialize for TipsetKeys {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -55,28 +55,28 @@ impl ser::Serialize for TipSetKeys {
     }
 }
 
-impl<'de> de::Deserialize<'de> for TipSetKeys {
+impl<'de> de::Deserialize<'de> for TipsetKeys {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let cids: Vec<Cid> = Deserialize::deserialize(deserializer)?;
-        Ok(TipSetKeys { cids })
+        Ok(TipsetKeys { cids })
     }
 }
 
-impl Cbor for TipSetKeys {}
+impl Cbor for TipsetKeys {}
 
 /// An immutable set of blocks at the same height with the same parent set.
 /// Blocks in a tipset are canonically ordered by ticket size.
 #[derive(Clone, PartialEq, Debug, PartialOrd, Ord, Eq)]
 pub struct Tipset {
     blocks: Vec<BlockHeader>,
-    key: TipSetKeys,
+    key: TipsetKeys,
 }
 
 impl Tipset {
-    /// Builds a new TipSet from a collection of blocks.
+    /// Builds a new Tipset from a collection of blocks.
     /// A valid tipset contains a non-empty collection of blocks that have distinct miners and all
     /// specify identical epoch, parents, weight, height, state root, receipt root;
     /// contentID for headers are supposed to be distinct but until encoding is added will be equal.
@@ -143,7 +143,7 @@ impl Tipset {
         // and the distinct keys
         Ok(Self {
             blocks: sorted_headers,
-            key: TipSetKeys {
+            key: TipsetKeys {
                 // interim until CID check is in place
                 cids,
             },
@@ -190,7 +190,7 @@ impl Tipset {
         self.blocks.is_empty()
     }
     /// Returns a key for the tipset.
-    pub fn key(&self) -> &TipSetKeys {
+    pub fn key(&self) -> &TipsetKeys {
         &self.key
     }
     /// Returns slice of Cids for the current tipset
@@ -198,8 +198,8 @@ impl Tipset {
         &self.key.cids()
     }
     /// Returns the CIDs of the parents of the blocks in the tipset
-    pub fn parents(&self) -> &TipSetKeys {
         &self.blocks[0].parents()
+    pub fn parents(&self) -> &TipsetKeys {
     }
     /// Returns the state root for the tipset parent.
     pub fn parent_state(&self) -> &Cid {
@@ -211,7 +211,7 @@ impl Tipset {
     }
 }
 
-/// FullTipSet is an expanded version of the TipSet that contains all the blocks and messages
+/// FullTipset is an expanded version of the Tipset that contains all the blocks and messages
 #[derive(Debug, PartialEq, Clone)]
 pub struct FullTipset {
     blocks: Vec<Block>,

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -145,9 +145,14 @@ impl Tipset {
             },
         })
     }
+    /// Returns the first block of the tipset
+    fn first_block(&self) -> &BlockHeader {
+        // `Tipset::new` guarantees that `blocks` isn't empty
+        &self.blocks.first().unwrap()
+    }
     /// Returns epoch of the tipset
     pub fn epoch(&self) -> ChainEpoch {
-        self.blocks[0].epoch()
+        self.first_block().epoch()
     }
     /// Returns all blocks in tipset
     pub fn blocks(&self) -> &[BlockHeader] {
@@ -159,7 +164,7 @@ impl Tipset {
     }
     /// Returns the smallest ticket of all blocks in the tipset
     pub fn min_ticket(&self) -> Ticket {
-        self.blocks[0].ticket().clone()
+        self.first_block().ticket().clone()
     }
     /// Returns the smallest timestamp of all blocks in the tipset
     pub fn min_timestamp(&self) -> u64 {
@@ -183,15 +188,15 @@ impl Tipset {
     }
     /// Returns the CIDs of the parents of the blocks in the tipset
     pub fn parents(&self) -> &TipsetKeys {
-        self.blocks[0].parents()
+        self.first_block().parents()
     }
     /// Returns the state root for the tipset parent.
     pub fn parent_state(&self) -> &Cid {
-        self.blocks[0].state_root()
+        self.first_block().state_root()
     }
     /// Returns the tipset's calculated weight
     pub fn weight(&self) -> &BigUint {
-        self.blocks[0].weight()
+        self.first_block().weight()
     }
 }
 
@@ -206,6 +211,11 @@ impl FullTipset {
     pub fn new(blocks: Vec<Block>) -> Self {
         assert!(!blocks.is_empty());
         Self { blocks }
+    }
+    /// Returns the first block of the tipset
+    fn first_block(&self) -> &Block {
+        // `FullTipset::new` guarantees that `blocks` isn't empty
+        &self.blocks.first().unwrap()
     }
     /// Returns reference to all blocks in a full tipset
     pub fn blocks(&self) -> &[Block] {
@@ -229,14 +239,14 @@ impl FullTipset {
     }
     /// Returns the state root for the tipset parent.
     pub fn parent_state(&self) -> &Cid {
-        self.blocks[0].header().state_root()
+        self.first_block().header().state_root()
     }
     /// Returns epoch of the tipset
     pub fn epoch(&self) -> ChainEpoch {
-        self.blocks[0].header().epoch()
+        self.first_block().header().epoch()
     }
     /// Returns the tipset's calculated weight
     pub fn weight(&self) -> &BigUint {
-        self.blocks[0].header().weight()
+        self.first_block().header().weight()
     }
 }

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -27,19 +27,6 @@ impl TipsetKeys {
         Self { cids }
     }
 
-    /// checks whether the set contains exactly the same CIDs as another.
-    pub fn equals(&self, key: &TipsetKeys) -> bool {
-        if self.cids.len() != key.cids.len() {
-            return false;
-        }
-        for i in 0..key.cids.len() {
-            if self.cids[i] != key.cids[i] {
-                return false;
-            }
-        }
-        true
-    }
-
     /// Returns tipset header cids
     pub fn cids(&self) -> &[Cid] {
         &self.cids
@@ -101,7 +88,7 @@ impl Tipset {
             // Skip redundant check
 
             verify(
-                header.parents().equals(first_header.parents()),
+                header.parents() == first_header.parents(),
                 "parent cids are not equal",
             )?;
             verify(

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -70,10 +70,7 @@ impl Tipset {
     /// contentID for headers are supposed to be distinct but until encoding is added will be equal.
     pub fn new(headers: Vec<BlockHeader>) -> Result<Self, Error> {
         // check header is non-empty
-        let (first_header, other_headers) = match headers.split_first() {
-            Some(x) => x,
-            None => return Err(Error::NoBlocks),
-        };
+        let (first_header, other_headers) = headers.split_first().ok_or(Error::NoBlocks)?;
 
         let verify = |predicate: bool, message: &'static str| {
             if predicate {
@@ -85,8 +82,6 @@ impl Tipset {
 
         // loop through headers and validate conditions against 0th header
         for header in other_headers {
-            // Skip redundant check
-
             verify(
                 header.parents() == first_header.parents(),
                 "parent cids are not equal",
@@ -135,7 +130,7 @@ impl Tipset {
     /// Returns the first block of the tipset
     fn first_block(&self) -> &BlockHeader {
         // `Tipset::new` guarantees that `blocks` isn't empty
-        &self.blocks.first().unwrap()
+        self.blocks.first().unwrap()
     }
     /// Returns epoch of the tipset
     pub fn epoch(&self) -> ChainEpoch {
@@ -202,7 +197,7 @@ impl FullTipset {
     /// Returns the first block of the tipset
     fn first_block(&self) -> &Block {
         // `FullTipset::new` guarantees that `blocks` isn't empty
-        &self.blocks.first().unwrap()
+        self.blocks.first().unwrap()
     }
     /// Returns reference to all blocks in a full tipset
     pub fn blocks(&self) -> &[Block] {

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -218,9 +218,10 @@ pub struct FullTipset {
 }
 
 impl FullTipset {
-    /// constructor
-    pub fn new(blks: Vec<Block>) -> Self {
-        Self { blocks: blks }
+    /// constructor, panics when the given vector is empty
+    pub fn new(blocks: Vec<Block>) -> Self {
+        assert!(!blocks.is_empty());
+        Self { blocks }
     }
     /// Returns reference to all blocks in a full tipset
     pub fn blocks(&self) -> &[Block] {

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -163,24 +163,16 @@ impl Tipset {
         self.blocks
     }
     /// Returns the smallest ticket of all blocks in the tipset
-    pub fn min_ticket(&self) -> Result<Ticket, Error> {
-        if self.blocks.is_empty() {
-            return Err(Error::NoBlocks);
-        }
-        Ok(self.blocks[0].ticket().clone())
+    pub fn min_ticket(&self) -> Ticket {
+        self.blocks[0].ticket().clone()
     }
     /// Returns the smallest timestamp of all blocks in the tipset
-    pub fn min_timestamp(&self) -> Result<u64, Error> {
-        if self.blocks.is_empty() {
-            return Err(Error::NoBlocks);
-        }
-        let mut min = self.blocks[0].timestamp();
-        for i in 1..self.blocks.len() {
-            if self.blocks[i].timestamp() < min {
-                min = self.blocks[i].timestamp()
-            }
-        }
-        Ok(min)
+    pub fn min_timestamp(&self) -> u64 {
+        self.blocks
+            .iter()
+            .map(|block| block.timestamp())
+            .min()
+            .unwrap()
     }
     /// Returns the number of blocks in the tipset
     pub fn len(&self) -> usize {

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -1,9 +1,9 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::{Error, TipIndex, TipSetMetadata};
+use super::{Error, TipIndex, TipsetMetadata};
 use actor::{power::State as PowerState, STORAGE_POWER_ACTOR_ADDR};
-use blocks::{Block, BlockHeader, FullTipset, TipSetKeys, Tipset, TxMeta};
+use blocks::{Block, BlockHeader, FullTipset, Tipset, TipsetKeys, TxMeta};
 use cid::Cid;
 use encoding::{de::DeserializeOwned, from_slice, Cbor};
 use ipld_amt::Amt;
@@ -65,7 +65,7 @@ where
     /// Sets tip_index tracker
     pub fn set_tipset_tracker(&mut self, header: &BlockHeader) -> Result<(), Error> {
         let ts: Tipset = Tipset::new(vec![header.clone()])?;
-        let meta = TipSetMetadata {
+        let meta = TipsetMetadata {
             tipset_state_root: header.state_root().clone(),
             tipset_receipts_root: header.message_receipts().clone(),
             tipset: ts,
@@ -146,7 +146,7 @@ where
     }
 
     /// Returns Tipset from key-value store from provided cids
-    pub fn tipset_from_keys(&self, tsk: &TipSetKeys) -> Result<Tipset, Error> {
+    pub fn tipset_from_keys(&self, tsk: &TipsetKeys) -> Result<Tipset, Error> {
         tipset_from_keys(self.db.as_ref(), tsk)
     }
 
@@ -284,14 +284,14 @@ where
     match db.read(HEAD_KEY)? {
         Some(bz) => {
             let keys: Vec<Cid> = from_slice(&bz)?;
-            Ok(Some(tipset_from_keys(db, &TipSetKeys::new(keys))?))
+            Ok(Some(tipset_from_keys(db, &TipsetKeys::new(keys))?))
         }
         None => Ok(None),
     }
 }
 
 /// Returns Tipset from key-value store from provided cids
-fn tipset_from_keys<DB>(db: &DB, tsk: &TipSetKeys) -> Result<Tipset, Error>
+fn tipset_from_keys<DB>(db: &DB, tsk: &TipsetKeys) -> Result<Tipset, Error>
 where
     DB: BlockStore,
 {

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -224,7 +224,8 @@ where
             });
         }
 
-        Ok(FullTipset::new(blocks))
+        // the given tipset has already been verified, so this cannot fail
+        Ok(FullTipset::new(blocks).unwrap())
     }
     /// Determines if provided tipset is heavier than existing known heaviest tipset
     fn update_heaviest(&mut self, ts: &Tipset) -> Result<(), Error> {

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -70,7 +70,8 @@ where
             tipset_receipts_root: header.message_receipts().clone(),
             tipset: ts,
         };
-        Ok(self.tip_index.put(&meta)?)
+        self.tip_index.put(&meta);
+        Ok(())
     }
 
     /// Writes genesis to blockstore
@@ -247,10 +248,6 @@ where
 
     /// Returns the weight of provided tipset
     fn weight(&self, ts: &Tipset) -> Result<BigUint, String> {
-        if ts.is_empty() {
-            return Ok(BigUint::zero());
-        }
-
         let mut tpow = BigUint::zero();
         let state = StateTree::new_from_root(self.db.as_ref(), ts.parent_state())?;
         if let Some(act) = state.get_actor(&*STORAGE_POWER_ACTOR_ADDR)? {

--- a/blockchain/chain/src/store/tip_index.rs
+++ b/blockchain/chain/src/store/tip_index.rs
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::errors::Error;
-use blocks::{TipSetKeys, Tipset};
+use blocks::{Tipset, TipsetKeys};
 use cid::Cid;
 use clock::ChainEpoch;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 
-/// TipSetMetadata is the type stored as the value in the TipIndex hashmap.  It contains
+/// TipsetMetadata is the type stored as the value in the TipIndex hashmap.  It contains
 /// a tipset pointing to blocks, the root cid of the chain's state after
 /// applying the messages in this tipset to it's parent state, and the cid of the receipts
 /// for these messages.
 #[derive(Clone, PartialEq, Debug)]
-pub struct TipSetMetadata {
+pub struct TipsetMetadata {
     /// Root of aggregate state after applying tipset
     pub tipset_state_root: Cid,
 
@@ -33,14 +33,14 @@ pub trait Index: Hash {
     }
 }
 impl Index for ChainEpoch {}
-impl Index for TipSetKeys {}
+impl Index for TipsetKeys {}
 
 /// Tracks tipsets and their states by TipsetKeys and ChainEpoch.
 #[derive(Default)]
 pub struct TipIndex {
     // metadata allows lookup of recorded Tipsets and their state roots
     // by TipsetKey and Epoch
-    metadata: HashMap<u64, TipSetMetadata>,
+    metadata: HashMap<u64, TipsetMetadata>,
 }
 
 impl TipIndex {
@@ -51,7 +51,7 @@ impl TipIndex {
         }
     }
     /// Adds an entry to TipIndex's metadata
-    /// After this call the input TipSetMetadata can be looked up by the TipsetKey of
+    /// After this call the input TipsetMetadata can be looked up by the TipsetKey of
     /// the tipset, or the tipset's epoch
     pub fn put(&mut self, meta: &TipSetMetadata) -> Result<(), Error> {
         if meta.tipset.is_empty() {
@@ -68,7 +68,7 @@ impl TipIndex {
         Ok(())
     }
     /// Returns the tipset given by hashed key
-    fn get(&self, key: u64) -> Result<TipSetMetadata, Error> {
+    fn get(&self, key: u64) -> Result<TipsetMetadata, Error> {
         self.metadata
             .get(&key)
             .cloned()

--- a/blockchain/chain/src/store/tip_index.rs
+++ b/blockchain/chain/src/store/tip_index.rs
@@ -53,10 +53,7 @@ impl TipIndex {
     /// Adds an entry to TipIndex's metadata
     /// After this call the input TipsetMetadata can be looked up by the TipsetKey of
     /// the tipset, or the tipset's epoch
-    pub fn put(&mut self, meta: &TipSetMetadata) -> Result<(), Error> {
-        if meta.tipset.is_empty() {
-            return Err(Error::NoBlocks);
-        }
+    pub fn put(&mut self, meta: &TipsetMetadata) {
         // retrieve parent cids to be used as hash map key
         let parent_key = meta.tipset.parents();
         // retrieve epoch to be used as hash map key
@@ -65,7 +62,6 @@ impl TipIndex {
         self.metadata.insert(parent_key.hash_key(), meta.clone());
         // insert value by epoch_key into hash map
         self.metadata.insert(epoch_key.hash_key(), meta.clone());
-        Ok(())
     }
     /// Returns the tipset given by hashed key
     fn get(&self, key: u64) -> Result<TipsetMetadata, Error> {

--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -5,7 +5,7 @@ use super::network_handler::RPCReceiver;
 use async_std::future;
 use async_std::prelude::*;
 use async_std::sync::{Receiver, Sender};
-use blocks::{FullTipset, TipSetKeys, Tipset};
+use blocks::{FullTipset, Tipset, TipsetKeys};
 use forest_libp2p::{
     blocksync::{BlockSyncRequest, BlockSyncResponse, BLOCKS, MESSAGES},
     hello::HelloMessage,
@@ -52,7 +52,7 @@ impl SyncNetworkContext {
     pub async fn blocksync_headers(
         &mut self,
         peer_id: PeerId,
-        tsk: &TipSetKeys,
+        tsk: &TipsetKeys,
         count: u64,
     ) -> Result<Vec<Tipset>, String> {
         let bs_res = self
@@ -75,7 +75,7 @@ impl SyncNetworkContext {
     pub async fn blocksync_fts(
         &mut self,
         peer_id: PeerId,
-        tsk: &TipSetKeys,
+        tsk: &TipsetKeys,
     ) -> Result<FullTipset, String> {
         let bs_res = self
             .blocksync_request(

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -13,7 +13,7 @@ use amt::Amt;
 use async_std::prelude::*;
 use async_std::sync::{channel, Receiver, Sender};
 use async_std::task;
-use blocks::{Block, FullTipset, TipSetKeys, Tipset, TxMeta};
+use blocks::{Block, FullTipset, Tipset, TipsetKeys, TxMeta};
 use chain::ChainStore;
 use cid::{multihash::Blake2b256, Cid};
 use core::time::Duration;
@@ -148,7 +148,7 @@ where
                     match self
                         .fetch_tipset(
                             source.clone(),
-                            &TipSetKeys::new(message.heaviest_tip_set.clone()),
+                            &TipsetKeys::new(message.heaviest_tip_set.clone()),
                         )
                         .await
                     {
@@ -473,12 +473,12 @@ where
 
         Ok(meta_root)
     }
-    /// Returns FullTipset from store if TipSetKeys exist in key-value store otherwise requests FullTipset
+    /// Returns FullTipset from store if TipsetKeys exist in key-value store otherwise requests FullTipset
     /// from block sync
     async fn fetch_tipset(
         &mut self,
         peer_id: PeerId,
-        tsk: &TipSetKeys,
+        tsk: &TipsetKeys,
     ) -> Result<FullTipset, String> {
         let fts = match self.load_fts(tsk) {
             Ok(fts) => fts,
@@ -488,9 +488,9 @@ where
         Ok(fts)
     }
     /// Returns a reconstructed FullTipset from store if keys exist
-    fn load_fts(&self, keys: &TipSetKeys) -> Result<FullTipset, Error> {
+    fn load_fts(&self, keys: &TipsetKeys) -> Result<FullTipset, Error> {
         let mut blocks = Vec::new();
-        // retrieve tipset from store based on passed in TipSetKeys
+        // retrieve tipset from store based on passed in TipsetKeys
         let ts = self.chain_store.tipset_from_keys(keys)?;
         for header in ts.blocks() {
             // retrieve bls and secp messages from specified BlockHeader
@@ -782,7 +782,7 @@ where
     /// checks to see if tipset is included in bad clocks cache
     fn validate_tipset_against_cache(
         &mut self,
-        ts: &TipSetKeys,
+        ts: &TipsetKeys,
         accepted_blocks: &[Cid],
     ) -> Result<(), Error> {
         for cid in ts.cids() {

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -329,7 +329,7 @@ where
                 secp_messages,
             });
         }
-        Ok(FullTipset::new(blocks))
+        Ok(FullTipset::new(blocks)?)
     }
 
     /// informs the syncer about a new potential tipset
@@ -506,7 +506,7 @@ where
             blocks.push(full_block);
         }
         // construct FullTipset
-        let fts = FullTipset::new(blocks);
+        let fts = FullTipset::new(blocks)?;
         Ok(fts)
     }
     // Block message validation checks

--- a/node/forest_libp2p/src/blocksync/message.rs
+++ b/node/forest_libp2p/src/blocksync/message.rs
@@ -51,7 +51,7 @@ impl<'de> Deserialize<'de> for BlockSyncRequest {
 #[derive(Clone, Debug, PartialEq)]
 pub struct BlockSyncResponse {
     /// The tipsets requested
-    pub chain: Vec<TipSetBundle>,
+    pub chain: Vec<TipsetBundle>,
     /// Error code
     pub status: u64,
     /// Status message indicating failure reason
@@ -98,7 +98,7 @@ impl<'de> Deserialize<'de> for BlockSyncResponse {
 
 /// Contains the blocks and messages in a particular tipset
 #[derive(Clone, Debug, PartialEq)]
-pub struct TipSetBundle {
+pub struct TipsetBundle {
     /// The blocks in the tipset
     pub blocks: Vec<BlockHeader>,
 
@@ -113,16 +113,17 @@ pub struct TipSetBundle {
     pub secp_msg_includes: Vec<Vec<u64>>,
 }
 
-impl TryFrom<TipSetBundle> for FullTipset {
+impl TryFrom<TipsetBundle> for FullTipset {
     type Error = &'static str;
 
-    fn try_from(tsb: TipSetBundle) -> Result<FullTipset, Self::Error> {
+    fn try_from(tsb: TipsetBundle) -> Result<FullTipset, Self::Error> {
         let mut blocks: Vec<Block> = Vec::with_capacity(tsb.blocks.len());
 
+        // TODO: we may already want to check this on construction of the bundle
         if tsb.blocks.len() != tsb.bls_msg_includes.len()
             || tsb.blocks.len() != tsb.secp_msg_includes.len()
         {
-            return Err("Invalid formed TipSet bundle, lengths of includes does not match blocks");
+            return Err("Invalid formed Tipset bundle, lengths of includes does not match blocks");
         }
 
         fn values_from_indexes<T: Clone>(
@@ -157,7 +158,7 @@ impl TryFrom<TipSetBundle> for FullTipset {
     }
 }
 
-impl ser::Serialize for TipSetBundle {
+impl ser::Serialize for TipsetBundle {
     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
     where
         S: Serializer,
@@ -173,14 +174,14 @@ impl ser::Serialize for TipSetBundle {
     }
 }
 
-impl<'de> de::Deserialize<'de> for TipSetBundle {
+impl<'de> de::Deserialize<'de> for TipsetBundle {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let (blocks, bls_msgs, bls_msg_includes, secp_msgs, secp_msg_includes) =
             Deserialize::deserialize(deserializer)?;
-        Ok(TipSetBundle {
+        Ok(TipsetBundle {
             blocks,
             bls_msgs,
             bls_msg_includes,

--- a/node/forest_libp2p/tests/decode_test.rs
+++ b/node/forest_libp2p/tests/decode_test.rs
@@ -43,17 +43,19 @@ fn convert_single_tipset_bundle() {
     .into_result()
     .unwrap();
 
-    assert_eq!(res, [FullTipset::new(vec![block])]);
+    assert_eq!(res, [FullTipset::new(vec![block]).unwrap()]);
 }
 
 #[test]
 fn tipset_bundle_to_full_tipset() {
     let h0 = BlockHeader::builder()
         .weight(BigUint::from(1u32))
+        .miner_address(Address::new_id(0))
         .build()
         .unwrap();
     let h1 = BlockHeader::builder()
-        .weight(BigUint::from(2u32))
+        .weight(BigUint::from(1u32))
+        .miner_address(Address::new_id(1))
         .build()
         .unwrap();
     let ua = UnsignedMessage::builder()
@@ -102,7 +104,7 @@ fn tipset_bundle_to_full_tipset() {
 
     assert_eq!(
         FullTipset::try_from(tsb.clone()).unwrap(),
-        FullTipset::new(vec![b0, b1])
+        FullTipset::new(vec![b0, b1]).unwrap()
     );
 
     // Invalidate tipset bundle by having invalid index

--- a/node/forest_libp2p/tests/decode_test.rs
+++ b/node/forest_libp2p/tests/decode_test.rs
@@ -22,12 +22,17 @@ impl Signer for DummySigner {
 
 #[test]
 fn convert_single_tipset_bundle() {
-    let bundle = TipSetBundle {
-        blocks: Vec::new(),
+    let block = Block {
+        header: BlockHeader::builder().build().unwrap(),
+        bls_messages: Vec::new(),
+        secp_messages: Vec::new(),
+    };
+    let bundle = TipsetBundle {
+        blocks: vec![block.header.clone()],
         bls_msgs: Vec::new(),
-        bls_msg_includes: Vec::new(),
+        bls_msg_includes: vec![Vec::new()],
         secp_msgs: Vec::new(),
-        secp_msg_includes: Vec::new(),
+        secp_msg_includes: vec![Vec::new()],
     };
 
     let res = BlockSyncResponse {
@@ -38,7 +43,7 @@ fn convert_single_tipset_bundle() {
     .into_result()
     .unwrap();
 
-    assert_eq!(res, [FullTipset::new(vec![])]);
+    assert_eq!(res, [FullTipset::new(vec![block])]);
 }
 
 #[test]

--- a/node/forest_libp2p/tests/decode_test.rs
+++ b/node/forest_libp2p/tests/decode_test.rs
@@ -4,7 +4,7 @@
 use crypto::{Signature, Signer};
 use forest_address::Address;
 use forest_blocks::{Block, BlockHeader, FullTipset};
-use forest_libp2p::blocksync::{BlockSyncResponse, TipSetBundle};
+use forest_libp2p::blocksync::{BlockSyncResponse, TipsetBundle};
 use forest_message::{SignedMessage, UnsignedMessage};
 use num_bigint::BigUint;
 use std::convert::TryFrom;
@@ -87,7 +87,7 @@ fn tipset_bundle_to_full_tipset() {
         bls_messages: vec![uc.clone(), ud.clone()],
     };
 
-    let mut tsb = TipSetBundle {
+    let mut tsb = TipsetBundle {
         blocks: vec![h0, h1],
         secp_msgs: vec![sa, sb, sc, sd],
         secp_msg_includes: vec![vec![0, 1, 3], vec![1, 2, 0]],

--- a/tests/serialization_tests/tests/block_header_ser.rs
+++ b/tests/serialization_tests/tests/block_header_ser.rs
@@ -9,7 +9,7 @@ use cid::{
 };
 use crypto::VRFProof;
 use encoding::{from_slice, to_vec};
-use forest_blocks::{BlockHeader, EPostProof, EPostTicket, Ticket, TipSetKeys};
+use forest_blocks::{BlockHeader, EPostProof, EPostTicket, Ticket, TipsetKeys};
 use hex::encode;
 use num_traits::FromPrimitive;
 use serde::Deserialize;
@@ -124,7 +124,7 @@ struct BlockVector {
 impl From<BlockVector> for BlockHeader {
     fn from(v: BlockVector) -> BlockHeader {
         BlockHeader::builder()
-            .parents(TipSetKeys::new(
+            .parents(TipsetKeys::new(
                 v.parents.into_iter().map(|c| c.0).collect(),
             ))
             .weight(v.parent_weight.parse().unwrap())

--- a/utils/test_utils/src/chain_structures.rs
+++ b/utils/test_utils/src/chain_structures.rs
@@ -142,7 +142,7 @@ pub fn construct_full_tipset() -> FullTipset {
         bls_messages: vec![bls_messages],
     });
 
-    FullTipset::new(blocks)
+    FullTipset::new(blocks).unwrap()
 }
 
 /// Returns TipsetMetadata used for testing

--- a/utils/test_utils/src/chain_structures.rs
+++ b/utils/test_utils/src/chain_structures.rs
@@ -5,13 +5,13 @@
 
 use address::Address;
 use blocks::{
-    Block, BlockHeader, EPostProof, EPostTicket, FullTipset, Ticket, TipSetKeys, Tipset, TxMeta,
+    Block, BlockHeader, EPostProof, EPostTicket, FullTipset, Ticket, Tipset, TipsetKeys, TxMeta,
 };
-use chain::TipSetMetadata;
+use chain::TipsetMetadata;
 use cid::{multihash::Blake2b256, Cid};
 use crypto::{Signature, Signer, VRFProof};
 use encoding::{from_slice, to_vec};
-use forest_libp2p::blocksync::{BlockSyncResponse, TipSetBundle};
+use forest_libp2p::blocksync::{BlockSyncResponse, TipsetBundle};
 use forest_libp2p::rpc::RPCResponse;
 
 use message::{SignedMessage, UnsignedMessage};
@@ -34,7 +34,7 @@ fn template_header(
 ) -> BlockHeader {
     let cids = construct_keys();
     BlockHeader::builder()
-        .parents(TipSetKeys {
+        .parents(TipsetKeys {
             cids: vec![cids[0].clone()],
         })
         .miner_address(Address::new_secp256k1(&ticket_p))
@@ -145,12 +145,12 @@ pub fn construct_full_tipset() -> FullTipset {
     FullTipset::new(blocks)
 }
 
-/// Returns TipSetMetadata used for testing
-pub fn construct_tipset_metadata() -> TipSetMetadata {
+/// Returns TipsetMetadata used for testing
+pub fn construct_tipset_metadata() -> TipsetMetadata {
     const EPOCH: u64 = 1;
     const WEIGHT: u64 = 10;
     let tip_set = construct_tipset(EPOCH, WEIGHT);
-    TipSetMetadata {
+    TipsetMetadata {
         tipset_state_root: tip_set.blocks()[0].state_root().clone(),
         tipset_receipts_root: tip_set.blocks()[0].message_receipts().clone(),
         tipset: tip_set,
@@ -179,12 +179,12 @@ pub fn construct_messages() -> (UnsignedMessage, SignedMessage) {
 }
 
 /// Returns a TipsetBundle used for testing
-pub fn construct_tipset_bundle(epoch: u64, weight: u64) -> TipSetBundle {
+pub fn construct_tipset_bundle(epoch: u64, weight: u64) -> TipsetBundle {
     let headers = construct_header(epoch, weight);
     let (bls, secp) = construct_messages();
     let includes: Vec<Vec<u64>> = (0..headers.len()).map(|_| vec![]).collect();
 
-    TipSetBundle {
+    TipsetBundle {
         blocks: headers,
         bls_msgs: vec![bls],
         secp_msgs: vec![secp],


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Normalization of the `Tipset` types to all use a lowercase `s`
- `Tipset::new` now doesn't clone block headers, and only clones `Cid`s after the verification is done
- `Tipset::is_empty` is removed because tipsets are guaranteed to never be empty
- `FullTipset::new` now asserts that the vector of blocks isn't empty which we were already assuming in some places
- Other minor cleanup