### PR TITLE
Selector explore implementation

### DIFF
--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -13,7 +13,6 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde_json = { version = "1.0", optional = true }
 multibase = { version = "0.8.0", optional = true }
-hex = "0.4.2"
 
 [dependencies.cid]
 package = "forest_cid"

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -14,6 +14,7 @@ thiserror = "1.0"
 serde_json = { version = "1.0", optional = true }
 multibase = { version = "0.8.0", optional = true }
 hex = "0.4.2"
+# derivative = "2.1.1"
 
 [dependencies.cid]
 package = "forest_cid"

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde_json = { version = "1.0", optional = true }
 multibase = { version = "0.8.0", optional = true }
+hex = "0.4.2"
 
 [dependencies.cid]
 package = "forest_cid"

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -14,7 +14,6 @@ thiserror = "1.0"
 serde_json = { version = "1.0", optional = true }
 multibase = { version = "0.8.0", optional = true }
 hex = "0.4.2"
-# derivative = "2.1.1"
 
 [dependencies.cid]
 package = "forest_cid"

--- a/ipld/src/selector/mod.rs
+++ b/ipld/src/selector/mod.rs
@@ -238,10 +238,7 @@ impl Selector {
     pub fn explore(self, ipld: &Ipld, p: &PathSegment) -> Option<Selector> {
         use Selector::*;
         match self {
-            ExploreAll { next } => {
-
-                Some(*next)
-            }
+            ExploreAll { next } => Some(*next),
             ExploreFields { mut fields } => match ipld {
                 Ipld::Map(m) => match p {
                     // Check if field exists on ipld, then explore selector
@@ -383,7 +380,7 @@ fn replace_recursive_edge(
     use Selector::*;
 
     match next_sel {
-        ExploreRecursiveEdge { .. } => replace,
+        ExploreRecursiveEdge => replace,
         ExploreUnion(selectors) => {
             let mut replace_selectors = Vec::with_capacity(selectors.len());
             for s in selectors {

--- a/ipld/src/selector/mod.rs
+++ b/ipld/src/selector/mod.rs
@@ -364,6 +364,15 @@ impl Selector {
                 }
                 false
             }
+            ExploreRecursive {
+                current, sequence, ..
+            } => {
+                if let Some(curr) = current {
+                    curr.decide()
+                } else {
+                    sequence.decide()
+                }
+            }
             _ => false,
         }
     }

--- a/ipld/src/selector/mod.rs
+++ b/ipld/src/selector/mod.rs
@@ -268,7 +268,6 @@ impl Selector {
             ExploreIndex { index, next } => match ipld {
                 Ipld::List(l) => {
                     let i = p.to_index()?;
-
                     if i != index || i >= l.len() {
                         None
                     } else {
@@ -315,10 +314,12 @@ impl Selector {
                 match limit {
                     RecursionLimit::Depth(depth) => {
                         if depth < 2 {
+                            // Replaces recursive edge with None on last iteration
+                            // TODO revisit, shouldn't need to replace, would be better to just
+                            // return none when edge is hit on final depth
                             return replace_recursive_edge(next, None).map(|s| *s);
                         }
                         Some(ExploreRecursive {
-                            // TODO revisit clone
                             current: replace_recursive_edge(next, Some(sequence.clone())),
                             sequence,
                             limit: RecursionLimit::Depth(depth - 1),
@@ -337,6 +338,7 @@ impl Selector {
                 let mut replace_selectors = Vec::with_capacity(selectors.len());
                 for s in selectors {
                     if let Some(new) = s.explore(ipld, p) {
+                        // Push all explorable selectors in union
                         replace_selectors.push(new)
                     }
                 }

--- a/ipld/src/selector/mod.rs
+++ b/ipld/src/selector/mod.rs
@@ -213,7 +213,7 @@ impl Selector {
             }
             ExploreRecursiveEdge => {
                 // Should never be called on this variant
-                panic!("Traversed explore recursive edge node with no parent")
+                Some(vec![])
             }
             ExploreUnion(selectors) => {
                 let mut segs = Vec::new();
@@ -238,7 +238,10 @@ impl Selector {
     pub fn explore(self, ipld: &Ipld, p: &PathSegment) -> Option<Selector> {
         use Selector::*;
         match self {
-            ExploreAll { next } => Some(*next),
+            ExploreAll { next } => {
+
+                Some(*next)
+            }
             ExploreFields { mut fields } => match ipld {
                 Ipld::Map(m) => match p {
                     // Check if field exists on ipld, then explore selector
@@ -312,7 +315,6 @@ impl Selector {
                         stop_at,
                     });
                 }
-
                 match limit {
                     RecursionLimit::Depth(depth) => {
                         if depth < 2 {
@@ -334,7 +336,6 @@ impl Selector {
                     }),
                 }
             }
-            ExploreRecursiveEdge => unreachable!("Travelled Explore Recursive Edge Node "),
             ExploreUnion(selectors) => {
                 let mut replace_selectors = Vec::with_capacity(selectors.len());
                 for s in selectors {
@@ -348,9 +349,10 @@ impl Selector {
                 if replace_selectors.len() == 1 {
                     return Some(replace_selectors.pop().unwrap());
                 }
-
                 Some(ExploreUnion(replace_selectors))
             }
+            // Go impl panics here, but panic on exploring malformed selector seems bad
+            ExploreRecursiveEdge => None,
             // Matcher is terminal selector
             Matcher => None,
         }

--- a/ipld/src/selector/mod.rs
+++ b/ipld/src/selector/mod.rs
@@ -110,7 +110,6 @@ pub enum Selector {
         stop_at: Option<Condition>,
         #[serde(skip_deserializing)]
         /// Used to index current
-        // TODO determine if this can be a reference to a selector
         current: Option<Box<Selector>>,
     },
 
@@ -270,9 +269,7 @@ impl Selector {
                 Ipld::List(l) => {
                     let i = p.to_index()?;
 
-                    if i != index {
-                        None
-                    } else if i >= l.len() {
+                    if i != index || i >= l.len() {
                         None
                     } else {
                         // Path segment matches selector index
@@ -286,9 +283,7 @@ impl Selector {
                     Ipld::List(l) => {
                         let i = p.to_index()?;
                         // Check to make sure index is within list bounds
-                        if i < start || i >= end {
-                            None
-                        } else if i >= l.len() {
+                        if i < start || i >= end || i >= l.len() {
                             None
                         } else {
                             // Path segment is within the selector range

--- a/ipld/src/selector/path_segment.rs
+++ b/ipld/src/selector/path_segment.rs
@@ -1,6 +1,10 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use serde::de;
+use std::convert::TryFrom;
+use std::fmt;
+
 /// Represents either a key in a map or an index in a list.
 #[derive(Clone, Debug)]
 pub enum PathSegment {
@@ -8,6 +12,17 @@ pub enum PathSegment {
     String(String),
     /// Index in a list
     Int(usize),
+}
+
+impl PathSegment {
+    /// Return index or conversion from string to index.
+    /// If path segment is a String and cannot be converted, None is returned.
+    pub fn to_index(&self) -> Option<usize> {
+        match self {
+            PathSegment::String(s) => s.parse().ok(),
+            PathSegment::Int(i) => Some(*i),
+        }
+    }
 }
 
 impl From<usize> for PathSegment {
@@ -19,5 +34,42 @@ impl From<usize> for PathSegment {
 impl From<String> for PathSegment {
     fn from(s: String) -> Self {
         Self::String(s)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for PathSegment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct PathSegmentVisitor;
+        impl<'de> de::Visitor<'de> for PathSegmentVisitor {
+            type Value = PathSegment;
+            fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.write_str("a string or a usize")
+            }
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(PathSegment::String(value))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_string(v.to_owned())
+            }
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(PathSegment::Int(
+                    usize::try_from(v).map_err(de::Error::custom)?,
+                ))
+            }
+        }
+        deserializer.deserialize_any(PathSegmentVisitor)
     }
 }

--- a/ipld/tests/selector_explore.json
+++ b/ipld/tests/selector_explore.json
@@ -297,5 +297,152 @@
             }
         ],
         "result_selector": null
+    },
+    {
+        "description": "ExploreRecursive hit max",
+        "initial_selector": {
+            "R": {
+                "l": {
+                    "depth": 2
+                },
+                ":>": {
+                    "a": {
+                        ">": {
+                            "f": {
+                                "f>": {
+                                    "Parents": {
+                                        "@": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": null,
+                "path_segment": 0
+            },
+            {
+                "ipld": {
+                    "Parents": null
+                },
+                "path_segment": "Parents"
+            },
+            {
+                "ipld": null,
+                "path_segment": 0
+            },
+            {
+                "ipld": {
+                    "Parents": null
+                },
+                "path_segment": "Parents"
+            }
+        ],
+        "result_selector": null
+    },
+    {
+        "description": "ExploreRecursive valid (current position not captured in test)",
+        "initial_selector": {
+            "R": {
+                "l": {
+                    "depth": 5
+                },
+                ":>": {
+                    "a": {
+                        ">": {
+                            "f": {
+                                "f>": {
+                                    "Parents": {
+                                        "@": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": null,
+                "path_segment": 0
+            },
+            {
+                "ipld": {
+                    "Parents": null
+                },
+                "path_segment": "Parents"
+            }
+        ],
+        "result_selector": {
+            "R": {
+                "l": {
+                    "depth": 4
+                },
+                ":>": {
+                    "a": {
+                        ">": {
+                            "f": {
+                                "f>": {
+                                    "Parents": {
+                                        "@": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "description": "ExploreRecursive reset to correct selector",
+        "initial_selector": {
+            "R": {
+                "l": {
+                    "depth": 5
+                },
+                ":>": {
+                    "a": {
+                        ">": {
+                            "f": {
+                                "f>": {
+                                    "Parents": {
+                                        "@": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": null,
+                "path_segment": 0
+            },
+            {
+                "ipld": {
+                    "Parents": null
+                },
+                "path_segment": "Parents"
+            },
+            {
+                "ipld": null,
+                "path_segment": 0
+            },
+            {
+                "ipld": {
+                    "Parents": null
+                },
+                "path_segment": "Not the correct field"
+            }
+        ],
+        "result_selector": null
     }
 ]

--- a/ipld/tests/selector_explore.json
+++ b/ipld/tests/selector_explore.json
@@ -444,5 +444,68 @@
             }
         ],
         "result_selector": null
+    },
+    {
+        "description": "ExploreRecursive with nested recursion",
+        "initial_selector": {
+            "R": {
+                "l": {
+                    "depth": 2
+                },
+                ":>": {
+                    "a": {
+                        ">": {
+                            "R": {
+                                "l": {
+                                    "depth": 2
+                                },
+                                ":>": {
+                                    "a": {
+                                        ">": {
+                                            "@": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": null,
+                "path_segment": 0
+            },
+            {
+                "ipld": null,
+                "path_segment": 0
+            }
+        ],
+        "result_selector": {
+            "R": {
+                "l": {
+                    "depth": 2
+                },
+                ":>": {
+                    "a": {
+                        ">": {
+                            "R": {
+                                "l": {
+                                    "depth": 2
+                                },
+                                ":>": {
+                                    "a": {
+                                        ">": {
+                                            "@": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 ]

--- a/ipld/tests/selector_explore.json
+++ b/ipld/tests/selector_explore.json
@@ -404,7 +404,7 @@
         "initial_selector": {
             "R": {
                 "l": {
-                    "depth": 5
+                    "none": {}
                 },
                 ":>": {
                     "a": {
@@ -446,66 +446,76 @@
         "result_selector": null
     },
     {
-        "description": "ExploreRecursive with nested recursion",
+        "description": "ExploreUnion no matches",
         "initial_selector": {
-            "R": {
-                "l": {
-                    "depth": 2
-                },
-                ":>": {
-                    "a": {
+            "|": [
+                {
+                    "r": {
+                        "^": 0,
+                        "$": 3,
                         ">": {
-                            "R": {
-                                "l": {
-                                    "depth": 2
-                                },
-                                ":>": {
-                                    "a": {
-                                        ">": {
-                                            "@": {}
-                                        }
-                                    }
-                                }
+                            "@": {}
+                        }
+                    }
+                },
+                {
+                    "f": {
+                        "f>": {
+                            "5": {
+                                ".": {}
                             }
                         }
                     }
                 }
-            }
+            ]
         },
         "explore": [
             {
                 "ipld": null,
-                "path_segment": 0
-            },
-            {
-                "ipld": null,
-                "path_segment": 0
+                "path_segment": 4
             }
         ],
-        "result_selector": {
-            "R": {
-                "l": {
-                    "depth": 2
-                },
-                ":>": {
-                    "a": {
+        "result_selector": null
+    },
+    {
+        "description": "ExploreUnion match",
+        "initial_selector": {
+            "|": [
+                {
+                    "r": {
+                        "^": 0,
+                        "$": 3,
                         ">": {
-                            "R": {
-                                "l": {
-                                    "depth": 2
-                                },
-                                ":>": {
-                                    "a": {
-                                        ">": {
-                                            "@": {}
-                                        }
-                                    }
-                                }
+                            "@": {}
+                        }
+                    }
+                },
+                {
+                    "f": {
+                        "f>": {
+                            "5": {
+                                ".": {}
                             }
                         }
                     }
                 }
+            ]
+        },
+        "explore": [
+            {
+                "ipld": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                "path_segment": 5
             }
+        ],
+        "result_selector": {
+            ".": {}
         }
     }
 ]

--- a/ipld/tests/selector_explore.json
+++ b/ipld/tests/selector_explore.json
@@ -1,0 +1,301 @@
+[
+    {
+        "description": "ExploreAll basic test",
+        "initial_selector": {
+            "a": {
+                ">": {
+                    ".": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": null,
+                "path_segment": 0
+            }
+        ],
+        "result_selector": {
+            ".": {}
+        }
+    },
+    {
+        "description": "ExploreFields path match",
+        "initial_selector": {
+            "f": {
+                "f>": {
+                    "one": {
+                        ".": {}
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": {
+                    "one": "some data"
+                },
+                "path_segment": "one"
+            }
+        ],
+        "result_selector": {
+            ".": {}
+        }
+    },
+    {
+        "description": "ExploreFields path not matching",
+        "initial_selector": {
+            "f": {
+                "f>": {
+                    "one": {
+                        ".": {}
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": {
+                    "0": {}
+                },
+                "path_segment": 0
+            }
+        ],
+        "result_selector": null
+    },
+    {
+        "description": "ExploreFields path from integer",
+        "initial_selector": {
+            "f": {
+                "f>": {
+                    "0": {
+                        ".": {}
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": {
+                    "0": null
+                },
+                "path_segment": 0
+            }
+        ],
+        "result_selector": {
+            ".": {}
+        }
+    },
+    {
+        "description": "ExploreFields invalid IPLD kind",
+        "initial_selector": {
+            "f": {
+                "f>": {
+                    "0": {
+                        ".": {}
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": "Not a map or list",
+                "path_segment": 0
+            }
+        ],
+        "result_selector": null
+    },
+    {
+        "description": "ExploreFields exploring index on a list",
+        "initial_selector": {
+            "f": {
+                "f>": {
+                    "0": {
+                        ".": {}
+                    }
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": [
+                    null
+                ],
+                "path_segment": 0
+            }
+        ],
+        "result_selector": {
+            ".": {}
+        }
+    },
+    {
+        "description": "ExploreIndex basic check",
+        "initial_selector": {
+            "i": {
+                "i": 2,
+                ">": {
+                    ".": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": [
+                    0,
+                    1,
+                    2
+                ],
+                "path_segment": 2
+            }
+        ],
+        "result_selector": {
+            ".": {}
+        }
+    },
+    {
+        "description": "ExploreIndex invalid IPLD kind",
+        "initial_selector": {
+            "i": {
+                "i": 2,
+                ">": {
+                    "@": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": "not a list",
+                "path_segment": 0
+            }
+        ],
+        "result_selector": null
+    },
+    {
+        "description": "ExploreIndex invalid index",
+        "initial_selector": {
+            "i": {
+                "i": 2,
+                ">": {
+                    ".": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": [
+                    0,
+                    1,
+                    2
+                ],
+                "path_segment": 1
+            }
+        ],
+        "result_selector": null
+    },
+    {
+        "description": "ExploreRange out of range index",
+        "initial_selector": {
+            "r": {
+                "^": 3,
+                "$": 4,
+                ">": {
+                    "@": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": [
+                    0,
+                    1,
+                    2,
+                    3
+                ],
+                "path_segment": 2
+            }
+        ],
+        "result_selector": null
+    },
+    {
+        "description": "ExploreRange invalid IPLD type",
+        "initial_selector": {
+            "r": {
+                "^": 1,
+                "$": 4,
+                ">": {
+                    "@": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": {},
+                "path_segment": 2
+            }
+        ],
+        "result_selector": null
+    },
+    {
+        "description": "ExploreRange non integer index",
+        "initial_selector": {
+            "r": {
+                "^": 1,
+                "$": 4,
+                ">": {
+                    "@": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": [],
+                "path_segment": "not parseable"
+            }
+        ],
+        "result_selector": null
+    },
+    {
+        "description": "ExploreRange valid index",
+        "initial_selector": {
+            "r": {
+                "^": 3,
+                "$": 4,
+                ">": {
+                    "@": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": [
+                    0,
+                    1,
+                    2,
+                    3
+                ],
+                "path_segment": 3
+            }
+        ],
+        "result_selector": {
+            "@": {}
+        }
+    },
+    {
+        "description": "ExploreRange ipld list too short",
+        "initial_selector": {
+            "r": {
+                "^": 3,
+                "$": 4,
+                ">": {
+                    "@": {}
+                }
+            }
+        },
+        "explore": [
+            {
+                "ipld": [],
+                "path_segment": 3
+            }
+        ],
+        "result_selector": null
+    }
+]

--- a/ipld/tests/selector_explore.rs
+++ b/ipld/tests/selector_explore.rs
@@ -21,33 +21,50 @@ struct TestVector {
     result_selector: Option<Selector>,
 }
 
-fn process_vector(
-    initial_selector: Selector,
-    params: Vec<ExploreParams>,
-    expected_result: Option<Selector>,
-    description: &str,
-) {
+// Just needed because cannot deserialize the current selector position in recursive selectors
+fn test_equal(s1: &Option<Selector>, s2: &Option<Selector>) -> bool {
+    use Selector::*;
+    if let (
+        &Some(ExploreRecursive {
+            current: _,
+            sequence: s1,
+            limit: l1,
+            stop_at: st1,
+        }),
+        &Some(ExploreRecursive {
+            current: _,
+            sequence: s2,
+            limit: l2,
+            stop_at: st2,
+        }),
+    ) = (&s1, &s2)
+    {
+        s1 == s2 && l1 == l2 && st1 == st2
+    } else {
+        s1 == s2
+    }
+}
+
+fn process_vector(initial_selector: Selector, params: Vec<ExploreParams>) -> Option<Selector> {
     let mut current = Some(initial_selector);
     for p in params {
-        current = current.unwrap().explore(&p.ipld, &p.path_segment);
+        current = current?.explore(&p.ipld, &p.path_segment);
     }
-
-    assert_eq!(current, expected_result, "{}", description);
+    current
 }
 
 #[test]
 fn selector_explore_tests() {
     let file = File::open("./tests/selector_explore.json").unwrap();
     let reader = BufReader::new(file);
-
     let vectors: Vec<TestVector> =
         serde_json::from_reader(reader).expect("Test vector deserialization failed");
     for tv in vectors {
-        process_vector(
-            tv.initial_selector,
-            tv.explore,
-            tv.result_selector,
-            &tv.description.unwrap_or("Unnamed test case".to_owned()),
+        let result = process_vector(tv.initial_selector, tv.explore);
+        assert!(
+            test_equal(&result, &tv.result_selector),
+            "{}",
+            tv.description.unwrap_or("Unnamed test case".to_owned())
         );
     }
 }

--- a/ipld/tests/selector_explore.rs
+++ b/ipld/tests/selector_explore.rs
@@ -41,7 +41,8 @@ fn test_equal(s1: &Option<Selector>, s2: &Option<Selector>) -> bool {
     {
         s1 == s2 && l1 == l2 && st1 == st2
     } else {
-        s1 == s2
+        let b = s1 == s2;
+        b
     }
 }
 
@@ -63,8 +64,10 @@ fn selector_explore_tests() {
         let result = process_vector(tv.initial_selector, tv.explore);
         assert!(
             test_equal(&result, &tv.result_selector),
-            "{}",
-            tv.description.unwrap_or("Unnamed test case".to_owned())
+            "({}) Failed:\nExpected: {:?}\nFound: {:?}",
+            tv.description.unwrap_or("Unnamed test case".to_owned()),
+            tv.result_selector,
+            result
         );
     }
 }

--- a/ipld/tests/selector_explore.rs
+++ b/ipld/tests/selector_explore.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use forest_ipld::selector::{PathSegment, Selector};
+use forest_ipld::Ipld;
+use serde::Deserialize;
+use std::fs::File;
+use std::io::BufReader;
+
+#[derive(Deserialize)]
+struct ExploreParams {
+    ipld: Ipld,
+    path_segment: PathSegment,
+}
+
+#[derive(Deserialize)]
+struct TestVector {
+    description: Option<String>,
+    initial_selector: Selector,
+    explore: Vec<ExploreParams>,
+    result_selector: Option<Selector>,
+}
+
+fn process_vector(
+    initial_selector: Selector,
+    params: Vec<ExploreParams>,
+    expected_result: Option<Selector>,
+    description: &str,
+) {
+    let mut current = Some(initial_selector);
+    for p in params {
+        current = current.unwrap().explore(&p.ipld, &p.path_segment);
+    }
+
+    assert_eq!(current, expected_result, "{}", description);
+}
+
+#[test]
+fn selector_explore_tests() {
+    let file = File::open("./tests/selector_explore.json").unwrap();
+    let reader = BufReader::new(file);
+
+    let vectors: Vec<TestVector> =
+        serde_json::from_reader(reader).expect("Test vector deserialization failed");
+    for tv in vectors {
+        process_vector(
+            tv.initial_selector,
+            tv.explore,
+            tv.result_selector,
+            &tv.description.unwrap_or("Unnamed test case".to_owned()),
+        );
+    }
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Logic for exploring selectors for progressing with traversing the ipld. I'm closely matching go-prime-ipld for now, but will likely change it in the next PR when I implement the last part of this (traversal) and have full functionality tested

I wrote the tests in json with a runner to be able to test against go impl and provide a language agnostic test suite (I believe JS selectors are in progress rn too)

#241 for reference to spec and go impl


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->