### PR TITLE
Fix CI for docs build

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -103,12 +103,20 @@ jobs:
     needs: [clippy, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
       - name: Install Rust
         run: rustup update beta && rustup default beta
 
       - name: Install OpenCL
-        run: sudo apt install ocl-icd-opencl-dev	
+        run: sudo apt install ocl-icd-opencl-dev
+      
+      - name: Install Protoc
+        uses: arduino/setup-protoc@master
+        with:
+          version: '3.9.1'
 
       - name: Build documentation
         run: cargo doc --no-deps --all-features

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ make install
 forest
 ```
 
+> protoc is also required to build, if not already installed follow [instructions here](http://google.github.io/proto-lens/installing-protoc.html)
+
 ### Config
 
 Run the node with custom config and bootnodes


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Docs build is broken because protoc is not installed for building docs from #375 
- Updated readme to include indication of requiring protoc installed

test build here https://github.com/austinabell/forest/actions/runs/101782859
(I'm too impatient to wait for it to pass but will fix if it doesn't pass)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to (e.g. closes #1). -->
Closes <!--ADD ISSUE NUMBER (don't remove Closes)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->