### PR TITLE
Add default implementations for Store bulk operations

### DIFF
--- a/node/db/src/lib.rs
+++ b/node/db/src/lib.rs
@@ -43,16 +43,31 @@ pub trait Store {
     /// Read slice of keys and return a vector of optional values.
     fn bulk_read<K>(&self, keys: &[K]) -> Result<Vec<Option<Vec<u8>>>, Error>
     where
-        K: AsRef<[u8]>;
+        K: AsRef<[u8]>,
+    {
+        keys.iter().map(|key| self.read(key)).collect()
+    }
 
     /// Write slice of KV pairs.
     fn bulk_write<K, V>(&self, keys: &[K], values: &[V]) -> Result<(), Error>
     where
         K: AsRef<[u8]>,
-        V: AsRef<[u8]>;
+        V: AsRef<[u8]>,
+    {
+        if keys.len() != values.len() {
+            return Err(Error::InvalidBulkLen);
+        }
+        keys.iter()
+            .zip(values)
+            .map(|(key, value)| self.write(key, value))
+            .collect()
+    }
 
     /// Bulk delete keys from the data store.
     fn bulk_delete<K>(&self, keys: &[K]) -> Result<(), Error>
     where
-        K: AsRef<[u8]>;
+        K: AsRef<[u8]>,
+    {
+        keys.iter().map(|key| self.delete(key)).collect()
+    }
 }

--- a/node/db/src/memory.rs
+++ b/node/db/src/memory.rs
@@ -61,34 +61,6 @@ impl Store for MemoryDB {
         Ok(())
     }
 
-    fn bulk_write<K, V>(&self, keys: &[K], values: &[V]) -> Result<(), Error>
-    where
-        K: AsRef<[u8]>,
-        V: AsRef<[u8]>,
-    {
-        // Safety check to make sure kv lengths are the same
-        if keys.len() != values.len() {
-            return Err(Error::InvalidBulkLen);
-        }
-
-        for (k, v) in keys.iter().zip(values.iter()) {
-            self.db
-                .write()
-                .insert(Self::db_index(k), v.as_ref().to_vec());
-        }
-        Ok(())
-    }
-
-    fn bulk_delete<K>(&self, keys: &[K]) -> Result<(), Error>
-    where
-        K: AsRef<[u8]>,
-    {
-        for k in keys.iter() {
-            self.db.write().remove(&Self::db_index(k));
-        }
-        Ok(())
-    }
-
     fn read<K>(&self, key: K) -> Result<Option<Vec<u8>>, Error>
     where
         K: AsRef<[u8]>,
@@ -101,16 +73,5 @@ impl Store for MemoryDB {
         K: AsRef<[u8]>,
     {
         Ok(self.db.read().contains_key(&Self::db_index(key)))
-    }
-
-    fn bulk_read<K>(&self, keys: &[K]) -> Result<Vec<Option<Vec<u8>>>, Error>
-    where
-        K: AsRef<[u8]>,
-    {
-        let mut v = Vec::with_capacity(keys.len());
-        for k in keys.iter() {
-            v.push(self.db.read().get(&Self::db_index(k)).cloned())
-        }
-        Ok(v)
     }
 }

--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -106,16 +106,6 @@ impl Store for RocksDb {
         Ok(self.db()?.write(batch)?)
     }
 
-    fn bulk_delete<K>(&self, keys: &[K]) -> Result<(), Error>
-    where
-        K: AsRef<[u8]>,
-    {
-        for k in keys.iter() {
-            self.db()?.delete(k)?;
-        }
-        Ok(())
-    }
-
     fn read<K>(&self, key: K) -> Result<Option<Vec<u8>>, Error>
     where
         K: AsRef<[u8]>,
@@ -131,19 +121,5 @@ impl Store for RocksDb {
             .get_pinned(key)
             .map(|v| v.is_some())
             .map_err(Error::from)
-    }
-
-    fn bulk_read<K>(&self, keys: &[K]) -> Result<Vec<Option<Vec<u8>>>, Error>
-    where
-        K: AsRef<[u8]>,
-    {
-        let mut v = Vec::with_capacity(keys.len());
-        for k in keys.iter() {
-            match self.db()?.get(k) {
-                Ok(val) => v.push(val),
-                Err(e) => return Err(Error::from(e)),
-            }
-        }
-        Ok(v)
     }
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Add default implementations of `Store`'s bulk operations that repeatedly call the corresponding non-bulk operation
- Remove type-specific implementations of these methods that already did this (`RocksDb::bulk_write` is unaffected because it improves over the default implementation)