### PR TITLE
Update prefix bytes encoding to include mh len

### DIFF
--- a/ipld/cid/src/prefix.rs
+++ b/ipld/cid/src/prefix.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::{Codec, Error, Version};
+use integer_encoding::{VarIntReader, VarIntWriter};
+use multihash::Code;
+use std::io::Cursor;
+
+/// Prefix represents all metadata of a CID, without the actual content.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Prefix {
+    pub version: Version,
+    pub codec: Codec,
+    pub mh_type: Code,
+    pub mh_len: usize,
+}
+
+impl Prefix {
+    /// Generate new prefix from encoded bytes
+    pub fn new_from_bytes(data: &[u8]) -> Result<Prefix, Error> {
+        let mut cur = Cursor::new(data);
+
+        let raw_version = cur.read_varint()?;
+        let raw_codec = cur.read_varint()?;
+        let raw_mh_type: u64 = cur.read_varint()?;
+        let mh_len: usize = cur.read_varint()?;
+
+        let version = Version::from(raw_version)?;
+        let codec = Codec::from(raw_codec)?;
+
+        let mh_type = Code::from_u64(raw_mh_type as u64);
+
+        Ok(Prefix {
+            version,
+            codec,
+            mh_type,
+            mh_len,
+        })
+    }
+
+    /// Encodes prefix to bytes
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(4);
+
+        // io can't fail on Vec
+        res.write_varint(u64::from(self.version)).unwrap();
+        res.write_varint(u64::from(self.codec)).unwrap();
+        res.write_varint(self.mh_type.to_u64()).unwrap();
+        res.write_varint(self.mh_len).unwrap();
+
+        res
+    }
+}

--- a/ipld/cid/src/prefix.rs
+++ b/ipld/cid/src/prefix.rs
@@ -28,7 +28,7 @@ impl Prefix {
         let version = Version::from(raw_version)?;
         let codec = Codec::from(raw_codec)?;
 
-        let mh_type = Code::from_u64(raw_mh_type as u64);
+        let mh_type = Code::from_u64(raw_mh_type);
 
         Ok(Prefix {
             version,

--- a/ipld/cid/tests/base_cid_tests.rs
+++ b/ipld/cid/tests/base_cid_tests.rs
@@ -65,7 +65,7 @@ fn prefix_roundtrip() {
 
     assert_eq!(cid, cid2);
 
-    let prefix_bytes = prefix.as_bytes();
+    let prefix_bytes = prefix.to_bytes();
     let prefix2 = Prefix::new_from_bytes(&prefix_bytes).unwrap();
 
     assert_eq!(prefix, prefix2);
@@ -95,6 +95,7 @@ fn test_hash() {
         version: Version::V0,
         codec: Codec::DagProtobuf,
         mh_type: Code::Sha2_256,
+        mh_len: 32,
     };
     let mut map = HashMap::new();
     let cid = Cid::new_from_prefix(&prefix, &data).unwrap();


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- I actually have the worst memory, #428 was misleading because it did exist and I had just removed the mh_len during the multihash refactor because it was redundant (at the time) so I added it back
  - Also figured I'd move prefix to own file because that file isn't setup the best (not going to do an actual refactor because hopefully we move to shared rust cid crate in future)

I assume the length is needed for variable length identity hashes, which is why it's included in the prefix bytes.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #428


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->