### PR TITLE
Update dockerfiles for protoc build dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ FROM rust:1.42-stretch AS build-env
 WORKDIR /usr/src/forest
 COPY . .
 
+# Install protoc
+ENV PROTOC_ZIP protoc-3.7.1-linux-x86_64.zip
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
+RUN unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+RUN unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
+RUN rm -f $PROTOC_ZIP
+
 # Extra dependencies needed for rust-fil-proofs
 RUN apt-get update && \
     apt-get install -y curl file gcc g++ git make openssh-client \

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -8,6 +8,13 @@ FROM rust:1.42-stretch
 WORKDIR /usr/src/forest
 COPY . .
 
+# Install protoc
+ENV PROTOC_ZIP protoc-3.7.1-linux-x86_64.zip
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
+RUN unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+RUN unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
+RUN rm -f $PROTOC_ZIP
+
 # Extra dependencies needed for rust-fil-proofs
 RUN apt-get update && \
     apt-get install -y curl file gcc g++ git make openssh-client \


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- After protoc build requirement, dockerfiles were never updated. 

Would be ideal to move away from the reliance on protoc for builds though at some point as a requirement tho



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->