### PR TITLE
Remove Duplicate Storage Power Types

### DIFF
--- a/types/src/sector/mod.rs
+++ b/types/src/sector/mod.rs
@@ -13,7 +13,7 @@ pub use self::registered_proof::*;
 pub use self::seal::*;
 
 use encoding::{repr::*, tuple::*};
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use num_derive::FromPrimitive;
 use std::fmt;
 use vm::ActorID;
@@ -21,7 +21,7 @@ use vm::ActorID;
 pub type SectorNumber = u64;
 
 /// Unit of storage power (measured in bytes)
-pub type StoragePower = BigInt;
+pub type StoragePower = BigUint;
 
 /// SectorSize indicates one of a set of possible sizes in the network.
 #[derive(Clone, Debug, PartialEq, Copy, FromPrimitive, Serialize_repr, Deserialize_repr)]

--- a/vm/actor/src/lib.rs
+++ b/vm/actor/src/lib.rs
@@ -17,16 +17,14 @@ pub use vm::{ActorState, DealID, Serialized};
 use encoding::Error as EncodingError;
 use ipld_blockstore::BlockStore;
 use ipld_hamt::{BytesKey, Hamt};
-use num_bigint::{BigInt, BigUint};
+use num_bigint::{BigInt};
 use unsigned_varint::decode::Error as UVarintError;
+use fil_types::StoragePower;
 
 const HAMT_BIT_WIDTH: u8 = 5;
 
 type EmptyType = [u8; 0];
 const EMPTY_VALUE: EmptyType = [];
-
-/// Storage power unit, could possibly be a BigUint
-type StoragePower = BigUint;
 
 /// Deal weight
 type DealWeight = BigInt;

--- a/vm/actor/src/lib.rs
+++ b/vm/actor/src/lib.rs
@@ -15,11 +15,11 @@ pub use self::util::*;
 pub use vm::{ActorState, DealID, Serialized};
 
 use encoding::Error as EncodingError;
+use fil_types::StoragePower;
 use ipld_blockstore::BlockStore;
 use ipld_hamt::{BytesKey, Hamt};
-use num_bigint::{BigInt};
+use num_bigint::BigInt;
 use unsigned_varint::decode::Error as UVarintError;
-use fil_types::StoragePower;
 
 const HAMT_BIT_WIDTH: u8 = 5;
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Removed duplicate storage power types as well as change StoragePower to a BigUint in types. 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #455 
