### PR TITLE
Batch seal verification implementation

### DIFF
--- a/vm/runtime/Cargo.toml
+++ b/vm/runtime/Cargo.toml
@@ -18,6 +18,7 @@ filecoin-proofs-api = { git = "https://github.com/filecoin-project/rust-filecoin
 base64 = "0.12.1"
 fil_types = { path = "../../types" }
 log = "0.4.8"
+rayon = "1.3"
 
 [dev-dependencies]
 interpreter = { path = "../interpreter/" }

--- a/vm/runtime/Cargo.toml
+++ b/vm/runtime/Cargo.toml
@@ -17,6 +17,7 @@ commcid = { path = "../../utils/commcid" }
 filecoin-proofs-api = { git = "https://github.com/filecoin-project/rust-filecoin-proofs-api", rev = "0e1c7cb464707c7a7ad82b0f8303f000f6f3fc8a" }
 base64 = "0.12.1"
 fil_types = { path = "../../types" }
+log = "0.4.8"
 
 [dev-dependencies]
 interpreter = { path = "../interpreter/" }

--- a/vm/runtime/src/lib.rs
+++ b/vm/runtime/src/lib.rs
@@ -24,6 +24,7 @@ use forest_encoding::{blake2b_256, Cbor};
 use ipld_blockstore::BlockStore;
 use log::warn;
 use message::UnsignedMessage;
+use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -197,31 +198,7 @@ pub trait Syscalls {
     }
     /// Verifies a sector seal proof.
     fn verify_seal(&self, vi: &SealVerifyInfo) -> Result<(), Box<dyn StdError>> {
-        let commd = cid_to_data_commitment_v1(&vi.unsealed_cid)?;
-        let commr = cid_to_replica_commitment_v1(&vi.on_chain.sealed_cid)?;
-        let miner_addr = Address::new_id(vi.sector_id.miner);
-        let miner_payload = miner_addr.payload_bytes();
-        let mut prover_id = ProverId::default();
-        prover_id[..miner_payload.len()].copy_from_slice(&miner_payload);
-
-        if !proofs_verify_seal(
-            vi.on_chain.registered_proof.into(),
-            commr,
-            commd,
-            prover_id,
-            SectorId::from(vi.sector_id.number),
-            vi.randomness.0,
-            vi.interactive_randomness.0,
-            &vi.on_chain.proof,
-        )? {
-            return Err(format!(
-                "Invalid proof detected: {:?}",
-                base64::encode(&vi.on_chain.proof)
-            )
-            .into());
-        }
-
-        Ok(())
+        verify_seal(vi)
     }
     /// Verifies a proof of spacetime.
     fn verify_post(&self, verify_info: &WindowPoStVerifyInfo) -> Result<(), Box<dyn StdError>> {
@@ -281,24 +258,56 @@ pub trait Syscalls {
         &self,
         vis: &[(Address, Vec<SealVerifyInfo>)],
     ) -> Result<HashMap<Address, Vec<bool>>, Box<dyn StdError>> {
-        // TODO make async
-        let mut out = HashMap::new();
-        for (addr, seals) in vis {
-            let mut results = vec![false; seals.len()];
-            for (i, s) in seals.iter().enumerate() {
-                if let Err(err) = self.verify_seal(s) {
-                    warn!(
-                        "seal verify in batch failed (miner: {}) (idx: {}) (err: {})",
-                        addr, i, err
-                    )
-                } else {
-                    results[i] = true
-                }
-            }
-            out.insert(*addr, results);
-        }
+        let out = vis
+            .par_iter()
+            .map(|(addr, seals)| {
+                let results = seals
+                    .par_iter()
+                    .map(|s| {
+                        if let Err(err) = verify_seal(s) {
+                            warn!(
+                                "seal verify in batch failed (miner: {}) (err: {})",
+                                addr, err
+                            );
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .collect();
+                (*addr, results)
+            })
+            .collect();
         Ok(out)
     }
+}
+
+fn verify_seal(vi: &SealVerifyInfo) -> Result<(), Box<dyn StdError>> {
+    let commd = cid_to_data_commitment_v1(&vi.unsealed_cid)?;
+    let commr = cid_to_replica_commitment_v1(&vi.on_chain.sealed_cid)?;
+    let miner_addr = Address::new_id(vi.sector_id.miner);
+    let miner_payload = miner_addr.payload_bytes();
+    let mut prover_id = ProverId::default();
+    prover_id[..miner_payload.len()].copy_from_slice(&miner_payload);
+
+    if !proofs_verify_seal(
+        vi.on_chain.registered_proof.into(),
+        commr,
+        commd,
+        prover_id,
+        SectorId::from(vi.sector_id.number),
+        vi.randomness.0,
+        vi.interactive_randomness.0,
+        &vi.on_chain.proof,
+    )? {
+        return Err(format!(
+            "Invalid proof detected: {:?}",
+            base64::encode(&vi.on_chain.proof)
+        )
+        .into());
+    }
+
+    Ok(())
 }
 
 /// Result of checking two headers for a consensus fault.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Parallelized seal verification using Rayon
  - Can't do with a hashmap input (to match go interface 1:1) but looking at the usage it seems better to do as a vector anyway, which can just be referenced to pass into this.
  - Not really much option to have a more generic interface, because it depends on the `IntoParallelRefIterator` trait, and that forces a specific implementation (which will then be incompatible with MockRuntime needs)

Seems like the best solution than managing threads in an async context, but very open to suggestions on how this can be parallelized better

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #457 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->