### PR TITLE
Added proposal_hash field for TxnIDParams;

### DIFF
--- a/vm/actor/src/builtin/multisig/types.rs
+++ b/vm/actor/src/builtin/multisig/types.rs
@@ -22,6 +22,12 @@ impl TxnID {
     }
 }
 
+/// Proposal Hash
+// Blake2b 32 hash 
+#[derive(Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ProposalHash(pub [u8; 32]);
+
 /// Transaction type used in multisig actor
 #[derive(Clone, PartialEq, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct Transaction {
@@ -56,6 +62,7 @@ pub struct ProposeParams {
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct TxnIDParams {
     pub id: TxnID,
+    pub proposal_hash: ProposalHash,
 }
 
 /// Add signer params


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Added `proposal_hash` field in TxnIDParams to fit new specs for actors



**Reference issue to close (if applicable)**
No issue associated

**Other information and links**
Required for multisig support and compatibility with Lotus.
See https://github.com/filecoin-project/specs-actors/commit/03a061425e56f5087f143dd08069117bdfd789bf

I haven't added the check in other place for multisig. Just the field so it can be serialize in order to create a correct message.



<!-- Thank you 🔥 -->