### PR TITLE
Switch to use MessageInfo and refactor MockRuntime

### DIFF
--- a/vm/actor/src/builtin/init/mod.rs
+++ b/vm/actor/src/builtin/init/mod.rs
@@ -13,7 +13,6 @@ use crate::{
 use address::Address;
 use cid::Cid;
 use ipld_blockstore::BlockStore;
-use message::Message;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use runtime::{ActorCode, Runtime};
@@ -94,7 +93,7 @@ impl Actor {
             &id_address,
             METHOD_CONSTRUCTOR,
             &params.constructor_params,
-            &rt.message().value().clone(),
+            &rt.message().value_received().clone(),
         )
         .map_err(|err| rt.abort(err.exit_code(), "constructor failed"))?;
 

--- a/vm/actor/src/builtin/init/mod.rs
+++ b/vm/actor/src/builtin/init/mod.rs
@@ -58,7 +58,7 @@ impl Actor {
     {
         rt.validate_immediate_caller_accept_any();
         let caller_code = rt
-            .get_actor_code_cid(rt.message().from())
+            .get_actor_code_cid(rt.message().caller())
             .expect("no code for actor");
         if !can_exec(&caller_code, &params.code_cid) {
             return Err(rt.abort(

--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -9,7 +9,6 @@ pub use self::types::*;
 use crate::{make_map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR};
 use address::Address;
 use ipld_blockstore::BlockStore;
-use message::Message;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use runtime::{ActorCode, Runtime};
@@ -67,7 +66,7 @@ impl Actor {
         };
 
         if params.unlock_duration != 0 {
-            st.initial_balance = rt.message().value().clone();
+            st.initial_balance = rt.message().value_received().clone();
             st.unlock_duration = params.unlock_duration;
             st.start_epoch = rt.curr_epoch();
         }
@@ -83,7 +82,7 @@ impl Actor {
         RT: Runtime<BS>,
     {
         rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
-        let caller_addr: Address = *rt.message().from();
+        let caller_addr: Address = *rt.message().caller();
 
         let st: State = rt.state()?;
         Self::validate_signer(rt, &st, &caller_addr)?;
@@ -129,7 +128,7 @@ impl Actor {
         RT: Runtime<BS>,
     {
         rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
-        let caller_addr: Address = *rt.message().from();
+        let caller_addr: Address = *rt.message().caller();
 
         // Validate signer
         let st = rt.state()?;
@@ -145,7 +144,7 @@ impl Actor {
         RT: Runtime<BS>,
     {
         rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
-        let caller_addr: Address = *rt.message().from();
+        let caller_addr: Address = *rt.message().caller();
 
         let st: State = rt.state()?;
         Self::validate_signer(rt, &st, &caller_addr)?;
@@ -187,7 +186,7 @@ impl Actor {
         BS: BlockStore,
         RT: Runtime<BS>,
     {
-        rt.validate_immediate_caller_is(std::iter::once(rt.message().to()))?;
+        rt.validate_immediate_caller_is(std::iter::once(rt.message().receiver()))?;
 
         rt.transaction::<State, _, _>(|st, _| {
             // Check if signer to add is already signer
@@ -214,7 +213,7 @@ impl Actor {
         BS: BlockStore,
         RT: Runtime<BS>,
     {
-        rt.validate_immediate_caller_is(std::iter::once(rt.message().to()))?;
+        rt.validate_immediate_caller_is(std::iter::once(rt.message().receiver()))?;
 
         rt.transaction::<State, _, _>(|st, _| {
             // Check that signer to remove exists
@@ -249,7 +248,7 @@ impl Actor {
         BS: BlockStore,
         RT: Runtime<BS>,
     {
-        rt.validate_immediate_caller_is(std::iter::once(rt.message().to()))?;
+        rt.validate_immediate_caller_is(std::iter::once(rt.message().receiver()))?;
 
         rt.transaction::<State, _, _>(|st, _| {
             // Check that signer to remove exists
@@ -287,7 +286,7 @@ impl Actor {
         BS: BlockStore,
         RT: Runtime<BS>,
     {
-        rt.validate_immediate_caller_is(std::iter::once(rt.message().to()))?;
+        rt.validate_immediate_caller_is(std::iter::once(rt.message().receiver()))?;
 
         rt.transaction::<State, _, _>(|st, _| {
             // Check if valid threshold value
@@ -309,7 +308,7 @@ impl Actor {
         BS: BlockStore,
         RT: Runtime<BS>,
     {
-        let from = *rt.message().from();
+        let from = *rt.message().caller();
         let curr_bal = rt.current_balance()?;
         let curr_epoch = rt.curr_epoch();
         // Approval transaction

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -10,7 +10,6 @@ use crate::{check_empty_params, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID};
 use address::Address;
 use encoding::to_vec;
 use ipld_blockstore::BlockStore;
-use message::Message;
 use num_bigint::BigInt;
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Zero};
@@ -87,7 +86,7 @@ impl Actor {
         let st: State = rt.state()?;
 
         rt.validate_immediate_caller_is([st.from, st.to].iter())?;
-        let signer = if rt.message().from() == &st.from {
+        let signer = if rt.message().caller() == &st.from {
             st.to
         } else {
             st.from

--- a/vm/actor/src/builtin/verifreg/mod.rs
+++ b/vm/actor/src/builtin/verifreg/mod.rs
@@ -11,7 +11,6 @@ use address::Address;
 use ipld_blockstore::BlockStore;
 use ipld_hamt::BytesKey;
 use ipld_hamt::Hamt;
-use message::Message;
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Zero};
 use runtime::{ActorCode, Runtime};
@@ -116,8 +115,7 @@ impl Actor {
         rt.validate_immediate_caller_accept_any();
         rt.transaction(|st: &mut State, rt| {
             // Validate caller is one of the verifiers.
-            let message: Box<&dyn Message> = Box::new(rt.message());
-            let verify_addr = message.from();
+            let verify_addr = rt.message().caller();
 
             let verifier_cap = st
                 .get_verifier(rt.store(), &verify_addr)

--- a/vm/actor/tests/account_actor_test.rs
+++ b/vm/actor/tests/account_actor_test.rs
@@ -6,8 +6,6 @@ mod common;
 use actor::{account::State, ACCOUNT_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR, SYSTEM_ACTOR_CODE_ID};
 use address::Address;
 use common::*;
-use db::MemoryDB;
-use message::UnsignedMessage;
 use vm::{ExitCode, Serialized};
 
 macro_rules! account_tests {
@@ -17,11 +15,12 @@ macro_rules! account_tests {
             fn $name() {
                 let (addr, exit_code) = $value;
 
-                let bs = MemoryDB::default();
-                let receiver = Address::new_id(100);
-                let message =  UnsignedMessage::builder().to(receiver.clone()).from(SYSTEM_ACTOR_ADDR.clone()).build().unwrap();
-                let mut rt = MockRuntime::new(&bs, message);
-                rt.caller_type = SYSTEM_ACTOR_CODE_ID.clone();
+                let mut rt = MockRuntime {
+                    receiver: Address::new_id(100),
+                    caller: SYSTEM_ACTOR_ADDR.clone(),
+                    caller_type: SYSTEM_ACTOR_CODE_ID.clone(),
+                    ..Default::default()
+                };
                 rt.expect_validate_caller_addr(&[*SYSTEM_ACTOR_ADDR]);
 
                 if exit_code.is_success() {

--- a/vm/actor/tests/init_actor_test.rs
+++ b/vm/actor/tests/init_actor_test.rs
@@ -12,29 +12,22 @@ use actor::{
 use address::Address;
 use cid::Cid;
 use common::*;
-use db::MemoryDB;
-use ipld_blockstore::BlockStore;
-use message::{Message, UnsignedMessage};
 use serde::Serialize;
 use vm::{ActorError, ExitCode, Serialized, TokenAmount, METHOD_CONSTRUCTOR};
 
-fn construct_runtime<'a, BS: BlockStore>(bs: &'a BS) -> MockRuntime<'a, BS> {
-    let receiver = Address::new_id(1000);
-    let message = UnsignedMessage::builder()
-        .to(receiver.clone())
-        .from(SYSTEM_ACTOR_ADDR.clone())
-        .build()
-        .unwrap();
-    let mut rt = MockRuntime::new(bs, message);
-    rt.caller_type = SYSTEM_ACTOR_CODE_ID.clone();
-    return rt;
+fn construct_runtime() -> MockRuntime {
+    MockRuntime {
+        receiver: Address::new_id(1000),
+        caller: *SYSTEM_ACTOR_ADDR,
+        caller_type: SYSTEM_ACTOR_CODE_ID.clone(),
+        ..Default::default()
+    }
 }
 
 // Test to make sure we abort actors that can not call the exec function
 #[test]
 fn abort_cant_call_exec() {
-    let bs = MemoryDB::default();
-    let mut rt = construct_runtime(&bs);
+    let mut rt = construct_runtime();
     construct_and_verify(&mut rt);
     let anne = Address::new_id(1001);
 
@@ -47,8 +40,7 @@ fn abort_cant_call_exec() {
 
 #[test]
 fn create_2_payment_channels() {
-    let bs = MemoryDB::default();
-    let mut rt = construct_runtime(&bs);
+    let mut rt = construct_runtime();
     construct_and_verify(&mut rt);
     let anne = Address::new_id(1001);
 
@@ -58,14 +50,8 @@ fn create_2_payment_channels() {
         let pay_channel_string = format!("paych_{}", n);
         let paych = pay_channel_string.as_bytes();
 
-        rt.balance = TokenAmount::from(100u8);
-
-        rt.message = UnsignedMessage::builder()
-            .to(rt.message.to().clone())
-            .from(rt.message.from().clone())
-            .value(TokenAmount::from(100u8))
-            .build()
-            .unwrap();
+        rt.balance = TokenAmount::from(100);
+        rt.value_received = TokenAmount::from(100);
 
         let unique_address = Address::new_actor(paych);
         rt.new_actor_addr = Some(Address::new_actor(paych));
@@ -102,7 +88,7 @@ fn create_2_payment_channels() {
 
         let state: State = rt.get_state().unwrap();
         let returned_address = state
-            .resolve_address(rt.store, &unique_address)
+            .resolve_address(&rt.store, &unique_address)
             .expect("Address should have been found");
 
         assert_eq!(returned_address, expected_id_addr, "Wrong Address returned");
@@ -111,8 +97,7 @@ fn create_2_payment_channels() {
 
 #[test]
 fn create_storage_miner() {
-    let bs = MemoryDB::default();
-    let mut rt = construct_runtime(&bs);
+    let mut rt = construct_runtime();
     construct_and_verify(&mut rt);
 
     // only the storage power actor can create a miner
@@ -149,21 +134,20 @@ fn create_storage_miner() {
     // Address should be resolved
     let state: State = rt.get_state().unwrap();
     let returned_address = state
-        .resolve_address(rt.store, &unique_address)
+        .resolve_address(&rt.store, &unique_address)
         .expect("Address should have been found");
     assert_eq!(expected_id_addr, returned_address);
 
     // Should return error since the address of flurbo is unknown
     let unknown_addr = Address::new_actor(b"flurbo");
     state
-        .resolve_address(rt.store, &unknown_addr)
+        .resolve_address(&rt.store, &unknown_addr)
         .expect_err("Address should have not been found");
 }
 
 #[test]
 fn create_multisig_actor() {
-    let bs = MemoryDB::default();
-    let mut rt = construct_runtime(&bs);
+    let mut rt = construct_runtime();
     construct_and_verify(&mut rt);
 
     // Actor creating multisig actor
@@ -206,8 +190,7 @@ fn create_multisig_actor() {
 
 #[test]
 fn sending_constructor_failure() {
-    let bs = MemoryDB::default();
-    let mut rt = construct_runtime(&bs);
+    let mut rt = construct_runtime();
     construct_and_verify(&mut rt);
 
     // Only the storage power actor can create a miner
@@ -250,7 +233,7 @@ fn sending_constructor_failure() {
     let state: State = rt.get_state().unwrap();
 
     let returned_address = state
-        .resolve_address(rt.store, &unique_address)
+        .resolve_address(&rt.store, &unique_address)
         .expect_err("Address resolution should have failed");
 
     assert_eq!(
@@ -259,7 +242,7 @@ fn sending_constructor_failure() {
     );
 }
 
-fn construct_and_verify<'a, BS: BlockStore>(rt: &mut MockRuntime<'a, BS>) {
+fn construct_and_verify(rt: &mut MockRuntime) {
     rt.expect_validate_caller_addr(&[SYSTEM_ACTOR_ADDR.clone()]);
     let params = ConstructorParams {
         network_name: "mock".to_string(),
@@ -278,7 +261,7 @@ fn construct_and_verify<'a, BS: BlockStore>(rt: &mut MockRuntime<'a, BS>) {
     let state_data: State = rt.get_state().unwrap();
 
     // Gets the Result(CID)
-    let empty_map = Multimap::from_root(rt.store, &state_data.address_map)
+    let empty_map = Multimap::from_root(&rt.store, &state_data.address_map)
         .unwrap()
         .root();
 
@@ -287,8 +270,8 @@ fn construct_and_verify<'a, BS: BlockStore>(rt: &mut MockRuntime<'a, BS>) {
     assert_eq!("mock".to_string(), state_data.network_name);
 }
 
-fn exec_and_verify<'a, BS: BlockStore, S: Serialize>(
-    rt: &mut MockRuntime<'a, BS>,
+fn exec_and_verify<'a, S: Serialize>(
+    rt: &mut MockRuntime,
     code_id: Cid,
     params: &S,
 ) -> Result<Serialized, ActorError>


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Changes the runtime message access to return a `dyn MessageInfo` reference. The reason for not making generic here is that it is very infrequently used and generics for this wouldn't be worth it

Just backporting this commit as well from my wip because it is isolated and will make reviewing easier

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->