### PR TITLE
Remove incorrectly ported sanity check from go implementation

### DIFF
--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -413,12 +413,6 @@ fn check_message(msg: &UnsignedMessage) -> Result<(), &'static str> {
     if msg.gas_limit() < 0 {
         return Err("Message has negative gas limit");
     }
-    if msg.value() == &BigInt::zero() {
-        return Err("Message has no value set");
-    }
-    if msg.gas_price() == &BigInt::zero() {
-        return Err("Message has no gas price set");
-    }
 
     Ok(())
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- There is no need for this as these values cannot be nil and was ported over I guess under the assumption it was ensuring the value could not be 0. Should have been a giveaway that value was checked to not be 0.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #596 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->