### PR TITLE
Returns an Error in case of slicing non-ascii strings

### DIFF
--- a/vm/address/src/lib.rs
+++ b/vm/address/src/lib.rs
@@ -162,7 +162,7 @@ impl FromStr for Address {
             return Err(Error::InvalidLength);
         }
         // ensure the network character is valid before converting
-        let network: Network = match &addr[0..1] {
+        let network: Network = match addr.get(0..1).ok_or(Error::UnknownNetwork)? {
             TESTNET_PREFIX => Network::Testnet,
             MAINNET_PREFIX => Network::Mainnet,
             _ => {
@@ -171,7 +171,7 @@ impl FromStr for Address {
         };
 
         // get protocol from second character
-        let protocol: Protocol = match &addr[1..2] {
+        let protocol: Protocol = match addr.get(1..2).ok_or(Error::UnknownProtocol)? {
             "0" => Protocol::ID,
             "1" => Protocol::Secp256k1,
             "2" => Protocol::Actor,
@@ -182,7 +182,7 @@ impl FromStr for Address {
         };
 
         // bytes after the protocol character is the data payload of the address
-        let raw = &addr[2..];
+        let raw = addr.get(2..).ok_or(Error::InvalidPayload)?;
         if protocol == Protocol::ID {
             if raw.len() > 20 {
                 // 20 is max u64 as string


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Uses the [str::get](https://doc.rust-lang.org/beta/std/primitive.str.html#method.get) to get a slice from a string.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #595


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->