### PR TITLE
New Genesis Template cli command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,7 @@ dependencies = [
  "clock",
  "commcid",
  "filecoin-proofs-api",
+ "forest_address",
  "forest_bigint",
  "forest_cid",
  "forest_encoding",
@@ -2361,6 +2362,7 @@ dependencies = [
  "structopt",
  "surf",
  "utils",
+ "uuid",
 ]
 
 [[package]]
@@ -7081,6 +7083,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "toml",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/forest/Cargo.toml
+++ b/forest/Cargo.toml
@@ -37,3 +37,4 @@ pin-project-lite = "0.1"
 message_pool = { package = "message_pool", path = "../blockchain/message_pool" }
 wallet = {package = "key_management", path = "../key_management"}
 jsonrpc-v2 = { version = "0.5.2", features = ["easy-errors", "macros"] }
+uuid = { version = "0.8.1", features = ["v4"] }

--- a/forest/src/cli/genesis_cmd.rs
+++ b/forest/src/cli/genesis_cmd.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fil_types::genesis;
+use std::fs::File;
+use structopt::StructOpt;
+use uuid::Uuid;
+
+#[derive(Debug, StructOpt)]
+pub enum GenesisCommands {
+    /// Creates new genesis template
+    #[structopt(about = "Create new Genesis template")]
+    NewTemplate {
+        #[structopt(short, help = "Input a network name")]
+        network_name: Option<String>,
+        #[structopt(
+            short,
+            default_value = "genesis.json",
+            help = "File path, i.e, './genesis.json'. This command WILL NOT create a directory if it does not exist."
+        )]
+        file_path: String,
+    },
+}
+
+impl GenesisCommands {
+    pub async fn run(&self) {
+        match self {
+            Self::NewTemplate {
+                network_name,
+                file_path,
+            } => {
+                let template = genesis::Template::new(
+                    network_name
+                        .as_ref()
+                        .unwrap_or(&format!("localnet-{}", Uuid::new_v4().to_string()))
+                        .to_string(),
+                );
+
+                match &File::create(file_path) {
+                    Ok(file) => {
+                        serde_json::to_writer_pretty(file, &template).unwrap();
+                    }
+                    Err(err) => {
+                        println!("Can not write to a file, error: {}", err);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -5,11 +5,13 @@ mod chain_cmd;
 mod config;
 mod fetch_params_cmd;
 mod genesis;
+mod genesis_cmd;
 
 pub(super) use self::chain_cmd::ChainCommands;
 pub use self::config::Config;
 pub(super) use self::fetch_params_cmd::FetchCommands;
 pub(super) use self::genesis::initialize_genesis;
+pub(super) use self::genesis_cmd::GenesisCommands;
 
 use jsonrpc_v2::Error as JsonRpcError;
 use std::cell::RefCell;
@@ -47,6 +49,9 @@ pub enum Subcommand {
 
     #[structopt(name = "chain", about = "Interact with Filecoin blockchain")]
     Chain(ChainCommands),
+
+    #[structopt(name = "genesis", about = "Work with blockchain genesis")]
+    Genesis(GenesisCommands),
 }
 
 /// Daemon process command line options.

--- a/forest/src/subcommand.rs
+++ b/forest/src/subcommand.rs
@@ -12,5 +12,8 @@ pub(super) async fn process(command: Subcommand) {
         Subcommand::Chain(cmd) => {
             cmd.run().await;
         }
+        Subcommand::Genesis(cmd) => {
+            cmd.run().await;
+        }
     }
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 features = ["json"]
 
 [dependencies]
+address = { package = "forest_address", path = "../vm/address" }
 serde = { version = "1.0", features = ["derive"] }
 commcid = { path = "../utils/commcid" }
 filecoin-proofs-api = "4.0.1"

--- a/types/src/genesis/mod.rs
+++ b/types/src/genesis/mod.rs
@@ -34,6 +34,7 @@ pub struct Miner {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct Template {
     accounts: Vec<Actor>,
     miners: Vec<Miner>,

--- a/types/src/genesis/mod.rs
+++ b/types/src/genesis/mod.rs
@@ -1,0 +1,52 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::SectorSize;
+use address::Address;
+use num_bigint::bigint_ser;
+use serde::Serialize;
+use vm::TokenAmount;
+
+#[derive(Serialize)]
+enum ActorType {
+    // Account,
+// MultiSig,
+}
+
+#[derive(Serialize)]
+pub struct Actor {
+    actor_type: ActorType,
+    #[serde(with = "bigint_ser")]
+    token_amount: TokenAmount,
+}
+
+#[derive(Serialize)]
+pub struct Miner {
+    owner: Address,
+    worker: Address,
+    peer_id: Vec<u8>,
+
+    #[serde(with = "bigint_ser")]
+    market_balance: TokenAmount,
+    #[serde(with = "bigint_ser")]
+    power_balance: TokenAmount,
+    sector_size: SectorSize,
+}
+
+#[derive(Serialize)]
+pub struct Template {
+    accounts: Vec<Actor>,
+    miners: Vec<Miner>,
+    network_name: String,
+    // timestamp: SystemTime,
+}
+
+impl Template {
+    pub fn new(network_name: String) -> Template {
+        Template {
+            accounts: Vec::new(),
+            miners: Vec::new(),
+            network_name,
+        }
+    }
+}

--- a/types/src/genesis/mod.rs
+++ b/types/src/genesis/mod.rs
@@ -8,37 +8,39 @@ use serde::Serialize;
 use vm::TokenAmount;
 
 #[derive(Serialize)]
-enum ActorType {
-    // Account,
-// MultiSig,
+pub enum ActorType {
+    Account,
+    MultiSig,
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct Actor {
-    actor_type: ActorType,
+    pub actor_type: ActorType,
     #[serde(with = "bigint_ser")]
-    token_amount: TokenAmount,
+    pub token_amount: TokenAmount,
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct Miner {
-    owner: Address,
-    worker: Address,
-    peer_id: Vec<u8>,
+    pub owner: Address,
+    pub worker: Address,
+    pub peer_id: Vec<u8>,
 
     #[serde(with = "bigint_ser")]
-    market_balance: TokenAmount,
+    pub market_balance: TokenAmount,
     #[serde(with = "bigint_ser")]
-    power_balance: TokenAmount,
-    sector_size: SectorSize,
+    pub power_balance: TokenAmount,
+    pub sector_size: SectorSize,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Template {
-    accounts: Vec<Actor>,
-    miners: Vec<Miner>,
-    network_name: String,
+    pub accounts: Vec<Actor>,
+    pub miners: Vec<Miner>,
+    pub network_name: String,
     // timestamp: SystemTime,
 }
 

--- a/types/src/genesis/mod.rs
+++ b/types/src/genesis/mod.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use vm::TokenAmount;
 
 #[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ActorType {
     Account,
     MultiSig,

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+pub mod genesis;
 mod piece;
 pub mod sector;
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- 

Added new CLI command to create Genesis template. 

Lotus-seed output for reference:

```
{
  "Accounts": [],
  "Miners": [],
  "NetworkName": "localnet-a793c73a-4db3-4755-910e-7466bce48023"
}
```

Forest's output:

```
{
  "Accounts": [],
  "Miners": [],
  "NetworkName": "localnet-a793c73a-4db3-4755-910e-7466bce4blah"
}
```

**How to test**

build and run

`forest genesis new-template`

Provide network name and output path optionally:

`forest genesis new-template -n "my-network" -f "./genesis_out.json"`





**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #580 #579 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->