### PR TITLE
Adding BlockReceiptTracker Struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
 name = "chain_sync"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.4.4",
  "async-std",
  "base64 0.12.3",
  "beacon",

--- a/blockchain/chain_sync/Cargo.toml
+++ b/blockchain/chain_sync/Cargo.toml
@@ -34,6 +34,7 @@ commcid = { path = "../../utils/commcid" }
 clock = { path = "../../node/clock" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 flo_stream = "0.4.0"
+ahash = "0.4"
 
 [dev-dependencies]
 test_utils = { version = "0.1.0", path = "../../utils/test_utils/", features = ["test_constructors"] }

--- a/blockchain/chain_sync/src/lib.rs
+++ b/blockchain/chain_sync/src/lib.rs
@@ -7,14 +7,15 @@ mod errors;
 mod network_context;
 mod network_handler;
 mod peer_manager;
+mod receipt_tracker;
 mod sync;
 mod sync_state;
-
 // workaround for a compiler bug, see https://github.com/rust-lang/rust/issues/55779
 extern crate serde;
 
 pub use self::bad_block_cache::BadBlockCache;
 pub use self::errors::Error;
 pub use self::network_context::SyncNetworkContext;
+pub use self::receipt_tracker::BlockReceiptTracker;
 pub use self::sync::ChainSyncer;
 pub use self::sync_state::{SyncStage, SyncState};

--- a/blockchain/chain_sync/src/receipt_tracker.rs
+++ b/blockchain/chain_sync/src/receipt_tracker.rs
@@ -1,0 +1,56 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use ahash::AHashMap;
+use async_std::sync::RwLock;
+use blocks::{Tipset, TipsetKeys};
+use libp2p::core::PeerId;
+use lru::LruCache;
+use std::time::SystemTime;
+
+type PeerSet = AHashMap<PeerId, SystemTime>;
+
+#[derive(Debug)]
+pub struct BlockReceiptTracker {
+    cache: RwLock<LruCache<TipsetKeys, PeerSet>>,
+}
+
+impl Default for BlockReceiptTracker {
+    fn default() -> Self {
+        Self::new(512)
+    }
+}
+
+impl BlockReceiptTracker {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            cache: RwLock::new(LruCache::new(cap)),
+        }
+    }
+
+    pub async fn add(&self, p: PeerId, ts: Tipset) -> Option<SystemTime> {
+        let current_time = SystemTime::now();
+        if let Some(ts_peer_set) = self.cache.write().await.get_mut(ts.key()) {
+            ts_peer_set.insert(p, current_time)
+        } else {
+            let mut map = AHashMap::new();
+            map.insert(p, current_time);
+            let key = ts.key().clone();
+            self.cache.write().await.put(key, map);
+            None
+        }
+    }
+
+    pub async fn get_peers(&self, ts: Tipset) -> Option<Vec<PeerId>> {
+        let mut v: Vec<PeerId> = vec![];
+
+        self.cache
+            .read()
+            .await
+            .peek(ts.key())?
+            .keys()
+            .for_each(|value| v.push(value.clone()));
+
+        Some(v)
+    }
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- Adds the BlockReceiptTracker, Lotus Parallel is : chain/block_receipt_tracker.go

Issue : 
PeerId struct is declared in libp2p::core so I can't implement the FromIterator trait for it, so not sure what the best way to create a sorted vec from the iterator is. Right now it just creates a vector buy pushing cloned elements from the iterator 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->