### PR TITLE
Update edge cases for dynamic error handling in VM

### DIFF
--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -27,14 +27,14 @@ use vm::{ExitCode, Serialized, TokenAmount};
 use walkdir::{DirEntry, WalkDir};
 
 lazy_static! {
-    static ref SKIP_TESTS: [Regex; 7] = [
-        Regex::new(r"actor_creation/.*").unwrap(),
-        Regex::new(r"msg_application/.*").unwrap(),
-        Regex::new(r"multisig/.*").unwrap(),
-        Regex::new(r"nested/.*").unwrap(),
-        Regex::new(r"paych/.*").unwrap(),
-        Regex::new(r"transfer/.*").unwrap(),
-        Regex::new(r"vm_violations/.*").unwrap(),
+    static ref SKIP_TESTS: [Regex; 4] = [
+        // These tests are marked as invalid as they return wrong exit code on Lotus
+        Regex::new(r"actor_creation/x--params*").unwrap(),
+        // Following two fail for the same invalid exit code return
+        Regex::new(r"nested/nested_sends--fail-missing-params.json").unwrap(),
+        Regex::new(r"nested/nested_sends--fail-mismatch-params.json").unwrap(),
+        // Lotus client does not fail in inner transaction for insufficient funds
+        Regex::new(r"test-vectors/corpus/nested/nested_sends--fail-insufficient-funds-for-transfer-in-inner-send.json").unwrap(),
     ];
     static ref BASE_FEE: TokenAmount = TokenAmount::from(100);
 }
@@ -380,11 +380,7 @@ fn conformance_test_runner() {
     }
 
     if !failed.is_empty() {
-        eprintln!(
-            "{}/{} tests failed:",
-            failed.len(),
-            failed.len() + succeeded
-        );
+        eprintln!("{}/{} tests passed:", succeeded, failed.len() + succeeded);
         for (path, meta, e) in failed {
             eprintln!(
                 "file {} failed:\n\tMeta: {:?}\n\tError: {}\n",

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -265,8 +265,6 @@ fn execute_message(
         }
     }
 
-    // TODO register puppet actor (and conditionally chaos actor)
-
     let ret = vm.apply_message(msg)?;
 
     let root = vm.flush()?;
@@ -379,8 +377,8 @@ fn conformance_test_runner() {
         }
     }
 
+    println!("{}/{} tests passed:", succeeded, failed.len() + succeeded);
     if !failed.is_empty() {
-        eprintln!("{}/{} tests passed:", succeeded, failed.len() + succeeded);
         for (path, meta, e) in failed {
             eprintln!(
                 "file {} failed:\n\tMeta: {:?}\n\tError: {}\n",

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -368,10 +368,12 @@ impl Actor {
             params.sector_expiry,
             params.sector_start,
         )
-        .map_err(|e| match e.downcast::<ActorError>() {
-            Ok(actor_err) => *actor_err,
-            Err(other) => actor_error!(ErrIllegalState;
-                "failed to validate deal proposals for activation: {}", other),
+        .map_err(|e| {
+            ActorError::downcast(
+                e,
+                ExitCode::ErrIllegalState,
+                "failed to validate deal proposals for activation",
+            )
         })?;
 
         Ok(VerifyDealsForActivationReturn {
@@ -401,10 +403,12 @@ impl Actor {
                 params.sector_expiry,
                 curr_epoch,
             )
-            .map_err(|e| match e.downcast::<ActorError>() {
-                Ok(actor_err) => *actor_err,
-                Err(other) => actor_error!(ErrIllegalState;
-                    "failed to validate deal proposals for activation: {}", other),
+            .map_err(|e| {
+                ActorError::downcast(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to validate deal proposals for activation",
+                )
             })?;
 
             let mut msm = st.mutator(rt.store());

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -116,11 +116,8 @@ impl Actor {
         // Validate signature
         rt.syscalls()
             .verify_signature(&sig, &signer, &sv_bz)
-            .map_err(|e| match e.downcast::<ActorError>() {
-                Ok(actor_err) => *actor_err,
-                Err(other) => {
-                    actor_error!(ErrIllegalArgument; "voucher signature invalid: {}", other)
-                }
+            .map_err(|e| {
+                ActorError::downcast(e, ExitCode::ErrIllegalArgument, "voucher signature invalid")
             })?;
 
         let pch_addr = rt.message().receiver();

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -12,8 +12,8 @@ use cid::{multihash::Blake2b256, Cid};
 use clock::ChainEpoch;
 use crypto::DomainSeparationTag;
 use fil_types::{DevnetParams, NetworkParams};
+use forest_encoding::to_vec;
 use forest_encoding::Cbor;
-use forest_encoding::{error::Error as EncodingError, to_vec};
 use ipld_blockstore::BlockStore;
 use log::warn;
 use message::{Message, UnsignedMessage};
@@ -213,11 +213,7 @@ where
     {
         self.store
             .put(obj, Blake2b256)
-            .map_err(|e| match e.downcast::<EncodingError>() {
-                Ok(ser_error) => actor_error!(ErrSerialization;
-                        "failed to marshal cbor object {}", ser_error),
-                Err(other) => actor_error!(fatal("failed to put cbor object: {}", other)),
-            })
+            .map_err(|e| ActorError::downcast_fatal(e, "failed to put cbor object"))
     }
 
     /// Helper function for getting deserializable objects from blockstore.
@@ -227,11 +223,7 @@ where
     {
         self.store
             .get(cid)
-            .map_err(|e| match e.downcast::<EncodingError>() {
-                Ok(ser_error) => actor_error!(ErrSerialization;
-                "failed to unmarshal cbor object {}", ser_error),
-                Err(other) => actor_error!(fatal("failed to get cbor object: {}", other)),
-            })
+            .map_err(|e| ActorError::downcast_fatal(e, "failed to get cbor object"))
     }
 
     fn internal_send(


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- If there was a read or write that ran out of gas, the error would not be downcasted correctly, as it was just checking for encoding errors. To be safe, all downcasts are updated to use the one attached to `ActorError` where both `EncodingError` and `ActorError` can be downcasted from a dynamic error.
- Updates test runner to only skip invalid files now that all others are passing (and prints passes instead of failures)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->