### PR TITLE
Switches out flostream for Single Producer Multiconsumer Bus

### DIFF
--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -24,7 +24,7 @@ actor = { path = "../../vm/actor/" }
 blake2b_simd = "0.5.9"
 byteorder = "1.3.4"
 beacon = { path = "../beacon" }
-flo_stream = "0.4.0"
+bus = "2.2.3"
 address = { package = "forest_address", path = "../../vm/address" }
 lazy_static = "1.4"
 async-std = "1.6.3"

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -8,6 +8,7 @@ use async_std::sync::RwLock;
 use beacon::{BeaconEntry, IGNORE_DRAND_VAR};
 use blake2b_simd::Params;
 use blocks::{Block, BlockHeader, FullTipset, Tipset, TipsetKeys, TxMeta};
+use bus::{Bus, BusReader};
 use byteorder::{BigEndian, WriteBytesExt};
 use cid::multihash::Blake2b256;
 use cid::Cid;
@@ -25,7 +26,6 @@ use state_tree::StateTree;
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
-use bus::{Bus,BusReader};
 
 const GENESIS_KEY: &str = "gen_block";
 const HEAD_KEY: &str = "head";

--- a/blockchain/message_pool/Cargo.toml
+++ b/blockchain/message_pool/Cargo.toml
@@ -20,7 +20,7 @@ chain = { path = "../chain" }
 state_tree = { path = "../../vm/state_tree/" }
 serde = { version = "1.0", features = ["derive"] }
 db = { path = "../../node/db" }
-flo_stream = "0.4.0"
+bus = "2.2.3"
 futures = "0.3.5"
 libsecp256k1 = "0.3.4"
 blake2b_simd = "0.5.10"

--- a/blockchain/message_pool/src/msgpool.rs
+++ b/blockchain/message_pool/src/msgpool.rs
@@ -8,12 +8,12 @@ use async_std::task;
 use async_trait::async_trait;
 use blocks::{BlockHeader, Tipset, TipsetKeys};
 use blockstore::BlockStore;
+use bus::BusReader;
 use chain::{ChainStore, HeadChange};
 use cid::multihash::Blake2b256;
 use cid::Cid;
 use crypto::{Signature, SignatureType};
 use encoding::Cbor;
-use bus::BusReader;
 use log::{error, warn};
 use lru::LruCache;
 use message::{Message, SignedMessage, UnsignedMessage};
@@ -736,8 +736,8 @@ pub mod test_provider {
     use super::*;
     use address::Address;
     use blocks::{BlockHeader, Tipset};
+    use bus::{Bus, BusReader};
     use cid::Cid;
-    use bus::{BusReader,Bus};
     use message::{SignedMessage, UnsignedMessage};
 
     /// Struct used for creating a provider when writing tests involving message pool

--- a/blockchain/message_pool/src/msgpool.rs
+++ b/blockchain/message_pool/src/msgpool.rs
@@ -13,13 +13,11 @@ use cid::multihash::Blake2b256;
 use cid::Cid;
 use crypto::{Signature, SignatureType};
 use encoding::Cbor;
-use flo_stream::Subscriber;
-use futures::StreamExt;
+use bus::BusReader;
 use log::{error, warn};
 use lru::LruCache;
 use message::{Message, SignedMessage, UnsignedMessage};
 use num_bigint::BigInt;
-use state_manager::StateManager;
 use state_tree::StateTree;
 use std::borrow::BorrowMut;
 use std::collections::{HashMap, HashSet};
@@ -77,7 +75,7 @@ impl MsgSet {
 #[async_trait]
 pub trait Provider {
     /// Update Mpool's cur_tipset whenever there is a chnge to the provider
-    async fn subscribe_head_changes(&mut self) -> Subscriber<HeadChange>;
+    async fn subscribe_head_changes(&mut self) -> BusReader<HeadChange>;
     /// Get the heaviest Tipset in the provider
     async fn get_heaviest_tipset(&mut self) -> Option<Tipset>;
     /// Add a message to the MpoolProvider, return either Cid or Error depending on successful put
@@ -121,7 +119,7 @@ impl<DB> Provider for MpoolProvider<DB>
 where
     DB: BlockStore + Send + Sync,
 {
-    async fn subscribe_head_changes(&mut self) -> Subscriber<HeadChange> {
+    async fn subscribe_head_changes(&mut self) -> BusReader<HeadChange> {
         self.cs.subscribe().await
     }
 
@@ -169,19 +167,18 @@ where
 
 /// This is the Provider implementation that will be used for the mpool RPC
 pub struct MpoolRpcProvider<DB> {
-    subscriber: Subscriber<HeadChange>,
-    sm: Arc<StateManager<DB>>,
+    chain_store: Arc<ChainStore<DB>>,
 }
 
 impl<DB> MpoolRpcProvider<DB>
 where
     DB: BlockStore,
 {
-    pub fn new(subscriber: Subscriber<HeadChange>, sm: Arc<StateManager<DB>>) -> Self
+    pub fn new(chain_store: Arc<ChainStore<DB>>) -> Self
     where
         DB: BlockStore,
     {
-        MpoolRpcProvider { subscriber, sm }
+        MpoolRpcProvider { chain_store }
     }
 }
 
@@ -190,27 +187,27 @@ impl<DB> Provider for MpoolRpcProvider<DB>
 where
     DB: BlockStore + Send + Sync,
 {
-    async fn subscribe_head_changes(&mut self) -> Subscriber<HeadChange> {
-        self.subscriber.clone()
+    async fn subscribe_head_changes(&mut self) -> BusReader<HeadChange> {
+        self.chain_store.subscribe().await
     }
 
     async fn get_heaviest_tipset(&mut self) -> Option<Tipset> {
-        chain::get_heaviest_tipset(self.sm.get_block_store_ref())
+        chain::get_heaviest_tipset(&*self.chain_store.blockstore())
             .ok()
             .unwrap_or(None)
     }
 
     fn put_message(&self, msg: &SignedMessage) -> Result<Cid, Error> {
         let cid = self
-            .sm
-            .get_block_store_ref()
+            .chain_store
+            .blockstore()
             .put(msg, Blake2b256)
             .map_err(|err| Error::Other(err.to_string()))?;
         Ok(cid)
     }
 
     fn state_get_actor(&self, addr: &Address, ts: &Tipset) -> Result<ActorState, Error> {
-        let state = StateTree::new_from_root(self.sm.get_block_store_ref(), ts.parent_state())
+        let state = StateTree::new_from_root(self.chain_store.blockstore(), ts.parent_state())
             .map_err(|e| Error::Other(e.to_string()))?;
         let actor = state
             .get_actor(addr)
@@ -222,20 +219,20 @@ where
         &self,
         h: &BlockHeader,
     ) -> Result<(Vec<UnsignedMessage>, Vec<SignedMessage>), Error> {
-        chain::block_messages(self.sm.get_block_store_ref(), h).map_err(|err| err.into())
+        chain::block_messages(self.chain_store.blockstore(), h).map_err(|err| err.into())
     }
 
     fn messages_for_tipset(&self, h: &Tipset) -> Result<Vec<UnsignedMessage>, Error> {
-        chain::unsigned_messages_for_tipset(self.sm.get_block_store_ref(), h)
+        chain::unsigned_messages_for_tipset(self.chain_store.blockstore(), h)
             .map_err(|err| err.into())
     }
 
     fn load_tipset(&self, tsk: &TipsetKeys) -> Result<Tipset, Error> {
-        let ts = chain::tipset_from_keys(self.sm.get_block_store_ref(), tsk)?;
+        let ts = chain::tipset_from_keys(self.chain_store.blockstore(), tsk)?;
         Ok(ts)
     }
     fn chain_compute_base_fee(&self, ts: &Tipset) -> Result<BigInt, Error> {
-        chain::compute_base_fee(self.sm.get_block_store_ref(), ts).map_err(|err| err.into())
+        chain::compute_base_fee(self.chain_store.blockstore(), ts).map_err(|err| err.into())
     }
 }
 
@@ -298,7 +295,7 @@ where
 
         task::spawn(async move {
             loop {
-                if let Some(ts) = subscriber.next().await {
+                if let Ok(ts) = subscriber.recv() {
                     let ts = match ts {
                         HeadChange::Current(tipset)
                         | HeadChange::Revert(tipset)
@@ -740,7 +737,7 @@ pub mod test_provider {
     use address::Address;
     use blocks::{BlockHeader, Tipset};
     use cid::Cid;
-    use flo_stream::{MessagePublisher, Publisher, Subscriber};
+    use bus::{BusReader,Bus};
     use message::{SignedMessage, UnsignedMessage};
 
     /// Struct used for creating a provider when writing tests involving message pool
@@ -748,7 +745,7 @@ pub mod test_provider {
         bmsgs: HashMap<Cid, Vec<SignedMessage>>,
         state_sequence: HashMap<Address, u64>,
         tipsets: Vec<Tipset>,
-        publisher: Publisher<HeadChange>,
+        publisher: Bus<HeadChange>,
     }
 
     impl Default for TestApi {
@@ -758,7 +755,7 @@ pub mod test_provider {
                 bmsgs: HashMap::new(),
                 state_sequence: HashMap::new(),
                 tipsets: Vec::new(),
-                publisher: Publisher::new(1),
+                publisher: Bus::new(1),
             }
         }
     }
@@ -777,14 +774,14 @@ pub mod test_provider {
 
         /// Set the heaviest tipset for TestApi
         pub async fn set_heaviest_tipset(&mut self, ts: Arc<Tipset>) {
-            self.publisher.publish(HeadChange::Current(ts)).await
+            self.publisher.broadcast(HeadChange::Current(ts))
         }
     }
 
     #[async_trait]
     impl Provider for TestApi {
-        async fn subscribe_head_changes(&mut self) -> Subscriber<HeadChange> {
-            self.publisher.subscribe()
+        async fn subscribe_head_changes(&mut self) -> BusReader<HeadChange> {
+            self.publisher.add_rx()
         }
 
         async fn get_heaviest_tipset(&mut self) -> Option<Tipset> {

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -66,10 +66,10 @@ pub(super) async fn start(config: Config) {
 
     // Initialize StateManager
     let state_manager = Arc::new(StateManager::new(Arc::clone(&db)));
+    let chain_store = Arc::new(ChainStore::new(db));
 
     // Initialize mpool
-    let subscriber = chain_store.subscribe().await;
-    let provider = MpoolRpcProvider::new(subscriber, Arc::clone(&state_manager));
+    let provider = MpoolRpcProvider::new(chain_store.clone());
     let mpool = Arc::new(
         MessagePool::new(provider, network_name.clone())
             .await
@@ -90,7 +90,7 @@ pub(super) async fn start(config: Config) {
 
     // Initialize ChainSyncer
     let chain_syncer = ChainSyncer::new(
-        Arc::new(chain_store),
+        chain_store,
         Arc::clone(&state_manager),
         Arc::new(beacon),
         network_send.clone(),

--- a/node/rpc/src/sync_api.rs
+++ b/node/rpc/src/sync_api.rs
@@ -118,12 +118,11 @@ mod tests {
         let db = Arc::new(MemoryDB::default());
         let state_manager = Arc::new(StateManager::new(db.clone()));
 
+        let cs = Arc::new(ChainStore::new(db.clone()));
         let pool = task::block_on(async {
-            let cs = ChainStore::new(db.clone());
             let bz = hex::decode("904300e80781586082cb7477a801f55c1f2ea5e5d1167661feea60a39f697e1099af132682b81cc5047beacf5b6e80d5f52b9fd90323fb8510a5396416dd076c13c85619e176558582744053a3faef6764829aa02132a1571a76aabdc498a638ea0054d3bb57f41d82015860812d2396cc4592cdf7f829374b01ffd03c5469a4b0a9acc5ccc642797aa0a5498b97b28d90820fedc6f79ff0a6005f5c15dbaca3b8a45720af7ed53000555667207a0ccb50073cd24510995abd4c4e45c1e9e114905018b2da9454190499941e818201582012dd0a6a7d0e222a97926da03adb5a7768d31cc7c5c2bd6828e14a7d25fa3a608182004b76616c69642070726f6f6681d82a5827000171a0e4022030f89a8b0373ad69079dbcbc5addfe9b34dce932189786e50d3eb432ede3ba9c43000f0001d82a5827000171a0e4022052238c7d15c100c1b9ebf849541810c9e3c2d86e826512c6c416d2318fcd496dd82a5827000171a0e40220e5658b3d18cd06e1db9015b4b0ec55c123a24d5be1ea24d83938c5b8397b4f2fd82a5827000171a0e4022018d351341c302a21786b585708c9873565a0d07c42521d4aaf52da3ff6f2e461586102c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001a5f2c5439586102b5cd48724dce0fec8799d77fd6c5113276e7f470c8391faa0b5a6033a3eaf357d635705c36abe10309d73592727289680515afd9d424793ba4796b052682d21b03c5c8a37d94827fecc59cdc5750e198fdf20dee012f4d627c6665132298ab95004500053724e0").unwrap();
             let header = BlockHeader::unmarshal_cbor(&bz).unwrap();
             let ts = Tipset::new(vec![header]).unwrap();
-            let subscriber = cs.subscribe().await;
             let db = cs.db.clone();
             let tsk = ts.key().cids.clone();
             cs.set_heaviest_tipset(Arc::new(ts)).await.unwrap();
@@ -132,7 +131,7 @@ mod tests {
                 let bz2 = bz.clone();
                 db.as_ref().write(i.key(), bz2).unwrap();
             }
-            let provider = MpoolRpcProvider::new(subscriber, state_manager.clone());
+            let provider = MpoolRpcProvider::new(cs.clone());
             MessagePool::new(provider, "test".to_string())
                 .await
                 .unwrap()


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- lock free, behaves in the same way flo_stream does. Downside is that it does not implement Stream or Sink traits



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #700 


**Other information and links**
<!-- Add any other context about the pull request here. -->
https://crates.io/crates/bus



<!-- Thank you 🔥 -->