### PR TITLE
Update Actors error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,7 @@ dependencies = [
  "ctrlc",
  "db",
  "fil_types",
+ "flo_stream",
  "forest_address",
  "forest_bigint",
  "forest_blocks",
@@ -2421,7 +2422,7 @@ dependencies = [
  "futures 0.3.5",
  "hex",
  "ipld_blockstore",
- "jsonrpc-v2",
+ "jsonrpc-v2 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "key_management",
  "libp2p",
  "log",
@@ -3482,6 +3483,23 @@ dependencies = [
 [[package]]
 name = "jsonrpc-v2"
 version = "0.5.2"
+source = "git+https://github.com/ChainSafe/jsonrpc-v2#d1d060576ede0bd76eee173545edbd8bfd698016"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "async-trait",
+ "bytes 0.5.6",
+ "erased-serde",
+ "extensions",
+ "futures 0.3.5",
+ "jsonrpc-v2-macros 0.1.0 (git+https://github.com/ChainSafe/jsonrpc-v2)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonrpc-v2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a88dfa47312f1fa91762334c057ce3a2c6fcafcacb5d816ad47338190e0e606"
 dependencies = [
@@ -3492,9 +3510,19 @@ dependencies = [
  "erased-serde",
  "extensions",
  "futures 0.3.5",
- "jsonrpc-v2-macros",
+ "jsonrpc-v2-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonrpc-v2-macros"
+version = "0.1.0"
+source = "git+https://github.com/ChainSafe/jsonrpc-v2#d1d060576ede0bd76eee173545edbd8bfd698016"
+dependencies = [
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -5620,7 +5648,7 @@ dependencies = [
  "hex",
  "interpreter",
  "ipld_blockstore",
- "jsonrpc-v2",
+ "jsonrpc-v2 0.5.2 (git+https://github.com/ChainSafe/jsonrpc-v2)",
  "key_management",
  "log",
  "message_pool",
@@ -5643,7 +5671,7 @@ dependencies = [
  "forest_cid",
  "forest_crypto",
  "forest_message",
- "jsonrpc-v2",
+ "jsonrpc-v2 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpsee",
  "log",
  "serde_json",

--- a/blockchain/chain/src/store/errors.rs
+++ b/blockchain/chain/src/store/errors.rs
@@ -33,8 +33,8 @@ pub enum Error {
     #[error(transparent)]
     Cid(#[from] CidErr),
     /// Amt error
-    #[error(transparent)]
-    Amt(#[from] AmtErr),
+    #[error("State error: {0}")]
+    State(String),
     /// Other chain error
     #[error("{0}")]
     Other(String),
@@ -49,6 +49,12 @@ impl From<EncErr> for Error {
 impl From<SerdeErr> for Error {
     fn from(e: SerdeErr) -> Error {
         Error::Encoding(e.to_string())
+    }
+}
+
+impl From<AmtErr> for Error {
+    fn from(e: AmtErr) -> Error {
+        Error::State(e.to_string())
     }
 }
 

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -845,5 +845,6 @@ where
             .load_actor_state(&*INIT_ACTOR_ADDR, ts.parent_state())
             .map_err(|e| format!("loading power actor state: {}", e))?;
         ps.miner_nominal_power_meets_consensus_minimum(self.blockstore(), addr)
+            .map_err(|e| e.to_string())
     }
 }

--- a/encoding/src/errors.rs
+++ b/encoding/src/errors.rs
@@ -7,41 +7,20 @@ use std::fmt;
 use std::io;
 use thiserror::Error;
 
-/// Error type for encoding and decoding data through any Forest supported protocol
+/// Error type for encoding and decoding data through any Forest supported protocol.
 ///
 /// This error will provide any details about the data which was attempted to be
-/// encoded or decoded. The
-///
-/// Usage:
-/// ```no_run
-/// use forest_encoding::{Error, CodecProtocol};
-///
-/// Error::Marshalling {
-///     description: format!("{:?}", vec![0]),
-///     protocol: CodecProtocol::Cbor,
-/// };
-/// Error::Unmarshalling {
-///     description: format!("{:?}", vec![0]),
-///     protocol: CodecProtocol::Cbor,
-/// };
-/// ```
+/// encoded or decoded.
 #[derive(Debug, PartialEq, Error)]
-pub enum Error {
-    #[error("Could not decode in format {protocol}: {description}")]
-    Unmarshalling {
-        description: String,
-        protocol: CodecProtocol,
-    },
-    #[error("Could not encode in format {protocol}: {description}")]
-    Marshalling {
-        description: String,
-        protocol: CodecProtocol,
-    },
+#[error("Serialization error for {protocol} protocol: {description}")]
+pub struct Error {
+    pub description: String,
+    pub protocol: CodecProtocol,
 }
 
 impl From<CborError> for Error {
     fn from(err: CborError) -> Error {
-        Error::Marshalling {
+        Self {
             description: err.to_string(),
             protocol: CodecProtocol::Cbor,
         }
@@ -49,8 +28,8 @@ impl From<CborError> for Error {
 }
 
 impl From<CidError> for Error {
-    fn from(err: CidError) -> Error {
-        Error::Marshalling {
+    fn from(err: CidError) -> Self {
+        Self {
             description: err.to_string(),
             protocol: CodecProtocol::Cbor,
         }
@@ -58,8 +37,8 @@ impl From<CidError> for Error {
 }
 
 impl From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, err)
+    fn from(err: Error) -> Self {
+        Self::new(io::ErrorKind::Other, err)
     }
 }
 

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -38,13 +38,6 @@ pub enum Error {
     Other(String),
 }
 
-// TODO Remove this impl, leading to actor errors being lost
-impl From<Error> for String {
-    fn from(e: Error) -> Self {
-        e.to_string()
-    }
-}
-
 impl From<EncodingError> for Error {
     fn from(e: EncodingError) -> Self {
         Self::Dynamic(Box::new(e))

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     /// Cid not found in store error
     #[error("Cid ({0}) did not match any in database")]
     CidNotFound(String),
+    /// Dynamic error for when the error needs to be forwarded as is.
+    #[error("{0}")]
+    Dynamic(Box<dyn StdError>),
     /// Custom AMT error
     #[error("{0}")]
     Other(String),
@@ -66,6 +69,6 @@ impl From<Error> for String {
 
 impl From<Box<dyn StdError>> for Error {
     fn from(e: Box<dyn StdError>) -> Self {
-        Self::Other(e.to_string())
+        Self::Dynamic(e)
     }
 }

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Error as CidError;
-use db::Error as DBError;
-use encoding::error::Error as EncodingError;
+use encoding::Error as EncodingError;
 use std::error::Error as StdError;
 use thiserror::Error;
 
@@ -16,15 +15,9 @@ pub enum Error {
     /// Height of root node is greater than max.
     #[error("failed to load AMT: height out of bounds: {0} > {1}")]
     MaxHeight(u64, u64),
-    /// Cbor encoding error
-    #[error(transparent)]
-    Encoding(#[from] EncodingError),
     /// Error generating a Cid for data
     #[error(transparent)]
     Cid(#[from] CidError),
-    /// Error interacting with underlying database
-    #[error(transparent)]
-    DB(#[from] DBError),
     /// Error when trying to serialize an AMT without a flushed cache
     #[error("Tried to serialize without saving cache, run flush() on Amt before serializing")]
     Cached,
@@ -45,25 +38,16 @@ pub enum Error {
     Other(String),
 }
 
-impl PartialEq for Error {
-    fn eq(&self, other: &Self) -> bool {
-        use Error::*;
-
-        match (self, other) {
-            (&OutOfRange(a), &OutOfRange(b)) => a == b,
-            (&Encoding(_), &Encoding(_)) => true,
-            (&Cid(ref a), &Cid(ref b)) => a == b,
-            (&DB(ref a), &DB(ref b)) => a == b,
-            (&Cached, &Cached) => true,
-            (&Other(ref a), &Other(ref b)) => a == b,
-            _ => false,
-        }
-    }
-}
-
+// TODO Remove this impl, leading to actor errors being lost
 impl From<Error> for String {
     fn from(e: Error) -> Self {
         e.to_string()
+    }
+}
+
+impl From<EncodingError> for Error {
+    fn from(e: EncodingError) -> Self {
+        Self::Dynamic(Box::new(e))
     }
 }
 

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -56,7 +56,7 @@ fn out_of_range() {
     assert!(matches!(res, Err(Error::OutOfRange(_))));
 
     let res = a.set(MAX_INDEX, "test".to_owned());
-    assert_eq!(res.err(), None);
+    assert!(res.err().is_none());
     assert_get(&mut a, MAX_INDEX, &"test".to_owned());
 }
 

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -28,13 +28,6 @@ pub enum Error {
     Other(String),
 }
 
-// TODO remove this IMPL, will cause issues with Actors error handling
-impl From<Error> for String {
-    fn from(e: Error) -> Self {
-        e.to_string()
-    }
-}
-
 impl From<EncodingError> for Error {
     fn from(e: EncodingError) -> Self {
         Self::Dynamic(Box::new(e))

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -8,7 +8,7 @@ use std::error::Error as StdError;
 use thiserror::Error;
 
 /// HAMT Error
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// Maximum depth error
     #[error("Maximum depth reached")]
@@ -28,6 +28,9 @@ pub enum Error {
     /// Cid not found in store error
     #[error("Cid ({0}) did not match any in database")]
     CidNotFound(String),
+    /// Dynamic error for when the error needs to be forwarded as is.
+    #[error("{0}")]
+    Dynamic(Box<dyn StdError>),
     /// Custom HAMT error
     #[error("{0}")]
     Other(String),
@@ -53,6 +56,6 @@ impl From<IpldError> for Error {
 
 impl From<Box<dyn StdError>> for Error {
     fn from(e: Box<dyn StdError>) -> Self {
-        Self::Other(e.to_string())
+        Self::Dynamic(e)
     }
 }

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -1,9 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use db::Error as DBError;
-use forest_encoding::error::Error as CborError;
-use forest_ipld::Error as IpldError;
+use forest_encoding::Error as EncodingError;
 use std::error::Error as StdError;
 use thiserror::Error;
 
@@ -19,12 +17,6 @@ pub enum Error {
     /// This should be treated as a fatal error, must have at least one pointer in node
     #[error("Invalid HAMT format, node cannot have 0 pointers")]
     ZeroPointers,
-    /// Error interacting with underlying database
-    #[error(transparent)]
-    Db(#[from] DBError),
-    /// Error encoding/ decoding values in store
-    #[error("{0}")]
-    Encoding(String),
     /// Cid not found in store error
     #[error("Cid ({0}) did not match any in database")]
     CidNotFound(String),
@@ -36,21 +28,16 @@ pub enum Error {
     Other(String),
 }
 
+// TODO remove this IMPL, will cause issues with Actors error handling
 impl From<Error> for String {
     fn from(e: Error) -> Self {
         e.to_string()
     }
 }
 
-impl From<CborError> for Error {
-    fn from(e: CborError) -> Error {
-        Error::Encoding(e.to_string())
-    }
-}
-
-impl From<IpldError> for Error {
-    fn from(e: IpldError) -> Error {
-        Error::Encoding(e.to_string())
+impl From<EncodingError> for Error {
+    fn from(e: EncodingError) -> Self {
+        Self::Dynamic(Box::new(e))
     }
 }
 

--- a/ipld/hamt/src/hash_bits.rs
+++ b/ipld/hamt/src/hash_bits.rs
@@ -93,11 +93,11 @@ mod tests {
         assert_eq!(hb.next(5).unwrap(), 0b01010);
         assert_eq!(hb.next(6).unwrap(), 0b111111);
         assert_eq!(hb.next(8).unwrap(), 0b11111111);
-        assert_eq!(hb.next(9), Err(Error::InvalidHashBitLen));
+        assert!(matches!(hb.next(9), Err(Error::InvalidHashBitLen)));
         for _ in 0..28 {
             // Iterate through rest of key to test depth
             hb.next(8).unwrap();
         }
-        assert_eq!(hb.next(1), Err(Error::MaxDepth));
+        assert!(matches!(hb.next(1), Err(Error::MaxDepth)));
     }
 }

--- a/utils/json_utils/src/lib.rs
+++ b/utils/json_utils/src/lib.rs
@@ -68,7 +68,6 @@ mod tests {
 
     #[test]
     fn test_json_basic() {
-        // #[derive(Debug, PartialEq)]
         struct BasicJson(Vec<u8>);
         impl<'de> Deserialize<'de> for BasicJson {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/vm/actor/src/builtin/init/mod.rs
+++ b/vm/actor/src/builtin/init/mod.rs
@@ -7,7 +7,7 @@ mod types;
 pub use self::state::State;
 pub use self::types::*;
 use crate::{
-    make_map, MINER_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID,
+    make_map, ActorDowncast, MINER_ACTOR_CODE_ID, MULTISIG_ACTOR_CODE_ID, PAYCH_ACTOR_CODE_ID,
     POWER_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR,
 };
 use address::Address;
@@ -40,9 +40,9 @@ impl Actor {
         let sys_ref: &Address = &SYSTEM_ACTOR_ADDR;
         rt.validate_immediate_caller_is(std::iter::once(sys_ref))?;
         let mut empty_map = make_map::<_, ()>(rt.store());
-        let root = empty_map
-            .flush()
-            .map_err(|err| actor_error!(ErrIllegalState; "failed to construct state: {}", err))?;
+        let root = empty_map.flush().map_err(|err| {
+            err.downcast_default(ExitCode::ErrIllegalState, "failed to construct state")
+        })?;
 
         rt.create(&State::new(root, params.network_name))?;
 
@@ -76,7 +76,9 @@ impl Actor {
         // Store mapping of pubkey or actor address to actor ID
         let id_address: Address = rt.transaction(|s: &mut State, rt| {
             s.map_address_to_new_id(rt.store(), &robust_address)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to allocate ID address: {}", e))
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to allocate ID address")
+                })
         })?;
 
         // Create an empty actor

--- a/vm/actor/src/builtin/init/state.rs
+++ b/vm/actor/src/builtin/init/state.rs
@@ -8,6 +8,7 @@ use encoding::tuple::*;
 use encoding::Cbor;
 use ipld_blockstore::BlockStore;
 use ipld_hamt::Error as HamtError;
+use std::error::Error as StdError;
 use vm::ActorID;
 
 /// State is reponsible for creating
@@ -58,7 +59,7 @@ impl State {
         &self,
         store: &BS,
         addr: &Address,
-    ) -> Result<Option<Address>, String> {
+    ) -> Result<Option<Address>, Box<dyn StdError>> {
         if addr.protocol() == Protocol::ID {
             return Ok(Some(*addr));
         }

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -13,9 +13,9 @@ pub use self::types::*;
 use crate::{
     check_empty_params, make_map, power, request_miner_control_addrs, reward,
     verifreg::{Method as VerifregMethod, RestoreBytesParams, UseBytesParams},
-    DealID, SetMultimap, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR,
-    MINER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
-    VERIFIED_REGISTRY_ACTOR_ADDR,
+    ActorDowncast, DealID, SetMultimap, BURNT_FUNDS_ACTOR_ADDR, CALLER_TYPES_SIGNABLE,
+    CRON_ACTOR_ADDR, MINER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR, STORAGE_POWER_ACTOR_ADDR,
+    SYSTEM_ACTOR_ADDR, VERIFIED_REGISTRY_ACTOR_ADDR,
 };
 use address::Address;
 use ahash::AHashMap;
@@ -291,7 +291,7 @@ impl Actor {
                 // schedule too many deals for the same tick.
                 let process_epoch = gen_rand_next_epoch(rt, rt.curr_epoch(), &deal.proposal)
                     .map_err(|e| {
-                        ActorError::downcast(
+                        ActorDowncast::downcast_default(
                             e,
                             ExitCode::ErrIllegalState,
                             "failed to generate random process epoch",
@@ -369,7 +369,7 @@ impl Actor {
             params.sector_start,
         )
         .map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 "failed to validate deal proposals for activation",
@@ -404,7 +404,7 @@ impl Actor {
                 curr_epoch,
             )
             .map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     "failed to validate deal proposals for activation",

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -65,17 +65,17 @@ impl Actor {
     {
         rt.validate_immediate_caller_is(std::iter::once(&*SYSTEM_ACTOR_ADDR))?;
 
-        let empty_root = Amt::<(), BS>::new(rt.store())
-            .flush()
-            .map_err(|e| actor_error!(ErrIllegalState; "Failed to create market state: {}", e))?;
+        let empty_root = Amt::<(), BS>::new(rt.store()).flush().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "Failed to create market state")
+        })?;
 
-        let empty_map = make_map::<_, ()>(rt.store())
-            .flush()
-            .map_err(|e| actor_error!(ErrIllegalState; "Failed to create market state: {}", e))?;
+        let empty_map = make_map::<_, ()>(rt.store()).flush().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "Failed to create market state")
+        })?;
 
-        let empty_m_set = SetMultimap::new(rt.store())
-            .root()
-            .map_err(|e| actor_error!(ErrIllegalState; "Failed to create market state: {}", e))?;
+        let empty_m_set = SetMultimap::new(rt.store()).root().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "Failed to create market state")
+        })?;
 
         let st = State::new(empty_root, empty_map, empty_m_set);
         rt.create(&st)?;
@@ -105,19 +105,24 @@ impl Actor {
             msm.with_escrow_table(Permission::Write)
                 .with_locked_table(Permission::Write)
                 .build()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to load state: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load state")
+                })?;
 
             msm.escrow_table
                 .as_mut()
                 .unwrap()
                 .add(&nominal, &msg_value)
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                            "failed to add balance to escrow table: {}", e)
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        "failed to add balance to escrow table",
+                    )
                 })?;
 
-            msm.commit_state()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush state: {}", e))?;
+            msm.commit_state().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush state")
+            })?;
 
             Ok(())
         })?;
@@ -151,14 +156,21 @@ impl Actor {
             msm.with_escrow_table(Permission::Write)
                 .with_locked_table(Permission::Write)
                 .build()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to load state: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load state")
+                })?;
 
             // The withdrawable amount might be slightly less than nominal
             // depending on whether or not all relevant entries have been processed
             // by cron
-            let min_balance = msm.locked_table.as_ref().unwrap().get(&nominal).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to get locked balance: {}", e),
-            )?;
+            let min_balance = msm
+                .locked_table
+                .as_ref()
+                .unwrap()
+                .get(&nominal)
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to get locked balance")
+                })?;
 
             let ex = msm
                 .escrow_table
@@ -166,12 +178,15 @@ impl Actor {
                 .unwrap()
                 .subtract_with_minimum(&nominal, &params.amount, &min_balance)
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                            "failed to subtract from escrow table: {}", e)
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        "failed to subtract from escrow table",
+                    )
                 })?;
 
-            msm.commit_state()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush state: {}", e))?;
+            msm.commit_state().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush state")
+            })?;
 
             Ok(ex)
         })?;
@@ -234,7 +249,9 @@ impl Actor {
                 .with_escrow_table(Permission::Write)
                 .with_locked_table(Permission::Write)
                 .build()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to load state: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load state")
+                })?;
 
             for deal in &mut params.deals {
                 validate_deal(rt, &deal, &baseline_power, &network_qa_power)?;
@@ -257,9 +274,10 @@ impl Actor {
 
                 let id = msm.generate_storage_deal_id();
 
-                let pcid = deal.proposal.cid().map_err(
-                    |e| actor_error!(ErrIllegalArgument; "failed to take cid of proposal: {}", e),
-                )?;
+                let pcid = deal
+                    .proposal
+                    .cid()
+                    .map_err(|e| ActorError::from(e).wrap("failed to take cid of proposal"))?;
 
                 let has = msm
                     .pending_deals
@@ -267,32 +285,38 @@ impl Actor {
                     .unwrap()
                     .contains_key(&pcid.to_bytes())
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                        "failed to check for existence of deal proposal: {}", e)
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            "failed to check for existence of deal proposal",
+                        )
                     })?;
                 if has {
-                    return Err(actor_error!(ErrIllegalArgument; "cannot publish duplicate deals"));
+                    return Err(actor_error!(
+                        ErrIllegalArgument,
+                        "cannot publish duplicate deals"
+                    ));
                 }
 
                 msm.pending_deals
                     .as_mut()
                     .unwrap()
                     .set(pcid.to_bytes().into(), deal.proposal.clone())
-                    .map_err(
-                        |e| actor_error!(ErrIllegalState; "failed to set pending deal: {}", e),
-                    )?;
+                    .map_err(|e| {
+                        e.downcast_default(ExitCode::ErrIllegalState, "failed to set pending deal")
+                    })?;
                 msm.deal_proposals
                     .as_mut()
                     .unwrap()
                     .set(id, deal.proposal.clone())
-                    .map_err(|e| actor_error!(ErrIllegalState; "failed to set deal: {}", e))?;
+                    .map_err(|e| {
+                        e.downcast_default(ExitCode::ErrIllegalState, "failed to set deal")
+                    })?;
 
                 // We should randomize the first epoch for when the deal will be processed so an attacker isn't able to
                 // schedule too many deals for the same tick.
                 let process_epoch = gen_rand_next_epoch(rt, rt.curr_epoch(), &deal.proposal)
                     .map_err(|e| {
-                        ActorDowncast::downcast_default(
-                            e,
+                        e.downcast_default(
                             ExitCode::ErrIllegalState,
                             "failed to generate random process epoch",
                         )
@@ -302,15 +326,19 @@ impl Actor {
                     .as_mut()
                     .unwrap()
                     .put(process_epoch, id)
-                    .map_err(
-                        |e| actor_error!(ErrIllegalState; "failed to set deal ops by epoch: {}", e),
-                    )?;
+                    .map_err(|e| {
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            "failed to set deal ops by epoch",
+                        )
+                    })?;
 
                 new_deal_ids.push(id);
             }
 
-            msm.commit_state()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush state: {}", e))?;
+            msm.commit_state().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush state")
+            })?;
             Ok(())
         })?;
 
@@ -369,8 +397,7 @@ impl Actor {
             params.sector_start,
         )
         .map_err(|e| {
-            ActorDowncast::downcast_default(
-                e,
+            e.downcast_default(
                 ExitCode::ErrIllegalState,
                 "failed to validate deal proposals for activation",
             )
@@ -404,8 +431,7 @@ impl Actor {
                 curr_epoch,
             )
             .map_err(|e| {
-                ActorDowncast::downcast_default(
-                    e,
+                e.downcast_default(
                     ExitCode::ErrIllegalState,
                     "failed to validate deal proposals for activation",
                 )
@@ -416,7 +442,9 @@ impl Actor {
                 .with_pending_proposals(Permission::ReadOnly)
                 .with_deal_proposals(Permission::ReadOnly)
                 .build()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to load state: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load state")
+                })?;
 
             for deal_id in params.deal_ids {
                 // This construction could be replaced with a single "update deal state"
@@ -427,8 +455,10 @@ impl Actor {
                     .unwrap()
                     .get(deal_id)
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                        "failed to get state for deal_id ({}): {}", deal_id, e)
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("failed to get state for deal_id ({})", deal_id),
+                        )
                     })?;
                 if s.is_some() {
                     return Err(actor_error!(ErrIllegalArgument;
@@ -441,15 +471,16 @@ impl Actor {
                     .unwrap()
                     .get(deal_id)
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                            "failed to get deal_id ({}): {}", deal_id, e)
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("failed to get deal_id ({})", deal_id),
+                        )
                     })?
                     .ok_or_else(|| actor_error!(ErrNotFound; "no such deal_id: {}", deal_id))?;
 
-                let propc = proposal.cid().map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                        "failed to calculate proposal CID: {}", e)
-                })?;
+                let propc = proposal
+                    .cid()
+                    .map_err(|e| ActorError::from(e).wrap("failed to calculate proposal Cid"))?;
 
                 let has = msm
                     .pending_deals
@@ -457,8 +488,10 @@ impl Actor {
                     .unwrap()
                     .contains_key(&propc.to_bytes())
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                            "failed to get pending proposal ({}): {}", propc, e)
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("failed to get pending proposal ({})", propc),
+                        )
                     })?;
 
                 if !has {
@@ -478,13 +511,16 @@ impl Actor {
                         },
                     )
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                            "failed to set deal state {}: {}", deal_id, e)
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("failed to set deal state {}", deal_id),
+                        )
                     })?;
             }
 
-            msm.commit_state()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush state: {}", e))?;
+            msm.commit_state().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush state")
+            })?;
             Ok(())
         })?;
 
@@ -510,12 +546,14 @@ impl Actor {
             msm.with_deal_states(Permission::Write)
                 .with_deal_proposals(Permission::ReadOnly)
                 .build()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to load state: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load state")
+                })?;
 
             for id in params.deal_ids {
-                let deal = msm.deal_proposals.as_ref().unwrap().get(id).map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to get deal proposal: {}", e),
-                )?;
+                let deal = msm.deal_proposals.as_ref().unwrap().get(id).map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to get deal proposal")
+                })?;
                 // deal could have terminated and hence deleted before the sector is terminated.
                 // we should simply continue instead of aborting execution here if a deal is not found.
                 if deal.is_none() {
@@ -538,7 +576,9 @@ impl Actor {
                     .as_ref()
                     .unwrap()
                     .get(id)
-                    .map_err(|e| actor_error!(ErrIllegalState; "failed to get deal state {}", e))?
+                    .map_err(|e| {
+                        e.downcast_default(ExitCode::ErrIllegalState, "failed to get deal state")
+                    })?
                     .ok_or_else(|| actor_error!(ErrIllegalArgument; "no state for deal {}", id))?;
 
                 // If a deal is already slashed, don't need to do anything
@@ -550,13 +590,21 @@ impl Actor {
                 // and slashing of provider collateral happens in cron_tick.
                 state.slash_epoch = params.epoch;
 
-                msm.deal_states.as_mut().unwrap().set(id, state).map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to set deal state ({}): {}", id, e),
-                )?;
+                msm.deal_states
+                    .as_mut()
+                    .unwrap()
+                    .set(id, state)
+                    .map_err(|e| {
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("failed to set deal state ({})", id),
+                        )
+                    })?;
             }
 
-            msm.commit_state()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush state: {}", e))?;
+            msm.commit_state().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush state")
+            })?;
             Ok(())
         })?;
         Ok(())
@@ -574,16 +622,20 @@ impl Actor {
 
         let st: State = rt.state()?;
 
-        let proposals = DealArray::load(&st.proposals, rt.store())
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to load deal proposals: {}", e))?;
+        let proposals = DealArray::load(&st.proposals, rt.store()).map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to load deal proposals")
+        })?;
 
         let mut pieces: Vec<PieceInfo> = Vec::with_capacity(params.deal_ids.len());
         for deal_id in params.deal_ids {
             let deal = proposals
                 .get(deal_id)
-                .map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to get deal_id ({}): {}", deal_id, e),
-                )?
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to get deal_id ({})", deal_id),
+                    )
+                })?
                 .ok_or_else(|| actor_error!(ErrNotFound; "proposal doesn't exist ({})", deal_id))?;
 
             pieces.push(PieceInfo {
@@ -596,8 +648,10 @@ impl Actor {
             .syscalls()
             .compute_unsealed_sector_cid(params.sector_type, &pieces)
             .map_err(|e| {
-                actor_error!(SysErrorIllegalArgument;
-                    "failed to compute unsealed sector CID: {}", e)
+                e.downcast_default(
+                    ExitCode::SysErrorIllegalArgument,
+                    "failed to compute unsealed sector CID",
+                )
             })?;
 
         Ok(commd)
@@ -625,7 +679,9 @@ impl Actor {
                 .with_deal_proposals(Permission::Write)
                 .with_pending_proposals(Permission::Write)
                 .build()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to load state: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load state")
+                })?;
 
             for i in (last_cron + 1)..rt.curr_epoch() {
                 // TODO specs-actors modifies msm as it's iterated through, which is memory unsafe
@@ -641,9 +697,9 @@ impl Actor {
                         deal_ids.push(deal_id);
                         Ok(())
                     })
-                    .map_err(
-                        |e| actor_error!(ErrIllegalState; "failed to set deal state: {}", e),
-                    )?;
+                    .map_err(|e| {
+                        e.downcast_default(ExitCode::ErrIllegalState, "failed to set deal state")
+                    })?;
 
                 for deal_id in deal_ids {
                     let deal = msm
@@ -652,8 +708,10 @@ impl Actor {
                         .unwrap()
                         .get(deal_id)
                         .map_err(|e| {
-                            actor_error!(ErrIllegalState;
-                                        "failed to get deal_id ({}): {}", deal_id, e)
+                            e.downcast_default(
+                                ExitCode::ErrIllegalState,
+                                format!("failed to get deal_id ({})", deal_id),
+                            )
                         })?
                         .ok_or_else(|| {
                             actor_error!(ErrNotFound;
@@ -661,13 +719,21 @@ impl Actor {
                         })?;
 
                     let dcid = deal.cid().map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                                    "failed to calculate cid for proposal {}: {}", deal_id, e)
+                        ActorError::from(e)
+                            .wrap(format!("failed to calculate cid for proposal {}", deal_id))
                     })?;
 
-                    let state = msm.deal_states.as_ref().unwrap().get(deal_id).map_err(
-                        |e| actor_error!(ErrIllegalState; "failed to get deal state: {}", e),
-                    )?;
+                    let state = msm
+                        .deal_states
+                        .as_ref()
+                        .unwrap()
+                        .get(deal_id)
+                        .map_err(|e| {
+                            e.downcast_default(
+                                ExitCode::ErrIllegalState,
+                                "failed to get deal state",
+                            )
+                        })?;
 
                     // deal has been published but not activated yet -> terminate it
                     // as it has timed out
@@ -692,9 +758,12 @@ impl Actor {
                             .as_mut()
                             .unwrap()
                             .delete(deal_id)
-                            .map_err(
-                                |e| actor_error!(ErrIllegalState; "failed to delete deal: {}", e),
-                            )?;
+                            .map_err(|e| {
+                                e.downcast_default(
+                                    ExitCode::ErrIllegalState,
+                                    "failed to delete deal",
+                                )
+                            })?;
                         if !deleted {
                             return Err(actor_error!(ErrIllegalState;
                                         "failed to delete deal proposal: does not exist"));
@@ -705,8 +774,10 @@ impl Actor {
                             .unwrap()
                             .delete(&dcid.to_bytes())
                             .map_err(|e| {
-                                actor_error!(ErrIllegalState;
-                                "failed to delete pending proposal: {}", e)
+                                e.downcast_default(
+                                    ExitCode::ErrIllegalState,
+                                    "failed to delete pending proposal",
+                                )
                             })?;
                         if !deleted {
                             return Err(actor_error!(ErrIllegalState;
@@ -722,8 +793,10 @@ impl Actor {
                             .unwrap()
                             .delete(&dcid.to_bytes())
                             .map_err(|e| {
-                                actor_error!(ErrIllegalState;
-                                "failed to delete pending proposal: {}", e)
+                                e.downcast_default(
+                                    ExitCode::ErrIllegalState,
+                                    "failed to delete pending proposal",
+                                )
                             })?;
                         if !deleted {
                             return Err(actor_error!(ErrIllegalState;
@@ -752,17 +825,27 @@ impl Actor {
                             .unwrap()
                             .delete(deal_id)
                             .map_err(|e| {
-                                actor_error!(ErrIllegalState;
-                                "failed to delete deal proposal: {}", e)
+                                e.downcast_default(
+                                    ExitCode::ErrIllegalState,
+                                    "failed to delete deal proposal",
+                                )
                             })?;
                         if !deleted {
                             return Err(actor_error!(ErrIllegalState;
                                 "failed to delete deal proposal: does not exist"));
                         }
 
-                        let deleted = msm.deal_states.as_mut().unwrap().delete(deal_id).map_err(
-                            |e| actor_error!(ErrIllegalState; "failed to delete deal state: {}", e),
-                        )?;
+                        let deleted =
+                            msm.deal_states
+                                .as_mut()
+                                .unwrap()
+                                .delete(deal_id)
+                                .map_err(|e| {
+                                    e.downcast_default(
+                                        ExitCode::ErrIllegalState,
+                                        "failed to delete deal state",
+                                    )
+                                })?;
                         if !deleted {
                             return Err(actor_error!(ErrIllegalState;
                                     "failed to delete deal state: does not exist"));
@@ -779,8 +862,10 @@ impl Actor {
                             .unwrap()
                             .set(deal_id, state)
                             .map_err(|e| {
-                                actor_error!(ErrIllegalState;
-                                    "failed to set deal state: {}", e)
+                                e.downcast_default(
+                                    ExitCode::ErrIllegalState,
+                                    "failed to set deal state",
+                                )
                             })?;
 
                         if let Some(ev) = updates_needed.get_mut(&next_epoch) {
@@ -795,8 +880,10 @@ impl Actor {
                     .unwrap()
                     .remove_all(i)
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                            "failed to delete deal ops for epoch {}: {}", i, e)
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("failed to delete deal ops for epoch {}", i),
+                        )
                     })?;
             }
 
@@ -815,15 +902,18 @@ impl Actor {
                         updates_needed.get(&epoch).expect("key checked to exist"),
                     )
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                            "failed to reinsert deal IDs for epoch {}: {}", epoch, e)
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("failed to reinsert deal IDs for epoch {}", epoch),
+                        )
                     })?;
             }
 
             msm.st.last_cron = rt.curr_epoch();
 
-            msm.commit_state()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush state: {}", e))?;
+            msm.commit_state().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush state")
+            })?;
             Ok(())
         })?;
 
@@ -907,9 +997,7 @@ where
     BS: BlockStore,
     RT: Runtime<BS>,
 {
-    let bytes = deal
-        .marshal_cbor()
-        .map_err(|e| format!("failed to marshal proposal: {}", e))?;
+    let bytes = deal.marshal_cbor()?;
 
     let rb = rt.get_randomness_from_beacon(
         DomainSeparationTag::MarketDealCronSeed,
@@ -968,7 +1056,7 @@ where
     proposal
         .piece_size
         .validate()
-        .map_err(|e| actor_error!(ErrIllegalArgument; "proposal piece size is invalid: {}", e))?;
+        .map_err(|e| actor_error!(ErrIllegalArgument, "proposal piece size is invalid: {}", e))?;
 
     // TODO we are skipping the check for if Cid is defined, but this shouldn't be possible
 
@@ -1029,9 +1117,9 @@ where
     RT: Runtime<BS>,
 {
     if proposal.proposal.end_epoch <= proposal.proposal.start_epoch {
-        return Err(ActorError::new(
-            ExitCode::ErrIllegalArgument,
-            "proposal end epoch before start epoch".to_owned(),
+        return Err(actor_error!(
+            ErrIllegalArgument,
+            "proposal end epoch before start epoch"
         ));
     }
     // Generate unsigned bytes
@@ -1044,12 +1132,7 @@ where
             &proposal.proposal.client,
             &sv_bz,
         )
-        .map_err(|e| {
-            ActorError::new(
-                ExitCode::ErrIllegalArgument,
-                format!("signature proposal invalid: {}", e),
-            )
-        })?;
+        .map_err(|e| actor_error!(ErrIllegalArgument, "signature proposal invalid: {}", e))?;
 
     Ok(())
 }

--- a/vm/actor/src/builtin/miner/bitfield_queue.rs
+++ b/vm/actor/src/builtin/miner/bitfield_queue.rs
@@ -81,11 +81,11 @@ impl<'db, BS: BlockStore> BitFieldQueue<'db, BS> {
 
                 Ok(())
             })
-            .map_err(|e| e.downcast_wrap(format!("failed to cut from bitfield queue")))?;
+            .map_err(|e| e.downcast_wrap("failed to cut from bitfield queue"))?;
 
-        self.amt.batch_delete(epochs_to_remove).map_err(|e| {
-            e.downcast_wrap(format!("failed to remove empty epochs from bitfield queue"))
-        })?;
+        self.amt
+            .batch_delete(epochs_to_remove)
+            .map_err(|e| e.downcast_wrap("failed to remove empty epochs from bitfield queue"))?;
 
         Ok(())
     }

--- a/vm/actor/src/builtin/miner/bitfield_queue.rs
+++ b/vm/actor/src/builtin/miner/bitfield_queue.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::QuantSpec;
+use crate::ActorDowncast;
 use bitfield::BitField;
 use cid::Cid;
 use clock::ChainEpoch;
@@ -41,12 +42,12 @@ impl<'db, BS: BlockStore> BitFieldQueue<'db, BS> {
         let bitfield = self
             .amt
             .get(epoch as u64)
-            .map_err(|e| format!("failed to lookup queue epoch {}: {:?}", epoch, e))?
+            .map_err(|e| e.downcast_wrap(format!("failed to lookup queue epoch {}", epoch)))?
             .unwrap_or_default();
 
         self.amt
             .set(epoch as u64, &bitfield | values)
-            .map_err(|e| format!("failed to set queue epoch {}: {:?}", epoch, e))?;
+            .map_err(|e| e.downcast_wrap(format!("failed to set queue epoch {}", epoch)))?;
 
         Ok(())
     }
@@ -67,7 +68,7 @@ impl<'db, BS: BlockStore> BitFieldQueue<'db, BS> {
     /// shifting other bits down and removing any newly empty entries.
     ///
     /// See the docs on `BitField::cut` to better understand what it does.
-    pub fn cut(&mut self, to_cut: &BitField) -> Result<(), String> {
+    pub fn cut(&mut self, to_cut: &BitField) -> Result<(), Box<dyn StdError>> {
         let mut epochs_to_remove = Vec::<u64>::new();
 
         self.amt
@@ -80,11 +81,11 @@ impl<'db, BS: BlockStore> BitFieldQueue<'db, BS> {
 
                 Ok(())
             })
-            .map_err(|e| format!("failed to cut from bitfield queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap(format!("failed to cut from bitfield queue")))?;
 
-        self.amt
-            .batch_delete(epochs_to_remove)
-            .map_err(|e| format!("failed to remove empty epochs from bitfield queue: {:?}", e))?;
+        self.amt.batch_delete(epochs_to_remove).map_err(|e| {
+            e.downcast_wrap(format!("failed to remove empty epochs from bitfield queue"))
+        })?;
 
         Ok(())
     }

--- a/vm/actor/src/builtin/miner/deadline_state.rs
+++ b/vm/actor/src/builtin/miner/deadline_state.rs
@@ -138,22 +138,27 @@ impl Deadline {
         store: &'db BS,
     ) -> Result<Amt<'db, Partition, BS>, ActorError> {
         Amt::load(&self.partitions, store)
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to load partitions: {:?}", e))
+            .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "failed to load partitions"))
     }
 
     pub fn load_partition<BS: BlockStore>(
         &self,
         store: &BS,
         partition_idx: u64,
-    ) -> Result<Partition, String> {
-        let partitions = Amt::<Partition, _>::load(&self.partitions, store)
-            .map_err(|e| format!("failed to load partitions: {:?}", e))?;
+    ) -> Result<Partition, Box<dyn StdError>> {
+        let partitions = Amt::<Partition, _>::load(&self.partitions, store)?;
 
         let partition = partitions
             .get(partition_idx)
-            .map_err(|e| format!("failed to lookup partition {}: {:?}", partition_idx, e))?;
+            .map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to lookup partition {}", partition_idx),
+                )
+            })?
+            .ok_or_else(|| actor_error!(ErrNotFound, "no partition {}", partition_idx))?;
 
-        partition.ok_or_else(|| format!("no partition {}", partition_idx))
+        Ok(partition)
     }
 
     /// Adds some partition numbers to the set expiring at an epoch.
@@ -163,21 +168,21 @@ impl Deadline {
         expiration_epoch: ChainEpoch,
         partitions: &[u64],
         quant: QuantSpec,
-    ) -> Result<(), String> {
+    ) -> Result<(), Box<dyn StdError>> {
         // Avoid doing any work if there's nothing to reschedule.
         if partitions.is_empty() {
             return Ok(());
         }
 
         let mut queue = BitFieldQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load expiration queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load expiration queue"))?;
         queue
             .add_to_queue_values(expiration_epoch, partitions)
-            .map_err(|e| format!("failed to mutate expiration queue: {}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to mutate expiration queue"))?;
         self.expirations_epochs = queue
             .amt
             .flush()
-            .map_err(|e| format!("failed to save expiration queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to save expiration queue"))?;
 
         Ok(())
     }
@@ -217,13 +222,10 @@ impl Deadline {
                 partition
                     .pop_expired_sectors(store, until, quant)
                     .map_err(|e| {
-                        ActorDowncast::downcast_wrap(
-                            e,
-                            format!(
-                                "failed to pop expired sectors from partition {}",
-                                partition_idx
-                            ),
-                        )
+                        e.downcast_wrap(format!(
+                            "failed to pop expired sectors from partition {}",
+                            partition_idx
+                        ))
                     })?;
 
             if !partition_expiration.early_sectors.is_empty() {
@@ -342,12 +344,10 @@ impl Deadline {
         // Next, update the expiration queue.
         let mut deadline_expirations =
             BitFieldQueue::new(store, &self.expirations_epochs, quant)
-                .map_err(|e| format!("failed to load expiration epochs: {:?}", e))?;
+                .map_err(|e| e.downcast_wrap("failed to load expiration epochs"))?;
         deadline_expirations
             .add_many_to_queue_values(&partition_deadline_updates)
-            .map_err(|e| {
-                ActorDowncast::downcast_wrap(e, "failed to add expirations for new deadlines")
-            })?;
+            .map_err(|e| e.downcast_wrap("failed to add expirations for new deadlines"))?;
         self.expirations_epochs = deadline_expirations.amt.flush()?;
 
         Ok(new_power)
@@ -367,10 +367,9 @@ impl Deadline {
         for i in self.early_terminations.iter() {
             let partition_idx = i as u64;
 
-            let mut partition = match partitions
-                .get(partition_idx)
-                .map_err(|e| format!("failed to load partition {}: {:?}", partition_idx, e))?
-            {
+            let mut partition = match partitions.get(partition_idx).map_err(|e| {
+                e.downcast_wrap(format!("failed to load partition {}", partition_idx))
+            })? {
                 Some(partition) => partition,
                 None => {
                     partitions_finished.push(partition_idx);
@@ -381,9 +380,7 @@ impl Deadline {
             // Pop early terminations.
             let (partition_result, more) = partition
                 .pop_early_terminations(store, max_sectors - result.sectors_processed)
-                .map_err(|e| {
-                    ActorDowncast::downcast_wrap(e, "failed to pop terminations from partition")
-                })?;
+                .map_err(|e| e.downcast_wrap("failed to pop terminations from partition"))?;
 
             result += partition_result;
 
@@ -393,9 +390,9 @@ impl Deadline {
             }
 
             // Save partition
-            partitions
-                .set(partition_idx, partition)
-                .map_err(|e| format!("failed to store partition {}: {:?}", partition_idx, e))?;
+            partitions.set(partition_idx, partition).map_err(|e| {
+                e.downcast_wrap(format!("failed to store partition {}", partition_idx))
+            })?;
 
             if !result.below_limit(max_partitions, max_sectors) {
                 break;
@@ -410,7 +407,7 @@ impl Deadline {
         // Save deadline's partitions
         self.partitions = partitions
             .flush()
-            .map_err(|e| format!("failed to update partitions: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to update partitions"))?;
 
         // Update global early terminations bitfield.
         let no_early_terminations = self.early_terminations.is_empty();
@@ -426,7 +423,7 @@ impl Deadline {
         let mut expirations = BitFieldQueue::new(store, &self.expirations_epochs, quant)?;
         let (popped, modified) = expirations
             .pop_until(until)
-            .map_err(|e| ActorDowncast::downcast_wrap(e, "failed to pop expiring partitions"))?;
+            .map_err(|e| e.downcast_wrap("failed to pop expiring partitions"))?;
 
         if modified {
             self.expirations_epochs = expirations.amt.flush()?;
@@ -450,7 +447,9 @@ impl Deadline {
         for (partition_idx, sector_numbers) in partition_sectors.iter() {
             let mut partition = partitions
                 .get(partition_idx)
-                .map_err(|e| format!("failed to load partition {}: {:?}", partition_idx, e))?
+                .map_err(|e| {
+                    e.downcast_wrap(format!("failed to load partition {}", partition_idx))
+                })?
                 .ok_or_else(
                     || actor_error!(ErrNotFound; "failed to find partition {}", partition_idx),
                 )?;
@@ -458,17 +457,17 @@ impl Deadline {
             let removed = partition
                 .terminate_sectors(store, sectors, epoch, sector_numbers, sector_size, quant)
                 .map_err(|e| {
-                    ActorDowncast::downcast_wrap(
-                        e,
-                        format!("failed to terminate sectors in partition {}", partition_idx),
-                    )
+                    e.downcast_wrap(format!(
+                        "failed to terminate sectors in partition {}",
+                        partition_idx
+                    ))
                 })?;
 
             partitions.set(partition_idx, partition).map_err(|e| {
-                format!(
-                    "failed to store updated partition {}: {:?}",
-                    partition_idx, e
-                )
+                e.downcast_wrap(format!(
+                    "failed to store updated partition {}",
+                    partition_idx
+                ))
             })?;
 
             if !removed.is_empty() {
@@ -488,7 +487,7 @@ impl Deadline {
         // save partitions back
         self.partitions = partitions
             .flush()
-            .map_err(|e| format!("failed to persist partitions: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to persist partitions"))?;
 
         Ok(power_lost)
     }
@@ -570,11 +569,11 @@ impl Deadline {
 
                 Ok(())
             })
-            .map_err(|e| ActorDowncast::downcast_wrap(e, "while removing partitions"))?;
+            .map_err(|e| e.downcast_wrap("while removing partitions"))?;
 
         self.partitions = new_partitions
             .flush()
-            .map_err(|e| format!("failed to persist new partition table: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to persist new partition table"))?;
 
         let dead = BitField::union(&all_dead_sectors);
         let live = BitField::union(&all_live_sectors);
@@ -588,19 +587,16 @@ impl Deadline {
 
         // Update expiration bitfields.
         let mut expiration_epochs = BitFieldQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load expiration queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load expiration queue"))?;
 
         expiration_epochs.cut(to_remove).map_err(|e| {
-            format!(
-                "failed cut removed partitions from deadline expiration queue: {}",
-                e
-            )
+            e.downcast_wrap("failed cut removed partitions from deadline expiration queue")
         })?;
 
         self.expirations_epochs = expiration_epochs
             .amt
             .flush()
-            .map_err(|e| format!("failed persist deadline expiration queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed persist deadline expiration queue"))?;
 
         Ok((live, dead, removed_power))
     }
@@ -624,7 +620,12 @@ impl Deadline {
         for (partition_idx, sector_numbers) in partition_sectors.iter() {
             let mut partition = partitions
                 .get(partition_idx)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to load partition {}: {:?}", partition_idx, e))?
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load partition {}", partition_idx),
+                    )
+                })?
                 .ok_or_else(|| actor_error!(ErrNotFound; "no such partition {}", partition_idx))?;
 
             let (new_faults, new_partition_faulty_power) = partition
@@ -637,10 +638,10 @@ impl Deadline {
                     quant,
                 )
                 .map_err(|e| {
-                    ActorDowncast::downcast_wrap(
-                        e,
-                        format!("failed to declare faults in partition {}", partition_idx),
-                    )
+                    e.downcast_wrap(format!(
+                        "failed to declare faults in partition {}",
+                        partition_idx
+                    ))
                 })?;
 
             new_faulty_power += &new_partition_faulty_power;
@@ -648,17 +649,30 @@ impl Deadline {
                 partitions_with_fault.push(partition_idx);
             }
 
-            partitions
-                .set(partition_idx, partition)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to store partition {}: {:?}", partition_idx, e))?;
+            partitions.set(partition_idx, partition).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to store partition {}", partition_idx),
+                )
+            })?;
         }
 
-        self.partitions = partitions.flush().map_err(
-            |e| actor_error!(ErrIllegalState; "failed to store partitions root: {:?}", e),
-        )?;
+        self.partitions = partitions.flush().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to store partitions root")
+        })?;
 
-        self.add_expiration_partitions(store, fault_expiration_epoch, &partitions_with_fault, quant)
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to update expirations for partitions with faults: {:?}", e))?;
+        self.add_expiration_partitions(
+            store,
+            fault_expiration_epoch,
+            &partitions_with_fault,
+            quant,
+        )
+        .map_err(|e| {
+            e.downcast_default(
+                ExitCode::ErrIllegalState,
+                "failed to update expirations for partitions with faults",
+            )
+        })?;
 
         self.faulty_power += &new_faulty_power;
         Ok(new_faulty_power)
@@ -676,25 +690,31 @@ impl Deadline {
         for (partition_idx, sector_numbers) in partition_sectors.iter() {
             let mut partition = partitions
                 .get(partition_idx)
-                .map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to load partition {}: {:?}", partition_idx, e),
-                )?
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load partition {}", partition_idx),
+                    )
+                })?
                 .ok_or_else(|| actor_error!(ErrNotFound; "no such partition {}", partition_idx))?;
 
             partition
                 .declare_faults_recovered(sectors, sector_size, sector_numbers)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to add recoveries: {:?}", e))?;
+                .map_err(|e| e.wrap("failed to add recoveries"))?;
 
-            partitions
-                .set(partition_idx, partition)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to update partition {}: {:?}", partition_idx, e))?;
+            partitions.set(partition_idx, partition).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to update partition {}", partition_idx),
+                )
+            })?;
         }
 
         // Power is not regained until the deadline end, when the recovery is confirmed.
 
-        self.partitions = partitions.flush().map_err(
-            |e| actor_error!(ErrIllegalState; "failed to store partitions root: {:?}", e),
-        )?;
+        self.partitions = partitions.flush().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to store partitions root")
+        })?;
 
         Ok(())
     }
@@ -712,7 +732,7 @@ impl Deadline {
 
         let mut partitions = self
             .partitions_amt(store)
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to load partitions: {:?}", e))?;
+            .map_err(|e| e.wrap("failed to load partitions"))?;
 
         let mut detected_any = false;
         let mut rescheduled_partitions = Vec::<u64>::new();
@@ -724,9 +744,15 @@ impl Deadline {
                 continue;
             }
 
-            let mut partition = partitions.get(partition_idx).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to load partition {}: {:?}", partition_idx, e),
-            )?.ok_or_else(|| actor_error!(ErrIllegalState; "no partition {}", partition_idx))?;
+            let mut partition = partitions
+                .get(partition_idx)
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load partition {}", partition_idx),
+                    )
+                })?
+                .ok_or_else(|| actor_error!(ErrIllegalState; "no partition {}", partition_idx))?;
 
             // If we have no recovering power/sectors, and all power is faulty, skip
             // this. This lets us skip some work if a miner repeatedly fails to PoSt.
@@ -741,7 +767,15 @@ impl Deadline {
 
             let (part_faulty_power, part_failed_recovery_power) = partition
                 .record_missed_post(store, fault_expiration_epoch, quant)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to record missed PoSt for partition {}: {:?}", partition_idx, e))?;
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!(
+                            "failed to record missed PoSt for partition {}",
+                            partition_idx
+                        ),
+                    )
+                })?;
 
             // We marked some sectors faulty, we need to record the new
             // expiration. We don't want to do this if we're just penalizing
@@ -751,9 +785,12 @@ impl Deadline {
             }
 
             // Save new partition state.
-            partitions
-                .set(partition_idx, partition)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to update partition {}: {:?}", partition_idx, e))?;
+            partitions.set(partition_idx, partition).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to update partition {}", partition_idx),
+                )
+            })?;
 
             new_faulty_power += &part_faulty_power;
             failed_recovery_power += &part_failed_recovery_power;
@@ -761,9 +798,9 @@ impl Deadline {
 
         // Save modified deadline state.
         if detected_any {
-            self.partitions = partitions.flush().map_err(
-                |e| actor_error!(ErrIllegalState; "failed to store partitions: {:?}", e),
-            )?;
+            self.partitions = partitions.flush().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to store partitions")
+            })?;
         }
 
         self.add_expiration_partitions(
@@ -772,7 +809,12 @@ impl Deadline {
             &rescheduled_partitions,
             quant,
         )
-        .map_err(|e| actor_error!(ErrIllegalState; "failed to update deadline expiration queue: {:?}", e))?;
+        .map_err(|e| {
+            e.downcast_default(
+                ExitCode::ErrIllegalState,
+                "failed to update deadline expiration queue",
+            )
+        })?;
 
         self.faulty_power += &new_faulty_power;
 
@@ -844,7 +886,7 @@ impl Deadline {
 
             let mut partition = partitions
                 .get(post.index)
-                .map_err(|e| format!("failed to load partition {}: {}", post.index, e))?
+                .map_err(|e| e.downcast_wrap(format!("failed to load partition {}", post.index)))?
                 .ok_or_else(|| actor_error!(ErrNotFound; "no such partition {}", post.index))?;
 
             // Process new faults and accumulate new faulty power.
@@ -874,13 +916,10 @@ impl Deadline {
             let recovered_power = partition
                 .recover_faults(store, sectors, sector_size, quant)
                 .map_err(|e| {
-                    ActorDowncast::downcast_wrap(
-                        e,
-                        format!(
-                            "failed to recover faulty sectors for partition {}",
-                            post.index
-                        ),
-                    )
+                    e.downcast_wrap(format!(
+                        "failed to recover faulty sectors for partition {}",
+                        post.index
+                    ))
                 })?;
 
             // note: we do this first because `partition` is moved in the upcoming `partitions.set` call
@@ -891,9 +930,12 @@ impl Deadline {
             all_ignored.push(partition.terminated.clone());
 
             // This will be rolled back if the method aborts with a failed proof.
-            partitions
-                .set(post.index, partition)
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to update partition {}: {:?}", post.index, e))?;
+            partitions.set(post.index, partition).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to update partition {}", post.index),
+                )
+            })?;
 
             new_faulty_power_total += &new_fault_power;
             retracted_recovery_power_total += &retracted_recovery_power;
@@ -904,15 +946,20 @@ impl Deadline {
         }
 
         self.add_expiration_partitions(store, fault_expiration, &rescheduled_partitions, quant)
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to update expirations for partitions with faults: {:?}", e))?;
+            .map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to update expirations for partitions with faults",
+                )
+            })?;
 
         // Save everything back.
         self.faulty_power -= &recovered_power_total;
         self.faulty_power += &new_faulty_power_total;
 
-        self.partitions = partitions
-            .flush()
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to persist partitions: {:?}", e))?;
+        self.partitions = partitions.flush().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to persist partitions")
+        })?;
 
         // Collect all sectors, faults, and recoveries for proof verification.
         let all_sector_numbers = BitField::union(&all_sectors);
@@ -950,10 +997,9 @@ impl Deadline {
         let mut rescheduled_partitions = Vec::<u64>::new();
 
         for (partition_idx, sector_numbers) in partition_sectors.iter() {
-            let mut partition = match partitions
-                .get(partition_idx)
-                .map_err(|e| format!("failed to load partition {}: {:?}", partition_idx, e))?
-            {
+            let mut partition = match partitions.get(partition_idx).map_err(|e| {
+                e.downcast_wrap(format!("failed to load partition {}", partition_idx))
+            })? {
                 Some(partition) => partition,
                 None => {
                     // We failed to find the partition, it could have moved
@@ -973,13 +1019,10 @@ impl Deadline {
                     quant,
                 )
                 .map_err(|e| {
-                    ActorDowncast::downcast_wrap(
-                        e,
-                        format!(
-                            "failed to reschedule expirations in partition {}",
-                            partition_idx
-                        ),
-                    )
+                    e.downcast_wrap(format!(
+                        "failed to reschedule expirations in partition {}",
+                        partition_idx
+                    ))
                 })?;
 
             if moved.is_empty() {
@@ -988,18 +1031,18 @@ impl Deadline {
             }
 
             rescheduled_partitions.push(partition_idx);
-            partitions
-                .set(partition_idx, partition)
-                .map_err(|e| format!("failed to store partition {}: {:?}", partition_idx, e))?;
+            partitions.set(partition_idx, partition).map_err(|e| {
+                e.downcast_wrap(format!("failed to store partition {}", partition_idx))
+            })?;
         }
 
         if !rescheduled_partitions.is_empty() {
             self.partitions = partitions
                 .flush()
-                .map_err(|e| format!("failed to save partitions: {:?}", e))?;
+                .map_err(|e| e.downcast_wrap("failed to save partitions"))?;
 
             self.add_expiration_partitions(store, expiration, &rescheduled_partitions, quant)
-                .map_err(|e| format!("failed to reschedule partition expirations: {}", e))?;
+                .map_err(|e| e.downcast_wrap("failed to reschedule partition expirations"))?;
         }
 
         Ok(())

--- a/vm/actor/src/builtin/miner/deadline_state.rs
+++ b/vm/actor/src/builtin/miner/deadline_state.rs
@@ -5,7 +5,7 @@ use super::{
     BitFieldQueue, ExpirationSet, Partition, PartitionSectorMap, PoStPartition, PowerPair,
     QuantSpec, SectorOnChainInfo, Sectors, TerminationResult, WPOST_PERIOD_DEADLINES,
 };
-use crate::{actor_error, ActorError, ExitCode, TokenAmount};
+use crate::{actor_error, ActorDowncast, ActorError, ExitCode, TokenAmount};
 use bitfield::BitField;
 use cid::{multihash::Blake2b256, Cid};
 use clock::ChainEpoch;
@@ -217,7 +217,7 @@ impl Deadline {
                 partition
                     .pop_expired_sectors(store, until, quant)
                     .map_err(|e| {
-                        ActorError::downcast_wrap(
+                        ActorDowncast::downcast_wrap(
                             e,
                             format!(
                                 "failed to pop expired sectors from partition {}",
@@ -346,7 +346,7 @@ impl Deadline {
         deadline_expirations
             .add_many_to_queue_values(&partition_deadline_updates)
             .map_err(|e| {
-                ActorError::downcast_wrap(e, "failed to add expirations for new deadlines")
+                ActorDowncast::downcast_wrap(e, "failed to add expirations for new deadlines")
             })?;
         self.expirations_epochs = deadline_expirations.amt.flush()?;
 
@@ -382,7 +382,7 @@ impl Deadline {
             let (partition_result, more) = partition
                 .pop_early_terminations(store, max_sectors - result.sectors_processed)
                 .map_err(|e| {
-                    ActorError::downcast_wrap(e, "failed to pop terminations from partition")
+                    ActorDowncast::downcast_wrap(e, "failed to pop terminations from partition")
                 })?;
 
             result += partition_result;
@@ -426,7 +426,7 @@ impl Deadline {
         let mut expirations = BitFieldQueue::new(store, &self.expirations_epochs, quant)?;
         let (popped, modified) = expirations
             .pop_until(until)
-            .map_err(|e| ActorError::downcast_wrap(e, "failed to pop expiring partitions"))?;
+            .map_err(|e| ActorDowncast::downcast_wrap(e, "failed to pop expiring partitions"))?;
 
         if modified {
             self.expirations_epochs = expirations.amt.flush()?;
@@ -458,7 +458,7 @@ impl Deadline {
             let removed = partition
                 .terminate_sectors(store, sectors, epoch, sector_numbers, sector_size, quant)
                 .map_err(|e| {
-                    ActorError::downcast_wrap(
+                    ActorDowncast::downcast_wrap(
                         e,
                         format!("failed to terminate sectors in partition {}", partition_idx),
                     )
@@ -570,7 +570,7 @@ impl Deadline {
 
                 Ok(())
             })
-            .map_err(|e| ActorError::downcast_wrap(e, "while removing partitions"))?;
+            .map_err(|e| ActorDowncast::downcast_wrap(e, "while removing partitions"))?;
 
         self.partitions = new_partitions
             .flush()
@@ -637,7 +637,7 @@ impl Deadline {
                     quant,
                 )
                 .map_err(|e| {
-                    ActorError::downcast_wrap(
+                    ActorDowncast::downcast_wrap(
                         e,
                         format!("failed to declare faults in partition {}", partition_idx),
                     )
@@ -874,7 +874,7 @@ impl Deadline {
             let recovered_power = partition
                 .recover_faults(store, sectors, sector_size, quant)
                 .map_err(|e| {
-                    ActorError::downcast_wrap(
+                    ActorDowncast::downcast_wrap(
                         e,
                         format!(
                             "failed to recover faulty sectors for partition {}",
@@ -973,7 +973,7 @@ impl Deadline {
                     quant,
                 )
                 .map_err(|e| {
-                    ActorError::downcast_wrap(
+                    ActorDowncast::downcast_wrap(
                         e,
                         format!(
                             "failed to reschedule expirations in partition {}",

--- a/vm/actor/src/builtin/miner/expiration_queue.rs
+++ b/vm/actor/src/builtin/miner/expiration_queue.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{power_for_sector, PowerPair, QuantSpec, SectorOnChainInfo, SECTORS_MAX};
+use crate::ActorDowncast;
 use bitfield::BitField;
 use cid::Cid;
 use clock::ChainEpoch;
@@ -64,19 +65,21 @@ impl ExpirationSet {
         on_time_pledge: &TokenAmount,
         active_power: &PowerPair,
         faulty_power: &PowerPair,
-    ) -> Result<(), String> {
+    ) -> Result<(), Box<dyn StdError>> {
         // Check for sector intersection. This could be cheaper with a combined intersection/difference method used below.
         if !self.on_time_sectors.contains_all(on_time_sectors) {
             return Err(format!(
                 "removing on-time sectors {:?} not contained in {:?}",
                 on_time_sectors, self.on_time_sectors
-            ));
+            )
+            .into());
         }
         if !self.early_sectors.contains_all(early_sectors) {
             return Err(format!(
                 "removing early sectors {:?} not contained in {:?}",
                 early_sectors, self.early_sectors
-            ));
+            )
+            .into());
         }
 
         self.on_time_sectors -= on_time_sectors;
@@ -87,10 +90,10 @@ impl ExpirationSet {
 
         // Check underflow.
         if self.on_time_pledge.is_negative() {
-            return Err(format!("expiration set pledge underflow: {:?}", self));
+            return Err(format!("expiration set pledge underflow: {:?}", self).into());
         }
         if self.active_power.qa.is_negative() || self.faulty_power.qa.is_negative() {
-            return Err(format!("expiration set power underflow: {:?}", self));
+            return Err(format!("expiration set power underflow: {:?}", self).into());
         }
 
         Ok(())
@@ -135,7 +138,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         &mut self,
         sectors: impl IntoIterator<Item = &'a SectorOnChainInfo>,
         sector_size: SectorSize,
-    ) -> Result<(BitField, PowerPair, TokenAmount), String> {
+    ) -> Result<(BitField, PowerPair, TokenAmount), Box<dyn StdError>> {
         let mut total_power = PowerPair::zero();
         let mut total_pledge = TokenAmount::zero();
         let mut total_sectors = Vec::<BitField>::new();
@@ -151,7 +154,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
                 &PowerPair::zero(),
                 &group.pledge,
             )
-            .map_err(|e| format!("failed to record new sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to record new sector expirations"))?;
 
             total_sectors.push(sector_numbers);
             total_power += &group.power;
@@ -171,14 +174,14 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         new_expiration: ChainEpoch,
         sectors: &[SectorOnChainInfo],
         sector_size: SectorSize,
-    ) -> Result<(), String> {
+    ) -> Result<(), Box<dyn StdError>> {
         if sectors.is_empty() {
             return Ok(());
         }
 
         let (sector_numbers, power, pledge) = self
             .remove_active_sectors(sectors, sector_size)
-            .map_err(|e| format!("failed to remove sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to remove sector expirations"))?;
 
         self.add(
             new_expiration,
@@ -188,7 +191,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
             &PowerPair::zero(),
             &pledge,
         )
-        .map_err(|e| format!("failed to record new sector expirations: {}", e))?;
+        .map_err(|e| e.downcast_wrap("failed to record new sector expirations"))?;
 
         Ok(())
     }
@@ -202,7 +205,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         new_expiration: ChainEpoch,
         sectors: &[SectorOnChainInfo],
         sector_size: SectorSize,
-    ) -> Result<PowerPair, String> {
+    ) -> Result<PowerPair, Box<dyn StdError>> {
         let mut sectors_total = Vec::new();
         let mut expiring_power = PowerPair::zero();
         let mut rescheduled_power = PowerPair::zero();
@@ -393,14 +396,14 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         old_sectors: &[SectorOnChainInfo],
         new_sectors: &[SectorOnChainInfo],
         sector_size: SectorSize,
-    ) -> Result<(BitField, BitField, PowerPair, TokenAmount), String> {
+    ) -> Result<(BitField, BitField, PowerPair, TokenAmount), Box<dyn StdError>> {
         let (old_sector_numbers, old_power, old_pledge) = self
             .remove_active_sectors(old_sectors, sector_size)
-            .map_err(|e| format!("failed to remove replaced sectors: {}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to remove replaced sectors"))?;
 
         let (new_sector_numbers, new_power, new_pledge) = self
             .add_active_sectors(new_sectors, sector_size)
-            .map_err(|e| format!("failed to add replacement sectors: {}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to add replacement sectors"))?;
 
         Ok((
             old_sector_numbers,
@@ -458,7 +461,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         // Remove non-faulty sectors.
         let (removed_sector_numbers, removed_power, removed_pledge) = self
             .remove_active_sectors(sectors, sector_size)
-            .map_err(|e| format!("failed to remove on-time recoveries: {}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to remove on-time recoveries"))?;
         removed.on_time_sectors = removed_sector_numbers;
         removed.active_power = removed_power;
         removed.on_time_pledge = removed_pledge;
@@ -572,7 +575,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         active_power: &PowerPair,
         faulty_power: &PowerPair,
         pledge: &TokenAmount,
-    ) -> Result<(), String> {
+    ) -> Result<(), Box<dyn StdError>> {
         let epoch = self.quant.quantize_up(raw_epoch);
         let mut expiration_set = self.may_get(epoch)?;
 
@@ -596,7 +599,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         active_power: &PowerPair,
         faulty_power: &PowerPair,
         pledge: &TokenAmount,
-    ) -> Result<(), String> {
+    ) -> Result<(), Box<dyn StdError>> {
         let epoch = self.quant.quantize_up(raw_epoch);
         let mut expiration_set = self.must_get(epoch)?;
         expiration_set
@@ -622,7 +625,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         &mut self,
         sectors: &[SectorOnChainInfo],
         sector_size: SectorSize,
-    ) -> Result<(BitField, PowerPair, TokenAmount), String> {
+    ) -> Result<(BitField, PowerPair, TokenAmount), Box<dyn StdError>> {
         let mut removed_sector_numbers = BitField::new();
         let mut removed_power = PowerPair::zero();
         let mut removed_pledge = TokenAmount::zero();
@@ -679,29 +682,31 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         Ok(())
     }
 
-    fn may_get(&self, key: ChainEpoch) -> Result<ExpirationSet, String> {
+    fn may_get(&self, key: ChainEpoch) -> Result<ExpirationSet, Box<dyn StdError>> {
         Ok(self
             .amt
             .get(key as u64)
-            .map_err(|e| format!("failed to lookup queue epoch {}: {:?}", key, e))?
+            .map_err(|e| e.downcast_wrap(format!("failed to lookup queue epoch {}", key)))?
             .unwrap_or_default())
     }
 
-    fn must_get(&self, key: ChainEpoch) -> Result<ExpirationSet, String> {
-        self.amt
+    fn must_get(&self, key: ChainEpoch) -> Result<ExpirationSet, Box<dyn StdError>> {
+        Ok(self
+            .amt
             .get(key as u64)
-            .map_err(|e| format!("failed to lookup queue epoch {}: {:?}", key, e))?
-            .ok_or_else(|| format!("missing expected expiration set at epoch {}", key))
+            .map_err(|e| e.downcast_wrap(format!("failed to lookup queue epoch {}", key)))?
+            .ok_or_else(|| format!("missing expected expiration set at epoch {}", key))?)
     }
 
     fn must_update(
         &mut self,
         epoch: ChainEpoch,
         expiration_set: ExpirationSet,
-    ) -> Result<(), String> {
-        self.amt
+    ) -> Result<(), Box<dyn StdError>> {
+        Ok(self
+            .amt
             .set(epoch as u64, expiration_set)
-            .map_err(|e| format!("failed to set queue epoch {}: {:?}", epoch, e))
+            .map_err(|e| e.downcast_wrap(format!("failed to set queue epoch {}", epoch)))?)
     }
 
     /// Since this might delete the node, it's not safe for use inside an iteration.
@@ -709,15 +714,15 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         &mut self,
         epoch: ChainEpoch,
         expiration_set: ExpirationSet,
-    ) -> Result<(), String> {
+    ) -> Result<(), Box<dyn StdError>> {
         if expiration_set.is_empty() {
             self.amt
                 .delete(epoch as u64)
-                .map_err(|e| format!("failed to delete queue epoch {}: {:?}", epoch, e))?;
+                .map_err(|e| e.downcast_wrap(format!("failed to delete queue epoch {}", epoch)))?;
         } else {
             self.amt
                 .set(epoch as u64, expiration_set)
-                .map_err(|e| format!("failed to set queue epoch {}: {:?}", epoch, e))?;
+                .map_err(|e| e.downcast_wrap(format!("failed to set queue epoch {}", epoch)))?;
         }
 
         Ok(())

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -1423,7 +1423,7 @@ impl Actor {
                         .map_err(|e| {
                             e.downcast_default(
                                 ExitCode::ErrIllegalState,
-                                format!("failed to replaces sector expirations at {:?}", key),
+                                format!("failed to replace sector expirations at {:?}", key),
                             )
                         })?;
 

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -50,6 +50,7 @@ use crate::{
 use crate::{
     power::{EnrollCronEventParams, Method as PowerMethod},
     reward::ThisEpochRewardReturn,
+    ActorDowncast,
 };
 use address::{Address, Payload, Protocol};
 use bitfield::BitField;
@@ -147,7 +148,7 @@ impl Actor {
         })?;
 
         let empty_bitfield_cid = rt.store().put(&BitField::new(), Blake2b256).map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 "failed to construct illegal state",
@@ -158,7 +159,7 @@ impl Actor {
             .store()
             .put(&Deadline::new(empty_array.clone()), Blake2b256)
             .map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     "failed to construct illegal state",
@@ -169,7 +170,7 @@ impl Actor {
             .store()
             .put(&Deadlines::new(empty_deadline_cid), Blake2b256)
             .map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     "failed to construct illegal state",
@@ -180,7 +181,7 @@ impl Actor {
             rt.store()
                 .put(&VestingFunds::new(), Blake2b256)
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         "failed to construct illegal state",
@@ -217,7 +218,7 @@ impl Actor {
             )
         })?;
         let info_cid = rt.store().put(&info, Blake2b256).map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 "failed to construct illegal state",
@@ -252,7 +253,11 @@ impl Actor {
         BS: BlockStore,
     {
         state.get_info(store).map_err(|e| {
-            ActorError::downcast(e, ExitCode::ErrIllegalState, "could not read miner info")
+            ActorDowncast::downcast_default(
+                e,
+                ExitCode::ErrIllegalState,
+                "could not read miner info",
+            )
         })
     }
 
@@ -315,7 +320,11 @@ impl Actor {
             };
 
             state.save_info(rt.store(), info).map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "could not save miner info")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "could not save miner info",
+                )
             })?;
 
             Ok(effective_epoch)
@@ -347,7 +356,11 @@ impl Actor {
 
             info.peer_id = params.new_id;
             state.save_info(rt.store(), info).map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "could not save miner info")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "could not save miner info",
+                )
             })?;
 
             Ok(())
@@ -374,7 +387,11 @@ impl Actor {
 
             info.multi_address = params.new_multi_addrs;
             state.save_info(rt.store(), info).map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "could not save miner info")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "could not save miner info",
+                )
             })?;
 
             Ok(())
@@ -516,7 +533,7 @@ impl Actor {
                     &params.partitions,
                 )
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         format!(
@@ -591,7 +608,7 @@ impl Actor {
                     &unlocked_balance,
                 )
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         format!(
@@ -607,7 +624,7 @@ impl Actor {
             deadlines
                 .update_deadline(rt.store(), params.deadline, &deadline)
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         format!("failed to update deadline {}", deadline_idx),
@@ -615,7 +632,11 @@ impl Actor {
                 })?;
 
             state.save_deadlines(rt.store(), deadlines).map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to save deadlines")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to save deadlines",
+                )
             })?;
 
             Ok(post_result)
@@ -824,7 +845,11 @@ impl Actor {
             let newly_vested = state
                 .unlock_vested_funds(store, rt.curr_epoch())
                 .map_err(|e| {
-                    ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to vest funds")
+                    ActorDowncast::downcast_default(
+                        e,
+                        ExitCode::ErrIllegalState,
+                        "failed to vest funds",
+                    )
                 })?;
 
             let available_balance = state.get_available_balance(&rt.current_balance()?);
@@ -897,7 +922,7 @@ impl Actor {
             state
                 .add_pre_commit_expiry(store, expiry_bound, sector_number)
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         "failed to add pre-commit expiry to queue",
@@ -1101,7 +1126,7 @@ impl Actor {
                     replace_sectors,
                 )
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         "failed to replace sector expirations",
@@ -1204,7 +1229,7 @@ impl Actor {
                     info.sector_size,
                 )
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         "failed to assign new sectors to deadlines",
@@ -1473,7 +1498,7 @@ impl Actor {
                 deadlines
                     .update_deadline(store, deadline_idx, &deadline)
                     .map_err(|e| {
-                        ActorError::downcast(
+                        ActorDowncast::downcast_default(
                             e,
                             ExitCode::ErrIllegalState,
                             format!("failed to save deadline {}", deadline_idx),
@@ -1590,7 +1615,7 @@ impl Actor {
                         quant,
                     )
                     .map_err(|e| {
-                        ActorError::downcast(
+                        ActorDowncast::downcast_default(
                             e,
                             ExitCode::ErrIllegalState,
                             format!("failed to terminate sectors in deadline {}", deadline_idx),
@@ -1603,7 +1628,7 @@ impl Actor {
                 deadlines
                     .update_deadline(store, deadline_idx, &deadline)
                     .map_err(|e| {
-                        ActorError::downcast(
+                        ActorDowncast::downcast_default(
                             e,
                             ExitCode::ErrIllegalState,
                             format!("failed to update deadline {}", deadline_idx),
@@ -1612,7 +1637,11 @@ impl Actor {
             }
 
             state.save_deadlines(store, deadlines).map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to save deadlines")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to save deadlines",
+                )
             })?;
 
             Ok((had_early_terminations, power_delta))
@@ -1729,7 +1758,7 @@ impl Actor {
                         partition_map,
                     )
                     .map_err(|e| {
-                        ActorError::downcast(
+                        ActorDowncast::downcast_default(
                             e,
                             ExitCode::ErrIllegalState,
                             format!("failed to declare faults for deadline {}", deadline_idx),
@@ -1739,7 +1768,7 @@ impl Actor {
                 deadlines
                     .update_deadline(store, deadline_idx, &deadline)
                     .map_err(|e| {
-                        ActorError::downcast(
+                        ActorDowncast::downcast_default(
                             e,
                             ExitCode::ErrIllegalState,
                             format!("failed to store deadline {} partitions", deadline_idx),
@@ -1750,7 +1779,11 @@ impl Actor {
             }
 
             state.save_deadlines(store, deadlines).map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to save deadlines")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to save deadlines",
+                )
             })?;
 
             Ok(new_fault_power_total)
@@ -1862,7 +1895,7 @@ impl Actor {
                 deadlines
                     .update_deadline(store, deadline_idx, &deadline)
                     .map_err(|e| {
-                        ActorError::downcast(
+                        ActorDowncast::downcast_default(
                             e,
                             ExitCode::ErrIllegalState,
                             format!("failed to store deadline {}", deadline_idx),
@@ -1871,7 +1904,11 @@ impl Actor {
             }
 
             state.save_deadlines(store, deadlines).map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to save deadlines")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to save deadlines",
+                )
             })?;
 
             Ok(())
@@ -1950,7 +1987,7 @@ impl Actor {
             let (live, dead, removed_power) = deadline
                 .remove_partitions(store, &params.partitions, quant)
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         format!(
@@ -1965,7 +2002,7 @@ impl Actor {
             })?;
 
             let sectors = state.load_sector_infos(store, &live).map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to load moved sectors")
+                ActorDowncast::downcast_default(e, ExitCode::ErrIllegalState, "failed to load moved sectors")
             })?;
 
             let new_power = deadline
@@ -1977,7 +2014,7 @@ impl Actor {
                     quant,
                 )
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         "failed to add back moved sectors",
@@ -2257,7 +2294,7 @@ where
             let (result, more) = state
                 .pop_early_terminations(store, ADDRESSED_PARTITIONS_MAX, ADDRESSED_SECTORS_MAX)
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         "failed to pop early terminations",
@@ -2322,7 +2359,7 @@ where
                     &unlocked_balance,
                 )
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         "failed to unlock unvested funds",
@@ -2381,7 +2418,11 @@ where
         let newly_vested = state
             .unlock_vested_funds(rt.store(), rt.curr_epoch())
             .map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to vest funds")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to vest funds",
+                )
             })?;
 
         pledge_delta += -newly_vested;
@@ -2401,7 +2442,7 @@ where
         })?;
 
         let (bitfield, modified) = expiry_queue.pop_until(curr_epoch).map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 "failed to pop expired sectors",
@@ -2485,7 +2526,11 @@ where
                 &unlocked_balance,
             )
             .map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to unlock penalty")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to unlock penalty",
+                )
             })?;
 
         unlocked_balance -= &penalty_from_balance;
@@ -2509,7 +2554,11 @@ where
                 &unlocked_balance,
             )
             .map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to unlock penalty")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to unlock penalty",
+                )
             })?;
 
         unlocked_balance -= &penalty_from_balance;
@@ -2521,7 +2570,7 @@ where
         let expired = deadline
             .pop_expired_sectors(rt.store(), deadline_info.last(), quant)
             .map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     "failed to load expired sectors",
@@ -2556,7 +2605,7 @@ where
         deadlines
             .update_deadline(rt.store(), deadline_info.index, &deadline)
             .map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     format!("failed to update deadline {}", deadline_info.index),
@@ -2564,7 +2613,11 @@ where
             })?;
 
         state.save_deadlines(rt.store(), deadlines).map_err(|e| {
-            ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to save deadlines")
+            ActorDowncast::downcast_default(
+                e,
+                ExitCode::ErrIllegalState,
+                "failed to save deadlines",
+            )
         })?;
 
         // Increment current deadline, and proving period if necessary.
@@ -2727,7 +2780,7 @@ where
             params.replace_sector_number,
         )
         .map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 format!("failed to replace sector {}", params.replace_sector_number),
@@ -3036,7 +3089,11 @@ where
         info.worker = key.new_worker;
         info.pending_worker_key = None;
         state.save_info(rt.store(), info).map_err(|e| {
-            ActorError::downcast(e, ExitCode::ErrSerialization, "failed to save miner info")
+            ActorDowncast::downcast_default(
+                e,
+                ExitCode::ErrSerialization,
+                "failed to save miner info",
+            )
         })?;
 
         Ok(())

--- a/vm/actor/src/builtin/miner/partition_state.rs
+++ b/vm/actor/src/builtin/miner/partition_state.rs
@@ -86,21 +86,21 @@ impl Partition {
         sectors: &[SectorOnChainInfo],
         sector_size: SectorSize,
         quant: QuantSpec,
-    ) -> Result<PowerPair, String> {
+    ) -> Result<PowerPair, Box<dyn StdError>> {
         let mut expirations = ExpirationQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load sector expirations"))?;
 
         let (sector_numbers, power, _) = expirations
             .add_active_sectors(sectors, sector_size)
-            .map_err(|e| format!("failed to record new sector expirations: {}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to record new sector expirations"))?;
 
         self.expirations_epochs = expirations
             .amt
             .flush()
-            .map_err(|e| format!("failed to store sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to store sector expirations"))?;
 
         if self.sectors.contains_any(&sector_numbers) {
-            return Err("not all added sectors are new".to_string());
+            return Err("not all added sectors are new".into());
         }
 
         // Update other metadata using the calculated totals.
@@ -124,12 +124,12 @@ impl Partition {
     ) -> Result<PowerPair, Box<dyn StdError>> {
         // Load expiration queue
         let mut queue = ExpirationQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load partition queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load partition queue"))?;
 
         // Reschedule faults
         let power = queue
             .reschedule_as_faults(fault_expiration, sectors, sector_size)
-            .map_err(|e| format!("failed to add faults to partition queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to add faults to partition queue"))?;
 
         // Save expiration queue
         self.expirations_epochs = queue.amt.flush()?;
@@ -190,7 +190,7 @@ impl Partition {
                     sector_size,
                     quant,
                 )
-                .map_err(|e| ActorDowncast::downcast_wrap(e, "failed to add faults"))?;
+                .map_err(|e| e.downcast_wrap("failed to add faults"))?;
         }
 
         Ok((new_faults, new_faulty_power))
@@ -220,9 +220,7 @@ impl Partition {
         // Reschedule recovered
         let power = queue
             .reschedule_recovered(recovered_sectors, sector_size)
-            .map_err(|e| {
-                ActorDowncast::downcast_wrap(e, "failed to reschedule faults in partition queue")
-            })?;
+            .map_err(|e| e.downcast_wrap("failed to reschedule faults in partition queue"))?;
 
         // Save expiration queue
         self.expirations_epochs = queue.amt.flush()?;
@@ -310,7 +308,7 @@ impl Partition {
 
         let sector_infos = sectors.load_sector(&active)?;
         let mut expirations = ExpirationQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load sector expirations"))?;
         expirations.reschedule_expirations(new_expiration, &sector_infos, sector_size)?;
         self.expirations_epochs = expirations.amt.flush()?;
 
@@ -329,18 +327,18 @@ impl Partition {
         new_sectors: &[SectorOnChainInfo],
         sector_size: SectorSize,
         quant: QuantSpec,
-    ) -> Result<(PowerPair, TokenAmount), String> {
+    ) -> Result<(PowerPair, TokenAmount), Box<dyn StdError>> {
         let mut expirations = ExpirationQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load sector expirations"))?;
 
         let (old_sector_numbers, new_sector_numbers, power_delta, pledge_delta) = expirations
             .replace_sectors(old_sectors, new_sectors, sector_size)
-            .map_err(|e| format!("failed to replace sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to replace sector expirations"))?;
 
         self.expirations_epochs = expirations
             .amt
             .flush()
-            .map_err(|e| format!("failed to save sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to save sector expirations"))?;
 
         // Check the sectors being removed are active (alive, not faulty).
         let active = self.active_sectors();
@@ -350,7 +348,8 @@ impl Partition {
             return Err(format!(
                 "refusing to replace inactive sectors in {:?} (active: {:?})",
                 old_sector_numbers, active
-            ));
+            )
+            .into());
         }
 
         // Update partition metadata.
@@ -372,18 +371,16 @@ impl Partition {
     ) -> Result<(), Box<dyn StdError>> {
         let mut early_termination_queue =
             BitFieldQueue::new(store, &self.early_terminated, NO_QUANTIZATION)
-                .map_err(|e| format!("failed to load early termination queue: {:?}", e))?;
+                .map_err(|e| e.downcast_wrap("failed to load early termination queue"))?;
 
         early_termination_queue
             .add_to_queue(epoch, sectors)
-            .map_err(|e| {
-                ActorDowncast::downcast_wrap(e, "failed to add to early termination queue")
-            })?;
+            .map_err(|e| e.downcast_wrap("failed to add to early termination queue"))?;
 
         self.early_terminated = early_termination_queue
             .amt
             .flush()
-            .map_err(|e| format!("failed to save early termination queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to save early termination queue"))?;
 
         Ok(())
     }
@@ -407,23 +404,21 @@ impl Partition {
 
         let sector_infos = sectors.load_sector(sector_numbers)?;
         let mut expirations = ExpirationQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load sector expirations"))?;
         let (removed, removed_recovering) = expirations
             .remove_sectors(&sector_infos, &self.faults, &self.recoveries, sector_size)
-            .map_err(|e| ActorDowncast::downcast_wrap(e, "failed to remove sector expirations"))?;
+            .map_err(|e| e.downcast_wrap("failed to remove sector expirations"))?;
 
         self.expirations_epochs = expirations
             .amt
             .flush()
-            .map_err(|e| format!("failed to save sector expirations: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to save sector expirations"))?;
 
         let removed_sectors = &removed.on_time_sectors | &removed.early_sectors;
 
         // Record early termination.
         self.record_early_termination(store, epoch, &removed_sectors)
-            .map_err(|e| {
-                ActorDowncast::downcast_wrap(e, "failed to record early sector termination")
-            })?;
+            .map_err(|e| e.downcast_wrap("failed to record early sector termination"))?;
 
         // Update partition metadata.
         self.faults -= &removed_sectors;
@@ -447,12 +442,9 @@ impl Partition {
         quant: QuantSpec,
     ) -> Result<ExpirationSet, Box<dyn StdError>> {
         let mut expirations = ExpirationQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load expiration queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load expiration queue"))?;
         let popped = expirations.pop_until(until).map_err(|e| {
-            ActorDowncast::downcast_wrap(
-                e,
-                format!("failed to pop expiration queue until {}", until),
-            )
+            e.downcast_wrap(format!("failed to pop expiration queue until {}", until))
         })?;
         self.expirations_epochs = expirations.amt.flush()?;
 
@@ -482,7 +474,7 @@ impl Partition {
 
         // Record the epoch of any sectors expiring early, for termination fee calculation later.
         self.record_early_termination(store, until, &popped.early_sectors)
-            .map_err(|e| ActorDowncast::downcast_wrap(e, "failed to record early terminations"))?;
+            .map_err(|e| e.downcast_wrap("failed to record early terminations"))?;
 
         Ok(popped)
     }
@@ -499,11 +491,11 @@ impl Partition {
         // Collapse tail of queue into the last entry, and mark all power faulty.
         // Load expiration queue
         let mut queue = ExpirationQueue::new(store, &self.expirations_epochs, quant)
-            .map_err(|e| format!("failed to load partition queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to load partition queue"))?;
 
         queue
             .reschedule_all_as_faults(fault_expiration)
-            .map_err(|e| ActorDowncast::downcast_wrap(e, "failed to reschedule all as faults"))?;
+            .map_err(|e| e.downcast_wrap("failed to reschedule all as faults"))?;
 
         // Save expiration queue
         self.expirations_epochs = queue.amt.flush()?;
@@ -562,19 +554,14 @@ impl Partition {
                 let keep_going = result.sectors_processed < max_sectors;
                 Ok(keep_going)
             })
-            .map_err(|e| {
-                ActorDowncast::downcast_wrap(e, "failed to walk early terminations queue")
-            })?;
+            .map_err(|e| e.downcast_wrap("failed to walk early terminations queue"))?;
 
         // Update early terminations
         early_terminated_queue
             .amt
             .batch_delete(processed)
             .map_err(|e| {
-                format!(
-                    "failed to remove entries from early terminations queue: {:?}",
-                    e
-                )
+                e.downcast_wrap("failed to remove entries from early terminations queue")
             })?;
 
         if let Some((remaining_sectors, remaining_epoch)) = remaining.take() {
@@ -582,10 +569,7 @@ impl Partition {
                 .amt
                 .set(remaining_epoch as u64, remaining_sectors)
                 .map_err(|e| {
-                    format!(
-                        "failed to update remaining entry early terminations queue: {:?}",
-                        e
-                    )
+                    e.downcast_wrap("failed to update remaining entry early terminations queue")
                 })?;
         }
 
@@ -593,7 +577,7 @@ impl Partition {
         self.early_terminated = early_terminated_queue
             .amt
             .flush()
-            .map_err(|e| format!("failed to store early terminations queue: {:?}", e))?;
+            .map_err(|e| e.downcast_wrap("failed to store early terminations queue"))?;
 
         let has_more = early_terminated_queue.amt.count() > 0;
         Ok((result, has_more))
@@ -629,14 +613,14 @@ impl Partition {
         let retracted_recoveries = &self.recoveries & skipped;
         let retracted_recovery_sectors = sectors
             .load_sector(&retracted_recoveries)
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to load sectors: {:?}", e))?;
+            .map_err(|e| e.wrap("failed to load sectors"))?;
         let retracted_recovery_power = power_for_sectors(sector_size, &retracted_recovery_sectors);
 
         // Ignore skipped faults that are already faults or terminated.
         let new_faults = &(skipped - &self.terminated) - &self.faults;
         let new_fault_sectors = sectors
             .load_sector(&new_faults)
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to load sectors: {:?}", e))?;
+            .map_err(|e| e.wrap("failed to load sectors"))?;
 
         // Record new faults
         let new_fault_power = self
@@ -649,11 +633,7 @@ impl Partition {
                 quant,
             )
             .map_err(|e| {
-                ActorDowncast::downcast_default(
-                    e,
-                    ExitCode::ErrIllegalState,
-                    "failed to add skipped faults",
-                )
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to add skipped faults")
             })?;
 
         // Remove faulty recoveries

--- a/vm/actor/src/builtin/miner/sectors.rs
+++ b/vm/actor/src/builtin/miner/sectors.rs
@@ -56,7 +56,6 @@ impl<'db, BS: BlockStore> Sectors<'db, BS> {
         for info in infos {
             let sector_number = info.sector_number;
 
-            // #[allow(clippy::absurd_extreme_comparisons)]
             if sector_number > MAX_SECTOR_NUMBER {
                 return Err(format!("sector number {} out of range", info.sector_number).into());
             }

--- a/vm/actor/src/builtin/miner/sectors.rs
+++ b/vm/actor/src/builtin/miner/sectors.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::SectorOnChainInfo;
-use crate::{actor_error, ActorError, ExitCode};
+use crate::{actor_error, ActorDowncast, ActorError, ExitCode};
 use bitfield::BitField;
 use cid::Cid;
 use fil_types::{SectorNumber, MAX_SECTOR_NUMBER};
 use ipld_amt::{Amt, Error as AmtError};
 use ipld_blockstore::BlockStore;
+use std::error::Error as StdError;
 
 pub struct Sectors<'db, BS> {
     pub amt: Amt<'db, SectorOnChainInfo, BS>,
@@ -43,35 +44,42 @@ impl<'db, BS: BlockStore> Sectors<'db, BS> {
         Ok(sector_infos)
     }
 
-    pub fn get(&self, sector_number: SectorNumber) -> Result<Option<SectorOnChainInfo>, String> {
-        self.amt
+    pub fn get(
+        &self,
+        sector_number: SectorNumber,
+    ) -> Result<Option<SectorOnChainInfo>, Box<dyn StdError>> {
+        Ok(self
+            .amt
             .get(sector_number)
-            .map_err(|e| format!("failed to get sector {}: {:?}", sector_number, e))
+            .map_err(|e| e.downcast_wrap(format!("failed to get sector {}", sector_number)))?)
     }
 
-    pub fn store(&mut self, infos: Vec<SectorOnChainInfo>) -> Result<(), String> {
+    pub fn store(&mut self, infos: Vec<SectorOnChainInfo>) -> Result<(), Box<dyn StdError>> {
         for info in infos {
             let sector_number = info.sector_number;
 
-            #[allow(clippy::absurd_extreme_comparisons)]
+            // #[allow(clippy::absurd_extreme_comparisons)]
             if sector_number > MAX_SECTOR_NUMBER {
-                return Err(format!("sector number {} out of range", info.sector_number));
+                return Err(format!("sector number {} out of range", info.sector_number).into());
             }
 
-            self.amt
-                .set(sector_number, info)
-                .map_err(|e| format!("failed to store sector {}: {:?}", sector_number, e))?;
+            self.amt.set(sector_number, info).map_err(|e| {
+                e.downcast_wrap(format!("failed to store sector {}", sector_number))
+            })?;
         }
 
         if self.amt.count() > super::SECTORS_MAX as u64 {
-            return Err("too many sectors".to_string());
+            return Err("too many sectors".into());
         }
 
         Ok(())
     }
 
-    pub fn must_get(&self, sector_number: SectorNumber) -> Result<SectorOnChainInfo, String> {
+    pub fn must_get(
+        &self,
+        sector_number: SectorNumber,
+    ) -> Result<SectorOnChainInfo, Box<dyn StdError>> {
         self.get(sector_number)?
-            .ok_or_else(|| format!("sector {} not found", sector_number))
+            .ok_or_else(|| format!("sector {} not found", sector_number).into())
     }
 }

--- a/vm/actor/src/builtin/miner/sectors.rs
+++ b/vm/actor/src/builtin/miner/sectors.rs
@@ -31,11 +31,9 @@ impl<'db, BS: BlockStore> Sectors<'db, BS> {
                 .amt
                 .get(sector_number as SectorNumber)
                 .map_err(|e| {
-                    actor_error!(
-                        ErrIllegalState,
-                        "failed to load sector {}: {:?}",
-                        sector_number,
-                        e
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load sector {}", sector_number),
                     )
                 })?
                 .ok_or_else(|| actor_error!(ErrNotFound; "sector not found: {}", sector_number))?;

--- a/vm/actor/src/builtin/miner/state.rs
+++ b/vm/actor/src/builtin/miner/state.rs
@@ -124,7 +124,7 @@ impl State {
         match store.get(&self.info) {
             Ok(Some(info)) => Ok(info),
             Ok(None) => Err(actor_error!(ErrNotFound, "failed to get miner info").into()),
-            Err(e) => Err(ActorDowncast::downcast_wrap(e, "failed to get miner info")),
+            Err(e) => Err(e.downcast_wrap("failed to get miner info")),
         }
     }
 

--- a/vm/actor/src/builtin/miner/state.rs
+++ b/vm/actor/src/builtin/miner/state.rs
@@ -4,7 +4,7 @@
 use super::{assign_deadlines, deadline_is_mutable, policy::*, Deadline};
 use super::{deadlines::DeadlineInfo, DeadlineSectorMap};
 use super::{types::*, Deadlines, PowerPair, QuantSpec, Sectors, TerminationResult, VestingFunds};
-use crate::{make_map_with_root, u64_key};
+use crate::{make_map_with_root, u64_key, ActorDowncast};
 use address::Address;
 use ahash::AHashSet;
 use bitfield::BitField;
@@ -124,7 +124,7 @@ impl State {
         match store.get(&self.info) {
             Ok(Some(info)) => Ok(info),
             Ok(None) => Err(actor_error!(ErrNotFound, "failed to get miner info").into()),
-            Err(e) => Err(ActorError::downcast_wrap(e, "failed to get miner info")),
+            Err(e) => Err(ActorDowncast::downcast_wrap(e, "failed to get miner info")),
         }
     }
 
@@ -496,7 +496,7 @@ impl State {
                     max_sectors - result.sectors_processed,
                 )
                 .map_err(|e| {
-                    ActorError::downcast_wrap(
+                    ActorDowncast::downcast_wrap(
                         e,
                         format!(
                             "failed to pop early terminations for deadline {}",
@@ -678,7 +678,7 @@ impl State {
         Ok(store
             .get(&self.vesting_funds)
             .map_err(|e| {
-                ActorError::downcast_wrap(
+                ActorDowncast::downcast_wrap(
                     e,
                     format!("failed to load vesting funds {:?}", self.vesting_funds),
                 )

--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -7,7 +7,7 @@ mod types;
 pub use self::state::*;
 pub use self::types::*;
 use crate::{
-    make_map, make_map_with_root, resolve_to_id_addr, Map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR,
+    make_map, make_map_with_root, resolve_to_id_addr, Map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR, ActorDowncast
 };
 use address::{Address, Protocol};
 use encoding::to_vec;
@@ -58,7 +58,7 @@ impl Actor {
         let mut dedup_signers = HashSet::with_capacity(params.signers.len());
         for signer in &params.signers {
             let resolved = resolve_to_id_addr(rt, signer).map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     &format!("failed to resolve addr {} to ID addr", signer),
@@ -268,7 +268,7 @@ impl Actor {
         let receiver = *rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_new_signer = resolve_to_id_addr(rt, &params.signer).map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 &format!("failed to resolve address {}", params.signer),
@@ -301,7 +301,7 @@ impl Actor {
         let receiver = *rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_old_signer = resolve_to_id_addr(rt, &params.signer).map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 &format!("failed to resolve address {}", params.signer),
@@ -344,14 +344,14 @@ impl Actor {
         let receiver = *rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let from_resolved = resolve_to_id_addr(rt, &params.from).map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 &format!("failed to resolve address {}", params.from),
             )
         })?;
         let to_resolved = resolve_to_id_addr(rt, &params.to).map_err(|e| {
-            ActorError::downcast(
+            ActorDowncast::downcast_default(
                 e,
                 ExitCode::ErrIllegalState,
                 &format!("failed to resolve address {}", params.to),

--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -59,10 +59,9 @@ impl Actor {
         let mut dedup_signers = HashSet::with_capacity(params.signers.len());
         for signer in &params.signers {
             let resolved = resolve_to_id_addr(rt, signer).map_err(|e| {
-                ActorDowncast::downcast_default(
-                    e,
+                e.downcast_default(
                     ExitCode::ErrIllegalState,
-                    &format!("failed to resolve addr {} to ID addr", signer),
+                    format!("failed to resolve addr {} to ID addr", signer),
                 )
             })?;
             if dedup_signers.contains(&resolved) {
@@ -88,9 +87,9 @@ impl Actor {
             return Err(actor_error!(ErrIllegalArgument; "negative unlock duration disallowed"));
         }
 
-        let empty_root = make_map::<_, ()>(rt.store())
-            .flush()
-            .map_err(|err| actor_error!(ErrIllegalState; "Failed to create empty map: {}", err))?;
+        let empty_root = make_map::<_, ()>(rt.store()).flush().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "Failed to create empty map")
+        })?;
 
         let mut st: State = State {
             signers: resolved_signers,
@@ -132,9 +131,12 @@ impl Actor {
                 return Err(actor_error!(ErrForbidden; "{} is not a signer", proposer));
             }
 
-            let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to load pending transactions: {}", e),
-            )?;
+            let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to load pending transactions",
+                )
+            })?;
 
             let t_id = st.next_tx_id;
             st.next_tx_id.0 += 1;
@@ -147,13 +149,19 @@ impl Actor {
                 approved: Vec::new(),
             };
 
-            ptx.set(t_id.key(), txn.clone()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to put transaction for propose: {}", e),
-            )?;
+            ptx.set(t_id.key(), txn.clone()).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to put transaction for propose",
+                )
+            })?;
 
-            st.pending_txs = ptx.flush().map_err(
-                |e| actor_error!(ErrIllegalState; "failed to flush pending transactions: {}", e),
-            )?;
+            st.pending_txs = ptx.flush().map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to flush pending transactions",
+                )
+            })?;
 
             Ok((t_id, txn))
         })?;
@@ -183,9 +191,12 @@ impl Actor {
                 return Err(actor_error!(ErrForbidden; "{} is not a signer", caller_addr));
             }
 
-            let ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to load pending transactions: {}", e),
-            )?;
+            let ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to load pending transactions",
+                )
+            })?;
 
             let txn = get_transaction(rt, &ptx, params.id, params.proposal_hash, true)?;
 
@@ -219,14 +230,20 @@ impl Actor {
                 return Err(actor_error!(ErrForbidden; "{} is not a signer", caller_addr));
             }
 
-            let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to load pending transactions: {}", e),
-            )?;
+            let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to load pending transactions",
+                )
+            })?;
 
             // Get transaction to cancel
-            let tx = get_pending_transaction(&ptx, params.id).map_err(
-                |err| actor_error!(ErrNotFound; "Failed to get transaction for cancel: {}", err),
-            )?;
+            let tx = get_pending_transaction(&ptx, params.id).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrNotFound,
+                    "Failed to get transaction for cancel",
+                )
+            })?;
 
             // Check to make sure transaction proposer is caller address
             if tx.approved.get(0) != Some(&caller_addr) {
@@ -236,25 +253,33 @@ impl Actor {
             }
 
             let calculated_hash = compute_proposal_hash(&tx, rt.syscalls()).map_err(|e| {
-                actor_error!(ErrIllegalState;
-                    "failed to compute proposal hash for (tx: {:?}): {}", params.id, e)
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to compute proposal hash for (tx: {:?})", params.id),
+                )
             })?;
 
             if params.proposal_hash != calculated_hash {
                 return Err(actor_error!(ErrIllegalState; "hash does not match proposal params"));
             }
 
-            let deleted = ptx.delete(&params.id.key()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to delete pending transaction: {}", e),
-            )?;
+            let deleted = ptx.delete(&params.id.key()).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to delete pending transaction",
+                )
+            })?;
             if !deleted {
                 return Err(actor_error!(ErrIllegalState;
                     "failed to delete pending transaction: does not exist"));
             }
 
-            st.pending_txs = ptx.flush().map_err(
-                |e| actor_error!(ErrIllegalState; "failed to flush pending transactions: {}", e),
-            )?;
+            st.pending_txs = ptx.flush().map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to flush pending transactions",
+                )
+            })?;
 
             Ok(())
         })
@@ -269,10 +294,9 @@ impl Actor {
         let receiver = *rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_new_signer = resolve_to_id_addr(rt, &params.signer).map_err(|e| {
-            ActorDowncast::downcast_default(
-                e,
+            e.downcast_default(
                 ExitCode::ErrIllegalState,
-                &format!("failed to resolve address {}", params.signer),
+                format!("failed to resolve address {}", params.signer),
             )
         })?;
 
@@ -302,10 +326,9 @@ impl Actor {
         let receiver = *rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let resolved_old_signer = resolve_to_id_addr(rt, &params.signer).map_err(|e| {
-            ActorDowncast::downcast_default(
-                e,
+            e.downcast_default(
                 ExitCode::ErrIllegalState,
-                &format!("failed to resolve address {}", params.signer),
+                format!("failed to resolve address {}", params.signer),
             )
         })?;
 
@@ -345,17 +368,15 @@ impl Actor {
         let receiver = *rt.message().receiver();
         rt.validate_immediate_caller_is(std::iter::once(&receiver))?;
         let from_resolved = resolve_to_id_addr(rt, &params.from).map_err(|e| {
-            ActorDowncast::downcast_default(
-                e,
+            e.downcast_default(
                 ExitCode::ErrIllegalState,
-                &format!("failed to resolve address {}", params.from),
+                format!("failed to resolve address {}", params.from),
             )
         })?;
         let to_resolved = resolve_to_id_addr(rt, &params.to).map_err(|e| {
-            ActorDowncast::downcast_default(
-                e,
+            e.downcast_default(
                 ExitCode::ErrIllegalState,
-                &format!("failed to resolve address {}", params.to),
+                format!("failed to resolve address {}", params.to),
             )
         })?;
 
@@ -425,21 +446,29 @@ impl Actor {
         }
 
         let st = rt.transaction(|st: &mut State, rt| {
-            let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to load pending transactions: {}", e),
-            )?;
+            let mut ptx = make_map_with_root(&st.pending_txs, rt.store()).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to load pending transactions",
+                )
+            })?;
 
             // update approved on the transaction
             txn.approved.push(*rt.message().caller());
 
             ptx.set(tx_id.key(), txn.clone()).map_err(|e| {
-                actor_error!(ErrIllegalState;
-                    "failed to put transaction {} for approval: {}", tx_id.0, e)
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to put transaction {} for approval", tx_id.0),
+                )
             })?;
 
-            st.pending_txs = ptx.flush().map_err(
-                |e| actor_error!(ErrIllegalState; "failed to flush pending transactions: {}", e),
-            )?;
+            st.pending_txs = ptx.flush().map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to flush pending transactions",
+                )
+            })?;
 
             // Go implementation holds reference to state after transaction so this must be cloned
             // to match to handle possible exit code inconsistency
@@ -482,21 +511,30 @@ where
 
         rt.transaction(|st: &mut State, rt| {
             let mut ptx = make_map_with_root::<_, Transaction>(&st.pending_txs, rt.store())
-                .map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to load pending transactions: {}", e),
-                )?;
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        "failed to load pending transactions",
+                    )
+                })?;
 
             let deleted = ptx.delete(&txn_id.key()).map_err(|e| {
-                actor_error!(ErrIllegalState; "failed to delete transaction for cleanup: {}", e)
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to delete transaction for cleanup",
+                )
             })?;
             if !deleted {
                 return Err(actor_error!(ErrIllegalState;
                     "failed to delete transaction for cleanup: does not exist"));
             }
 
-            st.pending_txs = ptx.flush().map_err(
-                |e| actor_error!(ErrIllegalState; "failed to flush pending transactions: {}", e),
-            )?;
+            st.pending_txs = ptx.flush().map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to flush pending transactions",
+                )
+            })?;
             Ok(())
         })?;
     }
@@ -507,12 +545,11 @@ where
 fn get_pending_transaction<'bs, BS: BlockStore>(
     ptx: &Map<'bs, BS, Transaction>,
     txn_id: TxnID,
-) -> Result<Transaction, String> {
-    match ptx.get(&txn_id.key()) {
-        Ok(Some(tx)) => Ok(tx),
-        Ok(None) => Err(format!("failed to find transaction: {}", txn_id.0,)),
-        Err(e) => Err(format!("failed to read transaction: {}", e)),
-    }
+) -> Result<Transaction, Box<dyn StdError>> {
+    Ok(ptx
+        .get(&txn_id.key())
+        .map_err(|e| e.downcast_wrap("failed to read transaction"))?
+        .ok_or_else(|| actor_error!(ErrNotFound, "failed to find transaction: {}", txn_id.0))?)
 }
 
 fn get_transaction<'bs, BS, RT>(
@@ -526,13 +563,19 @@ where
     BS: BlockStore,
     RT: Runtime<BS>,
 {
-    let txn = get_pending_transaction(ptx, txn_id)
-        .map_err(|e| actor_error!(ErrNotFound; "failed to get transaction for approval: {}", e))?;
+    let txn = get_pending_transaction(ptx, txn_id).map_err(|e| {
+        e.downcast_default(
+            ExitCode::ErrNotFound,
+            "failed to get transaction for approval",
+        )
+    })?;
 
     if check_hash {
         let calculated_hash = compute_proposal_hash(&txn, rt.syscalls()).map_err(|e| {
-            actor_error!(ErrIllegalState;
-                "failed to compute proposal hash for (tx: {:?}): {}", txn_id, e)
+            e.downcast_default(
+                ExitCode::ErrIllegalState,
+                format!("failed to compute proposal hash for (tx: {:?})", txn_id),
+            )
         })?;
 
         if proposal_hash != calculated_hash {
@@ -576,7 +619,7 @@ fn compute_proposal_hash(
         params: &txn.params,
     };
     let data = to_vec(&proposal_hash)
-        .map_err(|e| format!("failed to construct multisig approval hash: {}", e))?;
+        .map_err(|e| ActorError::from(e).wrap("failed to construct multisig approval hash"))?;
 
     sys.hash_blake2b(&data)
 }

--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -7,7 +7,8 @@ mod types;
 pub use self::state::*;
 pub use self::types::*;
 use crate::{
-    make_map, make_map_with_root, resolve_to_id_addr, Map, CALLER_TYPES_SIGNABLE, INIT_ACTOR_ADDR, ActorDowncast
+    make_map, make_map_with_root, resolve_to_id_addr, ActorDowncast, Map, CALLER_TYPES_SIGNABLE,
+    INIT_ACTOR_ADDR,
 };
 use address::{Address, Protocol};
 use encoding::to_vec;

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -49,9 +49,9 @@ impl Actor {
 
         let from = Self::resolve_account(rt, &params.from)?;
 
-        let empty_arr_cid = Amt::<(), _>::new(rt.store())
-            .flush()
-            .map_err(|e| actor_error!(ErrIllegalState; "failed to create empty AMT: {}", e))?;
+        let empty_arr_cid = Amt::<(), _>::new(rt.store()).flush().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "failed to create empty AMT")
+        })?;
 
         rt.create(&State::new(from, to, empty_arr_cid))?;
         Ok(())
@@ -109,19 +109,15 @@ impl Actor {
             .ok_or_else(|| actor_error!(ErrIllegalArgument; "voucher has no signature"))?;
 
         // Generate unsigned bytes
-        let sv_bz = sv.signing_bytes().map_err(
-            |e| actor_error!(ErrIllegalArgument; "failed to serialized SignedVoucher: {}", e),
-        )?;
+        let sv_bz = sv
+            .signing_bytes()
+            .map_err(|e| ActorError::from(e).wrap("failed to serialized SignedVoucher"))?;
 
         // Validate signature
         rt.syscalls()
             .verify_signature(&sig, &signer, &sv_bz)
             .map_err(|e| {
-                ActorDowncast::downcast_default(
-                    e,
-                    ExitCode::ErrIllegalArgument,
-                    "voucher signature invalid",
-                )
+                e.downcast_default(ExitCode::ErrIllegalArgument, "voucher signature invalid")
             })?;
 
         let pch_addr = rt.message().receiver();
@@ -148,7 +144,7 @@ impl Actor {
             let hashed_secret: &[u8] = &rt
                 .syscalls()
                 .hash_blake2b(&params.secret)
-                .map_err(|e| *e.downcast::<ActorError>().unwrap())?;
+                .map_err(|e| e.downcast_fatal("failed to hash secret"))?;
             if hashed_secret != sv.secret_pre_image.as_slice() {
                 return Err(actor_error!(ErrIllegalArgument; "incorrect secret"));
             }
@@ -168,8 +164,9 @@ impl Actor {
         }
 
         rt.transaction(|st: &mut State, rt| {
-            let mut l_states = Amt::load(&st.lane_states, rt.store())
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to load lane states {}", e))?;
+            let mut l_states = Amt::load(&st.lane_states, rt.store()).map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to load lane states")
+            })?;
 
             // Find the voucher lane, create and insert it in sorted order if necessary.
             let lane_id = sv.lane;
@@ -207,9 +204,12 @@ impl Actor {
 
                 redeemed_from_others += &other_ls.redeemed;
                 other_ls.nonce = merge.nonce;
-                l_states.set(merge.lane, other_ls).map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to store lane {}: {}", merge.lane, e),
-                )?;
+                l_states.set(merge.lane, other_ls).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to store lane {}", merge.lane),
+                    )
+                })?;
             }
 
             // 2. To prevent double counting, remove already redeemed amounts (from
@@ -246,13 +246,16 @@ impl Actor {
                 }
             }
 
-            l_states.set(lane_id, lane_state).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to store lane {}: {}", lane_id, e),
-            )?;
+            l_states.set(lane_id, lane_state).map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    format!("failed to store lane {}", lane_id),
+                )
+            })?;
 
-            st.lane_states = l_states
-                .flush()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to save lanes: {}", e))?;
+            st.lane_states = l_states.flush().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to save lanes")
+            })?;
             Ok(())
         })
     }
@@ -310,8 +313,12 @@ where
         return Err(actor_error!(ErrIllegalArgument; "maximum lane ID is 2^63-1"));
     }
 
-    ls.get(id)
-        .map_err(|e| actor_error!(ErrIllegalState; "failed to load lane {}: {}", id, e))
+    ls.get(id).map_err(|e| {
+        e.downcast_default(
+            ExitCode::ErrIllegalState,
+            format!("failed to load lane {}", id),
+        )
+    })
 }
 
 impl ActorCode for Actor {

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -144,7 +144,7 @@ impl Actor {
             let hashed_secret: &[u8] = &rt
                 .syscalls()
                 .hash_blake2b(&params.secret)
-                .map_err(|e| e.downcast_fatal("failed to hash secret"))?;
+                .map_err(|e| e.downcast_fatal("unexpected error from blake2b hash"))?;
             if hashed_secret != sv.secret_pre_image.as_slice() {
                 return Err(actor_error!(ErrIllegalArgument; "incorrect secret"));
             }

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -6,7 +6,7 @@ mod types;
 
 pub use self::state::{LaneState, Merge, State};
 pub use self::types::*;
-use crate::{check_empty_params, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID};
+use crate::{check_empty_params, ActorDowncast, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_CODE_ID};
 use address::Address;
 use ipld_amt::Amt;
 use ipld_blockstore::BlockStore;
@@ -117,7 +117,11 @@ impl Actor {
         rt.syscalls()
             .verify_signature(&sig, &signer, &sv_bz)
             .map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalArgument, "voucher signature invalid")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalArgument,
+                    "voucher signature invalid",
+                )
             })?;
 
         let pch_addr = rt.message().receiver();

--- a/vm/actor/src/builtin/power/mod.rs
+++ b/vm/actor/src/builtin/power/mod.rs
@@ -11,8 +11,9 @@ pub use self::types::*;
 use crate::miner::MinerConstructorParams;
 use crate::reward::Method as RewardMethod;
 use crate::{
-    check_empty_params, init, make_map, make_map_with_root, miner, Multimap, CALLER_TYPES_SIGNABLE,
-    CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, MINER_ACTOR_CODE_ID, REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    check_empty_params, init, make_map, make_map_with_root, miner, ActorDowncast, Multimap,
+    CALLER_TYPES_SIGNABLE, CRON_ACTOR_ADDR, INIT_ACTOR_ADDR, MINER_ACTOR_CODE_ID,
+    REWARD_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use address::Address;
 use ahash::AHashSet;
@@ -149,7 +150,7 @@ impl Actor {
                 &params.quality_adjusted_delta,
             )
             .map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     &format!(
@@ -280,7 +281,7 @@ impl Actor {
                 &claim.quality_adj_power.neg(),
             )
             .map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     &format!("could not add to claim for {}", miner_addr),
@@ -409,7 +410,7 @@ impl Actor {
                     Ok(())
                 })
                 .map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         &format!(
@@ -423,7 +424,7 @@ impl Actor {
                 Ok(())
             })
             .map_err(|e| {
-                ActorError::downcast(
+                ActorDowncast::downcast_default(
                     e,
                     ExitCode::ErrIllegalState,
                     "failed to iterate proof batch",
@@ -441,7 +442,11 @@ impl Actor {
             .syscalls()
             .batch_verify_seals(verif_arr.as_slice())
             .map_err(|e| {
-                ActorError::downcast(e, ExitCode::ErrIllegalState, "failed to batch verify")
+                ActorDowncast::downcast_default(
+                    e,
+                    ExitCode::ErrIllegalState,
+                    "failed to batch verify",
+                )
             })?;
 
         for (m, verifs) in verifies.iter() {
@@ -487,7 +492,7 @@ impl Actor {
 
             for epoch in st.first_cron_epoch..rt_epoch {
                 let mut epoch_events = load_cron_events(&events, epoch).map_err(|e| {
-                    ActorError::downcast(
+                    ActorDowncast::downcast_default(
                         e,
                         ExitCode::ErrIllegalState,
                         &format!("failed to load cron events at {}", epoch),

--- a/vm/actor/src/builtin/shared.rs
+++ b/vm/actor/src/builtin/shared.rs
@@ -1,9 +1,8 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::miner::Method;
+use crate::miner::{GetControlAddressesReturn, Method};
 use address::Address;
-use encoding::tuple::*;
 use ipld_blockstore::BlockStore;
 use num_traits::Zero;
 use runtime::Runtime;
@@ -24,16 +23,9 @@ where
         Serialized::default(),
         TokenAmount::zero(),
     )?;
-    let addrs: MinerAddrs = ret.deserialize()?;
+    let addrs: GetControlAddressesReturn = ret.deserialize()?;
 
-    Ok((addrs.owner, addrs.worker, addrs.control_addrs))
-}
-
-#[derive(Serialize_tuple, Deserialize_tuple)]
-struct MinerAddrs {
-    owner: Address,
-    worker: Address,
-    control_addrs: Vec<Address>,
+    Ok((addrs.owner, addrs.worker, addrs.control_addresses))
 }
 
 /// ResolveToIDAddr resolves the given address to it's ID address form.

--- a/vm/actor/src/builtin/verifreg/mod.rs
+++ b/vm/actor/src/builtin/verifreg/mod.rs
@@ -6,8 +6,9 @@ mod types;
 
 pub use self::state::State;
 pub use self::types::*;
-use crate::builtin::singletons::STORAGE_MARKET_ACTOR_ADDR;
-use crate::{make_map, make_map_with_root, SYSTEM_ACTOR_ADDR};
+use crate::{
+    make_map, make_map_with_root, ActorDowncast, STORAGE_MARKET_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+};
 use address::Address;
 use ipld_blockstore::BlockStore;
 use num_bigint::bigint_ser::BigIntDe;
@@ -46,9 +47,9 @@ impl Actor {
             .resolve_address(&root_key)?
             .ok_or_else(|| actor_error!(ErrIllegalArgument; "root should be an ID address"))?;
 
-        let empty_root = make_map::<_, ()>(rt.store())
-            .flush()
-            .map_err(|e| actor_error!(ErrIllegalState; "Failed to create registry state {}", e))?;
+        let empty_root = make_map::<_, ()>(rt.store()).flush().map_err(|e| {
+            e.downcast_default(ExitCode::ErrIllegalState, "Failed to create registry state")
+        })?;
 
         let st = State::new(empty_root, id_addr);
         rt.create(&st)?;
@@ -74,19 +75,24 @@ impl Actor {
         }
 
         rt.transaction(|st: &mut State, rt| {
-            let mut verifiers = make_map_with_root(&st.verifiers, rt.store()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to load verified clients: {}", e),
-            )?;
-            let verified_clients =
-                make_map_with_root::<_, BigIntDe>(&st.verified_clients, rt.store()).map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to load verified clients: {}", e),
-                )?;
+            let mut verifiers = make_map_with_root(&st.verifiers, rt.store()).map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+            })?;
+            let verified_clients = make_map_with_root::<_, BigIntDe>(
+                &st.verified_clients,
+                rt.store(),
+            )
+            .map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+            })?;
 
             let found = verified_clients
                 .contains_key(&params.address.to_bytes())
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                "failed to get client state for {}: {}", params.address, e)
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to get client state for {}", params.address,),
+                    )
                 })?;
             if found {
                 return Err(actor_error!(ErrIllegalArgument;
@@ -98,10 +104,12 @@ impl Actor {
                     params.address.to_bytes().into(),
                     BigIntDe(params.allowance.clone()),
                 )
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to add verifier: {}", e))?;
-            st.verifiers = verifiers
-                .flush()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush verifiers: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to add verifier")
+                })?;
+            st.verifiers = verifiers.flush().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verifiers")
+            })?;
 
             Ok(())
         })?;
@@ -119,19 +127,19 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let mut verifiers = make_map_with_root::<_, BigIntDe>(&st.verifiers, rt.store())
-                .map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to load verified clients: {}", e),
-                )?;
-            let deleted = verifiers
-                .delete(&verifier_addr.to_bytes())
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to remove verifier: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                })?;
+            let deleted = verifiers.delete(&verifier_addr.to_bytes()).map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to remove verifier")
+            })?;
             if !deleted {
                 return Err(actor_error!(ErrIllegalState; "failed to remove verifier: not found"));
             }
 
-            st.verifiers = verifiers
-                .flush()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush verifiers: {}", e))?;
+            st.verifiers = verifiers.flush().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verifiers")
+            })?;
             Ok(())
         })?;
 
@@ -162,21 +170,23 @@ impl Actor {
         }
 
         rt.transaction(|st: &mut State, rt| {
-            let mut verifiers = make_map_with_root(&st.verifiers, rt.store()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to load verified clients: {}", e),
-            )?;
+            let mut verifiers = make_map_with_root(&st.verifiers, rt.store()).map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+            })?;
             let mut verified_clients = make_map_with_root(&st.verified_clients, rt.store())
-                .map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to load verified clients: {}", e),
-                )?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                })?;
 
             // Validate caller is one of the verifiers.
             let verifier_addr = rt.message().caller();
             let BigIntDe(verifier_cap) = verifiers
                 .get(&verifier_addr.to_bytes())
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                        "failed to get Verifier {}: {}", verifier_addr, e)
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to get Verifier {}", verifier_addr),
+                    )
                 })?
                 .ok_or_else(|| {
                     actor_error!(ErrNotFound;
@@ -187,7 +197,9 @@ impl Actor {
             // Validate client to be added isn't a verifier
             let found = verifiers
                 .contains_key(&params.address.to_bytes())
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to get verifier: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to get verifier")
+                })?;
             if found {
                 return Err(actor_error!(ErrIllegalArgument;
                     "verifier {} cannot be added as a verified client", params.address));
@@ -205,9 +217,9 @@ impl Actor {
             verifiers
                 .set(verifier_addr.to_bytes().into(), BigIntDe(new_verifier_cap))
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                        "Failed to update new verifier cap for {}: {}",
-                        params.allowance, e
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("Failed to update new verifier cap for {}", params.allowance),
                     )
                 })?;
 
@@ -219,8 +231,10 @@ impl Actor {
             let found = verified_clients
                 .contains_key(&params.address.to_bytes())
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                        "Failed to get verified client {}: {}", params.address, e)
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("Failed to get verified client {}", params.address,),
+                    )
                 })?;
             if found {
                 return Err(actor_error!(ErrIllegalArgument;
@@ -233,18 +247,24 @@ impl Actor {
                     BigIntDe(params.allowance.clone()),
                 )
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                            "Failed to add verified client {} with cap {}: {}",
-                            params.address, params.allowance, e
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!(
+                            "Failed to add verified client {} with cap {}",
+                            params.address, params.allowance,
+                        ),
                     )
                 })?;
 
-            st.verifiers = verifiers
-                .flush()
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to flush verifiers: {}", e))?;
-            st.verified_clients = verified_clients.flush().map_err(
-                |e| actor_error!(ErrIllegalState; "failed to flush verified clients: {}", e),
-            )?;
+            st.verifiers = verifiers.flush().map_err(|e| {
+                e.downcast_default(ExitCode::ErrIllegalState, "failed to flush verifiers")
+            })?;
+            st.verified_clients = verified_clients.flush().map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to flush verified clients",
+                )
+            })?;
 
             Ok(())
         })?;
@@ -269,15 +289,17 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let mut verified_clients = make_map_with_root(&st.verified_clients, rt.store())
-                .map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to load verified clients: {}", e),
-                )?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                })?;
 
             let BigIntDe(vc_cap) = verified_clients
                 .get(&params.address.to_bytes())
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                        "failed to get verified client {}: {}", &params.address, e)
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to get verified client {}", &params.address),
+                    )
                 })?
                 .ok_or_else(
                     || actor_error!(ErrNotFound; "no such verified client {}", params.address),
@@ -298,9 +320,9 @@ impl Actor {
                 let deleted = verified_clients
                     .delete(&params.address.to_bytes())
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                            "Failed to delete verified client {}: {}",
-                            params.address, e
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("Failed to delete verified client {}", params.address),
                         )
                     })?;
                 if !deleted {
@@ -313,16 +335,19 @@ impl Actor {
                 verified_clients
                     .set(params.address.to_bytes().into(), BigIntDe(new_vc_cap))
                     .map_err(|e| {
-                        actor_error!(ErrIllegalState;
-                            "Failed to update verified client {}: {}",
-                            params.address, e
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("Failed to update verified client {}", params.address),
                         )
                     })?;
             }
 
-            st.verified_clients = verified_clients.flush().map_err(
-                |e| actor_error!(ErrIllegalState; "failed to flush verified clients: {}", e),
-            )?;
+            st.verified_clients = verified_clients.flush().map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to flush verified clients",
+                )
+            })?;
             Ok(())
         })?;
 
@@ -351,18 +376,21 @@ impl Actor {
         }
 
         rt.transaction(|st: &mut State, rt| {
-            let verifiers = make_map_with_root::<_, BigIntDe>(&st.verifiers, rt.store()).map_err(
-                |e| actor_error!(ErrIllegalState; "failed to load verified clients: {}", e),
-            )?;
+            let verifiers =
+                make_map_with_root::<_, BigIntDe>(&st.verifiers, rt.store()).map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                })?;
             let mut verified_clients = make_map_with_root(&st.verified_clients, rt.store())
-                .map_err(
-                    |e| actor_error!(ErrIllegalState; "failed to load verified clients: {}", e),
-                )?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to load verified clients")
+                })?;
 
             // validate we are NOT attempting to do this for a verifier
             let found = verifiers
                 .contains_key(&params.address.to_bytes())
-                .map_err(|e| actor_error!(ErrIllegalState; "failed to get verifier: {}", e))?;
+                .map_err(|e| {
+                    e.downcast_default(ExitCode::ErrIllegalState, "failed to get verifier")
+                })?;
             if found {
                 return Err(actor_error!(ErrIllegalArgument;
                     "cannot restore allowance for a verifier {}", params.address));
@@ -372,8 +400,10 @@ impl Actor {
             let BigIntDe(vc_cap) = verified_clients
                 .get(&params.address.to_bytes())
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                    "failed to get verified client {}: {}", &params.address, e)
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to get verified client {}", &params.address),
+                    )
                 })?
                 .unwrap_or_default();
 
@@ -382,15 +412,18 @@ impl Actor {
             verified_clients
                 .set(params.address.to_bytes().into(), BigIntDe(new_vc_cap))
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                        "Failed to put verified client {}: {}",
-                        params.address, e
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("Failed to put verified client {}", params.address),
                     )
                 })?;
 
-            st.verified_clients = verified_clients.flush().map_err(
-                |e| actor_error!(ErrIllegalState; "failed to flush verified clients: {}", e),
-            )?;
+            st.verified_clients = verified_clients.flush().map_err(|e| {
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to flush verified clients",
+                )
+            })?;
             Ok(())
         })?;
 

--- a/vm/actor/src/util/downcast.rs
+++ b/vm/actor/src/util/downcast.rs
@@ -1,0 +1,144 @@
+use encoding::{error::Error as CborError, Error as EncodingError};
+use ipld_amt::Error as AmtError;
+use ipld_hamt::Error as HamtError;
+use std::error::Error as StdError;
+use vm::{ActorError, ExitCode};
+
+/// Trait to allow multiple error types to be able to be downcasted into an `ActorError`.
+pub trait ActorDowncast {
+    /// Downcast a dynamic std Error into an `ActorError`. If the error cannot be downcasted
+    /// into an ActorError automatically, use the provided `ExitCode` to generate a new error.
+    fn downcast_default(self, default_exit_code: ExitCode, msg: impl AsRef<str>) -> ActorError;
+
+    /// Downcast a dynamic std Error into an `ActorError`. If the error cannot be downcasted
+    /// then it will convert the error into a fatal error.
+    fn downcast_fatal(self, msg: impl AsRef<str>) -> ActorError;
+
+    /// Wrap the error with a message, without overwriting an exit code.
+    fn downcast_wrap(self, msg: impl AsRef<str>) -> Box<dyn StdError>;
+}
+
+impl ActorDowncast for Box<dyn StdError> {
+    fn downcast_default(self, default_exit_code: ExitCode, msg: impl AsRef<str>) -> ActorError {
+        match downcast_util(self) {
+            Ok(actor_error) => actor_error.wrap(msg),
+            Err(other) => {
+                ActorError::new(default_exit_code, format!("{}: {}", msg.as_ref(), other))
+            }
+        }
+    }
+    fn downcast_fatal(self, msg: impl AsRef<str>) -> ActorError {
+        match downcast_util(self) {
+            Ok(actor_error) => actor_error.wrap(msg),
+            Err(other) => ActorError::new_fatal(format!("{}: {}", msg.as_ref(), other)),
+        }
+    }
+    fn downcast_wrap(self, msg: impl AsRef<str>) -> Box<dyn StdError> {
+        match downcast_util(self) {
+            Ok(actor_error) => Box::new(actor_error.wrap(msg)),
+            Err(other) => format!("{}: {}", msg.as_ref(), other).into(),
+        }
+    }
+}
+
+impl ActorDowncast for AmtError {
+    fn downcast_default(self, default_exit_code: ExitCode, msg: impl AsRef<str>) -> ActorError {
+        match self {
+            AmtError::Dynamic(e) => e.downcast_default(default_exit_code, msg),
+            other => ActorError::new(default_exit_code, format!("{}: {}", msg.as_ref(), other)),
+        }
+    }
+    fn downcast_fatal(self, msg: impl AsRef<str>) -> ActorError {
+        match self {
+            AmtError::Dynamic(e) => e.downcast_fatal(msg),
+            other => ActorError::new_fatal(format!("{}: {}", msg.as_ref(), other)),
+        }
+    }
+    fn downcast_wrap(self, msg: impl AsRef<str>) -> Box<dyn StdError> {
+        match self {
+            AmtError::Dynamic(e) => e.downcast_wrap(msg),
+            other => format!("{}: {}", msg.as_ref(), other).into(),
+        }
+    }
+}
+
+impl ActorDowncast for HamtError {
+    fn downcast_default(self, default_exit_code: ExitCode, msg: impl AsRef<str>) -> ActorError {
+        match self {
+            HamtError::Dynamic(e) => e.downcast_default(default_exit_code, msg),
+            other => ActorError::new(default_exit_code, format!("{}: {}", msg.as_ref(), other)),
+        }
+    }
+    fn downcast_fatal(self, msg: impl AsRef<str>) -> ActorError {
+        match self {
+            HamtError::Dynamic(e) => e.downcast_fatal(msg),
+            other => ActorError::new_fatal(format!("{}: {}", msg.as_ref(), other)),
+        }
+    }
+    fn downcast_wrap(self, msg: impl AsRef<str>) -> Box<dyn StdError> {
+        match self {
+            HamtError::Dynamic(e) => e.downcast_wrap(msg),
+            other => format!("{}: {}", msg.as_ref(), other).into(),
+        }
+    }
+}
+
+/// Attempts to downcast a `Box<dyn std::error::Error>` into an actor error.
+/// Returns `Ok` with the actor error if it can be downcasted automatically
+/// and returns `Err` with the original error if it cannot.
+fn downcast_util(error: Box<dyn StdError>) -> Result<ActorError, Box<dyn StdError>> {
+    // Check if error is ActorError, return as such
+    let error = match error.downcast::<ActorError>() {
+        Ok(actor_err) => return Ok(*actor_err),
+        Err(other) => other,
+    };
+
+    // Check if error is Encoding error, if so return `ErrSerialization`
+    let error = match error.downcast::<EncodingError>() {
+        Ok(enc_error) => {
+            return Ok(ActorError::new(
+                ExitCode::ErrSerialization,
+                enc_error.to_string(),
+            ))
+        }
+        Err(other) => other,
+    };
+
+    // Check also for Cbor error to be safe. All should be converted to EncodingError, but to
+    // future proof.
+    let error = match error.downcast::<CborError>() {
+        Ok(enc_error) => {
+            return Ok(ActorError::new(
+                ExitCode::ErrSerialization,
+                enc_error.to_string(),
+            ))
+        }
+        Err(other) => other,
+    };
+
+    // Dynamic errors can come from Amt and Hamt through blockstore usages, check them.
+    let error = match error.downcast::<AmtError>() {
+        Ok(amt_err) => match *amt_err {
+            AmtError::Dynamic(de) => match downcast_util(de) {
+                Ok(a) => return Ok(a),
+                Err(other) => other,
+            },
+            // TODO avoid reallocation if possible (low priority, these cases are rarely hit)
+            other => Box::new(other),
+        },
+        Err(other) => other,
+    };
+    let error = match error.downcast::<HamtError>() {
+        Ok(amt_err) => match *amt_err {
+            HamtError::Dynamic(de) => match downcast_util(de) {
+                Ok(a) => return Ok(a),
+                Err(other) => other,
+            },
+            other => Box::new(other),
+        },
+        Err(other) => other,
+    };
+
+    // Could not be downcasted automatically to actor error, return initial dynamic error.
+    Err(error)
+}

--- a/vm/actor/src/util/downcast.rs
+++ b/vm/actor/src/util/downcast.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use encoding::{error::Error as CborError, Error as EncodingError};
 use ipld_amt::Error as AmtError;
 use ipld_hamt::Error as HamtError;

--- a/vm/actor/src/util/mod.rs
+++ b/vm/actor/src/util/mod.rs
@@ -3,6 +3,7 @@
 
 mod balance_table;
 pub mod chaos;
+mod downcast;
 pub mod math;
 mod multimap;
 pub mod puppet;
@@ -12,6 +13,7 @@ pub mod smooth;
 mod unmarshallable;
 
 pub use self::balance_table::BalanceTable;
+pub use self::downcast::*;
 pub use self::multimap::*;
 pub use self::set::Set;
 pub use self::set_multimap::SetMultimap;

--- a/vm/actor/src/util/multimap.rs
+++ b/vm/actor/src/util/multimap.rs
@@ -33,7 +33,7 @@ where
     }
 
     /// Adds a value for a key.
-    pub fn add<V>(&mut self, key: BytesKey, value: V) -> Result<(), String>
+    pub fn add<V>(&mut self, key: BytesKey, value: V) -> Result<(), Box<dyn StdError>>
     where
         V: Serialize + DeserializeOwned + Clone,
     {
@@ -54,7 +54,7 @@ where
 
     /// Gets the Array of value type `V` using the multimap store.
     #[inline]
-    pub fn get<V>(&self, key: &[u8]) -> Result<Option<Amt<'a, V, BS>>, String>
+    pub fn get<V>(&self, key: &[u8]) -> Result<Option<Amt<'a, V, BS>>, Box<dyn StdError>>
     where
         V: DeserializeOwned + Serialize + Clone,
     {
@@ -66,7 +66,7 @@ where
 
     /// Removes all values for a key.
     #[inline]
-    pub fn remove_all(&mut self, key: &[u8]) -> Result<(), String> {
+    pub fn remove_all(&mut self, key: &[u8]) -> Result<(), Box<dyn StdError>> {
         // Remove entry from table
         self.0.delete(key)?;
 

--- a/vm/actor/src/util/set.rs
+++ b/vm/actor/src/util/set.rs
@@ -39,20 +39,20 @@ where
 
     /// Adds key to the set.
     #[inline]
-    pub fn put(&mut self, key: BytesKey) -> Result<(), String> {
+    pub fn put(&mut self, key: BytesKey) -> Result<(), Error> {
         // Set hamt node to array root
         Ok(self.0.set(key, ())?)
     }
 
     /// Checks if key exists in the set.
     #[inline]
-    pub fn has(&self, key: &[u8]) -> Result<bool, String> {
+    pub fn has(&self, key: &[u8]) -> Result<bool, Error> {
         Ok(self.0.get(key)?.is_some())
     }
 
     /// Deletes key from set.
     #[inline]
-    pub fn delete(&mut self, key: &[u8]) -> Result<(), String> {
+    pub fn delete(&mut self, key: &[u8]) -> Result<(), Error> {
         self.0.delete(key)?;
 
         Ok(())
@@ -68,7 +68,7 @@ where
     }
 
     /// Collects all keys from the set into a vector.
-    pub fn collect_keys(&self) -> Result<Vec<BytesKey>, Box<dyn StdError>> {
+    pub fn collect_keys(&self) -> Result<Vec<BytesKey>, Error> {
         let mut ret_keys = Vec::new();
 
         self.for_each(|k| {

--- a/vm/actor/src/util/set_multimap.rs
+++ b/vm/actor/src/util/set_multimap.rs
@@ -34,7 +34,7 @@ where
     }
 
     /// Puts the DealID in the hash set of the key.
-    pub fn put(&mut self, key: ChainEpoch, value: DealID) -> Result<(), String> {
+    pub fn put(&mut self, key: ChainEpoch, value: DealID) -> Result<(), Box<dyn StdError>> {
         // Get construct amt from retrieved cid or create new
         let mut set = self.get(key)?.unwrap_or_else(|| Set::new(self.0.store()));
 
@@ -48,7 +48,11 @@ where
     }
 
     /// Puts slice of DealIDs in the hash set of the key.
-    pub fn put_many(&mut self, key: ChainEpoch, values: &[DealID]) -> Result<(), String> {
+    pub fn put_many(
+        &mut self,
+        key: ChainEpoch,
+        values: &[DealID],
+    ) -> Result<(), Box<dyn StdError>> {
         // Get construct amt from retrieved cid or create new
         let mut set = self.get(key)?.unwrap_or_else(|| Set::new(self.0.store()));
 
@@ -65,7 +69,7 @@ where
 
     /// Gets the set at the given index of the `SetMultimap`
     #[inline]
-    pub fn get(&self, key: ChainEpoch) -> Result<Option<Set<'a, BS>>, String> {
+    pub fn get(&self, key: ChainEpoch) -> Result<Option<Set<'a, BS>>, Box<dyn StdError>> {
         match self.0.get(&u64_key(key as u64))? {
             Some(cid) => Ok(Some(Set::from_root(self.0.store(), &cid)?)),
             None => Ok(None),
@@ -74,7 +78,7 @@ where
 
     /// Removes a DealID from a key hash set.
     #[inline]
-    pub fn remove(&mut self, key: ChainEpoch, v: DealID) -> Result<(), String> {
+    pub fn remove(&mut self, key: ChainEpoch, v: DealID) -> Result<(), Box<dyn StdError>> {
         // Get construct amt from retrieved cid and return if no set exists
         let mut set = match self.get(key)? {
             Some(s) => s,
@@ -91,7 +95,7 @@ where
 
     /// Removes set at index.
     #[inline]
-    pub fn remove_all(&mut self, key: ChainEpoch) -> Result<(), String> {
+    pub fn remove_all(&mut self, key: ChainEpoch) -> Result<(), Box<dyn StdError>> {
         // Remove entry from table
         self.0.delete(&u64_key(key as u64))?;
 

--- a/vm/actor/tests/balance_table_test.rs
+++ b/vm/actor/tests/balance_table_test.rs
@@ -15,10 +15,10 @@ fn add_create() {
     assert_eq!(bt.has(&addr).unwrap(), false);
 
     bt.add_create(&addr, TokenAmount::from(10u8)).unwrap();
-    assert_eq!(bt.get(&addr), Ok(TokenAmount::from(10u8)));
+    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(10u8));
 
     bt.add_create(&addr, TokenAmount::from(20u8)).unwrap();
-    assert_eq!(bt.get(&addr), Ok(TokenAmount::from(30u8)));
+    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(30u8));
 }
 
 // Ported test from specs-actors
@@ -73,24 +73,26 @@ fn balance_subtracts() {
     let mut bt = BalanceTable::new(&store);
 
     bt.set(&addr, TokenAmount::from(80u8)).unwrap();
-    assert_eq!(bt.get(&addr), Ok(TokenAmount::from(80u8)));
+    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(80u8));
     // Test subtracting past minimum only subtracts correct amount
     assert_eq!(
-        bt.subtract_with_minimum(&addr, &TokenAmount::from(20u8), &TokenAmount::from(70u8)),
-        Ok(TokenAmount::from(10u8))
+        bt.subtract_with_minimum(&addr, &TokenAmount::from(20u8), &TokenAmount::from(70u8))
+            .unwrap(),
+        TokenAmount::from(10u8)
     );
-    assert_eq!(bt.get(&addr), Ok(TokenAmount::from(70u8)));
+    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(70u8));
 
     // Test subtracting to limit
     assert_eq!(
-        bt.subtract_with_minimum(&addr, &TokenAmount::from(10u8), &TokenAmount::from(60u8)),
-        Ok(TokenAmount::from(10u8))
+        bt.subtract_with_minimum(&addr, &TokenAmount::from(10u8), &TokenAmount::from(60u8))
+            .unwrap(),
+        TokenAmount::from(10u8)
     );
-    assert_eq!(bt.get(&addr), Ok(TokenAmount::from(60u8)));
+    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(60u8));
 
     // Test must subtract success
     bt.must_subtract(&addr, &TokenAmount::from(10u8)).unwrap();
-    assert_eq!(bt.get(&addr), Ok(TokenAmount::from(50u8)));
+    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(50u8));
 
     // Test subtracting more than available
     assert!(bt.must_subtract(&addr, &TokenAmount::from(100u8)).is_err());
@@ -103,7 +105,7 @@ fn remove() {
     let mut bt = BalanceTable::new(&store);
 
     bt.set(&addr, TokenAmount::from(1u8)).unwrap();
-    assert_eq!(bt.get(&addr), Ok(TokenAmount::from(1u8)));
+    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(1u8));
     bt.remove(&addr).unwrap();
     assert!(bt.get(&addr).is_err());
 }

--- a/vm/actor/tests/balance_table_test.rs
+++ b/vm/actor/tests/balance_table_test.rs
@@ -12,7 +12,7 @@ fn add_create() {
     let store = db::MemoryDB::default();
     let mut bt = BalanceTable::new(&store);
 
-    assert_eq!(bt.has(&addr), Ok(false));
+    assert_eq!(bt.has(&addr).unwrap(), false);
 
     bt.add_create(&addr, TokenAmount::from(10u8)).unwrap();
     assert_eq!(bt.get(&addr), Ok(TokenAmount::from(10u8)));

--- a/vm/actor/tests/multimap_test.rs
+++ b/vm/actor/tests/multimap_test.rs
@@ -11,7 +11,7 @@ fn basic_add() {
     let mut mm = Multimap::new(&store);
 
     let addr = Address::new_id(100);
-    assert_eq!(mm.get::<u64>(&addr.to_bytes()), Ok(None));
+    assert_eq!(mm.get::<u64>(&addr.to_bytes()).unwrap(), None);
 
     mm.add(addr.to_bytes().into(), 8).unwrap();
     let arr: Amt<u64, _> = mm.get(&addr.to_bytes()).unwrap().unwrap();
@@ -27,7 +27,7 @@ fn for_each() {
     let mut mm = Multimap::new(&store);
 
     let addr = Address::new_id(100);
-    assert_eq!(mm.get::<u64>(&addr.to_bytes()), Ok(None));
+    assert_eq!(mm.get::<u64>(&addr.to_bytes()).unwrap(), None);
 
     mm.add(addr.to_bytes().into(), 8).unwrap();
     mm.add(addr.to_bytes().into(), 2).unwrap();
@@ -60,9 +60,9 @@ fn remove_all() {
     assert_eq!(arr.get(1).unwrap(), Some(88));
 
     mm.remove_all(&addr1.to_bytes()).unwrap();
-    assert_eq!(mm.get::<u64>(&addr1.to_bytes()), Ok(None));
+    assert_eq!(mm.get::<u64>(&addr1.to_bytes()).unwrap(), None);
 
     assert!(mm.get::<u64>(&addr2.to_bytes()).unwrap().is_some());
     mm.remove_all(&addr2.to_bytes()).unwrap();
-    assert_eq!(mm.get::<u64>(&addr2.to_bytes()), Ok(None));
+    assert_eq!(mm.get::<u64>(&addr2.to_bytes()).unwrap(), None);
 }

--- a/vm/actor/tests/multimap_test.rs
+++ b/vm/actor/tests/multimap_test.rs
@@ -15,7 +15,7 @@ fn basic_add() {
 
     mm.add(addr.to_bytes().into(), 8).unwrap();
     let arr: Amt<u64, _> = mm.get(&addr.to_bytes()).unwrap().unwrap();
-    assert_eq!(arr.get(0), Ok(Some(8)));
+    assert_eq!(arr.get(0).unwrap(), Some(8));
 
     mm.add(addr.to_bytes().into(), 2).unwrap();
     mm.add(addr.to_bytes().into(), 78).unwrap();
@@ -57,7 +57,7 @@ fn remove_all() {
     mm.add(addr2.to_bytes().into(), 1).unwrap();
 
     let arr: Amt<u64, _> = mm.get(&addr1.to_bytes()).unwrap().unwrap();
-    assert_eq!(arr.get(1), Ok(Some(88)));
+    assert_eq!(arr.get(1).unwrap(), Some(88));
 
     mm.remove_all(&addr1.to_bytes()).unwrap();
     assert_eq!(mm.get::<u64>(&addr1.to_bytes()), Ok(None));

--- a/vm/actor/tests/multimap_test.rs
+++ b/vm/actor/tests/multimap_test.rs
@@ -15,7 +15,7 @@ fn basic_add() {
 
     mm.add(addr.to_bytes().into(), 8).unwrap();
     let arr: Amt<u64, _> = mm.get(&addr.to_bytes()).unwrap().unwrap();
-    assert_eq!(arr.get(0).unwrap(), Some(8));
+    assert_eq!(arr.get(0).unwrap(), Some(&8));
 
     mm.add(addr.to_bytes().into(), 2).unwrap();
     mm.add(addr.to_bytes().into(), 78).unwrap();
@@ -57,7 +57,7 @@ fn remove_all() {
     mm.add(addr2.to_bytes().into(), 1).unwrap();
 
     let arr: Amt<u64, _> = mm.get(&addr1.to_bytes()).unwrap().unwrap();
-    assert_eq!(arr.get(1).unwrap(), Some(88));
+    assert_eq!(arr.get(1).unwrap(), Some(&88));
 
     mm.remove_all(&addr1.to_bytes()).unwrap();
     assert_eq!(mm.get::<u64>(&addr1.to_bytes()).unwrap(), None);

--- a/vm/actor/tests/set_multimap_test.rs
+++ b/vm/actor/tests/set_multimap_test.rs
@@ -10,7 +10,7 @@ fn put_remove() {
     let mut smm = SetMultimap::new(&store);
 
     let epoch: ChainEpoch = 100;
-    assert_eq!(smm.get(epoch), Ok(None));
+    assert_eq!(smm.get(epoch).unwrap(), None);
 
     smm.put(epoch, 8).unwrap();
     smm.put(epoch, 2).unwrap();
@@ -21,7 +21,7 @@ fn put_remove() {
     assert_eq!(set.has(&u64_key(2)), Ok(false));
 
     smm.remove_all(epoch).unwrap();
-    assert_eq!(smm.get(epoch), Ok(None));
+    assert_eq!(smm.get(epoch).unwrap(), None);
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn for_each() {
     let mut smm = SetMultimap::new(&store);
 
     let epoch: ChainEpoch = 100;
-    assert_eq!(smm.get(epoch), Ok(None));
+    assert_eq!(smm.get(epoch).unwrap(), None);
 
     smm.put(epoch, 8).unwrap();
     smm.put(epoch, 3).unwrap();

--- a/vm/actor/tests/set_multimap_test.rs
+++ b/vm/actor/tests/set_multimap_test.rs
@@ -17,8 +17,8 @@ fn put_remove() {
     smm.remove(epoch, 2).unwrap();
 
     let set = smm.get(epoch).unwrap().unwrap();
-    assert_eq!(set.has(&u64_key(8)), Ok(true));
-    assert_eq!(set.has(&u64_key(2)), Ok(false));
+    assert_eq!(set.has(&u64_key(8)).unwrap(), true);
+    assert_eq!(set.has(&u64_key(2)).unwrap(), false);
 
     smm.remove_all(epoch).unwrap();
     assert_eq!(smm.get(epoch).unwrap(), None);

--- a/vm/actor/tests/set_test.rs
+++ b/vm/actor/tests/set_test.rs
@@ -9,10 +9,10 @@ fn put() {
     let mut set = Set::new(&store);
 
     let key = "test".as_bytes();
-    assert_eq!(set.has(&key), Ok(false));
+    assert_eq!(set.has(&key).unwrap(), false);
 
     set.put(key.into()).unwrap();
-    assert_eq!(set.has(&key), Ok(true));
+    assert_eq!(set.has(&key).unwrap(), true);
 }
 
 #[test]
@@ -38,11 +38,11 @@ fn delete() {
 
     let key = "0".as_bytes();
 
-    assert_eq!(set.has(key), Ok(false));
+    assert_eq!(set.has(key).unwrap(), false);
     set.put(key.into()).unwrap();
-    assert_eq!(set.has(key), Ok(true));
+    assert_eq!(set.has(key).unwrap(), true);
     set.delete(key).unwrap();
-    assert_eq!(set.has(key), Ok(false));
+    assert_eq!(set.has(key).unwrap(), false);
 
     // Test delete when doesn't exist doesn't error
     set.delete(key).unwrap();

--- a/vm/address/src/errors.rs
+++ b/vm/address/src/errors.rs
@@ -3,7 +3,6 @@
 
 use super::{BLS_PUB_LEN, PAYLOAD_HASH_LEN, SECP_PUB_LEN};
 use data_encoding::DecodeError;
-use encoding::{CodecProtocol, Error as EncodingError};
 use leb128::read::Error as Leb128Error;
 use std::{io, num};
 use thiserror::Error;
@@ -47,14 +46,5 @@ impl From<io::Error> for Error {
 impl From<Leb128Error> for Error {
     fn from(_: Leb128Error) -> Error {
         Error::InvalidPayload
-    }
-}
-
-impl From<Error> for EncodingError {
-    fn from(err: Error) -> EncodingError {
-        EncodingError::Marshalling {
-            description: err.to_string(),
-            protocol: CodecProtocol::Cbor,
-        }
     }
 }

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -213,7 +213,7 @@ where
     {
         self.store
             .put(obj, Blake2b256)
-            .map_err(|e| ActorError::downcast_fatal(e, "failed to put cbor object"))
+            .map_err(|e| ActorDowncast::downcast_fatal(e, "failed to put cbor object"))
     }
 
     /// Helper function for getting deserializable objects from blockstore.
@@ -223,7 +223,7 @@ where
     {
         self.store
             .get(cid)
-            .map_err(|e| ActorError::downcast_fatal(e, "failed to get cbor object"))
+            .map_err(|e| ActorDowncast::downcast_fatal(e, "failed to get cbor object"))
     }
 
     fn internal_send(

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -113,7 +113,7 @@ where
 
         let caller_id = state
             .lookup_id(&message.from())
-            .map_err(|e| actor_error!(fatal("failed to lookup id: {}", e)))?
+            .map_err(|e| e.downcast_fatal("failed to lookup id"))?
             .ok_or_else(
                 || actor_error!(SysErrInvalidReceiver; "resolve msg from address failed"),
             )?;
@@ -169,7 +169,7 @@ where
         Ok(self
             .state
             .get_actor(&addr)
-            .map_err(|e| actor_error!(fatal("failed to get actor in get balance: {}", e)))?
+            .map_err(|e| e.downcast_fatal("failed to get actor in get balance"))?
             .map(|act| act.balance)
             .unwrap_or_default())
     }
@@ -180,7 +180,7 @@ where
         let mut actor = self
             .state
             .get_actor(&to_addr)
-            .map_err(|e| actor_error!(fatal("failed to get actor to commit state: {}", e)))?
+            .map_err(|e| e.downcast_fatal("failed to get actor to commit state"))?
             .ok_or_else(|| actor_error!(fatal("failed to get actor to commit state")))?;
 
         if &actor.state != old_h {
@@ -191,7 +191,7 @@ where
         actor.state = new_h;
         self.state
             .set_actor(&to_addr, actor)
-            .map_err(|e| actor_error!(fatal("failed to set actor in state_commit: {}", e)))?;
+            .map_err(|e| e.downcast_fatal("failed to set actor in state_commit"))?;
 
         Ok(())
     }
@@ -213,7 +213,7 @@ where
     {
         self.store
             .put(obj, Blake2b256)
-            .map_err(|e| ActorDowncast::downcast_fatal(e, "failed to put cbor object"))
+            .map_err(|e| e.downcast_fatal("failed to put cbor object"))
     }
 
     /// Helper function for getting deserializable objects from blockstore.
@@ -223,7 +223,7 @@ where
     {
         self.store
             .get(cid)
-            .map_err(|e| ActorDowncast::downcast_fatal(e, "failed to get cbor object"))
+            .map_err(|e| e.downcast_fatal("failed to get cbor object"))
     }
 
     fn internal_send(
@@ -257,7 +257,7 @@ where
         // snapshot state tree
         self.state
             .snapshot()
-            .map_err(|e| actor_error!(fatal("failed to create snapshot {}", e)))?;
+            .map_err(|e| actor_error!(fatal("failed to create snapshot: {}", e)))?;
 
         // Since it is unsafe to share a mutable reference to the state tree by copying
         // the runtime, all variables must be copied and reset at the end of the transition.
@@ -297,13 +297,13 @@ where
         let addr_id = self
             .state
             .register_new_address(addr)
-            .map_err(|e| actor_error!(fatal("failed to register new address: {}", e)))?;
+            .map_err(|e| e.downcast_fatal("failed to register new address"))?;
 
         let act = make_actor(addr)?;
 
         self.state
             .set_actor(&addr_id, act)
-            .map_err(|e| actor_error!(fatal("failed to set actor: {}", e)))?;
+            .map_err(|e| e.downcast_fatal("failed to set actor"))?;
 
         let p = Serialized::serialize(&addr).map_err(|e| {
             actor_error!(fatal(
@@ -318,12 +318,13 @@ where
             account::Method::Constructor as u64,
             TokenAmount::from(0),
             p,
-        )?;
+        )
+        .map_err(|e| e.wrap("failed to invoke account constructor"))?;
 
         let act = self
             .state
             .get_actor(&addr_id)
-            .map_err(|e| actor_error!(fatal("failed to get actor: {}", e)))?
+            .map_err(|e| e.downcast_fatal("failed to get actor"))?
             .ok_or_else(|| actor_error!(fatal("failed to retrieve created actor state")))?;
 
         Ok(act)
@@ -387,14 +388,14 @@ where
     fn resolve_address(&self, address: &Address) -> Result<Option<Address>, ActorError> {
         self.state
             .lookup_id(&address)
-            .map_err(|e| actor_error!(fatal("failed to look up id: {}", e)))
+            .map_err(|e| e.downcast_fatal("failed to look up id"))
     }
 
     fn get_actor_code_cid(&self, addr: &Address) -> Result<Option<Cid>, ActorError> {
         Ok(self
             .state
             .get_actor(&addr)
-            .map_err(|e| actor_error!(fatal("failed to get actor: {}", e)))?
+            .map_err(|e| e.downcast_fatal("failed to get actor"))?
             .map(|act| act.code))
     }
 
@@ -407,7 +408,7 @@ where
         let r = self
             .rand
             .get_chain_randomness(&self.store, personalization, rand_epoch, entropy)
-            .map_err(|e| actor_error!(fatal("could not get randomness: {}", e.to_string())))?;
+            .map_err(|e| e.downcast_fatal("could not get randomness"))?;
 
         Ok(Randomness(r))
     }
@@ -421,7 +422,7 @@ where
         let r = self
             .rand
             .get_chain_randomness(&self.store, personalization, rand_epoch, entropy)
-            .map_err(|e| actor_error!(fatal("could not get randomness: {}", e.to_string())))?;
+            .map_err(|e| e.downcast_fatal("could not get randomness"))?;
 
         Ok(Randomness(r))
     }
@@ -437,8 +438,10 @@ where
             .state
             .get_actor(self.message().receiver())
             .map_err(|e| {
-                actor_error!(SysErrorIllegalArgument;
-                "failed to get actor for Readonly state: {}", e)
+                e.downcast_default(
+                    ExitCode::SysErrorIllegalArgument,
+                    "failed to get actor for Readonly state",
+                )
             })?
             .ok_or_else(
                 || actor_error!(SysErrorIllegalArgument; "Actor readonly state does not exist"),
@@ -459,10 +462,19 @@ where
         F: FnOnce(&mut C, &mut Self) -> Result<RT, ActorError>,
     {
         // get actor
-        let act = self.state.get_actor(self.message().receiver())
-            .map_err(|e| actor_error!(SysErrorIllegalActor; "failed to get actor for transaction: {}", e))?
-            .ok_or_else(|| actor_error!(SysErrorIllegalActor;
-                "actor state for transaction doesn't exist"))?;
+        let act = self
+            .state
+            .get_actor(self.message().receiver())
+            .map_err(|e| {
+                e.downcast_default(
+                    ExitCode::SysErrorIllegalActor,
+                    "failed to get actor for transaction",
+                )
+            })?
+            .ok_or_else(|| {
+                actor_error!(SysErrorIllegalActor;
+                "actor state for transaction doesn't exist")
+            })?;
 
         // get state for actor based on generic C
         let mut state: C = self
@@ -548,7 +560,7 @@ where
                 &address,
                 ActorState::new(code_id, EMPTY_ARR_CID.clone(), 0.into(), 0),
             )
-            .map_err(|e| actor_error!(fatal("creating actor entry: {}", e)))
+            .map_err(|e| e.downcast_fatal("creating actor entry"))
     }
 
     /// DeleteActor deletes the executing actor from the state tree, transferring
@@ -561,25 +573,21 @@ where
         let balance = self
             .state
             .get_actor(&receiver)
-            .map_err(|e| actor_error!(fatal("failed to get actor {}, {}", receiver, e)))?
+            .map_err(|e| e.downcast_fatal(format!("failed to get actor {}", receiver)))?
             .ok_or_else(
                 || actor_error!(SysErrorIllegalActor; "failed to load actor in delete actor"),
             )
             .map(|act| act.balance)?;
         if balance != 0.into() {
             // Transfer the executing actor's balance to the beneficiary
-            transfer(self.state, &receiver, beneficiary, &balance).map_err(|e| {
-                actor_error!(fatal(
-                    "failed to transfer balance to beneficiary actor: {}",
-                    e.msg()
-                ))
-            })?;
+            transfer(self.state, &receiver, beneficiary, &balance)
+                .map_err(|e| e.wrap("failed to transfer balance to beneficiary actor"))?;
         }
 
         // Delete the executing actor
         self.state
             .delete_actor(&receiver)
-            .map_err(|e| actor_error!(fatal("failed to delete actor: {}", e)))
+            .map_err(|e| e.downcast_fatal("failed to delete actor"))
     }
     fn syscalls(&self) -> &dyn Syscalls {
         &self.syscalls
@@ -589,8 +597,10 @@ where
             self.state
                 .get_actor(&addr)
                 .map_err(|e| {
-                    actor_error!(ErrIllegalState;
-                        "failed to get reward actor for cumputing total supply: {}", e)
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        "failed to get reward actor for cumputing total supply",
+                    )
                 })?
                 .ok_or_else(
                     || actor_error!(ErrIllegalState; "Actor address ({}) does not exist", addr),
@@ -606,8 +616,10 @@ where
             .store
             .get(&power.state)
             .map_err(|e| {
-                actor_error!(ErrIllegalState;
-                    "failed to get storage power state: {}", e.to_string())
+                e.downcast_default(
+                    ExitCode::ErrIllegalState,
+                    "failed to get storage power state",
+                )
             })?
             .ok_or_else(|| actor_error!(ErrIllegalState; "Failed to retrieve power state"))?;
 
@@ -643,7 +655,7 @@ where
     let to_actor = match rt
         .state
         .get_actor(msg.to())
-        .map_err(|e| actor_error!(fatal("failed to get actor: {}", e)))?
+        .map_err(|e| e.downcast_fatal("failed to get actor"))?
     {
         Some(act) => act,
         None => {
@@ -683,11 +695,11 @@ fn transfer<BS: BlockStore>(
 
     let from_id = state
         .lookup_id(from)
-        .map_err(|e| actor_error!(fatal("failed to lookup from id for address: {}", e)))?
+        .map_err(|e| e.downcast_fatal("failed to lookup from id for address"))?
         .ok_or_else(|| actor_error!(fatal("Failed to lookup from id for address {}", from)))?;
     let to_id = state
         .lookup_id(to)
-        .map_err(|e| actor_error!(fatal("failed to lookup to id for address: {}", e)))?
+        .map_err(|e| e.downcast_fatal("failed to lookup to id for address"))?
         .ok_or_else(|| actor_error!(fatal("Failed to lookup to id for address {}", to)))?;
 
     if from_id == to_id {
@@ -701,7 +713,7 @@ fn transfer<BS: BlockStore>(
 
     let mut f = state
         .get_actor(&from_id)
-        .map_err(|e| actor_error!(fatal("failed to get actor: {}", e)))?
+        .map_err(|e| e.downcast_fatal("failed to get actor"))?
         .ok_or_else(|| {
             actor_error!(fatal(
                 "sender actor does not exist in state during transfer"
@@ -709,7 +721,7 @@ fn transfer<BS: BlockStore>(
         })?;
     let mut t = state
         .get_actor(&to_id)
-        .map_err(|e| actor_error!(fatal("failed to get actor: {}", e)))?
+        .map_err(|e| e.downcast_fatal("failed to get actor: {}"))?
         .ok_or_else(|| {
             actor_error!(fatal(
                 "receiver actor does not exist in state during transfer"
@@ -724,10 +736,10 @@ fn transfer<BS: BlockStore>(
 
     state
         .set_actor(from, f)
-        .map_err(|e| actor_error!(fatal("failed to set actor: {}", e)))?;
+        .map_err(|e| e.downcast_fatal("failed to set from actor"))?;
     state
         .set_actor(to, t)
-        .map_err(|e| actor_error!(fatal("failed to set actor: {}", e)))?;
+        .map_err(|e| e.downcast_fatal("failed to set to actor"))?;
 
     Ok(())
 }
@@ -799,7 +811,7 @@ where
 
     let act = st
         .get_actor(&addr)
-        .map_err(|e| actor_error!(SysErrInternal; e))?
+        .map_err(|e| e.downcast_default(ExitCode::SysErrInternal, "Failed to get actor"))?
         .ok_or_else(|| actor_error!(SysErrInternal; "Failed to retrieve actor: {}", addr))?;
 
     if act.code != *ACCOUNT_ACTOR_CODE_ID {
@@ -810,13 +822,7 @@ where
     }
     let acc_st: account::State = store
         .get(&act.state)
-        .map_err(|e| {
-            actor_error!(fatal(
-                "Failed to get account actor state for: {}, e: {}",
-                addr,
-                e
-            ))
-        })?
+        .map_err(|e| e.downcast_fatal(format!("Failed to get account actor state for: {}", addr)))?
         .ok_or_else(|| {
             actor_error!(fatal(
                 "Address was not found for an account actor: {}",

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -351,7 +351,7 @@ where
             })
             .map_err(|e| e.to_string())?;
 
-        self.state.snapshot().map_err(|e| e.to_string())?;
+        self.state.snapshot()?;
 
         let (mut ret_data, rt, mut act_err) = self.send(msg, Some(msg_gas_cost));
         if let Some(err) = &act_err {
@@ -403,7 +403,7 @@ where
         let err_code = if let Some(err) = &act_err {
             if !err.is_ok() {
                 // Revert all state changes on error.
-                self.state.revert_to_snapshot().map_err(|e| e.to_string())?;
+                self.state.revert_to_snapshot()?;
             }
             err.exit_code()
         } else {
@@ -450,7 +450,7 @@ where
         if &base_fee_burn + over_estimation_burn + &refund + &miner_tip != gas_cost {
             return Err("Gas handling math is wrong".to_owned());
         }
-        self.state.clear_snapshot().map_err(|e| e.to_string())?;
+        self.state.clear_snapshot()?;
 
         Ok(ApplyRet {
             msg_receipt: MessageReceipt {

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -3,7 +3,6 @@
 
 use crate::ExitCode;
 use encoding::Error as EncodingError;
-use std::error::Error as StdError;
 use thiserror::Error;
 
 /// The error type that gets returned by actor method calls.
@@ -32,47 +31,6 @@ impl ActorError {
             fatal: true,
             exit_code: ExitCode::ErrPlaceholder,
             msg,
-        }
-    }
-
-    /// Downcast a dynamic std Error into an ActorError
-    pub fn downcast(
-        error: Box<dyn StdError>,
-        default_exit_code: ExitCode,
-        msg: impl AsRef<str>,
-    ) -> Self {
-        match error.downcast::<ActorError>() {
-            Ok(actor_err) => actor_err.wrap(msg.as_ref()),
-            Err(other) => match other.downcast::<EncodingError>() {
-                Ok(enc_error) => ActorError::new(ExitCode::ErrSerialization, enc_error.to_string()),
-                Err(other) => {
-                    ActorError::new(default_exit_code, format!("{}: {}", msg.as_ref(), other))
-                }
-            },
-        }
-    }
-
-    /// Downcast a dynamic std Error into a fatal ActorError
-    pub fn downcast_fatal(error: Box<dyn StdError>, msg: impl AsRef<str>) -> Self {
-        match error.downcast::<ActorError>() {
-            Ok(actor_err) => actor_err.wrap(msg.as_ref()),
-            Err(other) => match other.downcast::<EncodingError>() {
-                Ok(enc_error) => ActorError::new(ExitCode::ErrSerialization, enc_error.to_string()),
-                Err(other) => ActorError::new_fatal(format!("{}: {}", msg.as_ref(), other)),
-            },
-        }
-    }
-
-    /// Prefix a dynamic std Error with an error message.
-    pub fn downcast_wrap(error: Box<dyn StdError>, msg: impl AsRef<str>) -> Box<dyn StdError> {
-        match error.downcast::<ActorError>() {
-            Ok(actor_err) => actor_err.wrap(msg.as_ref()).into(),
-            Err(other) => match other.downcast::<EncodingError>() {
-                Ok(enc_error) => {
-                    ActorError::new(ExitCode::ErrSerialization, enc_error.to_string()).into()
-                }
-                Err(other) => format!("{}: {}", msg.as_ref(), other).into(),
-            },
         }
     }
 

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::ExitCode;
+use encoding::error::Error as CborError;
 use encoding::Error as EncodingError;
 use thiserror::Error;
 
@@ -63,6 +64,16 @@ impl ActorError {
 
 impl From<EncodingError> for ActorError {
     fn from(e: EncodingError) -> Self {
+        Self {
+            fatal: false,
+            exit_code: ExitCode::ErrSerialization,
+            msg: e.to_string(),
+        }
+    }
+}
+
+impl From<CborError> for ActorError {
+    fn from(e: CborError) -> Self {
         Self {
             fatal: false,
             exit_code: ExitCode::ErrSerialization,

--- a/vm/state_tree/src/lib.rs
+++ b/vm/state_tree/src/lib.rs
@@ -54,7 +54,7 @@ impl StateSnapshots {
         self.layers.push(StateSnapLayer::new())
     }
 
-    fn drop_layer(&mut self) -> Result<(), Box<dyn StdError>> {
+    fn drop_layer(&mut self) -> Result<(), String> {
         self.layers.pop().ok_or_else(|| {
             format!(
                 "drop layer failed to index snapshot layer at index {}",
@@ -65,7 +65,7 @@ impl StateSnapshots {
         Ok(())
     }
 
-    fn merge_last_layer(&mut self) -> Result<(), Box<dyn StdError>> {
+    fn merge_last_layer(&mut self) -> Result<(), String> {
         self.layers
             .get(&self.layers.len() - 2)
             .ok_or_else(|| {
@@ -318,18 +318,18 @@ where
     }
 
     /// Add snapshot layer to stack.
-    pub fn snapshot(&mut self) -> Result<(), Box<dyn StdError>> {
+    pub fn snapshot(&mut self) -> Result<(), String> {
         self.snaps.add_layer();
         Ok(())
     }
 
     /// Merges last two snap shot layers
-    pub fn clear_snapshot(&mut self) -> Result<(), Box<dyn StdError>> {
+    pub fn clear_snapshot(&mut self) -> Result<(), String> {
         Ok(self.snaps.merge_last_layer()?)
     }
 
     /// Revert state cache by removing last snapshot
-    pub fn revert_to_snapshot(&mut self) -> Result<(), Box<dyn StdError>> {
+    pub fn revert_to_snapshot(&mut self) -> Result<(), String> {
         self.snaps.drop_layer()?;
         self.snaps.add_layer();
         Ok(())


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- This all stems from the gas charging blockstore (and some from gas charging syscalls). In the go implementation, they panic exactly where the error is encountered and that error is caught outside of their vm. Since we are (and should) bubble the errors up instead of panicking, that error exit code cannot be lost. This is done through the error downcasting. The reason for the trait implementation is because Amt and Hamt errors, as well as dynamic errors can downcast into a `ActorError` because of `SysErrOutOfGas` from blockstore interactions within those structures.
  - I've checked every mapped error and conversion (there is over 500) and this is what I've come up with

The only time this can ever be a difference is if the go implementation uses `(ExitCode) Wrapf` or `rt.Abort`, an out of gas error was not hit, and there was a different actor error was hit that would be overwritten by this. After checking all usages of this (I could be missing a case and was just skimming, there was ~300 of these as well) I'm semi confident all of them do not fit this criteria, or when they do the go implementation would just fatal error (so it doesn't matter)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #720 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->