### PR TITLE
Switch bigint division usage to Euclidean to match Go

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ name = "forest_bigint"
 version = "0.1.1"
 dependencies = [
  "num-bigint 0.3.0",
+ "num-integer",
  "serde",
  "serde_bytes",
 ]

--- a/blockchain/blocks/src/election_proof.rs
+++ b/blockchain/blocks/src/election_proof.rs
@@ -4,7 +4,7 @@
 use crypto::VRFProof;
 use encoding::{blake2b_256, tuple::*};
 use fil_types::BLOCKS_PER_EPOCH;
-use num_bigint::{BigInt, ParseBigIntError, Sign};
+use num_bigint::{BigInt, Integer, ParseBigIntError, Sign};
 
 const PRECISION: u64 = 256;
 const MAX_WIN_COUNT: i64 = 3 * BLOCKS_PER_EPOCH as i64;
@@ -59,7 +59,7 @@ fn expneg(x: &BigInt) -> BigInt {
     let num = poly_val(&EXP_NUM_COEF, x);
     let deno = poly_val(&EXP_DENO_COEF, x);
 
-    (num << PRECISION) / deno
+    (num << PRECISION).div_floor(&deno)
 }
 
 /// polyval evaluates a polynomial given by coefficients `p` in Q.256 format
@@ -78,7 +78,7 @@ fn poly_val(poly: &[BigInt], x: &BigInt) -> BigInt {
 /// computes lambda in Q.256
 #[inline]
 fn lambda(power: &BigInt, total_power: &BigInt) -> BigInt {
-    ((power * BLOCKS_PER_EPOCH) << PRECISION) / total_power
+    ((power * BLOCKS_PER_EPOCH) << PRECISION).div_floor(&total_power)
 }
 
 /// Poisson inverted CDF
@@ -112,7 +112,7 @@ impl Poiss {
         self.k += 1;
 
         // calculate pmf for k
-        self.pmf /= self.k;
+        self.pmf = self.pmf.div_floor(&BigInt::from(self.k));
         self.pmf = (&self.pmf * &self.lam) >> PRECISION;
 
         // calculate output

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -21,7 +21,7 @@ use ipld_amt::Amt;
 use ipld_blockstore::BlockStore;
 use log::{info, warn};
 use message::{ChainMessage, Message, MessageReceipt, SignedMessage, UnsignedMessage};
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Integer};
 use num_traits::Zero;
 use serde::Serialize;
 use state_tree::StateTree;
@@ -732,8 +732,8 @@ where
 
     let out_add: BigInt = &log2_p << 8;
     let mut out = ts.weight().to_owned() + out_add;
-    let e_weight = ((log2_p * BigInt::from(ts.blocks().len())) * BigInt::from(W_RATIO_NUM)) << 8;
-    let value: BigInt = e_weight / (BigInt::from(BLOCKS_PER_EPOCH) * BigInt::from(W_RATIO_DEN));
+    let e_weight: BigInt = ((log2_p * BigInt::from(ts.blocks().len())) * W_RATIO_NUM) << 8;
+    let value: BigInt = e_weight.div_floor(&(BigInt::from(BLOCKS_PER_EPOCH) * W_RATIO_DEN));
     out += &value;
     Ok(out)
 }

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use walkdir::{DirEntry, WalkDir};
 
 lazy_static! {
-    static ref SKIP_TESTS: [Regex; 5] = [
+    static ref SKIP_TESTS: [Regex; 4] = [
         // These tests are marked as invalid as they return wrong exit code on Lotus
         Regex::new(r"actor_creation/x--params*").unwrap(),
         // Following two fail for the same invalid exit code return
@@ -27,8 +27,6 @@ lazy_static! {
         Regex::new(r"nested/nested_sends--fail-mismatch-params.json").unwrap(),
         // Lotus client does not fail in inner transaction for insufficient funds
         Regex::new(r"test-vectors/corpus/nested/nested_sends--fail-insufficient-funds-for-transfer-in-inner-send.json").unwrap(),
-        // TODO This fails but is blocked on miner actor refactor, remove skip after that comes in
-        Regex::new(r"test-vectors/corpus/reward/reward--ok-miners-awarded-no-premiums.json").unwrap(),
     ];
 }
 

--- a/utils/bigint/Cargo.toml
+++ b/utils/bigint/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/ChainSafe/forest"
 num-bigint = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.3"
+num-integer = "0.1"
 
 [features]
 json = []

--- a/utils/bigint/src/lib.rs
+++ b/utils/bigint/src/lib.rs
@@ -5,3 +5,4 @@ pub mod bigint_ser;
 pub mod biguint_ser;
 
 pub use num_bigint::*;
+pub use num_integer::{self, Integer};

--- a/vm/actor/src/builtin/miner/monies.rs
+++ b/vm/actor/src/builtin/miner/monies.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use clock::ChainEpoch;
 use fil_types::StoragePower;
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Integer};
 use num_traits::Zero;
 use std::cmp;
 
@@ -172,9 +172,9 @@ pub fn initial_pledge_for_power(
     let lock_target_denom = &*LOCK_TARGET_FACTOR_DENOM;
     let pledge_share_num = qa_power;
     let pledge_share_denom = cmp::max(cmp::max(&network_qa_power, baseline_power), qa_power); // use qaPower in case others are 0
-    let additional_ip_num = &lock_target_num * pledge_share_num;
+    let additional_ip_num: TokenAmount = &lock_target_num * pledge_share_num;
     let additional_ip_denom = lock_target_denom * pledge_share_denom;
-    let additional_ip = additional_ip_num / additional_ip_denom;
+    let additional_ip = additional_ip_num.div_floor(&additional_ip_denom);
 
     let nominal_pledge = ip_base + additional_ip;
     let space_race_pledge_cap = &*SPACE_RACE_INITIAL_PLEDGE_MAX_PER_BYTE * qa_power;

--- a/vm/actor/src/builtin/miner/policy.rs
+++ b/vm/actor/src/builtin/miner/policy.rs
@@ -5,8 +5,8 @@ use super::types::SectorOnChainInfo;
 use crate::{network::*, DealWeight};
 use clock::ChainEpoch;
 use fil_types::{RegisteredSealProof, SectorQuality, SectorSize, StoragePower};
-use num_bigint::BigInt;
 use num_bigint::BigUint;
+use num_bigint::{BigInt, Integer};
 use num_traits::Pow;
 use std::cmp;
 use vm::TokenAmount;
@@ -128,14 +128,17 @@ fn quality_for_weight(
     assert!(sector_space_time >= total_deal_space_time);
 
     let weighted_base_space_time =
-        (&sector_space_time - total_deal_space_time) * QUALITY_BASE_MULTIPLIER;
-    let weighted_deal_space_time = deal_weight * DEAL_WEIGHT_MULTIPLIER;
-    let weighted_verified_space_time = verified_weight * VERIFIED_DEAL_WEIGHT_MULTIPLIER;
+        (&sector_space_time - total_deal_space_time) * &*QUALITY_BASE_MULTIPLIER;
+    let weighted_deal_space_time = deal_weight * &*DEAL_WEIGHT_MULTIPLIER;
+    let weighted_verified_space_time = verified_weight * &*VERIFIED_DEAL_WEIGHT_MULTIPLIER;
     let weighted_sum_space_time =
         weighted_base_space_time + weighted_deal_space_time + weighted_verified_space_time;
-    let scaled_up_weighted_sum_space_time = weighted_sum_space_time << SECTOR_QUALITY_PRECISION;
+    let scaled_up_weighted_sum_space_time: SectorQuality =
+        weighted_sum_space_time << SECTOR_QUALITY_PRECISION;
 
-    scaled_up_weighted_sum_space_time / sector_space_time / QUALITY_BASE_MULTIPLIER
+    scaled_up_weighted_sum_space_time
+        .div_floor(&sector_space_time)
+        .div_floor(&QUALITY_BASE_MULTIPLIER)
 }
 
 /// Returns the power for a sector size and weight.
@@ -224,12 +227,12 @@ pub fn reward_for_consensus_slash_report(
     let slasher_share_denominator = consensus_fault_reporter_share_growth_rate
         .denominator
         .pow(&elapsed);
-    let num =
+    let num: BigInt =
         (slasher_share_numerator * consensus_fault_reporter_initial_share.numerator) * &collateral;
     let denom = slasher_share_denominator * consensus_fault_reporter_initial_share.denominator;
 
     cmp::min(
-        num / denom,
-        (collateral * max_reporter_share_num) / max_reporter_share_den,
+        num.div_floor(&denom),
+        (collateral * max_reporter_share_num).div_floor(&max_reporter_share_den),
     )
 }

--- a/vm/actor/src/builtin/miner/policy.rs
+++ b/vm/actor/src/builtin/miner/policy.rs
@@ -185,14 +185,14 @@ pub const PLEDGE_VESTING_SPEC: VestSpec = VestSpec {
     initial_delay: 180 * EPOCHS_IN_DAY, // PARAM_FINISH
     vest_period: 180 * EPOCHS_IN_DAY,   // PARAM_FINISH
     step_duration: EPOCHS_IN_DAY,       // PARAM_FINISH
-    quantization: 12 * SECONDS_IN_HOUR, // PARAM_FINISH
+    quantization: 12 * EPOCHS_IN_HOUR,  // PARAM_FINISH
 };
 
 pub const REWARD_VESTING_SPEC: VestSpec = VestSpec {
-    initial_delay: 20 * EPOCHS_IN_DAY,  // PARAM_FINISH
-    vest_period: 180 * EPOCHS_IN_DAY,   // PARAM_FINISH
-    step_duration: EPOCHS_IN_DAY,       // PARAM_FINISH
-    quantization: 12 * SECONDS_IN_HOUR, // PARAM_FINISH
+    initial_delay: 20 * EPOCHS_IN_DAY, // PARAM_FINISH
+    vest_period: 180 * EPOCHS_IN_DAY,  // PARAM_FINISH
+    step_duration: EPOCHS_IN_DAY,      // PARAM_FINISH
+    quantization: 12 * EPOCHS_IN_HOUR, // PARAM_FINISH
 };
 
 pub fn reward_for_consensus_slash_report(

--- a/vm/actor/src/builtin/miner/vesting_state.rs
+++ b/vm/actor/src/builtin/miner/vesting_state.rs
@@ -4,7 +4,7 @@
 use super::{QuantSpec, VestSpec};
 use clock::ChainEpoch;
 use encoding::tuple::*;
-use num_bigint::bigint_ser;
+use num_bigint::{bigint_ser, Integer};
 use num_traits::Zero;
 use std::{cmp::Ordering, collections::HashMap};
 use vm::TokenAmount;
@@ -74,7 +74,7 @@ impl VestingFunds {
             let elapsed = vest_epoch - vest_begin;
             let target_vest = if elapsed < spec.vest_period {
                 // Linear vesting, PARAM_FINISH
-                (vesting_sum * elapsed) / vest_period
+                (vesting_sum * elapsed).div_floor(&TokenAmount::from(vest_period))
             } else {
                 vesting_sum.clone()
             };

--- a/vm/actor/src/builtin/multisig/state.rs
+++ b/vm/actor/src/builtin/multisig/state.rs
@@ -6,7 +6,7 @@ use address::Address;
 use cid::Cid;
 use clock::ChainEpoch;
 use encoding::{tuple::*, Cbor};
-use num_bigint::bigint_ser;
+use num_bigint::{bigint_ser, Integer};
 use vm::TokenAmount;
 
 /// Multisig actor state
@@ -31,7 +31,9 @@ impl State {
         if elapsed_epoch >= self.unlock_duration {
             return TokenAmount::from(0);
         }
-        let unit_locked: TokenAmount = self.initial_balance.clone() / self.unlock_duration;
+        let unit_locked: TokenAmount = self
+            .initial_balance
+            .div_floor(&TokenAmount::from(self.unlock_duration));
         unit_locked * (self.unlock_duration - elapsed_epoch)
     }
 

--- a/vm/actor/src/builtin/network.rs
+++ b/vm/actor/src/builtin/network.rs
@@ -3,6 +3,7 @@
 
 pub use clock::EPOCH_DURATION_SECONDS;
 pub use fil_types::BLOCKS_PER_EPOCH as EXPECTED_LEADERS_PER_EPOCH;
+use num_bigint::BigInt;
 
 pub const SECONDS_IN_HOUR: i64 = 3600;
 pub const SECONDS_IN_DAY: i64 = 86400;
@@ -11,14 +12,16 @@ pub const EPOCHS_IN_HOUR: i64 = SECONDS_IN_HOUR / EPOCH_DURATION_SECONDS;
 pub const EPOCHS_IN_DAY: i64 = SECONDS_IN_DAY / EPOCH_DURATION_SECONDS;
 pub const EPOCHS_IN_YEAR: i64 = SECONDS_IN_YEAR / EPOCH_DURATION_SECONDS;
 
-/// Quality multiplier for committed capacity (no deals) in a sector
-pub const QUALITY_BASE_MULTIPLIER: i64 = 10;
-
-/// Quality multiplier for unverified deals in a sector
-pub const DEAL_WEIGHT_MULTIPLIER: i64 = 10;
-
-/// Quality multiplier for verified deals in a sector
-pub const VERIFIED_DEAL_WEIGHT_MULTIPLIER: i64 = 100;
-
 /// Precision used for making QA power calculations
 pub const SECTOR_QUALITY_PRECISION: i64 = 20;
+
+lazy_static! {
+    /// Quality multiplier for committed capacity (no deals) in a sector
+    pub static ref QUALITY_BASE_MULTIPLIER: BigInt = BigInt::from(10);
+
+    /// Quality multiplier for unverified deals in a sector
+    pub static ref DEAL_WEIGHT_MULTIPLIER: BigInt = BigInt::from(10);
+
+    /// Quality multiplier for verified deals in a sector
+    pub static ref VERIFIED_DEAL_WEIGHT_MULTIPLIER: BigInt = BigInt::from(100);
+}

--- a/vm/actor/src/builtin/reward/expneg.rs
+++ b/vm/actor/src/builtin/reward/expneg.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::math::{poly_parse, poly_val, PRECISION};
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Integer};
 
 lazy_static! {
     static ref EXP_NUM_COEF: Vec<BigInt> = poly_parse(&[
@@ -43,5 +43,5 @@ pub(crate) fn expneg(x: &BigInt) -> BigInt {
     let num = poly_val(&EXP_NUM_COEF, x);
     let deno = poly_val(&EXP_DENO_COEF, x);
 
-    (num << PRECISION) / deno
+    (num << PRECISION).div_floor(&deno)
 }

--- a/vm/actor/src/builtin/reward/logic.rs
+++ b/vm/actor/src/builtin/reward/logic.rs
@@ -5,7 +5,7 @@ use super::expneg::expneg;
 use crate::math::PRECISION;
 use clock::ChainEpoch;
 use fil_types::{StoragePower, FILECOIN_PRECISION};
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Integer};
 use std::str::FromStr;
 use vm::TokenAmount;
 
@@ -54,7 +54,7 @@ pub(crate) fn compute_r_theta(
     if effective_network_time != 0 {
         let reward_theta = BigInt::from(effective_network_time) << PRECISION;
         let diff = ((cumsum_baseline - cumsum_realized) << PRECISION)
-            / baseline_power_at_effective_network_time;
+            .div_floor(&baseline_power_at_effective_network_time);
 
         reward_theta - diff
     } else {

--- a/vm/actor/src/builtin/reward/mod.rs
+++ b/vm/actor/src/builtin/reward/mod.rs
@@ -15,13 +15,17 @@ use crate::{
 };
 use fil_types::StoragePower;
 use ipld_blockstore::BlockStore;
-use num_bigint::bigint_ser::{BigIntDe, BigIntSer};
 use num_bigint::Sign;
+use num_bigint::{
+    bigint_ser::{BigIntDe, BigIntSer},
+    Integer,
+};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use runtime::{ActorCode, Runtime};
 use vm::{
-    actor_error, ActorError, ExitCode, MethodNum, Serialized, METHOD_CONSTRUCTOR, METHOD_SEND,
+    actor_error, ActorError, ExitCode, MethodNum, Serialized, TokenAmount, METHOD_CONSTRUCTOR,
+    METHOD_SEND,
 };
 
 // * Updated to specs-actors commit: f4024efad09a66e32bfeef10a2845b2b35325297 (v0.9.3)
@@ -100,8 +104,8 @@ impl Actor {
             .ok_or_else(|| actor_error!(ErrNotFound; "failed to resolve given owner address"))?;
 
         let total_reward = rt.transaction(|st: &mut State, rt| {
-            let mut block_reward =
-                (&st.this_epoch_reward * params.win_count) / EXPECTED_LEADERS_PER_EPOCH;
+            let mut block_reward: TokenAmount = (&st.this_epoch_reward * params.win_count)
+                .div_floor(&TokenAmount::from(EXPECTED_LEADERS_PER_EPOCH));
             let mut total_reward = &params.gas_reward + &block_reward;
             let curr_balance = rt.current_balance()?;
             if total_reward > curr_balance {

--- a/vm/actor/src/builtin/reward/state.rs
+++ b/vm/actor/src/builtin/reward/state.rs
@@ -6,7 +6,7 @@ use crate::smooth::{AlphaBetaFilter, FilterEstimate, DEFAULT_ALPHA, DEFAULT_BETA
 use clock::{ChainEpoch, EPOCH_UNDEFINED};
 use encoding::{repr::*, tuple::*, Cbor};
 use fil_types::{Spacetime, StoragePower};
-use num_bigint::bigint_ser;
+use num_bigint::{bigint_ser, Integer};
 use num_derive::FromPrimitive;
 use vm::TokenAmount;
 
@@ -156,7 +156,8 @@ impl Reward {
                 if elapsed >= vest_duration {
                     self.value.clone()
                 } else {
-                    (self.value.clone() * elapsed as u64) / vest_duration as u64
+                    (self.value.clone() * elapsed as u64)
+                        .div_floor(&TokenAmount::from(vest_duration))
                 }
             }
         }

--- a/vm/actor/src/util/smooth/alpha_beta_filter.rs
+++ b/vm/actor/src/util/smooth/alpha_beta_filter.rs
@@ -5,7 +5,7 @@ use crate::util::math::PRECISION;
 use clock::ChainEpoch;
 use encoding::tuple::*;
 use encoding::Cbor;
-use num_bigint::{bigint_ser, BigInt};
+use num_bigint::{bigint_ser, BigInt, Integer};
 
 #[derive(Default, Serialize_tuple, Deserialize_tuple, Clone, Debug, PartialEq)]
 pub struct FilterEstimate {
@@ -64,8 +64,49 @@ impl<'a, 'b, 'f> AlphaBetaFilter<'a, 'b, 'f> {
         let revision_x = (self.alpha * &residual) >> PRECISION;
         position += &revision_x;
 
-        let revision_v = (residual * self.beta) / delta_t;
+        let revision_v = residual * self.beta;
+        let revision_v = revision_v.div_floor(&delta_t);
         let velocity = revision_v + &self.prev_est.velocity;
         FilterEstimate { position, velocity }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{DEFAULT_ALPHA, DEFAULT_BETA};
+    use super::*;
+
+    #[test]
+    fn rounding() {
+        let dd: BigInt =
+            "-251289069730820470307884994218072823111562842879766927769600000000000000000000000000"
+                .parse()
+                .unwrap();
+        let dv: BigInt = "1020847100762815390390123822295304634368".parse().unwrap();
+        assert_eq!(
+            (dd / dv).to_string(),
+            "-246157401576639455533333333333333333333333333"
+        );
+    }
+    #[test]
+    fn rounding_issue() {
+        let fe = FilterEstimate {
+            position: "12340768897043811082913117521041414330876498465539749838848"
+                .parse()
+                .unwrap(),
+            velocity: "-37396269384748225153347462373739139597454335279104"
+                .parse()
+                .unwrap(),
+        };
+        let filter_reward = AlphaBetaFilter::load(&fe, &DEFAULT_ALPHA, &DEFAULT_BETA);
+        let next = filter_reward.next_estimate(&36266252337034982540u128.into(), 3);
+        assert_eq!(
+            next.position.to_string(),
+            "12340768782449774548722755900999027209659079673176744001536"
+        );
+        assert_eq!(
+            next.velocity.to_string(),
+            "-37396515542149801792802995707072472930787668612438"
+        );
     }
 }

--- a/vm/actor/src/util/smooth/alpha_beta_filter.rs
+++ b/vm/actor/src/util/smooth/alpha_beta_filter.rs
@@ -78,16 +78,16 @@ mod tests {
 
     #[test]
     fn rounding() {
-        let dd: BigInt =
-            "-251289069730820470307884994218072823111562842879766927769600000000000000000000000000"
-                .parse()
-                .unwrap();
-        let dv: BigInt = "1020847100762815390390123822295304634368".parse().unwrap();
-        assert_eq!(
-            (dd / dv).to_string(),
-            "-246157401576639455533333333333333333333333333"
-        );
+        // Calculations in this mod are under the assumption division is euclidean and not truncated
+        let dd: BigInt = BigInt::from(-100);
+        let dv: BigInt = BigInt::from(3);
+        assert_eq!(dd.div_floor(&dv), BigInt::from(-34));
+
+        let dd: BigInt = BigInt::from(200);
+        let dv: BigInt = BigInt::from(3);
+        assert_eq!(dd.div_floor(&dv), BigInt::from(66));
     }
+
     #[test]
     fn rounding_issue() {
         let fe = FilterEstimate {

--- a/vm/actor/src/util/smooth/smooth_func.rs
+++ b/vm/actor/src/util/smooth/smooth_func.rs
@@ -4,7 +4,7 @@
 use super::alpha_beta_filter::*;
 use crate::math::{poly_parse, poly_val, PRECISION};
 use clock::ChainEpoch;
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Integer};
 
 lazy_static! {
     pub static ref NUM: Vec<BigInt> = poly_parse(&[
@@ -64,16 +64,16 @@ pub fn extrapolated_cum_sum_of_ratio(
 
         let m2_l = (&x2a - &x2b) * pos_2;
         let m2_r = velo_2 * &delta_t;
-        let m2 = ((m2_l + m2_r) * velo_1) >> PRECISION;
+        let m2: BigInt = ((m2_l + m2_r) * velo_1) >> PRECISION;
 
-        return (m2 + m1) / squared_velo_2;
+        return (m2 + m1).div_floor(&squared_velo_2);
     }
 
     let half_delta = &delta_t >> 1;
-    let mut x1m = velo_1 * (t0 + half_delta);
+    let mut x1m: BigInt = velo_1 * (t0 + half_delta);
     x1m = (x1m >> PRECISION) + pos_1;
 
-    (x1m * delta_t) / pos_2
+    (x1m * delta_t).div_floor(&pos_2)
 }
 
 /// The natural log of Q.128 x.
@@ -91,5 +91,5 @@ pub fn ln(z: &BigInt) -> BigInt {
 fn ln_between_one_and_two(x: BigInt) -> BigInt {
     let num = poly_val(&NUM, &x) << PRECISION;
     let denom = poly_val(&DENOM, &x);
-    num / denom
+    num.div_floor(&denom)
 }

--- a/vm/actor/tests/alpha_beta_filter_test.rs
+++ b/vm/actor/tests/alpha_beta_filter_test.rs
@@ -7,7 +7,7 @@ use actor::smooth::*;
 use actor::EPOCHS_IN_DAY;
 use clock::ChainEpoch;
 use fil_types::StoragePower;
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Integer};
 use num_traits::sign::Signed;
 
 const ERR_BOUND: u64 = 350;
@@ -18,7 +18,7 @@ const ERR_BOUND: u64 = 350;
 fn per_million_error(val_1: &BigInt, val_2: &BigInt) -> BigInt {
     let diff = (val_1 - val_2) << PRECISION;
 
-    let ratio = diff / val_1;
+    let ratio = diff.div_floor(&val_1);
     let million = BigInt::from(1_000_000) << PRECISION;
 
     let diff_per_million = (ratio * million).abs();
@@ -37,7 +37,7 @@ fn iterative_cum_sum_of_ratio(
     for i in 0..delta {
         let num_epsilon = num.extrapolate(t0 + i); // Q.256
         let denom_epsilon = denom.extrapolate(t0 + i) >> PRECISION; // Q.256
-        let mut epsilon = num_epsilon / denom_epsilon; // Q.256 / Q.128 => Q.128
+        let mut epsilon = num_epsilon.div_floor(&denom_epsilon); // Q.256 / Q.128 => Q.128
 
         if i != 0 && i != delta - 1 {
             epsilon *= 2; // Q.128 * Q.0 => Q.128
@@ -45,7 +45,7 @@ fn iterative_cum_sum_of_ratio(
         ratio += epsilon;
     }
 
-    ratio / 2
+    ratio.div_floor(&BigInt::from(2))
 }
 
 fn assert_err_bound(


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Updates all bigint divisions that can be negative to Euclidean (floored) division from truncated
  - Go uses Euclidean for bigints and truncated for integers, we can match with these changes
  - Did not change some of the bigint division that is guaranteed to be positive (truncated and floored are same for positive values). If anyone is really uncomfortable by this, I can switch others, but it means more allocations because `div_floor` does not allow for dividing by anything but a bigint
- Fixes bug in miner actor `VestSpec` constant
  - With both changes, can uncomment the tipset conformance vector skip


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->