### PR TITLE
Add caching to Hamt and update testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,6 @@ dependencies = [
  "hex",
  "ipld_blockstore",
  "lazycell",
- "murmur3",
  "serde",
  "serde_bytes",
  "sha2 0.9.1",
@@ -3816,14 +3815,6 @@ dependencies = [
  "pin-project",
  "smallvec",
  "unsigned-varint 0.4.0",
-]
-
-[[package]]
-name = "murmur3"
-version = "0.4.1"
-source = "git+https://github.com/dignifiedquire/murmur3?branch=nicer-hashing#c30ee28caae87847ba66aaa10fcaab783033f5f7"
-dependencies = [
- "byteorder 1.3.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,6 +2976,7 @@ dependencies = [
  "serde_bytes",
  "sha2 0.9.1",
  "thiserror",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ dependencies = [
  "forest_ipld",
  "hex",
  "ipld_blockstore",
+ "lazycell",
  "murmur3",
  "serde",
  "serde_bytes",

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -154,14 +154,15 @@ where
     ) -> Result<(power::Claim, power::Claim), Error> {
         let ps: power::State = self.load_actor_state(&*STORAGE_POWER_ACTOR_ADDR, state_cid)?;
 
-        let cm = make_map_with_root(&ps.claims, self.bs.as_ref())
+        let cm = make_map_with_root::<_, power::Claim>(&ps.claims, self.bs.as_ref())
             .map_err(|e| Error::State(e.to_string()))?;
-        let claim: power::Claim = cm
+        let claim = cm
             .get(&addr.to_bytes())
             .map_err(|e| Error::State(e.to_string()))?
             .ok_or_else(|| {
                 Error::State("Failed to retrieve claimed power from actor state".to_owned())
-            })?;
+            })?
+            .clone();
         Ok((
             claim,
             power::Claim {
@@ -800,12 +801,12 @@ where
             escrow: {
                 let et = BalanceTable::from_root(self.bs.as_ref(), &market_state.escrow_table)
                     .map_err(|_x| Error::State("Failed to build Escrow Table".to_string()))?;
-                et.get(&new_addr).unwrap_or_default()
+                et.get(&new_addr).map(Clone::clone).unwrap_or_default()
             },
             locked: {
                 let lt = BalanceTable::from_root(self.bs.as_ref(), &market_state.locked_table)
                     .map_err(|_x| Error::State("Failed to build Locked Table".to_string()))?;
-                lt.get(&new_addr).unwrap_or_default()
+                lt.get(&new_addr).map(Clone::clone).unwrap_or_default()
             },
         };
 

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -15,6 +15,7 @@ forest_ipld = { path = "../" }
 serde_bytes = "0.11.3"
 thiserror = "1.0"
 sha2 = "0.9.1"
+lazycell = "1.2.1"
 
 # TODO remove murmur3 support when finalized in Filecoin
 [dependencies.murmur3]

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -17,16 +17,9 @@ thiserror = "1.0"
 sha2 = "0.9.1"
 lazycell = "1.2.1"
 
-# TODO remove murmur3 support when finalized in Filecoin
-[dependencies.murmur3]
-git = "https://github.com/dignifiedquire/murmur3"
-branch = "nicer-hashing"
-optional = true
-
 [features]
-default = ["identity", "murmur3"]
+default = ["identity"]
 identity = []
-murmur = ["murmur3"]
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -31,6 +31,7 @@ murmur = ["murmur3"]
 hex = "0.4.2"
 criterion = "0.3.3"
 ipld_blockstore = { path = "../blockstore", features = ["tracking"] }
+unsigned-varint = "0.5"
 
 [[bench]]
 name = "hamt_beckmark"

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -30,6 +30,7 @@ murmur = ["murmur3"]
 [dev-dependencies]
 hex = "0.4.2"
 criterion = "0.3.3"
+ipld_blockstore = { path = "../blockstore", features = ["tracking"] }
 
 [[bench]]
 name = "hamt_beckmark"

--- a/ipld/hamt/src/bitfield.rs
+++ b/ipld/hamt/src/bitfield.rs
@@ -9,7 +9,7 @@ use forest_encoding::{
 };
 use std::u64;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Bitfield([u64; 4]);
 
 impl Serialize for Bitfield {

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -22,8 +22,8 @@ use std::marker::PhantomData;
 ///
 /// let mut map: Hamt<_, _, usize> = Hamt::new(&store);
 /// map.set(1, "a".to_string()).unwrap();
-/// assert_eq!(map.get(&1).unwrap(), Some("a".to_string()));
-/// assert_eq!(map.delete(&1).unwrap(), true);
+/// assert_eq!(map.get(&1).unwrap(), Some(&"a".to_string()));
+/// assert_eq!(map.delete(&1).unwrap(), Some((1, "a".to_string())));
 /// assert_eq!(map.get::<_>(&1).unwrap(), None);
 /// let cid = map.flush().unwrap();
 /// ```
@@ -152,7 +152,7 @@ where
     ///
     /// let mut map: Hamt<_, _, usize> = Hamt::new(&store);
     /// map.set(1, "a".to_string()).unwrap();
-    /// assert_eq!(map.get(&1).unwrap(), Some("a".to_string()));
+    /// assert_eq!(map.get(&1).unwrap(), Some(&"a".to_string()));
     /// assert_eq!(map.get(&2).unwrap(), None);
     /// ```
     #[inline]
@@ -211,8 +211,8 @@ where
     ///
     /// let mut map: Hamt<_, _, usize> = Hamt::new(&store);
     /// map.set(1, "a".to_string()).unwrap();
-    /// assert_eq!(map.delete(&1).unwrap(), true);
-    /// assert_eq!(map.delete(&1).unwrap(), false);
+    /// assert_eq!(map.delete(&1).unwrap(), Some((1, "a".to_string())));
+    /// assert_eq!(map.delete(&1).unwrap(), None);
     /// ```
     pub fn delete<Q: ?Sized>(&mut self, k: &Q) -> Result<Option<(K, V)>, Error>
     where

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -60,8 +60,8 @@ impl<'a, K: PartialEq, V: PartialEq, S: BlockStore, H: HashAlgorithm> PartialEq
 
 impl<'a, BS, V, K, H> Hamt<'a, BS, V, K, H>
 where
-    K: Hash + Eq + PartialOrd + Serialize + DeserializeOwned + Clone,
-    V: Serialize + DeserializeOwned + Clone,
+    K: Hash + Eq + PartialOrd + Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
     BS: BlockStore,
     H: HashAlgorithm,
 {
@@ -156,7 +156,7 @@ where
     /// assert_eq!(map.get(&2).unwrap(), None);
     /// ```
     #[inline]
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Result<Option<V>, Error>
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Result<Option<&V>, Error>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
@@ -214,15 +214,12 @@ where
     /// assert_eq!(map.delete(&1).unwrap(), true);
     /// assert_eq!(map.delete(&1).unwrap(), false);
     /// ```
-    pub fn delete<Q: ?Sized>(&mut self, k: &Q) -> Result<bool, Error>
+    pub fn delete<Q: ?Sized>(&mut self, k: &Q) -> Result<Option<(K, V)>, Error>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        match self.root.remove_entry(k, self.store, self.bit_width)? {
-            Some(_) => Ok(true),
-            None => Ok(false),
-        }
+        self.root.remove_entry(k, self.store, self.bit_width)
     }
 
     /// Flush root and return Cid for hamt

--- a/ipld/hamt/src/hash_algorithm.rs
+++ b/ipld/hamt/src/hash_algorithm.rs
@@ -4,9 +4,6 @@
 use crate::{Hash, HashedKey};
 use sha2::{Digest, Sha256 as Sha256Hasher};
 
-#[cfg(feature = "murmur")]
-use murmur3::murmur3_x64_128::MurmurHasher;
-
 /// Algorithm used as the hasher for the Hamt.
 pub trait HashAlgorithm {
     fn hash<X: ?Sized>(key: &X) -> HashedKey
@@ -40,25 +37,6 @@ impl HashAlgorithm for Sha256 {
         let mut hasher = Sha2HasherWrapper::default();
         key.hash(&mut hasher);
         hasher.0.finalize().into()
-    }
-}
-
-#[cfg(feature = "murmur")]
-#[derive(Debug)]
-pub enum Murmur3 {}
-
-#[cfg(feature = "murmur")]
-impl HashAlgorithm for Murmur3 {
-    fn hash<X: ?Sized>(key: &X) -> HashedKey
-    where
-        X: Hash,
-    {
-        let mut hasher = MurmurHasher::default();
-        key.hash(&mut hasher);
-        let mut bz: [u8; 32] = Default::default();
-        let hash: [u8; 16] = hasher.finalize().into();
-        bz[0..16].copy_from_slice(&hash);
-        bz
     }
 }
 

--- a/ipld/hamt/src/hash_bits.rs
+++ b/ipld/hamt/src/hash_bits.rs
@@ -5,7 +5,7 @@ use crate::{Error, HashedKey};
 use std::cmp::Ordering;
 
 /// Helper struct which indexes and allows returning bits from a hashed key
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct HashBits<'a> {
     b: &'a HashedKey,
     pub consumed: u32,

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -35,12 +35,15 @@ const DEFAULT_BIT_WIDTH: u32 = 8;
 
 type HashedKey = [u8; 32];
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct KeyValuePair<K, V>(K, V);
 
 impl<K, V> KeyValuePair<K, V> {
     pub fn key(&self) -> &K {
         &self.0
+    }
+    pub fn value(&self) -> &V {
+        &self.1
     }
 }
 

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -235,7 +235,7 @@ where
                     let mut sub = Node::default();
                     let consumed = hashed_key.consumed;
                     sub.modify_value(hashed_key, bit_width, depth + 1, key, value, store)?;
-                    let kvs = std::mem::replace(vals, Vec::new());
+                    let kvs = std::mem::take(vals);
                     for p in kvs.into_iter() {
                         let hash = H::hash(p.key());
                         sub.modify_value(

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 /// Node in Hamt tree which contains bitfield of set indexes and pointers to nodes
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct Node<K, V, H> {
     pub(crate) bitfield: Bitfield,
     pub(crate) pointers: Vec<Pointer<K, V, H>>,
@@ -71,9 +71,9 @@ impl<K, V, H> Default for Node<K, V, H> {
 
 impl<K, V, H> Node<K, V, H>
 where
-    K: Hash + Eq + PartialOrd + Serialize + DeserializeOwned + Clone,
+    K: Hash + Eq + PartialOrd + Serialize + DeserializeOwned,
     H: HashAlgorithm,
-    V: Serialize + DeserializeOwned + Clone,
+    V: Serialize + DeserializeOwned,
 {
     pub fn set<S: BlockStore>(
         &mut self,
@@ -92,12 +92,12 @@ where
         k: &Q,
         store: &S,
         bit_width: u32,
-    ) -> Result<Option<V>, Error>
+    ) -> Result<Option<&V>, Error>
     where
         K: Borrow<Q>,
         Q: Eq + Hash,
     {
-        Ok(self.search(k, store, bit_width)?.map(|kv| kv.1))
+        Ok(self.search(k, store, bit_width)?.map(|kv| kv.value()))
     }
 
     #[inline]
@@ -127,13 +127,13 @@ where
     {
         for p in &self.pointers {
             match p {
-                Pointer::Link(cid) => {
+                Pointer::Link { cid, .. } => {
                     match store.get::<Node<K, V, H>>(cid).map_err(|e| e.to_string())? {
                         Some(node) => node.for_each(store, f)?,
                         None => return Err(format!("Node with cid {} not found", cid).into()),
                     }
                 }
-                Pointer::Cache(n) => n.for_each(store, f)?,
+                Pointer::Dirty(n) => n.for_each(store, f)?,
                 Pointer::Values(kvs) => {
                     for kv in kvs {
                         f(kv.0.borrow(), kv.1.borrow())?;
@@ -150,7 +150,7 @@ where
         q: &Q,
         store: &S,
         bit_width: u32,
-    ) -> Result<Option<KeyValuePair<K, V>>, Error>
+    ) -> Result<Option<&KeyValuePair<K, V>>, Error>
     where
         K: Borrow<Q>,
         Q: Eq + Hash,
@@ -166,7 +166,7 @@ where
         depth: usize,
         key: &Q,
         store: &S,
-    ) -> Result<Option<KeyValuePair<K, V>>, Error>
+    ) -> Result<Option<&KeyValuePair<K, V>>, Error>
     where
         K: Borrow<Q>,
         Q: Eq + Hash,
@@ -180,12 +180,24 @@ where
         let cindex = self.index_for_bit_pos(idx);
         let child = self.get_child(cindex);
         match child {
-            Pointer::Link(cid) => match store.get::<Node<K, V, H>>(cid)? {
-                Some(node) => Ok(node.get_value(hashed_key, bit_width, depth + 1, key, store)?),
-                None => Err(Error::CidNotFound(cid.to_string())),
-            },
-            Pointer::Cache(n) => n.get_value(hashed_key, bit_width, depth + 1, key, store),
-            Pointer::Values(vals) => Ok(vals.iter().find(|kv| key.eq(kv.key().borrow())).cloned()),
+            Pointer::Link { cid, cache } => {
+                if let Some(cached_node) = cache.borrow() {
+                    // Link node is cached
+                    cached_node.get_value(hashed_key, bit_width, depth + 1, key, store)
+                } else {
+                    // Link is not cached, need to load and fill cache, then traverse for value.
+                    let node = store
+                        .get::<Box<Node<K, V, H>>>(cid)?
+                        .ok_or_else(|| Error::CidNotFound(cid.to_string()))?;
+
+                    // Intentionally ignoring error, cache will always be the same.
+                    let _ = cache.fill(node);
+                    let cache_node = cache.borrow().expect("cache filled on line above");
+                    cache_node.get_value(hashed_key, bit_width, depth + 1, key, store)
+                }
+            }
+            Pointer::Dirty(n) => n.get_value(hashed_key, bit_width, depth + 1, key, store),
+            Pointer::Values(vals) => Ok(vals.iter().find(|kv| key.eq(kv.key().borrow()))),
         }
     }
 
@@ -211,16 +223,16 @@ where
         let child = self.get_child_mut(cindex);
 
         match child {
-            Pointer::Link(cid) => match store.get::<Node<K, V, H>>(cid)? {
+            Pointer::Link { cid, .. } => match store.get::<Node<K, V, H>>(cid)? {
                 Some(mut node) => {
                     // Pull value from store and update to cached node
                     node.modify_value(hashed_key, bit_width, depth + 1, key, value, store)?;
-                    *child = Pointer::Cache(Box::new(node));
+                    *child = Pointer::Dirty(Box::new(node));
                     Ok(())
                 }
                 None => Err(Error::CidNotFound(cid.to_string())),
             },
-            Pointer::Cache(n) => {
+            Pointer::Dirty(n) => {
                 Ok(n.modify_value(hashed_key, bit_width, depth + 1, key, value, store)?)
             }
             Pointer::Values(vals) => {
@@ -248,7 +260,7 @@ where
                         )?;
                     }
 
-                    *child = Pointer::Cache(Box::new(sub));
+                    *child = Pointer::Dirty(Box::new(sub));
                     return Ok(());
                 }
 
@@ -291,11 +303,11 @@ where
         let child = self.get_child_mut(cindex);
 
         match child {
-            Pointer::Link(cid) => match store.get::<Node<K, V, H>>(cid)? {
+            Pointer::Link { cid, .. } => match store.get::<Node<K, V, H>>(cid)? {
                 Some(mut node) => {
                     // Pull value from store and update to cached node
                     let del = node.rm_value(hashed_key, bit_width, depth + 1, key, store)?;
-                    *child = Pointer::Cache(Box::new(node));
+                    *child = Pointer::Dirty(Box::new(node));
 
                     // Clean to retrieve canonical form
                     child.clean()?;
@@ -303,7 +315,7 @@ where
                 }
                 None => Err(Error::CidNotFound(cid.to_string())),
             },
-            Pointer::Cache(n) => {
+            Pointer::Dirty(n) => {
                 // Delete value and return deleted value
                 let deleted = n.rm_value(hashed_key, bit_width, depth + 1, key, store)?;
 
@@ -335,7 +347,7 @@ where
 
     pub fn flush<S: BlockStore>(&mut self, store: &S) -> Result<(), Error> {
         for pointer in &mut self.pointers {
-            if let Pointer::Cache(node) = pointer {
+            if let Pointer::Dirty(node) = pointer {
                 // Flush cached sub node to clear it's cache
                 node.flush(store)?;
 
@@ -343,7 +355,10 @@ where
                 let cid = store.put(node, Blake2b256)?;
 
                 // Replace cached node with Cid link
-                *pointer = Pointer::Link(cid);
+                *pointer = Pointer::Link {
+                    cid,
+                    cache: Default::default(),
+                };
             }
         }
 

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -4,25 +4,29 @@
 use super::node::Node;
 use super::{Error, Hash, HashAlgorithm, KeyValuePair, MAX_ARRAY_WIDTH};
 use cid::Cid;
+use lazycell::LazyCell;
 use serde::de::{self, DeserializeOwned};
 use serde::ser;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
 
 /// Pointer to index values or a link to another child node.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum Pointer<K, V, H> {
     Values(Vec<KeyValuePair<K, V>>),
-    Link(Cid),
-    Cache(Box<Node<K, V, H>>),
+    Link {
+        cid: Cid,
+        cache: LazyCell<Box<Node<K, V, H>>>,
+    },
+    Dirty(Box<Node<K, V, H>>),
 }
 
 impl<K: PartialEq, V: PartialEq, H> PartialEq for Pointer<K, V, H> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (&Pointer::Values(ref a), &Pointer::Values(ref b)) => a == b,
-            (&Pointer::Link(ref a), &Pointer::Link(ref b)) => a == b,
-            (&Pointer::Cache(ref a), &Pointer::Cache(ref b)) => a == b,
+            (&Pointer::Link { cid: ref a, .. }, &Pointer::Link { cid: ref b, .. }) => a == b,
+            (&Pointer::Dirty(ref a), &Pointer::Dirty(ref b)) => a == b,
             _ => false,
         }
     }
@@ -46,7 +50,7 @@ where
                 };
                 ValsSer { vals }.serialize(serializer)
             }
-            Pointer::Link(cid) => {
+            Pointer::Link { cid, .. } => {
                 #[derive(Serialize)]
                 struct LinkSer<'a> {
                     #[serde(rename = "0")]
@@ -54,7 +58,7 @@ where
                 };
                 LinkSer { cid }.serialize(serializer)
             }
-            Pointer::Cache(_) => Err(ser::Error::custom("Cannot serialize cached values")),
+            Pointer::Dirty(_) => Err(ser::Error::custom("Cannot serialize cached values")),
         }
     }
 }
@@ -79,7 +83,10 @@ where
         let pointer_map = PointerDeser::deserialize(deserializer)?;
         match pointer_map {
             PointerDeser { vals: Some(v), .. } => Ok(Pointer::Values(v)),
-            PointerDeser { cid: Some(cid), .. } => Ok(Pointer::Link(cid)),
+            PointerDeser { cid: Some(cid), .. } => Ok(Pointer::Link {
+                cid,
+                cache: Default::default(),
+            }),
             _ => Err(de::Error::custom("Unexpected pointer serialization")),
         }
     }
@@ -93,8 +100,8 @@ impl<K, V, H> Default for Pointer<K, V, H> {
 
 impl<K, V, H> Pointer<K, V, H>
 where
-    K: Serialize + DeserializeOwned + Clone + Hash + PartialOrd,
-    V: Serialize + DeserializeOwned + Clone,
+    K: Serialize + DeserializeOwned + Hash + PartialOrd,
+    V: Serialize + DeserializeOwned,
     H: HashAlgorithm,
 {
     pub(crate) fn from_key_value(key: K, value: V) -> Self {
@@ -105,12 +112,12 @@ where
     /// after deletes.
     pub(crate) fn clean(&mut self) -> Result<(), Error> {
         match self {
-            Pointer::Cache(n) => match n.pointers.len() {
+            Pointer::Dirty(n) => match n.pointers.len() {
                 0 => Err(Error::ZeroPointers),
                 1 => {
                     // Node has only one pointer, swap with parent node
                     if let Pointer::Values(vals) = &mut n.pointers[0] {
-                        // Take child values and sort, to ensure canonical ordering
+                        // Take child values, to ensure canonical ordering
                         let values = std::mem::take(vals);
 
                         // move parent node up
@@ -119,24 +126,36 @@ where
                     Ok(())
                 }
                 2..=MAX_ARRAY_WIDTH => {
-                    // Iterate over all pointers in cached node to see if it can fit all within
-                    // one values node
-                    let mut child_vals: Vec<KeyValuePair<K, V>> =
-                        Vec::with_capacity(MAX_ARRAY_WIDTH);
-                    for pointer in n.pointers.iter() {
-                        if let Pointer::Values(kvs) = pointer {
-                            for kv in kvs.iter() {
-                                if child_vals.len() == MAX_ARRAY_WIDTH {
-                                    // Child values cannot be fit into parent node, keep as is
-                                    return Ok(());
-                                }
-                                // TODO avoid clone by checking length before removing
-                                child_vals.push(kv.clone());
+                    // If more child values than max width, nothing to change.
+                    let children_len: usize = n
+                        .pointers
+                        .iter()
+                        .filter_map(|p| {
+                            if let Pointer::Values(vals) = p {
+                                Some(vals.len())
+                            } else {
+                                None
                             }
-                        } else {
-                            return Ok(());
-                        }
+                        })
+                        .sum();
+                    if children_len > MAX_ARRAY_WIDTH {
+                        return Ok(());
                     }
+
+                    // Collect values from child nodes to collapse.
+                    let mut child_vals: Vec<KeyValuePair<K, V>> = n
+                        .pointers
+                        .iter_mut()
+                        .filter_map(|p| {
+                            if let Pointer::Values(kvs) = p {
+                                Some(std::mem::take(kvs))
+                            } else {
+                                None
+                            }
+                        })
+                        .flatten()
+                        .collect();
+
                     // Sorting by key, values are inserted based on the ordering of the key itself,
                     // so when collapsed, it needs to be ensured that this order is equal.
                     child_vals.sort_unstable_by(|a, b| {
@@ -149,7 +168,7 @@ where
                 }
                 _ => Ok(()),
             },
-            _ => unreachable!("clean is only called on cached pointer"),
+            _ => unreachable!("clean is only called on dirty pointer"),
         }
     }
 }

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -127,8 +127,8 @@ fn set_delete_many() {
 
     let c1 = hamt.flush().unwrap();
     assert_eq!(
-        hex::encode(c1.to_bytes()),
-        "0171a0e402207c660382de99c174ce39517bdbd28f3967801aebbd9795f0591e226d93e2f010"
+        c1.to_string().as_str(),
+        "bafy2bzaceaneyzybb37pn4rtg2mvn2qxb43rhgmqoojgtz7avdfjw2lhz4dge"
     );
 
     for i in 200..400 {
@@ -137,8 +137,8 @@ fn set_delete_many() {
 
     let cid_all = hamt.flush().unwrap();
     assert_eq!(
-        hex::encode(cid_all.to_bytes()),
-        "0171a0e40220dba161623db24093bd90e00c3d185bae8468f8d3e81f01f112b3afe47e603fd1"
+        cid_all.to_string().as_str(),
+        "bafy2bzaceaqmub32nf33s3joo6x2l3schxreuow7jkla7a27l7qcrsb2elzay"
     );
 
     for i in 200..400 {
@@ -151,9 +151,11 @@ fn set_delete_many() {
 
     let cid_d = hamt.flush().unwrap();
     assert_eq!(
-        hex::encode(cid_d.to_bytes()),
-        "0171a0e402207c660382de99c174ce39517bdbd28f3967801aebbd9795f0591e226d93e2f010"
+        cid_d.to_string().as_str(),
+        "bafy2bzaceaneyzybb37pn4rtg2mvn2qxb43rhgmqoojgtz7avdfjw2lhz4dge"
     );
+    #[rustfmt::skip]
+    assert_eq!(*store.stats.borrow(), BSStats {r: 87, w: 119, br: 7671, bw: 14042});
 }
 
 #[cfg(feature = "identity")]
@@ -162,6 +164,7 @@ fn add_and_remove_keys(
     keys: &[&[u8]],
     extra_keys: &[&[u8]],
     expected: &'static str,
+    stats: BSStats,
 ) {
     let all: Vec<(BytesKey, u8)> = keys
         .iter()
@@ -201,47 +204,81 @@ fn add_and_remove_keys(
     let cid1 = h1.flush().unwrap();
     let cid2 = h2.flush().unwrap();
     assert_eq!(cid1, cid2);
-    assert_eq!(hex::encode(cid1.to_bytes()), expected);
+    assert_eq!(cid1.to_string().as_str(), expected);
+    assert_eq!(*store.stats.borrow(), stats);
 }
 
 #[test]
 #[cfg(feature = "identity")]
 fn canonical_structure() {
     // Champ mutation semantics test
+    #[rustfmt::skip]
     add_and_remove_keys(
         DEFAULT_BIT_WIDTH,
         &[b"K"],
         &[b"B"],
-        "0171a0e402208683c5cd09bc6c1df93d100bee677d7a6bbe8db0b340361866e3fb20fb0a981e",
+        "bafy2bzacecdihronbg6gyhpzhuiax3thpv5gxpunwczuanqym3r7wih3bkmb4",
+        BSStats {r: 2, w: 5, br: 42, bw: 105},
     );
+    #[rustfmt::skip]
     add_and_remove_keys(
         DEFAULT_BIT_WIDTH,
         &[b"K0", b"K1", b"KAA1", b"KAA2", b"KAA3"],
         &[b"KAA4"],
-        "0171a0e40220e2a9e53c77d146010b60f2be9b3ba423c0db4efea06e66bd87e072671c8ef411",
+        "bafy2bzaceaxfdngr56h3kj5hplwslhyxauizcpwx3agwjqns6gjhroepgnfkm",
+        BSStats {r: 2, w: 5, br: 168, bw: 420},
     );
 }
 
 #[test]
 #[cfg(feature = "identity")]
 fn canonical_structure_alt_bit_width() {
+    #[rustfmt::skip]
     let kb_cases = [
-        "0171a0e402209a00d457b7d5d398a225fa837125db401a5eabdf4833352aed48dd28dc6eca56",
-        "0171a0e40220b45f48552b1b802fafcb79b417c4d2972ea42cd24600eaf9a0d1314c7d46c214",
-        "0171a0e40220c4ac32c9bb0dbec96b290d68b1b1fc6e1ddfe33f99420b4b46a078255d997db8",
+        (
+            "bafy2bzacedckymwjxmg35sllfegwrmnr7rxb3x7dh6muec2li2qhqjk5tf63q",
+            BSStats {r: 2, w: 5, br: 32, bw: 80},
+        ),
+        (
+            "bafy2bzacec2f6scvfmnyal5pzn43if6e2kls5jbm2jdab2xzuditctd5i3bbi",
+            BSStats {r: 2, w: 5, br: 28, bw: 70},
+        ),
+        (
+            "bafy2bzacecnabvcxw7k5hgfcex5ig4jf3nabuxvl35edgnjk5ven2kg4n3ffm",
+            BSStats {r: 2, w: 5, br: 26, bw: 65},
+        ),
     ];
+    #[rustfmt::skip]
     let other_cases = [
-        "0171a0e40220c5f39f53c67de67dbf8a058b699fb1e4673d78a5f6a0dc59583f9a175db234e3",
-        "0171a0e40220c84814bb7fdbb71a17ac24b0eb110a38e4e79c93fccaa6d87fa9e5aa771bb453",
-        "0171a0e4022094833c20da84ad6e18a603a47aa143e3393171d45786eddc5b182ae647dafd64",
+        (
+            "bafy2bzaceckigpba3kck23qyuyb2i6vbiprtsmlr2rlyn3o4lmmcvzsh3l6wi",
+            BSStats {r: 8, w: 13, br: 419, bw: 687},
+        ),
+        (
+            "bafy2bzacedeeqff3p7n3ogqxvqslb2yrbi4ojz44sp6mvjwyp6u6lktxdo2fg",
+            BSStats {r: 8, w: 13, br: 385, bw: 639},
+        ),
+        (
+            "bafy2bzacedc7hh2tyz66m7n7ricyw2m7whsgoplyux3kbxczla7zuf25wi2og",
+            BSStats {r: 9, w: 14, br: 420, bw: 661},
+        ),
     ];
     for i in 5..8 {
-        add_and_remove_keys(i, &[b"K"], &[b"B"], kb_cases[(i - 5) as usize]);
+        #[rustfmt::skip]
+        add_and_remove_keys(
+            i,
+            &[b"K"],
+            &[b"B"],
+            kb_cases[(i - 5) as usize].0,
+            kb_cases[(i - 5) as usize].1,
+        );
+        #[rustfmt::skip]
         add_and_remove_keys(
             i,
             &[b"K0", b"K1", b"KAA1", b"KAA2", b"KAA3"],
             &[b"KAA4"],
-            other_cases[(i - 5) as usize],
+            other_cases[(i - 5) as usize].0,
+            other_cases[(i - 5) as usize].1,
         );
     }
 }

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -158,7 +158,8 @@ fn set_delete_many() {
         "bafy2bzaceaneyzybb37pn4rtg2mvn2qxb43rhgmqoojgtz7avdfjw2lhz4dge"
     );
     #[rustfmt::skip]
-    assert_eq!(*store.stats.borrow(), BSStats {r: 87, w: 119, br: 7671, bw: 14042});
+    // TODO https://github.com/ChainSafe/forest/issues/729
+    assert_eq!(*store.stats.borrow(), BSStats { r: 61, w: 93, br: 6478, bw: 12849 });
 }
 
 #[cfg(feature = "identity")]
@@ -229,7 +230,9 @@ fn canonical_structure() {
         &[b"K0", b"K1", b"KAA1", b"KAA2", b"KAA3"],
         &[b"KAA4"],
         "bafy2bzacedrktzj4o7iumailmdzl5gz3uqr4bw2o72qg4zv5q7qhezy4r32bc",
-        BSStats {r: 7, w: 10, br: 388, bw: 561},
+        // TODO we have a LOT less reads and writes, match go with 
+        // https://github.com/ChainSafe/forest/issues/729
+        BSStats { r: 4, w: 6, br: 228, bw: 346 },
     );
 }
 
@@ -240,30 +243,36 @@ fn canonical_structure_alt_bit_width() {
     let kb_cases = [
         (
             "bafy2bzacecnabvcxw7k5hgfcex5ig4jf3nabuxvl35edgnjk5ven2kg4n3ffm",
-            BSStats {r: 2, w: 5, br: 26, bw: 65},
+            // TODO https://github.com/ChainSafe/forest/issues/729
+            BSStats { r: 2, w: 4, br: 26, bw: 52 },
         ),
         (
             "bafy2bzacec2f6scvfmnyal5pzn43if6e2kls5jbm2jdab2xzuditctd5i3bbi",
-            BSStats {r: 2, w: 5, br: 28, bw: 70},
+            // TODO https://github.com/ChainSafe/forest/issues/729
+            BSStats { r: 2, w: 4, br: 28, bw: 56 },
         ),
         (
             "bafy2bzacedckymwjxmg35sllfegwrmnr7rxb3x7dh6muec2li2qhqjk5tf63q",
-            BSStats {r: 2, w: 5, br: 32, bw: 80},
+            // TODO https://github.com/ChainSafe/forest/issues/729
+            BSStats { r: 2, w: 4, br: 32, bw: 64 },
         ),
     ];
     #[rustfmt::skip]
     let other_cases = [
         (
             "bafy2bzacedc7hh2tyz66m7n7ricyw2m7whsgoplyux3kbxczla7zuf25wi2og",
-            BSStats {r: 9, w: 14, br: 420, bw: 661},
+            // TODO https://github.com/ChainSafe/forest/issues/729
+            BSStats { r: 4, w: 6, br: 190, bw: 292 },
         ),
         (
             "bafy2bzacedeeqff3p7n3ogqxvqslb2yrbi4ojz44sp6mvjwyp6u6lktxdo2fg",
-            BSStats {r: 8, w: 13, br: 385, bw: 639},
+            // TODO https://github.com/ChainSafe/forest/issues/729
+            BSStats { r: 4, w: 6, br: 202, bw: 306 },
         ),
         (
             "bafy2bzaceckigpba3kck23qyuyb2i6vbiprtsmlr2rlyn3o4lmmcvzsh3l6wi",
-            BSStats {r: 8, w: 13, br: 419, bw: 687},
+            // TODO https://github.com/ChainSafe/forest/issues/729
+            BSStats { r: 4, w: 6, br: 214, bw: 322 },
         ),
     ];
     for i in 5..8 {
@@ -322,5 +331,6 @@ fn clean_child_ordering() {
         "bafy2bzacec6ro3q36okye22evifu6h7kwdkjlb4keq6ogpfqivka6myk6wkjo"
     );
     #[rustfmt::skip]
-    assert_eq!(*store.stats.borrow(), BSStats {r: 9, w: 17, br: 2327, bw: 2845});
+    // TODO https://github.com/ChainSafe/forest/issues/729
+    assert_eq!(*store.stats.borrow(), BSStats { r: 3, w: 11, br: 1992, bw: 2510 });
 }

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -19,9 +19,9 @@ fn test_basics() {
     let mut hamt = Hamt::<_, String, _>::new(&store);
     hamt.set(1, "world".to_string()).unwrap();
 
-    assert_eq!(hamt.get(&1).unwrap(), Some("world".to_string()));
+    assert_eq!(hamt.get(&1).unwrap(), Some(&"world".to_string()));
     hamt.set(1, "world2".to_string()).unwrap();
-    assert_eq!(hamt.get(&1).unwrap(), Some("world2".to_string()));
+    assert_eq!(hamt.get(&1).unwrap(), Some(&"world2".to_string()));
 }
 
 #[test]
@@ -31,9 +31,9 @@ fn test_load() {
     let mut hamt: Hamt<_, _, usize> = Hamt::new(&store);
     hamt.set(1, "world".to_string()).unwrap();
 
-    assert_eq!(hamt.get(&1).unwrap(), Some("world".to_string()));
+    assert_eq!(hamt.get(&1).unwrap(), Some(&"world".to_string()));
     hamt.set(1, "world2".to_string()).unwrap();
-    assert_eq!(hamt.get(&1).unwrap(), Some("world2".to_string()));
+    assert_eq!(hamt.get(&1).unwrap(), Some(&"world2".to_string()));
     let c = hamt.flush().unwrap();
 
     let new_hamt = Hamt::load(&c, &store).unwrap();
@@ -82,7 +82,7 @@ fn delete() {
     );
 
     let mut h2 = Hamt::<_, ByteBuf>::load(&c, &store).unwrap();
-    assert_eq!(h2.delete(&b"foo".to_vec()).unwrap(), true);
+    assert!(h2.delete(&b"foo".to_vec()).unwrap().is_some());
     assert_eq!(h2.get(&b"foo".to_vec()).unwrap(), None);
 
     let c2 = h2.flush().unwrap();
@@ -142,11 +142,14 @@ fn set_delete_many() {
     );
 
     for i in 200..400 {
-        assert_eq!(hamt.delete(&format!("{}", i).into_bytes()).unwrap(), true);
+        assert!(hamt
+            .delete(&format!("{}", i).into_bytes())
+            .unwrap()
+            .is_some());
     }
     // Ensure first 200 keys still exist
     for i in 0..200 {
-        assert_eq!(hamt.get(&format!("{}", i).into_bytes()).unwrap(), Some(i));
+        assert_eq!(hamt.get(&format!("{}", i).into_bytes()).unwrap(), Some(&i));
     }
 
     let cid_d = hamt.flush().unwrap();
@@ -187,7 +190,7 @@ fn add_and_remove_keys(
         Hamt::load_with_bit_width(&cid, &store, bit_width).unwrap();
 
     for (k, v) in all {
-        assert_eq!(Some(v), h1.get(&k).unwrap());
+        assert_eq!(Some(&v), h1.get(&k).unwrap());
     }
 
     // Set and delete extra keys

--- a/vm/actor/src/builtin/init/state.rs
+++ b/vm/actor/src/builtin/init/state.rs
@@ -66,7 +66,7 @@ impl State {
 
         let map = make_map_with_root(&self.address_map, store)?;
 
-        Ok(map.get(&addr.to_bytes())?.map(Address::new_id))
+        Ok(map.get(&addr.to_bytes())?.copied().map(Address::new_id))
     }
 }
 

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -770,8 +770,7 @@ impl Actor {
                             return Err(actor_error!(ErrIllegalState;
                                         "failed to delete deal proposal: does not exist"));
                         }
-                        let deleted = msm
-                            .pending_deals
+                        msm.pending_deals
                             .as_mut()
                             .unwrap()
                             .delete(&dcid.to_bytes())
@@ -780,17 +779,18 @@ impl Actor {
                                     ExitCode::ErrIllegalState,
                                     "failed to delete pending proposal",
                                 )
+                            })?
+                            .ok_or_else(|| {
+                                actor_error!(
+                                    ErrIllegalState,
+                                    "failed to delete pending proposal: does not exist"
+                                )
                             })?;
-                        if !deleted {
-                            return Err(actor_error!(ErrIllegalState;
-                                            "failed to delete pending proposal: does not exist"));
-                        }
                     }
                     let mut state = state.unwrap();
 
                     if state.last_updated_epoch == EPOCH_UNDEFINED {
-                        let deleted = msm
-                            .pending_deals
+                        msm.pending_deals
                             .as_mut()
                             .unwrap()
                             .delete(&dcid.to_bytes())
@@ -799,11 +799,13 @@ impl Actor {
                                     ExitCode::ErrIllegalState,
                                     "failed to delete pending proposal",
                                 )
+                            })?
+                            .ok_or_else(|| {
+                                actor_error!(
+                                    ErrIllegalState,
+                                    "failed to delete pending proposal: does not exist"
+                                )
                             })?;
-                        if !deleted {
-                            return Err(actor_error!(ErrIllegalState;
-                                    "failed to delete pending proposal: does not exist"));
-                        }
                     }
 
                     let (slash_amount, next_epoch, remove_deal) =

--- a/vm/actor/src/builtin/market/state.rs
+++ b/vm/actor/src/builtin/market/state.rs
@@ -511,7 +511,7 @@ where
             e.downcast_default(ExitCode::ErrIllegalState, "failed to get escrow balance")
         })?;
 
-        if &prev_locked + amount > escrow_balance {
+        if prev_locked + amount > *escrow_balance {
             return Err(actor_error!(ErrInsufficientFunds;
                     "not enough balance to lock for addr{}: \
                     escrow balance {} < prev locked {} + amount {}", 

--- a/vm/actor/src/builtin/miner/state.rs
+++ b/vm/actor/src/builtin/miner/state.rs
@@ -254,7 +254,7 @@ impl State {
         sector_num: SectorNumber,
     ) -> Result<Option<SectorPreCommitOnChainInfo>, HamtError> {
         let precommitted = make_map_with_root(&self.pre_committed_sectors, store)?;
-        precommitted.get(&u64_key(sector_num))
+        Ok(precommitted.get(&u64_key(sector_num))?.cloned())
     }
 
     /// Gets and returns the requested pre-committed sectors, skipping missing sectors.
@@ -263,7 +263,10 @@ impl State {
         store: &BS,
         sector_numbers: &[SectorNumber],
     ) -> Result<Vec<SectorPreCommitOnChainInfo>, Box<dyn StdError>> {
-        let precommitted = make_map_with_root(&self.pre_committed_sectors, store)?;
+        let precommitted = make_map_with_root::<_, SectorPreCommitOnChainInfo>(
+            &self.pre_committed_sectors,
+            store,
+        )?;
         let mut result = Vec::with_capacity(sector_numbers.len());
 
         for &sector_number in sector_numbers {
@@ -273,7 +276,7 @@ impl State {
                     sector_number
                 ))
             })? {
-                Some(info) => info,
+                Some(info) => info.clone(),
                 None => continue,
             };
 

--- a/vm/actor/src/builtin/power/state.rs
+++ b/vm/actor/src/builtin/power/state.rs
@@ -232,10 +232,10 @@ pub(super) fn load_cron_events<BS: BlockStore>(
 }
 
 /// Gets claim from claims map by address
-pub fn get_claim<BS: BlockStore>(
-    claims: &Map<BS, Claim>,
+pub fn get_claim<'m, BS: BlockStore>(
+    claims: &'m Map<BS, Claim>,
     a: &Address,
-) -> Result<Option<Claim>, Box<dyn StdError>> {
+) -> Result<Option<&'m Claim>, Box<dyn StdError>> {
     Ok(claims
         .get(&a.to_bytes())
         .map_err(|e| e.downcast_wrap(format!("failed to get claim for address {}", a)))?)

--- a/vm/actor/tests/balance_table_test.rs
+++ b/vm/actor/tests/balance_table_test.rs
@@ -15,10 +15,10 @@ fn add_create() {
     assert_eq!(bt.has(&addr).unwrap(), false);
 
     bt.add_create(&addr, TokenAmount::from(10u8)).unwrap();
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(10u8));
+    assert_eq!(bt.get(&addr).unwrap(), &TokenAmount::from(10u8));
 
     bt.add_create(&addr, TokenAmount::from(20u8)).unwrap();
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(30u8));
+    assert_eq!(bt.get(&addr).unwrap(), &TokenAmount::from(30u8));
 }
 
 // Ported test from specs-actors
@@ -73,14 +73,14 @@ fn balance_subtracts() {
     let mut bt = BalanceTable::new(&store);
 
     bt.set(&addr, TokenAmount::from(80u8)).unwrap();
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(80u8));
+    assert_eq!(bt.get(&addr).unwrap(), &TokenAmount::from(80u8));
     // Test subtracting past minimum only subtracts correct amount
     assert_eq!(
         bt.subtract_with_minimum(&addr, &TokenAmount::from(20u8), &TokenAmount::from(70u8))
             .unwrap(),
         TokenAmount::from(10u8)
     );
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(70u8));
+    assert_eq!(bt.get(&addr).unwrap(), &TokenAmount::from(70u8));
 
     // Test subtracting to limit
     assert_eq!(
@@ -88,24 +88,12 @@ fn balance_subtracts() {
             .unwrap(),
         TokenAmount::from(10u8)
     );
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(60u8));
+    assert_eq!(bt.get(&addr).unwrap(), &TokenAmount::from(60u8));
 
     // Test must subtract success
     bt.must_subtract(&addr, &TokenAmount::from(10u8)).unwrap();
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(50u8));
+    assert_eq!(bt.get(&addr).unwrap(), &TokenAmount::from(50u8));
 
     // Test subtracting more than available
     assert!(bt.must_subtract(&addr, &TokenAmount::from(100u8)).is_err());
-}
-
-#[test]
-fn remove() {
-    let addr = Address::new_id(100);
-    let store = db::MemoryDB::default();
-    let mut bt = BalanceTable::new(&store);
-
-    bt.set(&addr, TokenAmount::from(1u8)).unwrap();
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(1u8));
-    bt.remove(&addr).unwrap();
-    assert!(bt.get(&addr).is_err());
 }

--- a/vm/actor/tests/market_actor_test.rs
+++ b/vm/actor/tests/market_actor_test.rs
@@ -47,7 +47,7 @@ fn get_escrow_balance(rt: &MockRuntime, addr: &Address) -> Result<TokenAmount, A
 
     let et = BalanceTable::from_root(rt.store(), &st.escrow_table).unwrap();
 
-    Ok(et.get(addr).unwrap())
+    Ok(et.get(addr).unwrap().clone())
 }
 
 // TODO add array stuff

--- a/vm/state_tree/src/lib.rs
+++ b/vm/state_tree/src/lib.rs
@@ -130,8 +130,8 @@ impl StateSnapshots {
 
     fn get_actor(&self, addr: &Address) -> Option<ActorState> {
         for layer in self.layers.iter().rev() {
-            if let Some(state) = layer.actors.read().get(addr).cloned() {
-                return state;
+            if let Some(state) = layer.actors.read().get(addr) {
+                return state.clone();
             }
         }
 
@@ -209,7 +209,7 @@ where
         }
 
         // if state doesn't exist, find using hamt
-        let act = self.hamt.get(&addr.to_bytes())?;
+        let act = self.hamt.get(&addr.to_bytes())?.cloned();
 
         // Update cache if state was found
         if let Some(act_s) = &act {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Adds cache to Hamt, similar to one added with #716 
- Removes murmur3 support
  - No need for it anymore
- Update serialization tests for sha hashing, and include blockstore vectors (testing against https://github.com/austinabell/go-hamt-ipld/commit/5ee4d42b45677cd62386b60428fd56d5746141aa)
  - Our reads and writes are a LOT lower than the go impl, but we will have to match with #729 (splitting up to make it easier to revert if needed in future)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #719 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->