### PR TITLE
Fix base fee in conformance, bump versions and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "interpreter",
  "ipld_blockstore",
  "lazy_static",
+ "log",
  "pretty_env_logger",
  "regex",
  "runtime",

--- a/tests/conformance_tests/Cargo.toml
+++ b/tests/conformance_tests/Cargo.toml
@@ -57,3 +57,4 @@ forest_car = { path = "../../ipld/car" }
 flate2 = "1.0"
 lazy_static = "1.4"
 pretty_env_logger = "0.4.0"
+log = "0.4"

--- a/tests/conformance_tests/src/lib.rs
+++ b/tests/conformance_tests/src/lib.rs
@@ -26,8 +26,6 @@ use serde::{Deserialize, Deserializer};
 use std::error::Error as StdError;
 use vm::{ExitCode, Serialized};
 
-const BASE_FEE: u64 = 100;
-
 mod base64_bytes {
     use super::*;
     use serde::de;
@@ -113,6 +111,8 @@ pub struct MetaData {
 pub struct PreConditions {
     pub epoch: ChainEpoch,
     pub state_tree: StateTreeVector,
+    #[serde(default)]
+    pub basefee: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/tests/conformance_tests/src/message.rs
+++ b/tests/conformance_tests/src/message.rs
@@ -17,6 +17,7 @@ pub fn execute_message(
     msg: &ChainMessage,
     pre_root: &Cid,
     epoch: ChainEpoch,
+    basefee: u64,
     selector: &Option<Selector>,
 ) -> Result<(ApplyRet, Cid), Box<dyn StdError>> {
     let mut vm = VM::<_, _, _>::new(
@@ -25,7 +26,7 @@ pub fn execute_message(
         epoch,
         TestSyscalls,
         &TestRand,
-        TokenAmount::from(BASE_FEE),
+        TokenAmount::from(basefee),
     )?;
 
     if let Some(s) = &selector {

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -19,10 +19,12 @@ use std::io::BufReader;
 use std::sync::Arc;
 use walkdir::{DirEntry, WalkDir};
 
+const DEFAULT_BASE_FEE: u64 = 100;
+
 lazy_static! {
     static ref SKIP_TESTS: Vec<Regex> = vec![
-        Regex::new(r"test-vectors/corpus/vm_violations/x--*").unwrap(),
-        Regex::new(r"test-vectors/corpus/nested/x--*").unwrap(),
+        Regex::new(r"test-vectors/corpus/vm_violations/x--").unwrap(),
+        Regex::new(r"test-vectors/corpus/nested/x--").unwrap(),
         // These tests are marked as invalid as they return wrong exit code on Lotus
         Regex::new(r"actor_creation/x--params*").unwrap(),
         // Following two fail for the same invalid exit code return
@@ -37,71 +39,33 @@ lazy_static! {
         Regex::new(r"test-vectors/corpus/vm_violations/x--state_mutation--after-transaction.json").unwrap(),
         Regex::new(r"test-vectors/corpus/vm_violations/x--state_mutation--readonly.json").unwrap(),
 
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storagemarket/AddBalance/Ok/ext-0001-fil_1_storagemarket-AddBalance-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/AddLockedFund/Ok/ext-0001-fil_1_storageminer-AddLockedFund-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ChangeMultiaddrs/Ok/ext-0001-fil_1_storageminer-ChangeMultiaddrs-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ChangePeerID/Ok/ext-0001-fil_1_storageminer-ChangePeerID-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ChangeWorkerAddress/Ok/ext-0001-fil_1_storageminer-ChangeWorkerAddress-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/DeclareFaults/16/ext-0001-fil_1_storageminer-DeclareFaults-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/DeclareFaultsRecovered/Ok/ext-0001-fil_1_storageminer-DeclareFaultsRecovered-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/16/ext-0001-fil_1_storageminer-PreCommitSector-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/SysErrInsufficientFunds/ext-0001-fil_1_storageminer-PreCommitSector-SysErrInsufficientFunds-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-PreCommitSector-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrInsufficientFunds/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrInsufficientFunds-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/Send/Ok/ext-0001-fil_1_storageminer-Send-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/Send/SysErrInsufficientFunds/ext-0001-fil_1_storageminer-Send-SysErrInsufficientFunds-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/WithdrawBalance/Ok/ext-0001-fil_1_storageminer-WithdrawBalance-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storagepower/CreateMiner/Ok/extracted-msg-0001-fil_1_storagepower-CreateMiner-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0002-init-actor/fil_1_init/Exec/Ok/ext-0002-fil_1_init-Exec-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0003-sends-to-sysactors/fil_1_reward/Send/Ok/ext-0003-fil_1_reward-Send-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0003-sends-to-sysactors/fil_1_storagemarket/Send/Ok/ext-0003-fil_1_storagemarket-Send-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/AddBalance/Ok/extracted-msg-fil_1_storagemarket-AddBalance-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/AddBalance/SysErrInsufficientFunds/extracted-msg-fil_1_storagemarket-AddBalance-SysErrInsufficientFunds-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/16/extracted-msg-fil_1_storagemarket-PublishStorageDeals-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/extracted-msg-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/AddLockedFund/19/extracted-msg-fil_1_storageminer-AddLockedFund-19-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ChangeMultiaddrs/Ok/extracted-msg-fil_1_storageminer-ChangeMultiaddrs-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ChangePeerID/Ok/extracted-msg-fil_1_storageminer-ChangePeerID-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ChangeWorkerAddress/Ok/extracted-msg-fil_1_storageminer-ChangeWorkerAddress-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/DeclareFaults/16/extracted-msg-fil_1_storageminer-DeclareFaults-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/DeclareFaultsRecovered/Ok/extracted-msg-fil_1_storageminer-DeclareFaultsRecovered-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/DeclareFaultsRecovered/SysErrOutOfGas/extracted-msg-fil_1_storageminer-DeclareFaultsRecovered-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/16/extracted-msg-fil_1_storageminer-PreCommitSector-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/17/extracted-msg-fil_1_storageminer-PreCommitSector-17-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/18/extracted-msg-fil_1_storageminer-PreCommitSector-18-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/19/extracted-msg-fil_1_storageminer-PreCommitSector-19-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/Ok/extracted-msg-fil_1_storageminer-PreCommitSector-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/SysErrInsufficientFunds/extracted-msg-fil_1_storageminer-PreCommitSector-SysErrInsufficientFunds-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/PreCommitSector/SysErrOutOfGas/extracted-msg-fil_1_storageminer-PreCommitSector-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/16/extracted-msg-fil_1_storageminer-ProveCommitSector-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/17/extracted-msg-fil_1_storageminer-ProveCommitSector-17-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/18/extracted-msg-fil_1_storageminer-ProveCommitSector-18-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/19/extracted-msg-fil_1_storageminer-ProveCommitSector-19-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/extracted-msg-fil_1_storageminer-ProveCommitSector-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrInsufficientFunds/extracted-msg-fil_1_storageminer-ProveCommitSector-SysErrInsufficientFunds-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/extracted-msg-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/Send/Ok/extracted-msg-fil_1_storageminer-Send-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/Send/SysErrInsufficientFunds/extracted-msg-fil_1_storageminer-Send-SysErrInsufficientFunds-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/16/extracted-msg-fil_1_storageminer-SubmitWindowedPoSt-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrSenderInvalid/extracted-msg-fil_1_storageminer-SubmitWindowedPoSt-SysErrSenderInvalid-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/WithdrawBalance/Ok/extracted-msg-fil_1_storageminer-WithdrawBalance-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/WithdrawBalance/SysErrOutOfGas/extracted-msg-fil_1_storageminer-WithdrawBalance-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storagepower/CreateMiner/16/extracted-msg-fil_1_storagepower-CreateMiner-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storagepower/CreateMiner/SysErrOutOfGas/extracted-msg-fil_1_storagepower-CreateMiner-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/DeclareFaults/Ok/ext-0001-fil_1_storageminer-DeclareFaults-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/19/ext-0001-fil_1_storageminer-PreCommitSector-19-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_storageminer/PreCommitSector/Ok/ext-0001-fil_1_storageminer-PreCommitSector-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/19/extracted-msg-fil_1_storagemarket-PublishStorageDeals-19-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/AddLockedFund/Ok/extracted-msg-fil_1_storageminer-AddLockedFund-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/DeclareFaultsRecovered/16/extracted-msg-fil_1_storageminer-DeclareFaultsRecovered-16-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storagepower/CreateMiner/Ok/extracted-msg-fil_1_storagepower-CreateMiner-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0001-initial-extraction/fil_1_account/Send/Ok/ext-0001-fil_1_account-Send-Ok-3").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/Send/SysErrOutOfGas/extracted-msg-fil_1_storageminer-Send-SysErrOutOfGas-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/extracted/0004-coverage-boost/fil_1_storageminer/DeclareFaults/Ok/extracted-msg-fil_1_storageminer-DeclareFaults-Ok-*").unwrap(),
-        Regex::new(r"test-vectors/corpus/reward/penalties--not-penalized-insufficient-balance-to-cover-gas-and-transfer.json").unwrap(),
+
+        // Extracted miner faults
+        Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-").unwrap(),
+        Regex::new(r"fil_1_storageminer-ProveCommitSector-Ok-").unwrap(),
+        Regex::new(r"fil_1_storageminer-ProveCommitSector-16").unwrap(),
+        Regex::new(r"fil_1_storageminer-ProveCommitSector-18").unwrap(),
+        Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-Ok-").unwrap(),
+        Regex::new(r"fil_1_storageminer-PreCommitSector-").unwrap(),
+        Regex::new(r"fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-").unwrap(),
+        Regex::new(r"fil_1_storageminer-AddLockedFund-Ok-").unwrap(),
+        Regex::new(r"fil_1_storageminer-SubmitWindowedPoSt-SysErrSenderInvalid-").unwrap(),
+        Regex::new(r"fil_1_storageminer-WithdrawBalance-Ok-").unwrap(),
+        Regex::new(r"fil_1_storageminer-PreCommitSector-SysErrOutOfGas-").unwrap(),
+        Regex::new(r"fil_1_storageminer-ChangePeerID-Ok-").unwrap(),
+        Regex::new(r"fil_1_storageminer-Send-SysErrInsufficientFunds-").unwrap(),
+        Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-SysErrOutOfGas-1").unwrap(),
+        Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-SysErrOutOfGas-2").unwrap(),
+        
+        // Extracted market faults
+        Regex::new(r"fil_1_storagemarket-AddBalance-Ok-").unwrap(),
+        Regex::new(r"fil_1_storagemarket-AddBalance-Ok-6").unwrap(),
+        Regex::new(r"fil_1_storagemarket-PublishStorageDeals-").unwrap(),
+        
+        // Extracted power faults (although all miner related)
+        Regex::new(r"fil_1_storagepower-CreateMiner-16-").unwrap(),
+        Regex::new(r"fil_1_storagepower-CreateMiner-Ok-").unwrap(),
+        Regex::new(r"fil_1_storagepower-CreateMiner-SysErrOutOfGas-").unwrap(),
     ];
 }
 
@@ -193,7 +157,14 @@ fn execute_message_vector(
             epoch = ep;
         }
 
-        let (ret, post_root) = execute_message(&bs, &to_chain_msg(msg), &root, epoch, &selector)?;
+        let (ret, post_root) = execute_message(
+            &bs,
+            &to_chain_msg(msg),
+            &root,
+            epoch,
+            preconditions.basefee.unwrap_or(DEFAULT_BASE_FEE),
+            &selector,
+        )?;
         root = post_root;
 
         let receipt = &postconditions.receipts[i];
@@ -276,7 +247,13 @@ fn conformance_test_runner() {
         let file = File::open(entry.path()).unwrap();
         let reader = BufReader::new(file);
         let test_name = entry.path().display();
-        let vector: TestVector = serde_json::from_reader(reader).unwrap();
+        let vector: TestVector = match serde_json::from_reader(reader) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("Could not deserialize vector: {}", e);
+                continue;
+            }
+        };
 
         match vector {
             TestVector::Message {

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -56,12 +56,12 @@ lazy_static! {
         Regex::new(r"fil_1_storageminer-Send-SysErrInsufficientFunds-").unwrap(),
         Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-SysErrOutOfGas-1").unwrap(),
         Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-SysErrOutOfGas-2").unwrap(),
-        
+
         // Extracted market faults
         Regex::new(r"fil_1_storagemarket-AddBalance-Ok-").unwrap(),
         Regex::new(r"fil_1_storagemarket-AddBalance-Ok-6").unwrap(),
         Regex::new(r"fil_1_storagemarket-PublishStorageDeals-").unwrap(),
-        
+
         // Extracted power faults (although all miner related)
         Regex::new(r"fil_1_storagepower-CreateMiner-16-").unwrap(),
         Regex::new(r"fil_1_storagepower-CreateMiner-Ok-").unwrap(),


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Another discrepancy in the test-vector update, base fee wasn't being used if included in vector
- bumps test vectors version (wanted to debug with more recent, but didn't include the randomness change)
- Organize skips to be more readable

442/589 tests total are passing, but the overlap with skips brings it down lower, but seems like all failures are related

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->