### PR TITLE
Fix miner constructor params and proving period offset calculation

### DIFF
--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -39,6 +39,8 @@ lazy_static! {
         Regex::new(r"test-vectors/corpus/vm_violations/x--state_mutation--after-transaction.json").unwrap(),
         Regex::new(r"test-vectors/corpus/vm_violations/x--state_mutation--readonly.json").unwrap(),
 
+        // Same as marked tests above -- Go impl has the incorrect behaviour
+        Regex::new(r"fil_1_storageminer-SubmitWindowedPoSt-SysErrSenderInvalid-").unwrap(),
 
         // Extracted miner faults
         Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-").unwrap(),
@@ -49,7 +51,6 @@ lazy_static! {
         Regex::new(r"fil_1_storageminer-PreCommitSector-").unwrap(),
         Regex::new(r"fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-").unwrap(),
         Regex::new(r"fil_1_storageminer-AddLockedFund-Ok-").unwrap(),
-        Regex::new(r"fil_1_storageminer-SubmitWindowedPoSt-SysErrSenderInvalid-").unwrap(),
         Regex::new(r"fil_1_storageminer-WithdrawBalance-Ok-").unwrap(),
         Regex::new(r"fil_1_storageminer-PreCommitSector-SysErrOutOfGas-").unwrap(),
         Regex::new(r"fil_1_storageminer-ChangePeerID-Ok-").unwrap(),

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -54,7 +54,7 @@ use crate::{
 };
 use address::{Address, Payload, Protocol};
 use bitfield::BitField;
-use byteorder::{BigEndian, ByteOrder};
+use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 use cid::{multihash::Blake2b256, Cid};
 use clock::ChainEpoch;
 use crypto::DomainSeparationTag::{
@@ -3173,14 +3173,15 @@ fn assign_proving_period_offset(
     blake2b: impl FnOnce(&[u8]) -> Result<[u8; 32], Box<dyn StdError>>,
 ) -> Result<ChainEpoch, Box<dyn StdError>> {
     let mut my_addr = addr.marshal_cbor()?;
-    BigEndian::write_i64(&mut my_addr, current_epoch);
+    my_addr.write_i64::<BigEndian>(current_epoch)?;
 
     let digest = blake2b(&my_addr)?;
 
-    let mut offset: ChainEpoch = BigEndian::read_i64(&digest);
-    offset %= WPOST_PROVING_PERIOD;
+    let mut offset: u64 = BigEndian::read_u64(&digest);
+    offset %= WPOST_PROVING_PERIOD as u64;
 
-    Ok(offset)
+    // Conversion from i64 to u64 is safe because it's % WPOST_PROVING_PERIOD which is i64
+    Ok(offset as ChainEpoch)
 }
 
 /// Computes the epoch at which a proving period should start such that it is greater than the current epoch, and

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -3314,7 +3314,6 @@ impl ActorCode for Actor {
     {
         match FromPrimitive::from_u64(method) {
             Some(Method::Constructor) => {
-                check_empty_params(params)?;
                 Self::constructor(rt, params.deserialize()?)?;
                 Ok(Serialized::default())
             }

--- a/vm/actor/src/builtin/power/mod.rs
+++ b/vm/actor/src/builtin/power/mod.rs
@@ -93,6 +93,15 @@ impl Actor {
         rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
         let value = rt.message().value_received().clone();
 
+        let constructor_params = Serialized::serialize(MinerConstructorParams {
+            owner: params.owner,
+            worker: params.worker,
+            seal_proof_type: params.seal_proof_type,
+            peer_id: params.peer,
+            multi_addresses: params.multiaddrs,
+            control_addresses: Default::default(),
+        })?;
+
         let init::ExecReturn {
             id_address,
             robust_address,
@@ -100,13 +109,9 @@ impl Actor {
             .send(
                 *INIT_ACTOR_ADDR,
                 init::Method::Exec as u64,
-                Serialized::serialize(MinerConstructorParams {
-                    owner: params.owner,
-                    worker: params.worker,
-                    control_addresses: Default::default(),
-                    seal_proof_type: params.seal_proof_type,
-                    peer_id: params.peer.0,
-                    multi_addresses: params.multiaddrs,
+                Serialized::serialize(init::ExecParams {
+                    code_cid: MINER_ACTOR_CODE_ID.clone(),
+                    constructor_params,
                 })?,
                 value,
             )?

--- a/vm/actor/src/builtin/power/types.rs
+++ b/vm/actor/src/builtin/power/types.rs
@@ -4,7 +4,7 @@
 use crate::{smooth::FilterEstimate, DealWeight};
 use address::Address;
 use clock::ChainEpoch;
-use encoding::{tuple::*, BytesDe, Cbor};
+use encoding::{serde_bytes, tuple::*, BytesDe, Cbor};
 use fil_types::{RegisteredSealProof, SectorSize, StoragePower};
 use num_bigint::bigint_ser;
 use vm::{Serialized, TokenAmount};
@@ -23,7 +23,8 @@ pub struct CreateMinerParams {
     pub owner: Address,
     pub worker: Address,
     pub seal_proof_type: RegisteredSealProof,
-    pub peer: BytesDe,
+    #[serde(with = "serde_bytes")]
+    pub peer: Vec<u8>,
     pub multiaddrs: Vec<BytesDe>,
 }
 impl Cbor for CreateMinerParams {}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
Bugs:
- Miner constructor params were not being wrapped in init::ExecParams when calling init exec method
- miner constructor was checking empty params (even though params are deserialized)
- `assign_proving_period_offset` was panicking when writing to the address bytes (because it was attempting to write over the address bytes and would fail if the current length was not enough to write a BE u64 value) so I switched to using the buffer writing variant
- Offset was not read and `%` from a unsigned integer, so values were off when calculating period offset

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->