### PR TITLE
Fix trailing 0s on bitfield serialization

### DIFF
--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -46,8 +46,6 @@ lazy_static! {
         Regex::new(r"test-vectors/corpus/nested/nested_sends--fail-insufficient-funds-for-transfer-in-inner-send.json").unwrap(),
 
         // These 2 tests ignore test cases for Chaos actor that are checked at compile time
-        // Link to discussion https://github.com/ChainSafe/forest/pull/696/files
-        // Maybe should look at fixing to match exit codes
         Regex::new(r"test-vectors/corpus/vm_violations/x--state_mutation--after-transaction.json").unwrap(),
         Regex::new(r"test-vectors/corpus/vm_violations/x--state_mutation--readonly.json").unwrap(),
 
@@ -55,9 +53,9 @@ lazy_static! {
         Regex::new(r"fil_1_storageminer-SubmitWindowedPoSt-SysErrSenderInvalid-").unwrap(),
 
         // Extracted miner faults
-        Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-").unwrap(),
-        Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-Ok-").unwrap(),
-        Regex::new(r"fil_1_storageminer-PreCommitSector-").unwrap(),
+        Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-3").unwrap(),
+        Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-7").unwrap(),
+        Regex::new(r"fil_1_storageminer-PreCommitSector-SysErrOutOfGas").unwrap(),
         Regex::new(r"fil_1_storageminer-AddLockedFund-Ok-").unwrap(),
         Regex::new(r"fil_1_storageminer-WithdrawBalance-Ok-").unwrap(),
         Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-SysErrOutOfGas-1").unwrap(),

--- a/utils/bitfield/src/rleplus/writer.rs
+++ b/utils/bitfield/src/rleplus/writer.rs
@@ -58,8 +58,14 @@ impl BitWriter {
 
     /// Writes any remaining bits to the buffer and returns it.
     pub fn finish(mut self) -> Vec<u8> {
-        if self.num_bits > 0 {
+        if self.bits > 0 {
             self.bytes.push(self.bits as u8);
+        }
+
+        // This check should not be necessary, but as a sanity check to make sure 0 bytes
+        // aren't added at the end of the bytes
+        while let Some(0) = self.bytes.last() {
+            self.bytes.pop();
         }
         self.bytes
     }

--- a/utils/bitfield/src/rleplus/writer.rs
+++ b/utils/bitfield/src/rleplus/writer.rs
@@ -81,13 +81,12 @@ mod tests {
         let empty_vec: Vec<u8> = Vec::new();
         assert_eq!(writer.clone().finish(), empty_vec);
 
+        // Trailing 0 bits are not included
         writer.write(0b0000_0000, 4);
-        assert_eq!(writer.clone().finish(), &[0b0000_0000]);
-        //                                           ^^^^
+        assert_eq!(writer.clone().finish(), &[] as &[u8]);
 
         writer.write(0b0000_0000, 4);
-        assert_eq!(writer.clone().finish(), &[0b0000_0000]);
-        //                                      ^^^^
+        assert_eq!(writer.clone().finish(), &[] as &[u8]);
 
         writer.write(0b0000_0001, 4);
         assert_eq!(writer.clone().finish(), &[0b0000_0000, 0b0000_0001]);
@@ -104,10 +103,7 @@ mod tests {
         ); //                ^^                   ^
 
         writer.write(0b0111_0100, 8);
-        assert_eq!(
-            writer.finish(),
-            &[0b0000_0000, 0b1011_0001, 0b1110_1001, 0b0000_0000]
-        ); //                             ^^^^ ^^^             ^
+        assert_eq!(writer.finish(), &[0b0000_0000, 0b1011_0001, 0b1110_1001]); //                                                         ^^^^ ^^^
     }
 
     #[test]
@@ -142,8 +138,6 @@ mod tests {
                 //^^^^ ^
                 0b0011_0010,
                 //^^^^ ^^^^
-                0b0000_0000,
-                //   ^ ^^^^
             ]
         );
     }

--- a/utils/bitfield/src/rleplus/writer.rs
+++ b/utils/bitfield/src/rleplus/writer.rs
@@ -103,7 +103,8 @@ mod tests {
         ); //                ^^                   ^
 
         writer.write(0b0111_0100, 8);
-        assert_eq!(writer.finish(), &[0b0000_0000, 0b1011_0001, 0b1110_1001]); //                                                         ^^^^ ^^^
+        assert_eq!(writer.finish(), &[0b0000_0000, 0b1011_0001, 0b1110_1001]);
+        //                                                        ^^^^ ^^^
     }
 
     #[test]

--- a/utils/bitfield/tests/bitfield_tests.rs
+++ b/utils/bitfield/tests/bitfield_tests.rs
@@ -201,7 +201,7 @@ fn bit_vec_unset_vector() {
 
     // Test cbor marshal and unmarshal
     let cbor_bz = encoding::to_vec(&bf).unwrap();
-    assert_eq!(&cbor_bz, &[0x43, 0xa8, 0x54, 0x00]);
+    assert_eq!(&cbor_bz, &[0x42, 0xa8, 0x54]);
 
     let deserialized: BitField = encoding::from_slice(&cbor_bz).unwrap();
     assert_eq!(deserialized.len(), 4);

--- a/vm/interpreter/src/gas_tracker/mod.rs
+++ b/vm/interpreter/src/gas_tracker/mod.rs
@@ -24,6 +24,7 @@ impl GasTracker {
     /// Safely consumes gas
     pub fn charge_gas(&mut self, charge: GasCharge) -> Result<(), ActorError> {
         let to_use = charge.total();
+        // println!("{} {} {}", charge.name, to_use, self.gas_used);
         if self.gas_used + to_use > self.gas_available {
             self.gas_used = self.gas_available;
             Err(actor_error!(SysErrOutOfGas;

--- a/vm/interpreter/src/gas_tracker/mod.rs
+++ b/vm/interpreter/src/gas_tracker/mod.rs
@@ -24,7 +24,6 @@ impl GasTracker {
     /// Safely consumes gas
     pub fn charge_gas(&mut self, charge: GasCharge) -> Result<(), ActorError> {
         let to_use = charge.total();
-        // println!("{} {} {}", charge.name, to_use, self.gas_used);
         if self.gas_used + to_use > self.gas_available {
             self.gas_used = self.gas_available;
             Err(actor_error!(SysErrOutOfGas;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Trailing 0 was being added to end of serialized bytes in an edge case
  - Also added a loop to remove any other 0 bytes because @timvermeulen suggested that it may be possible for this to happen

538/592

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->