### PR TITLE
Fix blockstore get gas charge

### DIFF
--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -6,7 +6,7 @@
 use super::BlockStore;
 use cid::{multihash::MultihashDigest, Cid, Codec};
 use db::{Error, Store};
-use encoding::{from_slice, ser::Serialize, to_vec};
+use encoding::from_slice;
 use forest_ipld::Ipld;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -113,14 +113,12 @@ where
         self.base.get_bytes(cid)
     }
 
-    fn put<S, T>(&self, obj: &S, hash: T) -> Result<Cid, Box<dyn StdError>>
+    fn put_raw<T>(&self, bytes: Vec<u8>, hash: T) -> Result<Cid, Box<dyn StdError>>
     where
-        S: Serialize,
         T: MultihashDigest,
     {
-        let bz = to_vec(obj)?;
-        let cid = Cid::new_from_cbor(&bz, hash);
-        self.write.borrow_mut().insert(cid.clone(), bz);
+        let cid = Cid::new_from_cbor(&bytes, hash);
+        self.write.borrow_mut().insert(cid.clone(), bytes);
         Ok(cid)
     }
 }

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -24,12 +24,12 @@ use db::{RocksDb, WriteBatch};
 
 /// Wrapper for database to handle inserting and retrieving ipld data with Cids
 pub trait BlockStore: Store {
-    /// Get bytes from block store by Cid
+    /// Get bytes from block store by Cid.
     fn get_bytes(&self, cid: &Cid) -> Result<Option<Vec<u8>>, Box<dyn StdError>> {
         Ok(self.read(cid.to_bytes())?)
     }
 
-    /// Get typed object from block store by Cid
+    /// Get typed object from block store by Cid.
     fn get<T>(&self, cid: &Cid) -> Result<Option<T>, Box<dyn StdError>>
     where
         T: DeserializeOwned,
@@ -40,15 +40,23 @@ pub trait BlockStore: Store {
         }
     }
 
-    /// Put an object in the block store and return the Cid identifier
+    /// Put an object in the block store and return the Cid identifier.
     fn put<S, T>(&self, obj: &S, hash: T) -> Result<Cid, Box<dyn StdError>>
     where
         S: Serialize,
         T: MultihashDigest,
     {
-        let bz = to_vec(obj)?;
-        let cid = Cid::new_from_cbor(&bz, hash);
-        self.write(cid.to_bytes(), bz)?;
+        let bytes = to_vec(obj)?;
+        self.put_raw(&bytes, hash)
+    }
+
+    /// Put raw bytes in the block store and return the Cid identifier.
+    fn put_raw<T>(&self, bytes: &[u8], hash: T) -> Result<Cid, Box<dyn StdError>>
+    where
+        T: MultihashDigest,
+    {
+        let cid = Cid::new_from_cbor(&bytes, hash);
+        self.write(cid.to_bytes(), bytes)?;
         Ok(cid)
     }
 

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -47,11 +47,11 @@ pub trait BlockStore: Store {
         T: MultihashDigest,
     {
         let bytes = to_vec(obj)?;
-        self.put_raw(&bytes, hash)
+        self.put_raw(bytes, hash)
     }
 
     /// Put raw bytes in the block store and return the Cid identifier.
-    fn put_raw<T>(&self, bytes: &[u8], hash: T) -> Result<Cid, Box<dyn StdError>>
+    fn put_raw<T>(&self, bytes: Vec<u8>, hash: T) -> Result<Cid, Box<dyn StdError>>
     where
         T: MultihashDigest,
     {

--- a/ipld/blockstore/src/tracking.rs
+++ b/ipld/blockstore/src/tracking.rs
@@ -6,7 +6,6 @@
 use super::BlockStore;
 use cid::{multihash::MultihashDigest, Cid};
 use db::{Error, Store};
-use encoding::{ser::Serialize, to_vec};
 use std::cell::RefCell;
 use std::error::Error as StdError;
 

--- a/ipld/blockstore/src/tracking.rs
+++ b/ipld/blockstore/src/tracking.rs
@@ -55,12 +55,10 @@ where
         Ok(bytes)
     }
 
-    fn put<S, T>(&self, obj: &S, hash: T) -> Result<Cid, Box<dyn StdError>>
+    fn put_raw<T>(&self, bytes: Vec<u8>, hash: T) -> Result<Cid, Box<dyn StdError>>
     where
-        S: Serialize,
         T: MultihashDigest,
     {
-        let bytes = to_vec(obj)?;
         self.stats.borrow_mut().w += 1;
         self.stats.borrow_mut().bw += bytes.len();
         let cid = Cid::new_from_cbor(&bytes, hash);

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -55,9 +55,6 @@ lazy_static! {
         // Extracted miner faults
         Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-3").unwrap(),
         Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-7").unwrap(),
-        Regex::new(r"fil_1_storageminer-PreCommitSector-SysErrOutOfGas").unwrap(),
-        Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-SysErrOutOfGas-1").unwrap(),
-        Regex::new(r"fil_1_storageminer-DeclareFaultsRecovered-SysErrOutOfGas-2").unwrap(),
 
         // Extracted market faults
         Regex::new(r"fil_1_storagemarket-PublishStorageDeals-").unwrap(),

--- a/vm/interpreter/src/gas_block_store.rs
+++ b/vm/interpreter/src/gas_block_store.rs
@@ -4,7 +4,7 @@
 use super::gas_tracker::{GasTracker, PriceList};
 use cid::{multihash::MultihashDigest, Cid};
 use db::{Error, Store};
-use forest_encoding::{de::DeserializeOwned, from_slice, ser::Serialize, to_vec};
+use forest_encoding::{de::DeserializeOwned, ser::Serialize, to_vec};
 use ipld_blockstore::BlockStore;
 use std::cell::RefCell;
 use std::error::Error as StdError;
@@ -22,30 +22,16 @@ impl<BS> BlockStore for GasBlockStore<'_, BS>
 where
     BS: BlockStore,
 {
-    /// Get bytes from block store by Cid
-    fn get_bytes(&self, cid: &Cid) -> Result<Option<Vec<u8>>, Box<dyn StdError>> {
-        self.gas
-            .borrow_mut()
-            .charge_gas(self.price_list.on_ipld_get())?;
-        let ret = self
-            .store
-            .get_bytes(cid)
-            .map_err(|e| actor_error!(fatal("failed to get block from blockstore: {}", e)))?;
-        Ok(ret)
-    }
-
-    /// Get typed object from block store by Cid
     fn get<T>(&self, cid: &Cid) -> Result<Option<T>, Box<dyn StdError>>
     where
         T: DeserializeOwned,
     {
-        match self.get_bytes(cid)? {
-            Some(bz) => Ok(Some(from_slice(&bz)?)),
-            None => Ok(None),
-        }
+        self.gas
+            .borrow_mut()
+            .charge_gas(self.price_list.on_ipld_get())?;
+        self.store.get(cid)
     }
 
-    /// Put an object in the block store and return the Cid identifier
     fn put<S, T>(&self, obj: &S, hash: T) -> Result<Cid, Box<dyn StdError>>
     where
         S: Serialize,

--- a/vm/interpreter/src/gas_block_store.rs
+++ b/vm/interpreter/src/gas_block_store.rs
@@ -41,7 +41,7 @@ where
             .borrow_mut()
             .charge_gas(self.price_list.on_ipld_put(bytes.len()))?;
 
-        Ok(self.store.put_raw(&bytes, hash)?)
+        Ok(self.store.put_raw(bytes, hash)?)
     }
 }
 

--- a/vm/interpreter/src/gas_tracker/price_list.rs
+++ b/vm/interpreter/src/gas_tracker/price_list.rs
@@ -186,7 +186,7 @@ impl PriceList {
     }
     /// Returns the gas required for storing an object
     #[inline]
-    pub fn on_ipld_get(&self, _: usize) -> GasCharge {
+    pub fn on_ipld_get(&self) -> GasCharge {
         GasCharge::new("on_ipld_get", self.ipld_get_base, 0)
     }
     /// Returns the gas required for storing an object


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Gas charge for get used to be after the data was retrieved (because it included bytes written) which has changed. Thanks to how the extracted vectors are setup, this was caught (could have been a diff if an error was hit in the read)

577/592

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->