### PR TITLE
Remove protoc dependency and update README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,15 +56,16 @@ commands:
                 curl file gcc g++ git make openssh-client \
                 autoconf automake cmake libtool libcurl4-openssl-dev libssl-dev \
                 libelf-dev libdw-dev binutils-dev zlib1g-dev libiberty-dev wget \
-                xz-utils pkg-config python clang ocl-icd-opencl-dev libgflags-dev
+                xz-utils pkg-config python clang ocl-icd-opencl-dev libgflags-dev libhwloc-dev
             rustup component add clippy rustfmt
             git submodule update --init
-            PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip
-            curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
-            sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
-            sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
-            rm -f $PROTOC_ZIP
-            sudo apt-get install -y libhwloc-dev
+
+          # TODO enable when protoc used again
+          # PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip
+          # curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
+          # sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+          # sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
+          # rm -f $PROTOC_ZIP
   save_cargo_package_cache:
     description: Save cargo package cache for subsequent jobs
     steps:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -23,10 +23,11 @@ jobs:
             sudo apt install ocl-icd-opencl-dev
             sudo apt-get install -y libhwloc-dev
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: "3.9.1"
+      # TODO enable when protoc needed again
+      # - name: Install Protoc
+      #   uses: arduino/setup-protoc@master
+      #   with:
+      #     version: "3.9.1"
 
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
@@ -81,10 +82,10 @@ jobs:
       - name: Install OpenCL
         run: sudo apt install ocl-icd-opencl-dev
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: "3.9.1"
+      # - name: Install Protoc
+      #   uses: arduino/setup-protoc@master
+      #   with:
+      #     version: "3.9.1"
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -124,10 +125,10 @@ jobs:
       - name: Install OpenCL
         run: sudo apt install ocl-icd-opencl-dev
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: "3.9.1"
+      # - name: Install Protoc
+      #   uses: arduino/setup-protoc@master
+      #   with:
+      #     version: "3.9.1"
 
       - name: Build documentation
         run: cargo doc --no-deps --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,6 @@ dependencies = [
  "forest_encoding",
  "forest_json_utils",
  "hex",
- "protoc-rust-grpc",
  "serde",
  "serde_json",
  "sha2 0.9.1",
@@ -608,7 +607,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "which 3.1.1",
+ "which",
 ]
 
 [[package]]
@@ -2120,7 +2119,7 @@ dependencies = [
  "forest_car",
  "forest_cid",
  "forest_libp2p",
- "futures 0.3.5",
+ "futures 0.3.6",
  "genesis",
  "hex",
  "ipld_blockstore",
@@ -2674,32 +2673,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphsync"
-version = "0.1.0"
-dependencies = [
- "async-std",
- "async-trait",
- "bytes",
- "fnv",
- "forest_cid",
- "forest_encoding",
- "forest_ipld",
- "futures 0.3.5",
- "futures-util",
- "futures_codec",
- "ipld_blockstore",
- "libp2p",
- "log",
- "multihash 0.10.1",
- "protobuf",
- "protoc-rust",
- "rand 0.7.3",
- "serde",
- "smallvec",
- "unsigned-varint 0.5.1",
-]
-
-[[package]]
 name = "groupy"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,16 +2682,6 @@ dependencies = [
  "rand 0.7.3",
  "rand_xorshift",
  "thiserror",
-]
-
-[[package]]
-name = "grpc-compiler"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2861b7dc0787cf7804c986da795827e7f73f72353677525bb83c2b5332b1ee"
-dependencies = [
- "protobuf",
- "protobuf-codegen",
 ]
 
 [[package]]
@@ -4691,7 +4654,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 3.1.1",
+ "which",
 ]
 
 [[package]]
@@ -4715,56 +4678,6 @@ checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
  "bytes",
  "prost",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d147edb77bcccbfc81fabffdc7bd50c13e103b15ca1e27515fe40de69a5776b"
-
-[[package]]
-name = "protobuf-codegen"
-version = "2.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e81f70c25aab9506f87253c55f7cdcd8917635d5597382958d20025c211bbbd"
-dependencies = [
- "protobuf",
-]
-
-[[package]]
-name = "protoc"
-version = "2.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57408af2c106a7f08cc61e15be6a31e3ace8ea26f90dd1be1ad19abf1073d36a"
-dependencies = [
- "log",
- "which 4.0.2",
-]
-
-[[package]]
-name = "protoc-rust"
-version = "2.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c1582ff3efeccef1385b1c2dfaf4a9b5bc7794865624fc2a3ca9dff1145fa1"
-dependencies = [
- "protobuf",
- "protobuf-codegen",
- "protoc",
- "tempfile",
-]
-
-[[package]]
-name = "protoc-rust-grpc"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77ca3fdfd93c9d20aa208aee8bbdea7a5559b24ec8cb3a057a484faa2f963ff"
-dependencies = [
- "grpc-compiler",
- "protobuf",
- "protoc",
- "protoc-rust",
- "tempdir",
 ]
 
 [[package]]
@@ -6739,16 +6652,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "which"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
-dependencies = [
- "libc",
- "thiserror",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make install
 forest
 ```
 
-> `protoc` and `OpenCL` are also required to build. Installation for protoc can be found [here](http://google.github.io/proto-lens/installing-protoc.html).
+> `OpenCL`, `hwloc` and a compatible assembly linker (ex. `clang`) are also required to build Filecoin proofs.
 
 ### Config
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </p>
 
 
-![](https://github.com/ChainSafe/forest/workflows/Rust%20CI/badge.svg?event=push&branch=main)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/Q6A3YA2)
-[![](https://img.shields.io/twitter/follow/espadrine.svg?label=Follow&style=social)](https://twitter.com/chainsafeth)
+[<img alt="build status" src="https://img.shields.io/github/workflow/status/ChainSafe/forest/Rust%20CI/main?style=for-the-badge" height="20">](https://github.com/dtolnay/serde-repr/actions?query=branch%3Amaster)
+[<img alt="Apache License" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" height="20">](https://opensource.org/licenses/Apache-2.0)
+[<img alt="MIT License" src="https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge" height="20">](https://opensource.org/licenses/MIT)
+[<img alt="Discord" src="https://img.shields.io/discord/593655374469660673.svg?style=for-the-badge&label=Discord&logo=discord" height="20">](https://discord.gg/Q6A3YA2)
+[<img alt="Twitter" src="https://img.shields.io/twitter/follow/espadrine.svg?style=for-the-badge&label=Twitter&color=1DA1F2" height="20">](https://twitter.com/chainsafeth)
 
 
 Forest is an implementation of [Filecoin](https://filecoin.io/) written in Rust. The implementation will take a modular approach to building a full Filecoin node in two parts — (i) building Filecoin’s security critical systems in Rust from the [Filecoin Protocol Specification](https://filecoin-project.github.io/specs/), specifically the virtual machine, blockchain, and node system, and (ii) integrating functional components for storage mining and storage & retrieval markets to compose a fully functional Filecoin node implementation.
@@ -23,7 +23,7 @@ Our crates:
 | `encoding` | Forest encoding and decoding |
 | `ipld` | IPLD data model for content-addressable data |
 | `node` | Networking synchronization and storage |
-| `vm` | State transition and actor, message and address definitions |
+| `vm` | State transition and actors, message and address definitions |
 
 ## Dependencies
 rustc >= 1.40.0

--- a/blockchain/beacon/Cargo.toml
+++ b/blockchain/beacon/Cargo.toml
@@ -27,8 +27,5 @@ base64 = "0.12.1"
 async-std = { version = "1.6.3", features = ["unstable", "attributes"] }
 serde_json = "1.0"
 
-[build-dependencies]
-protoc-rust-grpc = "0.8"
-
 [features]
 json = ["base64", "forest_json_utils"]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Removes grpc protobuf build dependency (artifact from when drand interface was grpc)
- Updates readme to list updated build dependencies
  - Updates badges too https://github.com/ChainSafe/forest/blob/austin/protocrem/README.md



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->