### PR TITLE
Fix Amt iter mut guard

### DIFF
--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -57,7 +57,6 @@ lazy_static! {
         // Extracted miner faults
         Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-3").unwrap(),
         Regex::new(r"fil_1_storageminer-DeclareFaults-Ok-7").unwrap(),
-        Regex::new(r"fil_1_storageminer-SubmitWindowedPoSt").unwrap(),
 
         // Other fault
         Regex::new(r"fail-insufficient-funds-for-transfer-in-inner-send--genesis").unwrap(),

--- a/vm/actor/src/builtin/miner/expiration_queue.rs
+++ b/vm/actor/src/builtin/miner/expiration_queue.rs
@@ -8,7 +8,7 @@ use cid::Cid;
 use clock::ChainEpoch;
 use encoding::tuple::*;
 use fil_types::{SectorNumber, SectorSize};
-use ipld_amt::{Amt, Error as AmtError};
+use ipld_amt::{Amt, Error as AmtError, ValueMut};
 use ipld_blockstore::BlockStore;
 use num_bigint::bigint_ser;
 use num_traits::{Signed, Zero};
@@ -660,7 +660,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         &mut self,
         mut f: impl FnMut(
             ChainEpoch,
-            &mut ExpirationSet,
+            &mut ValueMut<'_, ExpirationSet>,
         ) -> Result</* keep going */ bool, Box<dyn StdError>>,
     ) -> Result<(), Box<dyn StdError>> {
         let mut epochs_emptied = Vec::<ChainEpoch>::new();


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Issue was is that all values were mutably dereferenced because generic function was the type within the guard

Thanks @ec2  for the heavy lifting

888/894

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->