### PR TITLE
Fix tipset sorting function

### DIFF
--- a/blockchain/blocks/src/header/mod.rs
+++ b/blockchain/blocks/src/header/mod.rs
@@ -215,7 +215,6 @@ impl<'de> Deserialize<'de> for BlockHeader {
     }
 }
 
-
 impl BlockHeader {
     /// Generates a BlockHeader builder as a constructor
     pub fn builder() -> BlockHeaderBuilder {

--- a/blockchain/blocks/src/header/mod.rs
+++ b/blockchain/blocks/src/header/mod.rs
@@ -8,6 +8,7 @@ use cid::{multihash::Blake2b256, Cid};
 use clock::ChainEpoch;
 use crypto::Signature;
 use derive_builder::Builder;
+use encoding::blake2b_256;
 use encoding::{Cbor, Error as EncodingError};
 use fil_types::PoStProof;
 use num_bigint::{
@@ -16,7 +17,6 @@ use num_bigint::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Digest;
-use std::cmp::Ordering;
 use std::fmt;
 use vm::TokenAmount;
 
@@ -215,20 +215,6 @@ impl<'de> Deserialize<'de> for BlockHeader {
     }
 }
 
-impl Ord for BlockHeader {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.ticket()
-            .cmp(other.ticket())
-            // Only compare cid bytes when tickets are equal
-            .then_with(|| self.cid().to_bytes().cmp(&other.cid().to_bytes()))
-    }
-}
-
-impl PartialOrd for BlockHeader {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
 
 impl BlockHeader {
     /// Generates a BlockHeader builder as a constructor
@@ -303,6 +289,11 @@ impl BlockHeader {
     /// Getter for BlockHeader signature
     pub fn signature(&self) -> &Option<Signature> {
         &self.signature
+    }
+    /// Key used for sorting headers and blocks.
+    pub fn to_sort_key(&self) -> Option<([u8; 32], Vec<u8>)> {
+        let ticket_hash = blake2b_256(self.ticket().as_ref()?.vrfproof.as_bytes());
+        Some((ticket_hash, self.cid().to_bytes()))
     }
     /// Updates cache and returns mutable reference of header back
     fn update_cache(&mut self) -> Result<(), String> {

--- a/blockchain/blocks/src/ticket.rs
+++ b/blockchain/blocks/src/ticket.rs
@@ -8,9 +8,7 @@ use fil_types::PoStProof;
 /// A Ticket is a marker of a tick of the blockchain's clock.  It is the source
 /// of randomness for proofs of storage and leader election.  It is generated
 /// by the miner of a block using a VRF and a VDF.
-#[derive(
-    Clone, Debug, PartialEq, PartialOrd, Eq, Default, Ord, Serialize_tuple, Deserialize_tuple,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize_tuple, Deserialize_tuple)]
 pub struct Ticket {
     /// A proof output by running a VRF on the VDFResult of the parent ticket
     pub vrfproof: VRFProof,

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -72,7 +72,7 @@ impl Tipset {
 
         // sort headers by ticket size
         // break ticket ties with the header CIDs, which are distinct
-        headers.sort();
+        headers.sort_by_cached_key(|h| h.to_sort_key());
 
         // return tipset where sorted headers have smallest ticket size in the 0th index
         // and the distinct keys
@@ -152,8 +152,7 @@ impl FullTipset {
 
         // sort blocks on creation to allow for more seamless conversions between FullTipset
         // and Tipset
-        #[allow(clippy::unnecessary_sort_by)]
-        blocks.sort_by(|block1, block2| block1.header().cmp(block2.header()));
+        blocks.sort_by_cached_key(|block| block.header().to_sort_key());
         Ok(Self { blocks })
     }
     /// Returns the first block of the tipset


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- There is a blake hash of the ticket vrf for sorting, at one point this was not the case on Lotus, must have been unlucky that when we did this is was while this was the case

Backporting this commit because it's contained and important

Honestly idk how this didn't get hit before this block.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->