### PR TITLE
Fix get_sectors_for_winning_post and cleanup

### DIFF
--- a/blockchain/blocks/src/header/json.rs
+++ b/blockchain/blocks/src/header/json.rs
@@ -39,7 +39,7 @@ where
         #[serde(with = "beacon_entries::json::vec")]
         beacon_entries: &'a [BeaconEntry],
         #[serde(rename = "WinPoStProof", with = "post::json::vec")]
-        win_post_proof: &'a [PoStProof],
+        winning_post_proof: &'a [PoStProof],
         #[serde(rename = "Parents", with = "tipset_keys_json")]
         parents: &'a TipsetKeys,
         #[serde(rename = "ParentWeight")]
@@ -65,7 +65,7 @@ where
         miner: m.miner_address.to_string(),
         ticket: &m.ticket,
         election_proof: &m.election_proof,
-        win_post_proof: &m.win_post_proof,
+        winning_post_proof: &m.winning_post_proof,
         parents: &m.parents,
         weight: m.weight.to_string(),
         height: &m.epoch,
@@ -97,7 +97,7 @@ where
         #[serde(default, with = "beacon_entries::json::vec")]
         beacon_entries: Vec<BeaconEntry>,
         #[serde(default, rename = "WinPoStProof", with = "post::json::vec")]
-        win_post_proof: Vec<PoStProof>,
+        winning_post_proof: Vec<PoStProof>,
         #[serde(rename = "Parents", with = "tipset_keys_json")]
         parents: TipsetKeys,
         #[serde(rename = "ParentWeight")]
@@ -126,7 +126,7 @@ where
         .ticket(v.ticket)
         .beacon_entries(v.beacon_entries)
         .epoch(v.height)
-        .win_post_proof(v.win_post_proof)
+        .winning_post_proof(v.winning_post_proof)
         .state_root(v.state_root)
         .message_receipts(v.message_receipts)
         .messages(v.messages)

--- a/blockchain/blocks/src/header/mod.rs
+++ b/blockchain/blocks/src/header/mod.rs
@@ -43,7 +43,7 @@ const BLOCKS_PER_EPOCH: u64 = 5;
 ///     .state_root(Cid::new_from_cbor(&[], Identity)) // required
 ///     .miner_address(Address::new_id(0)) // optional
 ///     .beacon_entries(Vec::new()) // optional
-///     .win_post_proof(Vec::new()) // optional
+///     .winning_post_proof(Vec::new()) // optional
 ///     .election_proof(None) // optional
 ///     .bls_aggregate(None) // optional
 ///     .signature(None) // optional
@@ -82,7 +82,7 @@ pub struct BlockHeader {
 
     /// PoStProofs are the winning post proofs
     #[builder(default)]
-    win_post_proof: Vec<PoStProof>,
+    winning_post_proof: Vec<PoStProof>,
 
     // MINER INFO
     /// miner_address is the address of the miner actor that mined this block
@@ -150,7 +150,7 @@ impl Serialize for BlockHeader {
             &self.ticket,
             &self.election_proof,
             &self.beacon_entries,
-            &self.win_post_proof,
+            &self.winning_post_proof,
             &self.parents,
             BigIntSer(&self.weight),
             &self.epoch,
@@ -177,7 +177,7 @@ impl<'de> Deserialize<'de> for BlockHeader {
             ticket,
             election_proof,
             beacon_entries,
-            win_post_proof,
+            winning_post_proof,
             parents,
             BigIntDe(weight),
             epoch,
@@ -196,7 +196,7 @@ impl<'de> Deserialize<'de> for BlockHeader {
             .weight(weight)
             .epoch(epoch)
             .beacon_entries(beacon_entries)
-            .win_post_proof(win_post_proof)
+            .winning_post_proof(winning_post_proof)
             .miner_address(miner_address)
             .messages(messages)
             .message_receipts(message_receipts)
@@ -237,8 +237,8 @@ impl BlockHeader {
         &self.beacon_entries
     }
     /// Getter for winning PoSt proof
-    pub fn win_post_proof(&self) -> &[PoStProof] {
-        &self.win_post_proof
+    pub fn winning_post_proof(&self) -> &[PoStProof] {
+        &self.winning_post_proof
     }
     /// Getter for BlockHeader miner_address
     pub fn miner_address(&self) -> &Address {

--- a/blockchain/blocks/src/header/mod.rs
+++ b/blockchain/blocks/src/header/mod.rs
@@ -236,7 +236,7 @@ impl BlockHeader {
     pub fn beacon_entries(&self) -> &[BeaconEntry] {
         &self.beacon_entries
     }
-    /// Getter for window PoSt proof
+    /// Getter for winning PoSt proof
     pub fn win_post_proof(&self) -> &[PoStProof] {
         &self.win_post_proof
     }

--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -923,7 +923,7 @@ where
                 Error::Validation(format!("Failed to get sectors for post: {}", e.to_string()))
             })?;
 
-        V::verify_winning_post(Randomness(rand), header.win_post_proof(), &sectors, id).map_err(
+        V::verify_winning_post(Randomness(rand), header.winning_post_proof(), &sectors, id).map_err(
             |e| Error::Validation(format!("Failed to verify winning PoSt: {}", e.to_string())),
         )
     }

--- a/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
+++ b/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
@@ -9,7 +9,7 @@ use async_std::task;
 use beacon::{DrandBeacon, DrandPublic};
 use chain::tipset_from_keys;
 use db::MemoryDB;
-use fil_types::verifier::MockVerifier;
+use fil_types::verifier::FullVerifier;
 use forest_car::load_car;
 use forest_libp2p::{blocksync::make_blocksync_response, NetworkMessage};
 use genesis::{initialize_genesis, EXPORT_SR_40};
@@ -78,7 +78,7 @@ async fn space_race_full_sync() {
         genesis,
         bad_blocks: Default::default(),
         // Mock verifier for now, but can test FullVerifier (depends on params fetched)
-        verifier: PhantomData::<MockVerifier>::default(),
+        verifier: PhantomData::<FullVerifier>::default(),
     };
 
     // Setup process to handle requests from syncer

--- a/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
+++ b/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
@@ -77,7 +77,6 @@ async fn space_race_full_sync() {
         network,
         genesis,
         bad_blocks: Default::default(),
-        // Mock verifier for now, but can test FullVerifier (depends on params fetched)
         verifier: PhantomData::<FullVerifier>::default(),
     };
 

--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -45,12 +45,9 @@ where
     {
         let store = self.blockstore();
 
-        let mas: miner::State = self.load_actor_state(&miner_address, &st).map_err(|err| {
-            Error::State(format!(
-                "(get sectors) failed to load miner actor state: %{:}",
-                err
-            ))
-        })?;
+        let mas: miner::State = self
+        .load_actor_state(&miner_address, &st)
+        .map_err(|err| format!("(get sectors) failed to load miner actor state: %{:}", err))?;
 
         let deadlines = mas.load_deadlines(store)?;
 

--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -7,7 +7,10 @@ use crate::errors::*;
 use crate::StateManager;
 use actor::miner::{self, Partition};
 use actor::{
-    miner::{ChainSectorInfo, Deadlines, MinerInfo, SectorOnChainInfo, SectorPreCommitOnChainInfo},
+    miner::{
+        ChainSectorInfo, Deadlines, MinerInfo, SectorOnChainInfo, SectorPreCommitOnChainInfo,
+        Sectors,
+    },
     power,
 };
 use address::{Address, Protocol};
@@ -49,8 +52,6 @@ where
             ))
         })?;
 
-        let info = mas.get_info(store)?;
-
         let deadlines = mas.load_deadlines(store)?;
 
         let mut proving_sectors = BitField::new();
@@ -58,11 +59,15 @@ where
         deadlines.for_each(store, |dl_idx, deadline| {
             let partitions = deadline.partitions_amt(store)?;
 
+            let mut fault_sectors = BitField::new();
             partitions.for_each(|part_idx, partition: &miner::Partition| {
-                let p = &partition.sectors - &partition.faults;
-                proving_sectors |= &p;
+                proving_sectors |= &partition.sectors;
+                fault_sectors |= &partition.faults;
                 Ok(())
-            })
+            })?;
+
+            proving_sectors -= &fault_sectors;
+            Ok(())
         })?;
 
         let num_prov_sect = proving_sectors.len() as u64;
@@ -70,6 +75,8 @@ where
         if num_prov_sect == 0 {
             return Ok(Vec::new());
         }
+
+        let info = mas.get_info(store)?;
 
         let spt = RegisteredSealProof::from(info.sector_size);
 
@@ -79,26 +86,31 @@ where
 
         let ids = V::generate_winning_post_sector_challenge(wpt, m_id, rand, num_prov_sect)?;
 
-        let sectors: Vec<u64> = proving_sectors.iter().map(|i| i as u64).collect();
-        let sectors_amt = Amt::<SectorOnChainInfo, _>::load(&mas.sectors, store)?;
+        let mut iter = proving_sectors.iter();
 
-        Ok(ids
-            .iter()
-            .map(|n| {
-                let sid = sectors
-                    .get(*n as usize)
-                    .ok_or_else(|| "id from challenge does not exist in sectors")?;
-                let s_info = sectors_amt
-                    .get(*sid)
-                    .map_err(|e| format!("failed to get sector {}: {}", sid, e))?
-                    .ok_or_else(|| format!("failed to find sector {}", sid))?;
-                Ok(SectorInfo {
-                    sealed_cid: s_info.sealed_cid.clone(),
-                    sector_number: s_info.sector_number,
-                    proof: spt,
-                })
+        let mut selected_sectors = BitField::new();
+        for n in ids {
+            let sno = iter.nth(n as usize).ok_or_else(|| {
+                format!(
+                    "Error iterating over proving sectors, id {} does not exist",
+                    n
+                )
+            })?;
+            selected_sectors.set(sno);
+        }
+
+        let sectors = mas.load_sector_infos(store, &selected_sectors)?;
+
+        let out = sectors
+            .into_iter()
+            .map(|s_info| SectorInfo {
+                proof: spt,
+                sector_number: s_info.sector_number,
+                sealed_cid: s_info.sealed_cid,
             })
-            .collect::<Result<_, String>>()?)
+            .collect();
+
+        Ok(out)
     }
 
     pub fn get_miner_sector_set<V>(

--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -46,8 +46,8 @@ where
         let store = self.blockstore();
 
         let mas: miner::State = self
-        .load_actor_state(&miner_address, &st)
-        .map_err(|err| format!("(get sectors) failed to load miner actor state: %{:}", err))?;
+            .load_actor_state(&miner_address, &st)
+            .map_err(|err| format!("(get sectors) failed to load miner actor state: %{:}", err))?;
 
         let deadlines = mas.load_deadlines(store)?;
 

--- a/ipld/blockstore/src/resolve.rs
+++ b/ipld/blockstore/src/resolve.rs
@@ -7,7 +7,11 @@ use forest_ipld::Ipld;
 use std::error::Error as StdError;
 
 /// Resolves link to recursively resolved Ipld with no hash links.
-pub fn resolve_cids_recursive<BS>(bs: &BS, cid: &Cid) -> Result<Ipld, Box<dyn StdError>>
+pub fn resolve_cids_recursive<BS>(
+    bs: &BS,
+    cid: &Cid,
+    depth: Option<u64>,
+) -> Result<Ipld, Box<dyn StdError>>
 where
     BS: BlockStore,
 {
@@ -15,25 +19,35 @@ where
         .get(cid)?
         .ok_or_else(|| "Cid does not exist in blockstore")?;
 
-    resolve_ipld(bs, &mut ipld)?;
+    resolve_ipld(bs, &mut ipld, depth)?;
 
     Ok(ipld)
 }
 
 /// Resolves Ipld links recursively, building an Ipld structure with no hash links.
-pub fn resolve_ipld<BS>(bs: &BS, ipld: &mut Ipld) -> Result<(), Box<dyn StdError>>
+pub fn resolve_ipld<BS>(
+    bs: &BS,
+    ipld: &mut Ipld,
+    mut depth: Option<u64>,
+) -> Result<(), Box<dyn StdError>>
 where
     BS: BlockStore,
 {
+    if let Some(dep) = depth.as_mut() {
+        if *dep == 0 {
+            return Ok(());
+        }
+        *dep -= 1;
+    }
     match ipld {
         Ipld::Map(m) => {
             for (_, v) in m.iter_mut() {
-                resolve_ipld(bs, v)?;
+                resolve_ipld(bs, v, depth)?;
             }
         }
         Ipld::List(list) => {
             for v in list.iter_mut() {
-                resolve_ipld(bs, v)?;
+                resolve_ipld(bs, v, depth)?;
             }
         }
         Ipld::Link(cid) => {

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -121,7 +121,7 @@ fn compare_state_roots(bs: &db::MemoryDB, root: &Cid, expected_root: &Cid) -> Re
         if std::env::var("FOREST_DIFF") == Ok("1".to_owned()) {
             println!("{}:", error_msg);
 
-            print_state_diff(bs, root, expected_root).unwrap();
+            print_state_diff(bs, root, expected_root, None).unwrap();
         }
 
         return Err(error_msg.into());

--- a/types/src/verifier/mod.rs
+++ b/types/src/verifier/mod.rs
@@ -135,7 +135,7 @@ enum ProofType {
 
 fn prover_id_from_u64(id: u64) -> ProverId {
     let mut prover_id = ProverId::default();
-    let prover_bytes = Address::new_id(id).payload().to_bytes();
+    let prover_bytes = Address::new_id(id).payload().to_raw_bytes();
     prover_id[..prover_bytes.len()].copy_from_slice(&prover_bytes);
     prover_id
 }

--- a/vm/address/src/payload.rs
+++ b/vm/address/src/payload.rs
@@ -72,7 +72,7 @@ impl Payload {
     }
 
     /// Returns encoded bytes of Address including the protocol byte.
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
         use Payload::*;
         let mut bz = match self {
             ID(i) => to_leb_bytes(*i).unwrap(),


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- There was logic broken within getting sectors for winning verification
  - There was an issue with prover id using address bytes with the protocol byte included, where they don't (I removed the `pub` tag on this method so no one else goes through the same debugging I had to
- Updates state diff to allow passing a depth to limit recursion (since when using on real network it gets unusable quick


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->