### PR TITLE
Put Hamt reordering fix under a feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,6 +1939,7 @@ dependencies = [
 name = "fil_types"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "base64 0.12.3",
  "chrono",
  "clock",

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -20,6 +20,8 @@ lazycell = "1.2.1"
 [features]
 identity = []
 go-interop = []
+# TODO would be best to just cut a release with v1 functionality and use that when needed
+v2 = []
 # This feature should just be used for testing (ignoring links that don't exist in store)
 ignore-dead-links = []
 

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -8,7 +8,6 @@ use lazycell::LazyCell;
 use serde::de::{self, DeserializeOwned};
 use serde::ser;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::cmp::Ordering;
 
 /// Pointer to index values or a link to another child node.
 #[derive(Debug)]
@@ -143,6 +142,7 @@ where
                     }
 
                     // Collect values from child nodes to collapse.
+                    #[allow(unused_mut)]
                     let mut child_vals: Vec<KeyValuePair<K, V>> = n
                         .pointers
                         .iter_mut()
@@ -158,9 +158,15 @@ where
 
                     // Sorting by key, values are inserted based on the ordering of the key itself,
                     // so when collapsed, it needs to be ensured that this order is equal.
-                    child_vals.sort_unstable_by(|a, b| {
-                        a.key().partial_cmp(b.key()).unwrap_or(Ordering::Equal)
-                    });
+                    // ! This was fixed only with the v2 actors upgrade, not used in v1
+                    #[cfg(feature = "v2")]
+                    {
+                        use std::cmp::Ordering;
+
+                        child_vals.sort_unstable_by(|a, b| {
+                            a.key().partial_cmp(b.key()).unwrap_or(Ordering::Equal)
+                        });
+                    }
 
                     // Replace link node with child values
                     *self = Pointer::Values(child_vals);


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- So turns out they fixed this in-between actors v1 and v2 lol
  - Put behind feature instead of releasing and using that version to avoid maintaining two versions for now

That was funny to debug

WIth #782, syncing to height 214

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->