### PR TITLE
Wrap cached state in async mutex to avoid duplicate state calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,6 +1939,7 @@ dependencies = [
 name = "fil_types"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "base64 0.12.3",
  "chrono",
  "clock",

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -192,7 +192,7 @@ where
     where
         R: Rand,
         V: ProofVerifier,
-        CB: FnMut(Cid, &ChainMessage, ApplyRet) -> Result<(), String>,
+        CB: FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String>,
     {
         let mut buf_store = BufferedBlockStore::new(self.bs.as_ref());
         // TODO change from statically using devnet params when needed
@@ -267,7 +267,7 @@ where
             } else {
                 let block_headers = tipset.blocks();
                 // generic constants are not implemented yet this is a lowcost method for now
-                let no_func = None::<fn(Cid, &ChainMessage, ApplyRet) -> Result<(), String>>;
+                let no_func = None::<fn(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String>>;
                 self.compute_tipset_state::<V, _>(&block_headers, no_func)?
             };
 
@@ -406,10 +406,10 @@ where
     {
         let mut outm: Option<UnsignedMessage> = None;
         let mut outr: Option<ApplyRet> = None;
-        let callback = |cid: Cid, unsigned: &ChainMessage, apply_ret: ApplyRet| {
-            if cid == mcid.clone() {
+        let callback = |cid: &Cid, unsigned: &ChainMessage, apply_ret: &ApplyRet| {
+            if cid == mcid {
                 outm = Some(unsigned.message().clone());
-                outr = Some(apply_ret);
+                outr = Some(apply_ret.clone());
                 return Err("halt".to_string());
             }
 
@@ -439,7 +439,7 @@ where
     ) -> Result<CidPair, Box<dyn StdError>>
     where
         V: ProofVerifier,
-        CB: FnMut(Cid, &ChainMessage, ApplyRet) -> Result<(), String>,
+        CB: FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String>,
     {
         span!("compute_tipset_state", {
             let first_block = block_headers

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -250,7 +250,7 @@ where
             let mut entry_lock = cache_entry.write().await;
             if let Some(ref entry) = *entry_lock {
                 // Entry had successfully populated state, return Cid and drop lock
-                debug!("hit cache for tipset {:?}", tipset.cids());
+                trace!("hit cache for tipset {:?}", tipset.cids());
                 return Ok(entry.clone());
             }
 

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -63,7 +63,7 @@ pub struct StateManager<DB> {
 
     /// This is a cache which indexes tipsets to their calculated state.
     /// The calculated state is wrapped in a mutex to avoid duplicate computation
-    /// of the state/ receipt root.
+    /// of the state/receipt root.
     cache: RwLock<HashMap<TipsetKeys, Arc<RwLock<Option<CidPair>>>>>,
     subscriber: Option<Subscriber<HeadChange>>,
 }
@@ -235,7 +235,7 @@ where
             // mutex until the value is updated, which task `B` will await.
             //
             // If two tasks are computing different tipset states, they will only block computation
-            // when accessing/ initializing the entry in cache, not during the whole tipset calc.
+            // when accessing/initializing the entry in cache, not during the whole tipset calc.
             let cache_entry: Arc<_> = self
                 .cache
                 .write()

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -258,12 +258,11 @@ where
                     .blocks()
                     .first()
                     .ok_or_else(|| Error::Other("Could not get message receipts".to_string()))?;
-                let cid_pair = (
+
+                (
                     tipset.parent_state().clone(),
                     message_receipts.message_receipts().clone(),
-                );
-
-                cid_pair.clone()
+                )
             } else {
                 let block_headers = tipset.blocks();
                 // generic constants are not implemented yet this is a lowcost method for now

--- a/tests/conformance_tests/src/tipset.rs
+++ b/tests/conformance_tests/src/tipset.rs
@@ -86,9 +86,9 @@ pub fn execute_tipset(
         exec_epoch,
         &TestRand,
         tipset.basefee.to_bigint().unwrap_or_default(),
-        Some(|_, msg: &ChainMessage, ret| {
+        Some(|_: &Cid, msg: &ChainMessage, ret: &ApplyRet| {
             _applied_messages.push(msg.clone());
-            applied_results.push(ret);
+            applied_results.push(ret.clone());
             Ok(())
         }),
     )?;

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -119,7 +119,7 @@ where
     fn run_cron(
         &mut self,
         epoch: ChainEpoch,
-        callback: Option<&mut impl FnMut(Cid, &ChainMessage, ApplyRet) -> Result<(), String>>,
+        callback: Option<&mut impl FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String>>,
     ) -> Result<(), Box<dyn StdError>> {
         let cron_msg = UnsignedMessage {
             from: *SYSTEM_ACTOR_ADDR,
@@ -141,7 +141,7 @@ where
         }
 
         if let Some(callback) = callback {
-            callback(cron_msg.cid()?, &ChainMessage::Unsigned(cron_msg), ret)?;
+            callback(&cron_msg.cid()?, &ChainMessage::Unsigned(cron_msg), &ret)?;
         }
         Ok(())
     }
@@ -153,7 +153,7 @@ where
         messages: &[BlockMessages],
         parent_epoch: ChainEpoch,
         epoch: ChainEpoch,
-        mut callback: Option<impl FnMut(Cid, &ChainMessage, ApplyRet) -> Result<(), String>>,
+        mut callback: Option<impl FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String>>,
     ) -> Result<Vec<MessageReceipt>, Box<dyn StdError>> {
         let mut receipts = Vec::new();
         let mut processed = HashSet::<Cid>::default();
@@ -177,7 +177,7 @@ where
                 }
                 let ret = self.apply_message(msg)?;
                 if let Some(cb) = &mut callback {
-                    cb(msg.cid()?, msg, ret.clone())?;
+                    cb(&cid, msg, &ret)?;
                 }
 
                 // Update totals
@@ -235,7 +235,7 @@ where
             }
 
             if let Some(callback) = &mut callback {
-                callback(rew_msg.cid()?, &ChainMessage::Unsigned(rew_msg), ret)?;
+                callback(&rew_msg.cid()?, &ChainMessage::Unsigned(rew_msg), &ret)?;
             }
         }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- So I documented the behaviour, but tldr tasks will wait for ones already computing state to finish instead of doing duplicate work in parallel, without blocking separate tipset's state transitions 
- Changed callback function to references, to avoid unnecessary clones

You can test the functionality by uncommenting the full sync test and setting the RUST_LOG env variable to see logs, no duplicate tipset state calculation should happen

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #776 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->