### PR TITLE
Optimize statediff and fix hamt bug

### DIFF
--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -126,17 +126,14 @@ where
                 }
                 2..=MAX_ARRAY_WIDTH => {
                     // If more child values than max width, nothing to change.
-                    let children_len: usize = n
-                        .pointers
-                        .iter()
-                        .filter_map(|p| {
-                            if let Pointer::Values(vals) = p {
-                                Some(vals.len())
-                            } else {
-                                None
-                            }
-                        })
-                        .sum();
+                    let mut children_len = 0;
+                    for c in n.pointers.iter() {
+                        if let Pointer::Values(vals) = c {
+                            children_len += vals.len();
+                        } else {
+                            return Ok(());
+                        }
+                    }
                     if children_len > MAX_ARRAY_WIDTH {
                         return Ok(());
                     }

--- a/utils/statediff/src/lib.rs
+++ b/utils/statediff/src/lib.rs
@@ -81,7 +81,8 @@ fn try_print_actor_states<BS: BlockStore>(
                 let expected_json =
                     serde_json::to_string_pretty(&actor_to_resolved(bs, &other, depth))?;
                 let Changeset { diffs, .. } = Changeset::new(&expected_json, &calc_json, "\n");
-                print_diffs(&diffs)
+                println!("Address {} changed: ", addr);
+                print_diffs(&diffs);
             }
         } else {
             // Added actor, print out the json format actor state.

--- a/utils/statediff/src/lib.rs
+++ b/utils/statediff/src/lib.rs
@@ -12,7 +12,7 @@ use ipld::json::{IpldJson, IpldJsonRef};
 use ipld::Ipld;
 use ipld_hamt::{BytesKey, Hamt};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::error::Error as StdError;
 use vm::ActorState;
 
@@ -24,26 +24,31 @@ struct ActorStateResolved {
     state: IpldJson,
 }
 
+fn actor_to_resolved(
+    bs: &impl BlockStore,
+    actor: &ActorState,
+    depth: Option<u64>,
+) -> ActorStateResolved {
+    let resolved = resolve_cids_recursive(bs, &actor.state, depth)
+        .unwrap_or_else(|_| Ipld::Link(actor.state.clone()));
+    ActorStateResolved {
+        state: IpldJson(resolved),
+        code: CidJson(actor.code.clone()),
+        balance: actor.balance.to_string(),
+        sequence: actor.sequence,
+    }
+}
+
 fn root_to_state_map<BS: BlockStore>(
     bs: &BS,
     root: &Cid,
-    depth: Option<u64>,
-) -> Result<BTreeMap<String, ActorStateResolved>, Box<dyn StdError>> {
-    let mut actors = BTreeMap::new();
+) -> Result<HashMap<Address, ActorState>, Box<dyn StdError>> {
+    let mut actors = HashMap::default();
     let hamt: Hamt<_, _> = Hamt::load_with_bit_width(root, bs, HAMT_BIT_WIDTH)?;
     hamt.for_each(|k: &BytesKey, actor: &ActorState| {
         let addr = Address::from_bytes(&k.0)?;
 
-        let resolved = resolve_cids_recursive(bs, &actor.state, depth)
-            .unwrap_or_else(|_| Ipld::Link(actor.state.clone()));
-        let resolved_state = ActorStateResolved {
-            state: IpldJson(resolved),
-            code: CidJson(actor.code.clone()),
-            balance: actor.balance.to_string(),
-            sequence: actor.sequence,
-        };
-
-        actors.insert(addr.to_string(), resolved_state);
+        actors.insert(addr, actor.clone());
         Ok(())
     })?;
 
@@ -52,19 +57,66 @@ fn root_to_state_map<BS: BlockStore>(
 
 /// Tries to resolve state tree actors, if all data exists in store.
 /// The actors hamt is hard to parse in a diff, so this attempts to remedy this.
-fn try_resolve_actor_states<BS: BlockStore>(
+/// This function will only print the actors that are added, removed, or changed so it
+/// can be used on large state trees.
+fn try_print_actor_states<BS: BlockStore>(
     bs: &BS,
     root: &Cid,
     expected_root: &Cid,
     depth: Option<u64>,
-) -> Result<Changeset, Box<dyn StdError>> {
-    let e_state = root_to_state_map(bs, expected_root, depth)?;
-    let c_state = root_to_state_map(bs, root, depth)?;
+) -> Result<(), Box<dyn StdError>> {
+    // For now, resolving to a map, because we need to use go implementation's inefficient caching
+    // this would probably be faster in most cases.
+    let mut e_state = root_to_state_map(bs, expected_root)?;
 
-    let expected_json = serde_json::to_string_pretty(&e_state)?;
-    let actual_json = serde_json::to_string_pretty(&c_state)?;
+    // Compare state with expected
+    let hamt: Hamt<_, _> = Hamt::load_with_bit_width(root, bs, HAMT_BIT_WIDTH)?;
+    hamt.for_each(|k: &BytesKey, actor: &ActorState| {
+        let addr = Address::from_bytes(&k.0)?;
 
-    Ok(Changeset::new(&expected_json, &actual_json, "\n"))
+        let calc_json = serde_json::to_string_pretty(&actor_to_resolved(bs, actor, depth))?;
+
+        if let Some(other) = e_state.remove(&addr) {
+            if &other != actor {
+                let expected_json =
+                    serde_json::to_string_pretty(&actor_to_resolved(bs, &other, depth))?;
+                let Changeset { diffs, .. } = Changeset::new(&expected_json, &calc_json, "\n");
+                print_diffs(&diffs)
+            }
+        } else {
+            // Added actor, print out the json format actor state.
+            println!("{}", format!("+ Address {}:\n{}", addr, calc_json).green())
+        }
+
+        Ok(())
+    })?;
+
+    // Print all addresses that no longer have actor state
+    for (addr, state) in e_state.into_iter() {
+        let expected_json = serde_json::to_string_pretty(&actor_to_resolved(bs, &state, depth))?;
+        println!(
+            "{}",
+            format!("- Address {}:\n{}", addr, expected_json).red()
+        );
+    }
+
+    Ok(())
+}
+
+fn print_diffs(diffs: &[Difference]) {
+    for diff in diffs.iter() {
+        match diff {
+            Difference::Same(x) => {
+                println!(" {}", x);
+            }
+            Difference::Add(x) => {
+                println!("{}", format!("+{}", x).green());
+            }
+            Difference::Rem(x) => {
+                println!("{}", format!("-{}", x).red());
+            }
+        }
+    }
 }
 
 /// Prints a diff of the resolved state tree.
@@ -78,35 +130,19 @@ pub fn print_state_diff<BS>(
 where
     BS: BlockStore,
 {
-    let Changeset { diffs, .. } = match try_resolve_actor_states(bs, root, expected_root, depth) {
-        Ok(cs) => cs,
-        Err(e) => {
-            println!(
-                "Could not resolve actor states: {}\nUsing default resolution:",
-                e
-            );
-            let expected = resolve_cids_recursive(bs, &expected_root, depth)?;
-            let actual = resolve_cids_recursive(bs, &root, depth)?;
+    if let Err(e) = try_print_actor_states(bs, root, expected_root, depth) {
+        println!(
+            "Could not resolve actor states: {}\nUsing default resolution:",
+            e
+        );
+        let expected = resolve_cids_recursive(bs, &expected_root, depth)?;
+        let actual = resolve_cids_recursive(bs, &root, depth)?;
 
-            let expected_json = serde_json::to_string_pretty(&IpldJsonRef(&expected))?;
-            let actual_json = serde_json::to_string_pretty(&IpldJsonRef(&actual))?;
+        let expected_json = serde_json::to_string_pretty(&IpldJsonRef(&expected))?;
+        let actual_json = serde_json::to_string_pretty(&IpldJsonRef(&actual))?;
 
-            Changeset::new(&expected_json, &actual_json, "\n")
-        }
-    };
-
-    for diff in diffs.iter() {
-        match diff {
-            Difference::Same(x) => {
-                println!(" {}", x);
-            }
-            Difference::Add(x) => {
-                println!("{}", format!("+{}", x).green());
-            }
-            Difference::Rem(x) => {
-                println!("{}", format!("-{}", x).red());
-            }
-        }
+        let Changeset { diffs, .. } = Changeset::new(&expected_json, &actual_json, "\n");
+        print_diffs(&diffs);
     }
 
     Ok(())


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Now the diff only shows the added, removed, or changed actor states instead of diffing the whole resolved and ordered (through BTreeMap) JSON state.
  - There was not a good reason to print out all other actors anyway, but this can be added if others want
  - It's basically instant now, and now usable on this much larger state
- Bug in hamt was in the case of one of the child nodes being a link, if the other values are less than the max array length, it would be pulled up and the link would be removed

syncing to epoch: 1442

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->