### PR TITLE
Cleanup batch_verify_seal and tipset state execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,6 +2328,7 @@ dependencies = [
  "libp2p-bitswap",
  "libp2p-request-response",
  "log",
+ "message_pool",
  "serde",
  "smallvec",
  "tiny-cid",

--- a/blockchain/message_pool/src/msgpool.rs
+++ b/blockchain/message_pool/src/msgpool.rs
@@ -165,7 +165,7 @@ where
 #[async_trait]
 impl<DB> Provider for MpoolRpcProvider<DB>
 where
-    DB: BlockStore + Sync + Send,
+    DB: BlockStore + Sync + Send + 'static,
 {
     async fn subscribe_head_changes(&mut self) -> Subscriber<HeadChange> {
         self.subscriber.clone()

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -77,7 +77,7 @@ pub struct StateManager<DB> {
 
 impl<DB> StateManager<DB>
 where
-    DB: BlockStore,
+    DB: BlockStore + Send + Sync + 'static,
 {
     pub fn new(bs: Arc<DB>) -> Self {
         Self {
@@ -232,7 +232,10 @@ where
     }
 
     /// Returns the pair of (parent state root, message receipt root)
-    pub async fn tipset_state<V>(&self, tipset: &Tipset) -> Result<CidPair, Box<dyn StdError>>
+    pub async fn tipset_state<V>(
+        self: &Arc<Self>,
+        tipset: &Tipset,
+    ) -> Result<CidPair, Box<dyn StdError>>
     where
         V: ProofVerifier,
     {
@@ -285,7 +288,8 @@ where
                 let block_headers = tipset.blocks();
                 // generic constants are not implemented yet this is a lowcost method for now
                 let no_func = None::<fn(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String>>;
-                self.compute_tipset_state::<V, _>(&block_headers, no_func)?
+                self.compute_tipset_state::<V, _>(&block_headers, no_func)
+                    .await?
             };
 
             // Fill entry with calculated cid pair
@@ -362,7 +366,7 @@ where
     }
 
     pub async fn call_with_gas<V>(
-        &self,
+        self: &Arc<Self>,
         message: &mut ChainMessage,
         prior_messages: &[ChainMessage],
         tipset: Option<Tipset>,
@@ -413,55 +417,58 @@ where
     }
 
     /// returns the result of executing the indicated message, assuming it was executed in the indicated tipset.
-    pub fn replay<V>(
-        &self,
-        ts: &Tipset,
-        mcid: &Cid,
+    pub async fn replay<V>(
+        self: &Arc<Self>,
+        _ts: &Tipset,
+        _mcid: &Cid,
     ) -> Result<(UnsignedMessage, Option<ApplyRet>), Error>
     where
         V: ProofVerifier,
     {
-        let mut outm: Option<UnsignedMessage> = None;
-        let mut outr: Option<ApplyRet> = None;
-        let callback = |cid: &Cid, unsigned: &ChainMessage, apply_ret: &ApplyRet| {
-            if cid == mcid {
-                outm = Some(unsigned.message().clone());
-                outr = Some(apply_ret.clone());
-                return Err("halt".to_string());
-            }
+        // TODO fix
+        todo!()
+        // let mut outm: Option<UnsignedMessage> = None;
+        // let mut outr: Option<ApplyRet> = None;
+        // let callback = |cid: &Cid, unsigned: &ChainMessage, apply_ret: &ApplyRet| {
+        //     if *cid == mcid {
+        //         outm = Some(unsigned.message().clone());
+        //         outr = Some(apply_ret.clone());
+        //         return Err("halt".to_string());
+        //     }
 
-            Ok(())
-        };
-        let result: Result<CidPair, Box<dyn StdError>> =
-            self.compute_tipset_state::<V, _>(ts.blocks(), Some(callback));
+        //     Ok(())
+        // };
+        // let result = self
+        //     .compute_tipset_state::<V, _>(ts.blocks(), Some(callback))
+        //     .await;
 
-        if let Err(error_message) = result {
-            if error_message.to_string() != "halt" {
-                return Err(Error::Other(format!(
-                    "unexpected error during execution : {:}",
-                    error_message
-                )));
-            }
-        }
+        // if let Err(error_message) = result {
+        //     if error_message.to_string() != "halt" {
+        //         return Err(Error::Other(format!(
+        //             "unexpected error during execution : {:}",
+        //             error_message
+        //         )));
+        //     }
+        // }
 
-        let out_mes =
-            outm.ok_or_else(|| Error::Other("given message not found in tipset".to_string()))?;
-        Ok((out_mes, outr))
+        // let out_mes =
+        //     outm.ok_or_else(|| Error::Other("given message not found in tipset".to_string()))?;
+        // Ok((out_mes, outr))
     }
 
-    pub fn compute_tipset_state<V, CB>(
-        &self,
+    pub async fn compute_tipset_state<V, CB: 'static>(
+        self: &Arc<Self>,
         block_headers: &[BlockHeader],
         callback: Option<CB>,
-    ) -> Result<CidPair, Box<dyn StdError>>
+    ) -> Result<CidPair, Error>
     where
         V: ProofVerifier,
-        CB: FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String>,
+        CB: FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String> + Send + 'static,
     {
         span!("compute_tipset_state", {
             let first_block = block_headers
                 .first()
-                .ok_or("Empty tipset in compute_tipset_state")?;
+                .ok_or_else(|| Error::Other("Empty tipset in compute_tipset_state".to_string()))?;
 
             let check_for_duplicates = |s: &BlockHeader| {
                 block_headers
@@ -472,10 +479,7 @@ where
             };
             if let Some(a) = block_headers.iter().find(|s| check_for_duplicates(s) > 1) {
                 // Duplicate Miner found
-                return Err(Box::new(Error::Other(format!(
-                    "duplicate miner in a tipset ({})",
-                    a
-                ))));
+                return Err(Error::Other(format!("duplicate miner in a tipset ({})", a)));
             }
 
             let parent_epoch = if first_block.epoch() > 0 {
@@ -483,10 +487,14 @@ where
                     .parents()
                     .cids()
                     .get(0)
-                    .ok_or("block must have parents")?;
-                let parent: BlockHeader = self.bs.get(parent_cid)?.ok_or_else(|| {
-                    format!("Could not find parent block with cid {}", parent_cid)
-                })?;
+                    .ok_or_else(|| Error::Other("block must have parents".to_string()))?;
+                let parent: BlockHeader = self
+                    .bs
+                    .get(parent_cid)
+                    .map_err(|e| Error::Other(e.to_string()))?
+                    .ok_or_else(|| {
+                        format!("Could not find parent block with cid {}", parent_cid)
+                    })?;
                 parent.epoch()
             } else {
                 Default::default()
@@ -495,9 +503,9 @@ where
             let tipset_keys =
                 TipsetKeys::new(block_headers.iter().map(|s| s.cid()).cloned().collect());
             let chain_rand = ChainRand::new(tipset_keys);
-            let base_fee = first_block.parent_base_fee();
+            let base_fee = first_block.parent_base_fee().clone();
 
-            let blocks = block_headers
+            let blocks: Vec<BlockMessages> = block_headers
                 .iter()
                 .map(|s: &BlockHeader| {
                     let messages = chain_messages(self.bs.as_ref(), &s)?;
@@ -511,17 +519,25 @@ where
                             .unwrap_or_default(),
                     })
                 })
-                .collect::<Result<Vec<_>, Box<dyn StdError>>>()?;
+                .collect::<Result<Vec<_>, Box<dyn StdError>>>()
+                .map_err(|e| Error::Other(e.to_string()))?;
 
-            self.apply_blocks::<_, V, _>(
-                parent_epoch,
-                &first_block.state_root(),
-                &blocks,
-                first_block.epoch(),
-                &chain_rand,
-                base_fee.clone(),
-                callback,
-            )
+            let sm = self.clone();
+            let sr = first_block.state_root().clone();
+            let epoch = first_block.epoch();
+            task::spawn_blocking(move || {
+                sm.apply_blocks::<_, V, _>(
+                    parent_epoch,
+                    &sr,
+                    &blocks,
+                    epoch,
+                    &chain_rand,
+                    base_fee,
+                    callback,
+                )
+                .map_err(|e| Error::Other(e.to_string()))
+            })
+            .await
         })
     }
 
@@ -853,7 +869,7 @@ where
     /// Similar to `resolve_to_key_addr` in the vm crate but does not allow `Actor` type of addresses.
     /// Uses `ts` to generate the VM state.
     pub async fn resolve_to_key_addr<V>(
-        &self,
+        self: &Arc<Self>,
         addr: &Address,
         ts: &Tipset,
     ) -> Result<Address, Box<dyn StdError>>
@@ -890,7 +906,7 @@ where
     }
 
     pub async fn validate_chain<V: ProofVerifier>(
-        &self,
+        self: &Arc<Self>,
         ts: Tipset,
     ) -> Result<(), Box<dyn StdError>> {
         let mut ts_chain = Vec::<Tipset>::new();

--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -31,7 +31,7 @@ use std::error::Error as StdError;
 
 impl<DB> StateManager<DB>
 where
-    DB: BlockStore,
+    DB: BlockStore + Send + Sync + 'static,
 {
     /// Retrieves and generates a vector of sector info for the winning PoSt verification.
     pub fn get_sectors_for_winning_post<V>(

--- a/node/rpc/src/state_api.rs
+++ b/node/rpc/src/state_api.rs
@@ -244,14 +244,12 @@ pub(crate) async fn state_replay<
     let (cidjson, key) = params;
     let cid = cidjson.into();
     let tipset = chain::tipset_from_keys(data.state_manager.blockstore(), &key)?;
-    let (msg, ret) = state_manager.replay::<FullVerifier>(&tipset, &cid).await?;
+    let (msg, ret) = state_manager.replay::<FullVerifier>(&tipset, cid).await?;
 
     Ok(InvocResult {
         msg,
-        msg_rct: ret.as_ref().map(|s| s.msg_receipt.clone()),
-        error: ret
-            .map(|act| act.act_error.map(|e| e.to_string()))
-            .unwrap_or_default(),
+        msg_rct: Some(ret.msg_receipt),
+        error: ret.act_error.map(|e| e.to_string()),
     })
 }
 

--- a/utils/genesis/src/lib.rs
+++ b/utils/genesis/src/lib.rs
@@ -25,7 +25,7 @@ pub fn initialize_genesis<BS>(
     state_manager: &StateManager<BS>,
 ) -> Result<(Tipset, String), Box<dyn StdError>>
 where
-    BS: BlockStore,
+    BS: BlockStore + Send + Sync + 'static,
 {
     let genesis = match genesis_fp {
         Some(path) => {

--- a/vm/actor/src/builtin/power/mod.rs
+++ b/vm/actor/src/builtin/power/mod.rs
@@ -474,9 +474,8 @@ impl Actor {
             Ok(())
         })?;
 
-        // TODO update this to not need to create vector to verify these things (ref batch_v_s)
-        let verif_arr: Vec<(Address, &Vec<SealVerifyInfo>)> =
-            verifies.iter().map(|(a, v)| (*a, v)).collect();
+        // TODO if verifies is ever Rayon compatible, this won't be needed
+        let verif_arr: Vec<(&Address, &Vec<SealVerifyInfo>)> = verifies.iter().collect();
         let res = rt
             .syscalls()
             .batch_verify_seals(verif_arr.as_slice())

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -785,14 +785,13 @@ where
 
     fn batch_verify_seals(
         &self,
-        vis: &[(Address, &Vec<SealVerifyInfo>)],
+        vis: &[(&Address, &Vec<SealVerifyInfo>)],
     ) -> Result<HashMap<Address, Vec<bool>>, Box<dyn StdError>> {
         // Gas charged for batch verify in actor
 
-        // TODO ideal to not use rayon https://github.com/ChainSafe/forest/issues/676
         let out = vis
             .par_iter()
-            .map(|(addr, seals)| {
+            .map(|(&addr, seals)| {
                 let results = seals
                     .par_iter()
                     .map(|s| {
@@ -807,7 +806,7 @@ where
                         }
                     })
                     .collect();
-                (*addr, results)
+                (addr, results)
             })
             .collect();
         Ok(out)

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -108,8 +108,8 @@ where
     }
 
     /// Flush stores in VM and return state root.
-    pub fn flush(&mut self) -> Result<Cid, String> {
-        self.state.flush().map_err(|e| e.to_string())
+    pub fn flush(&mut self) -> Result<Cid, Box<dyn StdError>> {
+        self.state.flush()
     }
 
     /// Returns ChainEpoch

--- a/vm/runtime/src/lib.rs
+++ b/vm/runtime/src/lib.rs
@@ -205,12 +205,12 @@ pub trait Syscalls {
 
     fn batch_verify_seals(
         &self,
-        vis: &[(Address, &Vec<SealVerifyInfo>)],
+        vis: &[(&Address, &Vec<SealVerifyInfo>)],
     ) -> Result<HashMap<Address, Vec<bool>>, Box<dyn StdError>> {
         let mut verified = HashMap::new();
-        for (addr, s) in vis {
+        for (&addr, s) in vis.iter() {
             let vals = s.iter().map(|si| self.verify_seal(si).is_ok()).collect();
-            verified.insert(*addr, vals);
+            verified.insert(addr, vals);
         }
         Ok(verified)
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Cleaned up types and removed TODO for #676 since Rayon will be our best bet here
  - Looked pretty in depth with this, and handling manually or with an async alternative is not as performant or just unnecessarily unergonomic with no benefit in practice
- Wrapped state execution in a `spawn_blocking` to avoid starving the runtime executor
  - I want to do a larger refactor later of the state manager/cs to follow a similar pattern for the function signatures (`&Arc<Self>` when the function can possibly spawn a new thread which uses `self` and `&self` otherwise, which has no implications outside of this aside from maybe tests and allows us to use and implement caching and other logic on top of them)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #676


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->