### PR TITLE
Use concrete implementations

### DIFF
--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -4,10 +4,7 @@
 #![cfg(feature = "buffered")]
 
 use super::BlockStore;
-use cid::{
-    multihash::{MultihashDigest, U32},
-    Cid, Codec,
-};
+use cid::{Cid, Code, Codec};
 use db::{Error, Store};
 use encoding::from_slice;
 use forest_ipld::Ipld;
@@ -116,11 +113,8 @@ where
         self.base.get_bytes(cid)
     }
 
-    fn put_raw<T>(&self, bytes: Vec<u8>, hash: T) -> Result<Cid, Box<dyn StdError>>
-    where
-        T: MultihashDigest<AllocSize = U32>,
-    {
-        let cid = Cid::new_from_cbor(&bytes, hash);
+    fn put_raw(&self, bytes: Vec<u8>, code: Code) -> Result<Cid, Box<dyn StdError>> {
+        let cid = Cid::new_from_cbor(&bytes, code);
         self.write.borrow_mut().insert(cid, bytes);
         Ok(cid)
     }
@@ -179,7 +173,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cid::{Code, Codec};
+    use cid::{multihash::MultihashDigest, Code, Codec};
     use commcid::commitment_to_cid;
     use forest_ipld::{ipld, Ipld};
 

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -14,10 +14,7 @@ pub use self::buffered::BufferedBlockStore;
 #[cfg(feature = "tracking")]
 pub use self::tracking::{BSStats, TrackingBlockStore};
 
-use cid::{
-    multihash::{MultihashDigest, U32},
-    Cid,
-};
+use cid::{Cid, Code};
 use db::{MemoryDB, Store};
 use encoding::{de::DeserializeOwned, from_slice, ser::Serialize, to_vec};
 use std::error::Error as StdError;
@@ -44,35 +41,30 @@ pub trait BlockStore: Store {
     }
 
     /// Put an object in the block store and return the Cid identifier.
-    fn put<S, T>(&self, obj: &S, hash: T) -> Result<Cid, Box<dyn StdError>>
+    fn put<S>(&self, obj: &S, code: Code) -> Result<Cid, Box<dyn StdError>>
     where
         S: Serialize,
-        T: MultihashDigest<AllocSize = U32>,
     {
         let bytes = to_vec(obj)?;
-        self.put_raw(bytes, hash)
+        self.put_raw(bytes, code)
     }
 
     /// Put raw bytes in the block store and return the Cid identifier.
-    fn put_raw<T>(&self, bytes: Vec<u8>, hash: T) -> Result<Cid, Box<dyn StdError>>
-    where
-        T: MultihashDigest<AllocSize = U32>,
-    {
-        let cid = Cid::new_from_cbor(&bytes, hash);
+    fn put_raw(&self, bytes: Vec<u8>, code: Code) -> Result<Cid, Box<dyn StdError>> {
+        let cid = Cid::new_from_cbor(&bytes, code);
         self.write(cid.to_bytes(), bytes)?;
         Ok(cid)
     }
 
     /// Batch put cbor objects into blockstore and returns vector of Cids
-    fn bulk_put<'a, S, T, V>(&self, values: V, hash: T) -> Result<Vec<Cid>, Box<dyn StdError>>
+    fn bulk_put<'a, S, V>(&self, values: V, code: Code) -> Result<Vec<Cid>, Box<dyn StdError>>
     where
         S: Serialize + 'a,
-        T: MultihashDigest<AllocSize = U32>,
         V: IntoIterator<Item = &'a S>,
     {
         values
             .into_iter()
-            .map(|value| self.put(value, hash))
+            .map(|value| self.put(value, code))
             .collect()
     }
 }
@@ -81,10 +73,9 @@ impl BlockStore for MemoryDB {}
 
 #[cfg(feature = "rocksdb")]
 impl BlockStore for RocksDb {
-    fn bulk_put<'a, S, T, V>(&self, values: V, hash: T) -> Result<Vec<Cid>, Box<dyn StdError>>
+    fn bulk_put<'a, S, V>(&self, values: V, code: Code) -> Result<Vec<Cid>, Box<dyn StdError>>
     where
         S: Serialize + 'a,
-        T: MultihashDigest<AllocSize = U32>,
         V: IntoIterator<Item = &'a S>,
     {
         let mut batch = WriteBatch::default();
@@ -92,7 +83,7 @@ impl BlockStore for RocksDb {
             .into_iter()
             .map(|v| {
                 let bz = to_vec(v)?;
-                let cid = Cid::new_from_cbor(&bz, hash);
+                let cid = Cid::new_from_cbor(&bz, code);
                 batch.put(cid.to_bytes(), bz);
                 Ok(cid)
             })

--- a/ipld/blockstore/src/tracking.rs
+++ b/ipld/blockstore/src/tracking.rs
@@ -4,10 +4,7 @@
 #![cfg(feature = "tracking")]
 
 use super::BlockStore;
-use cid::{
-    multihash::{MultihashDigest, U32},
-    Cid,
-};
+use cid::{Cid, Code};
 use db::{Error, Store};
 use std::cell::RefCell;
 use std::error::Error as StdError;
@@ -57,13 +54,10 @@ where
         Ok(bytes)
     }
 
-    fn put_raw<T>(&self, bytes: Vec<u8>, hash: T) -> Result<Cid, Box<dyn StdError>>
-    where
-        T: MultihashDigest<AllocSize = U32>,
-    {
+    fn put_raw(&self, bytes: Vec<u8>, code: Code) -> Result<Cid, Box<dyn StdError>> {
         self.stats.borrow_mut().w += 1;
         self.stats.borrow_mut().bw += bytes.len();
-        let cid = Cid::new_from_cbor(&bytes, hash);
+        let cid = Cid::new_from_cbor(&bytes, code);
         self.write(cid.to_bytes(), bytes)?;
         Ok(cid)
     }

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -10,13 +10,12 @@ mod version;
 
 pub use self::codec::Codec;
 pub use self::error::Error;
-pub use self::mh_code::*;
+pub use self::mh_code::{Code, Multihash, POSEIDON_BLS12_381_A1_FC1, SHA2_256_TRUNC254_PADDED};
 pub use self::prefix::Prefix;
 pub use self::version::Version;
 use integer_encoding::VarIntWriter;
 pub use multihash;
 use multihash::derive::Multihash;
-use multihash::typenum::U32;
 use multihash::MultihashDigest;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -127,8 +126,8 @@ impl Cid {
     }
 
     /// Constructs a cid with bytes using default version and codec
-    pub fn new_from_cbor<T: MultihashDigest<AllocSize = U32>>(bz: &[u8], hash: T) -> Self {
-        let hash = hash.digest(bz);
+    pub fn new_from_cbor(bz: &[u8], code: Code) -> Self {
+        let hash = code.digest(bz);
         Cid {
             version: Version::V1,
             codec: Codec::DagCBOR,

--- a/vm/interpreter/src/gas_block_store.rs
+++ b/vm/interpreter/src/gas_block_store.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::gas_tracker::{GasTracker, PriceList};
-use cid::{
-    multihash::{MultihashDigest, U32},
-    Cid,
-};
+use cid::{Cid, Code};
 use db::{Error, Store};
 use forest_encoding::{de::DeserializeOwned, ser::Serialize, to_vec};
 use ipld_blockstore::BlockStore;
@@ -34,17 +31,16 @@ where
         self.store.get(cid)
     }
 
-    fn put<S, T>(&self, obj: &S, hash: T) -> Result<Cid, Box<dyn StdError>>
+    fn put<S>(&self, obj: &S, code: Code) -> Result<Cid, Box<dyn StdError>>
     where
         S: Serialize,
-        T: MultihashDigest<AllocSize = U32>,
     {
         let bytes = to_vec(obj)?;
         self.gas
             .borrow_mut()
             .charge_gas(self.price_list.on_ipld_put(bytes.len()))?;
 
-        Ok(self.store.put_raw(bytes, hash)?)
+        Ok(self.store.put_raw(bytes, code)?)
     }
 }
 


### PR DESCRIPTION
**Summary of changes**

Instead of trait bounds, use concrete implementations. I think this improves the code, I prefer having less trait bounds.

**Other information and links**

It is possible to change this due to the upgrade to `multihash` 0.13.