### PR TITLE
Fix makefile test commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,4 +84,4 @@ license:
 docs:
 	cargo doc --no-deps --all-features
 
-.PHONY: clean clean-all lint build release test test-all license test-vectors run-vectors pull-serialization-tests install docs run-serialization-vectors run-conformance-vectors
+.PHONY: clean clean-all lint build release test test-all test-release license test-vectors run-vectors pull-serialization-tests install docs run-serialization-vectors run-conformance-vectors

--- a/Makefile
+++ b/Makefile
@@ -84,4 +84,4 @@ license:
 docs:
 	cargo doc --no-deps --all-features
 
-.PHONY: clean clean-all lint build release test license test-vectors run-vectors pull-serialization-tests install docs run-serialization-vectors run-conformance-vectors
+.PHONY: clean clean-all lint build release test test-all license test-vectors run-vectors pull-serialization-tests install docs run-serialization-vectors run-conformance-vectors

--- a/Makefile
+++ b/Makefile
@@ -72,18 +72,10 @@ test-vectors: pull-serialization-tests run-vectors
 test:
 	cargo test --all --all-features --exclude serialization_tests --exclude conformance_tests
 
-# This will run all tests will all features enabled, which will exclude some tests with
-# specific features disabled
-test-all: pull-serialization-tests
-	cargo test --all-features
+test-release:
+	cargo test --release --all --all-features --exclude serialization_tests --exclude conformance_tests
 
-# This will run all tests will all features enabled, which will exclude some tests with
-# specific features disabled with verbose compiler output
-test-all-verbose: pull-serialization-tests
-	cargo test --verbose --all-features
-
-test-all-no-run: pull-serialization-tests
-	cargo test --all-features --no-run
+test-all: test-release run-vectors
 
 # Checks if all headers are present and adds if not
 license:
@@ -92,4 +84,4 @@ license:
 docs:
 	cargo doc --no-deps --all-features
 
-.PHONY: clean clean-all lint build release test license test-all test-vectors run-vectors pull-serialization-tests install docs
+.PHONY: clean clean-all lint build release test license test-vectors run-vectors pull-serialization-tests install docs run-serialization-vectors run-conformance-vectors

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Will show all debug logs by default, but the `forest_libp2p::service` logs will 
 ### Testing
 ```bash
 # To run base tests
-make test # use test-release for longer compilation but faster execution
+cargo test # use `make test-release` for longer compilation but faster execution
 
 # To pull serialization vectors submodule and run serialization and conformance tests
 make test-vectors

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Will show all debug logs by default, but the `forest_libp2p::service` logs will 
 ### Testing
 ```bash
 # To run base tests
-cargo test # add --release flag for longer compilation but faster execution
+make test # use test-release for longer compilation but faster execution
 
 # To pull serialization vectors submodule and run serialization and conformance tests
 make test-vectors

--- a/utils/bitfield/src/rleplus/reader.rs
+++ b/utils/bitfield/src/rleplus/reader.rs
@@ -157,6 +157,7 @@ mod tests {
         assert_eq!(reader.read_len().unwrap(), None);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "assertion failed")]
     fn too_many_bits_at_once() {

--- a/utils/bitfield/src/rleplus/writer.rs
+++ b/utils/bitfield/src/rleplus/writer.rs
@@ -143,6 +143,7 @@ mod tests {
         );
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "assertion failed")]
     fn zero_len() {
@@ -150,6 +151,7 @@ mod tests {
         writer.write_len(0);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "assertion failed")]
     fn more_bits_than_indicated() {
@@ -157,6 +159,7 @@ mod tests {
         writer.write(100, 0);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "assertion failed")]
     fn too_many_bits_at_once() {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixes CI conformance build https://app.circleci.com/pipelines/github/ChainSafe/forest/2596/workflows/b8650f54-dee5-42d9-96d1-331ab74c93b0/jobs/6252
  - Currently the CI runs `test-all` which runs test with all features in debug mode (which now fails on conformance because one vector submits and invalid proof which hits the assertion)
  - This will now also be faster since running conformance vectors not in release is really slow


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->