### PR TITLE
Fix bug with import and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,9 +2624,11 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "chain",
+ "fil_types",
  "forest_blocks",
  "forest_car",
  "forest_cid",
+ "forest_encoding",
  "ipld_blockstore",
  "log",
  "state_manager",

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -908,9 +908,10 @@ where
     pub async fn validate_chain<V: ProofVerifier>(
         self: &Arc<Self>,
         mut ts: Tipset,
+        height: i64,
     ) -> Result<(), Box<dyn StdError>> {
         let mut ts_chain = Vec::<Tipset>::new();
-        while ts.epoch() != 0 {
+        while ts.epoch() != height {
             let next = self.cs.tipset_from_keys(ts.parents())?;
             ts_chain.push(std::mem::replace(&mut ts, next));
         }

--- a/node/db/src/lib.rs
+++ b/node/db/src/lib.rs
@@ -11,12 +11,6 @@ pub use memory::MemoryDB;
 #[cfg(feature = "rocksdb")]
 pub use rocks::{RocksDb, WriteBatch};
 
-pub trait DatabaseService {
-    fn open(&mut self) -> Result<(), Error> {
-        Ok(())
-    }
-}
-
 /// Store interface used as a KV store implementation
 pub trait Store {
     /// Read single value from data store and return `None` if key doesn't exist.

--- a/node/db/src/memory.rs
+++ b/node/db/src/memory.rs
@@ -1,13 +1,13 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::{DatabaseService, Error, Store};
+use super::{Error, Store};
 use parking_lot::RwLock;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 
 /// A thread-safe `HashMap` wrapper.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MemoryDB {
     db: RwLock<HashMap<u64, Vec<u8>>>,
 }
@@ -30,16 +30,6 @@ impl Clone for MemoryDB {
         }
     }
 }
-
-impl Default for MemoryDB {
-    fn default() -> Self {
-        Self {
-            db: RwLock::new(HashMap::new()),
-        }
-    }
-}
-
-impl DatabaseService for MemoryDB {}
 
 impl Store for MemoryDB {
     fn write<K, V>(&self, key: K, value: V) -> Result<(), Error>

--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "rocksdb")]
 
 use super::errors::Error;
-use super::{DatabaseService, Store};
+use super::Store;
 pub use rocksdb::{Options, WriteBatch, DB};
 use std::env::temp_dir;
 use std::path::{Path, PathBuf};
@@ -64,12 +64,6 @@ impl RocksDb {
             DbStatus::Unopened(_) => Err(Error::Unopened),
             DbStatus::Open(db) => Ok(db),
         }
-    }
-}
-
-impl DatabaseService for RocksDb {
-    fn open(&mut self) -> Result<(), Error> {
-        self.open()
     }
 }
 

--- a/node/db/tests/mem_test.rs
+++ b/node/db/tests/mem_test.rs
@@ -6,14 +6,6 @@ mod subtests;
 use db::MemoryDB;
 
 #[test]
-fn mem_db_open() {
-    let mut db = MemoryDB::default();
-    subtests::open(&mut db);
-    // Calling open on opened db should not error
-    subtests::open(&mut db);
-}
-
-#[test]
 fn mem_db_write() {
     let db = MemoryDB::default();
     subtests::write(&db);

--- a/node/db/tests/rocks_test.rs
+++ b/node/db/tests/rocks_test.rs
@@ -10,19 +10,10 @@ use db::RocksDb;
 use db_utils::DBPath;
 
 #[test]
-fn rocks_db_open() {
-    let path = DBPath::new("start_rocks_test");
-    let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
-    // Calling open on opened db should not error
-    subtests::open(&mut db);
-}
-
-#[test]
 fn rocks_db_write() {
     let path = DBPath::new("write_rocks_test");
     let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
+    db.open().unwrap();
     subtests::write(&db);
 }
 
@@ -30,7 +21,7 @@ fn rocks_db_write() {
 fn rocks_db_read() {
     let path = DBPath::new("read_rocks_test");
     let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
+    db.open().unwrap();
     subtests::read(&db);
 }
 
@@ -38,7 +29,7 @@ fn rocks_db_read() {
 fn rocks_db_exists() {
     let path = DBPath::new("exists_rocks_test");
     let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
+    db.open().unwrap();
     subtests::exists(&db);
 }
 
@@ -46,7 +37,7 @@ fn rocks_db_exists() {
 fn rocks_db_does_not_exist() {
     let path = DBPath::new("does_not_exists_rocks_test");
     let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
+    db.open().unwrap();
     subtests::does_not_exist(&db);
 }
 
@@ -54,7 +45,7 @@ fn rocks_db_does_not_exist() {
 fn rocks_db_delete() {
     let path = DBPath::new("delete_rocks_test");
     let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
+    db.open().unwrap();
     subtests::delete(&db);
 }
 
@@ -62,7 +53,7 @@ fn rocks_db_delete() {
 fn rocks_db_bulk_write() {
     let path = DBPath::new("bulk_write_rocks_test");
     let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
+    db.open().unwrap();
     subtests::bulk_write(&db);
 }
 
@@ -70,7 +61,7 @@ fn rocks_db_bulk_write() {
 fn rocks_db_bulk_read() {
     let path = DBPath::new("bulk_read_rocks_test");
     let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
+    db.open().unwrap();
     subtests::bulk_read(&db);
 }
 
@@ -78,6 +69,6 @@ fn rocks_db_bulk_read() {
 fn rocks_db_bulk_delete() {
     let path = DBPath::new("bulk_delete_rocks_test");
     let mut db = RocksDb::new(path.as_ref());
-    subtests::open(&mut db);
+    db.open().unwrap();
     subtests::bulk_delete(&db);
 }

--- a/node/db/tests/subtests/mod.rs
+++ b/node/db/tests/subtests/mod.rs
@@ -1,14 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use db::{DatabaseService, Store};
-
-pub fn open<DB>(db: &mut DB)
-where
-    DB: DatabaseService,
-{
-    db.open().unwrap();
-}
+use db::Store;
 
 pub fn write<DB>(db: &DB)
 where

--- a/utils/genesis/Cargo.toml
+++ b/utils/genesis/Cargo.toml
@@ -16,3 +16,5 @@ state_manager = { path = "../../blockchain/state_manager" }
 cid = { package = "forest_cid", path = "../../ipld/cid" }
 blocks = { package = "forest_blocks", path = "../../blockchain/blocks" }
 chain = { path = "../../blockchain/chain" }
+fil_types = { path = "../../types" }
+encoding = { path = "../../encoding", package = "forest_encoding" }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixes bug where if starting on a fresh data directory, importing a chain would fail during validations because the genesis was not initialized
- Cleaned up code and setup import to be used outside of forest (I'm benchmarking and testing using an external bin to avoid compiling all of forest, only what I need)
- Removed `DatabaseService` trait, very useless, no need to ever swap out database implementation at runtime, should be a build flag


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->