### PR TITLE
Fix gossipsub handling to process only when in follow state

### DIFF
--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -108,7 +108,7 @@ where
         };
 
         // Result intentionally ignored, doesn't matter if heaviest doesn't exist in store yet
-        let _ = cs.load_heaviest_tipset();
+        let _ = task::block_on(cs.load_heaviest_tipset());
 
         cs
     }

--- a/blockchain/message_pool/src/msgpool.rs
+++ b/blockchain/message_pool/src/msgpool.rs
@@ -255,7 +255,7 @@ where
         // LruCache sizes have been taken from the lotus implementation
         let pending = Arc::new(RwLock::new(HashMap::new()));
         let tipset = Arc::new(RwLock::new(api.get_heaviest_tipset().await.ok_or_else(
-            || Error::Other("No ts in api to set as cur_tipset".to_owned()),
+            || Error::Other("Failed to retrieve heaviest tipset from provider".to_owned()),
         )?));
         let bls_sig_cache = Arc::new(RwLock::new(LruCache::new(40000)));
         let sig_val_cache = Arc::new(RwLock::new(LruCache::new(32000)));


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Issue is now the bitswap interactions are a bit broken when requesting messages, and it's stalling the chain_sync polling thread
  - This PR does not solve the underlying issue, we will still run into this when we get into follow state, but this check needs to be in place anyway (shouldn't handle gossip events outside of follow state) and I added a `TODO` and will create an issue for solving the greater issue

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->