### PR TITLE
Update amt for_each caching mechanisms and usages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,6 +3115,7 @@ dependencies = [
 name = "ipld_amt"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.5.8",
  "criterion",
  "db",
  "forest_cid",

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -12,9 +12,10 @@ serde = { version = "1.0", features = ["derive"] }
 ipld_blockstore = { path = "../blockstore" }
 thiserror = "1.0"
 lazycell = "1.2.1"
+ahash = { version = "0.5", optional = true }
 
 [features]
-go-interop = []
+go-interop = ["ahash"]
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
 [dependencies]
-cid = { package = "forest_cid", path = "../cid" }
+cid = { package = "forest_cid", path = "../cid", features = ["cbor"] }
 db = { path = "../../node/db" }
 encoding = { package = "forest_encoding", path = "../../encoding" }
 serde = { version = "1.0", features = ["derive"] }

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -289,6 +289,7 @@ where
     /// each value.
     pub fn for_each_mut<F>(&mut self, mut f: F) -> Result<(), Box<dyn StdError>>
     where
+        V: Clone,
         F: FnMut(u64, &mut ValueMut<'_, V>) -> Result<(), Box<dyn StdError>>,
     {
         self.for_each_while_mut(|i, x| {
@@ -301,11 +302,53 @@ where
     /// each value, for as long as that function keeps returning `true`.
     pub fn for_each_while_mut<F>(&mut self, mut f: F) -> Result<(), Box<dyn StdError>>
     where
+        // TODO remove clone bound when go-interop doesn't require it.
+        // (If needed without, this bound can be removed by duplicating function signatures)
+        V: Clone,
         F: FnMut(u64, &mut ValueMut<'_, V>) -> Result<bool, Box<dyn StdError>>,
     {
-        self.root
-            .node
-            .for_each_while_mut(self.block_store, self.height(), 0, &mut f)
-            .map(|_| ())
+        #[cfg(not(feature = "go-interop"))]
+        {
+            self.root
+                .node
+                .for_each_while_mut(self.block_store, self.height(), 0, &mut f)
+                .map(|_| ())
+        }
+
+        // TODO remove requirement for this when/if changed in go-implementation
+        // This is not 100% compatible, because the blockstore reads/writes are not in the same
+        // order. If this is to be achieved, the for_each iteration would have to pause when
+        // a mutation occurs, set, then continue where it left off. This is a much more extensive
+        // change, and since it should not be feasibly triggered, it's left as this for now.
+        #[cfg(feature = "go-interop")]
+        {
+            let mut mutated = ahash::AHashMap::new();
+
+            self.root.node.for_each_while_mut(
+                self.block_store,
+                self.height(),
+                0,
+                &mut |idx, value| {
+                    let keep_going = f(idx, value)?;
+
+                    if value.value_changed() {
+                        // ! this is not ideal to clone and mark unchanged here, it is only done
+                        // because the go-implementation mutates the Amt as they iterate through it,
+                        // which we cannot do because it is memory unsafe (and I'm not certain we
+                        // don't have side effects from doing this unsafely)
+                        value.mark_unchanged();
+                        mutated.insert(idx, value.clone());
+                    }
+
+                    Ok(keep_going)
+                },
+            )?;
+
+            for (i, v) in mutated.into_iter() {
+                self.set(i, v)?;
+            }
+
+            Ok(())
+        }
     }
 }

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -265,7 +265,6 @@ where
     #[inline]
     pub fn for_each<F>(&self, mut f: F) -> Result<(), Box<dyn StdError>>
     where
-        V: DeserializeOwned,
         F: FnMut(u64, &V) -> Result<(), Box<dyn StdError>>,
     {
         self.for_each_while(|i, x| {
@@ -278,7 +277,6 @@ where
     /// function keeps returning `true`.
     pub fn for_each_while<F>(&self, mut f: F) -> Result<(), Box<dyn StdError>>
     where
-        V: DeserializeOwned,
         F: FnMut(u64, &V) -> Result<bool, Box<dyn StdError>>,
     {
         self.root
@@ -291,7 +289,6 @@ where
     /// each value.
     pub fn for_each_mut<F>(&mut self, mut f: F) -> Result<(), Box<dyn StdError>>
     where
-        V: DeserializeOwned,
         F: FnMut(u64, &mut ValueMut<'_, V>) -> Result<(), Box<dyn StdError>>,
     {
         self.for_each_while_mut(|i, x| {
@@ -304,7 +301,6 @@ where
     /// each value, for as long as that function keeps returning `true`.
     pub fn for_each_while_mut<F>(&mut self, mut f: F) -> Result<(), Box<dyn StdError>>
     where
-        V: DeserializeOwned,
         F: FnMut(u64, &mut ValueMut<'_, V>) -> Result<bool, Box<dyn StdError>>,
     {
         self.root

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -453,11 +453,18 @@ where
                                         .get(cid)?
                                         .ok_or_else(|| Error::CidNotFound(cid.to_string()))?;
 
-                                    // Ignore error intentionally, the cache value will always be the same
-                                    let _ = cache.fill(node);
-                                    let cache_node =
-                                        cache.borrow().expect("cache filled on line above");
-                                    cache_node.for_each_while(store, height - 1, offs, f)?
+                                    #[cfg(not(feature = "go-interop"))]
+                                    {
+                                        // Ignore error intentionally, the cache value will always be the same
+                                        let _ = cache.fill(node);
+                                        let cache_node =
+                                            cache.borrow().expect("cache filled on line above");
+
+                                        cache_node.for_each_while(store, height - 1, offs, f)?
+                                    }
+
+                                    #[cfg(feature = "go-interop")]
+                                    node.for_each_while(store, height - 1, offs, f)?
                                 }
                             }
                         };

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -22,9 +22,8 @@ impl<'a, V> ValueMut<'a, V> {
         self.value_mutated
     }
 
-    /// Marks guard as unchanged. This should only be used when
-    /// the value was updated but it is intended to remove it. Otherwise,
-    /// this function would give unexpected behaviour on flush.
+    /// Marks guard as unchanged. This should only be used when the value was updated but it is
+    /// intended to remove it. Otherwise, this function would give unexpected behaviour on flush.
     #[cfg(feature = "go-interop")]
     pub fn mark_unchanged(&mut self) {
         self.value_mutated = false;

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -21,6 +21,14 @@ impl<'a, V> ValueMut<'a, V> {
     pub fn value_changed(&self) -> bool {
         self.value_mutated
     }
+
+    /// Marks guard as unchanged. This should only be used when
+    /// the value was updated but it is intended to remove it. Otherwise,
+    /// this function would give unexpected behaviour on flush.
+    #[cfg(feature = "go-interop")]
+    pub fn mark_unchanged(&mut self) {
+        self.value_mutated = false;
+    }
 }
 
 impl<V> Deref for ValueMut<'_, V> {

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -397,18 +397,38 @@ fn for_each_mutate() {
 
     // Flush and regenerate amt
     let c = a.flush().unwrap();
+    drop(a);
     let mut new_amt = Amt::load(&c, &db).unwrap();
     assert_eq!(new_amt.count(), indexes.len() as u64);
 
+    #[cfg(not(feature = "go-interop"))]
     new_amt
         .for_each_mut(|i, v: &mut ipld_amt::ValueMut<'_, String>| {
-            if let 1 | 74 | 515 = i {
+            if let 1 | 74 = i {
                 // Value it's set to doesn't matter, just cloning for expedience
                 **v = (*v).clone();
             }
             Ok(())
         })
         .unwrap();
+
+    #[cfg(feature = "go-interop")]
+    {
+        let mut updated = std::collections::HashMap::new();
+        new_amt
+            .for_each(|i, v: &String| {
+                if let 1 | 74 = i {
+                    // Value it's set to doesn't matter, just cloning for expedience
+                    updated.insert(i, v.clone());
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        for (i, v) in updated.into_iter() {
+            new_amt.set(i, v).unwrap();
+        }
+    }
 
     assert_eq!(
         c.to_string().as_str(),
@@ -421,7 +441,7 @@ fn for_each_mutate() {
 
     #[rustfmt::skip]
     #[cfg(feature = "go-interop")]
-    assert_eq!(*db.stats.borrow(), BSStats {r: 20, w: 12, br: 1017, bw: 572});
+    assert_eq!(*db.stats.borrow(), BSStats {r: 17, w: 12, br: 910, bw: 572});
 }
 
 #[test]

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -401,7 +401,6 @@ fn for_each_mutate() {
     let mut new_amt = Amt::load(&c, &db).unwrap();
     assert_eq!(new_amt.count(), indexes.len() as u64);
 
-    #[cfg(not(feature = "go-interop"))]
     new_amt
         .for_each_mut(|i, v: &mut ipld_amt::ValueMut<'_, String>| {
             if let 1 | 74 = i {
@@ -411,24 +410,6 @@ fn for_each_mutate() {
             Ok(())
         })
         .unwrap();
-
-    #[cfg(feature = "go-interop")]
-    {
-        let mut updated = std::collections::HashMap::new();
-        new_amt
-            .for_each(|i, v: &String| {
-                if let 1 | 74 = i {
-                    // Value it's set to doesn't matter, just cloning for expedience
-                    updated.insert(i, v.clone());
-                }
-                Ok(())
-            })
-            .unwrap();
-
-        for (i, v) in updated.into_iter() {
-            new_amt.set(i, v).unwrap();
-        }
-    }
 
     assert_eq!(
         c.to_string().as_str(),

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -383,6 +383,48 @@ fn for_each() {
 }
 
 #[test]
+fn for_each_mutate() {
+    let mem = db::MemoryDB::default();
+    let db = TrackingBlockStore::new(&mem);
+    let mut a = Amt::new(&db);
+
+    let indexes = [1, 9, 66, 74, 82, 515];
+
+    // Set all indices in the Amt
+    for &i in indexes.iter() {
+        a.set(i, "value".to_owned()).unwrap();
+    }
+
+    // Flush and regenerate amt
+    let c = a.flush().unwrap();
+    let mut new_amt = Amt::load(&c, &db).unwrap();
+    assert_eq!(new_amt.count(), indexes.len() as u64);
+
+    new_amt
+        .for_each_mut(|i, v: &mut ipld_amt::ValueMut<'_, String>| {
+            if let 1 | 74 | 515 = i {
+                // Value it's set to doesn't matter, just cloning for expedience
+                **v = (*v).clone();
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(
+        c.to_string().as_str(),
+        "bafy2bzacecipze2lcvpcrcqy4nyqs4p2sinbytflyyuytge5lc6uz632bj6fu"
+    );
+
+    #[rustfmt::skip]
+    #[cfg(not(feature = "go-interop"))]
+    assert_eq!(*db.stats.borrow(), BSStats { r: 12, w: 12, br: 572, bw: 572 });
+
+    #[rustfmt::skip]
+    #[cfg(feature = "go-interop")]
+    assert_eq!(*db.stats.borrow(), BSStats {r: 20, w: 12, br: 1017, bw: 572});
+}
+
+#[test]
 fn delete_bug_test() {
     let mem = db::MemoryDB::default();
     let db = TrackingBlockStore::new(&mem);

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -792,6 +792,8 @@ impl Actor {
                                     "failed to delete pending proposal: does not exist"
                                 )
                             })?;
+
+                        return Ok(());
                     }
                     let mut state = state.unwrap();
 

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -793,7 +793,7 @@ impl Actor {
                                 )
                             })?;
 
-                        return Ok(());
+                        continue;
                     }
                     let mut state = state.unwrap();
 

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -757,7 +757,7 @@ impl Actor {
                             amount_slashed += slashed;
                         }
                         if deal.verified_deal {
-                            timed_out_verified_deals.push(deal.clone());
+                            timed_out_verified_deals.push(deal);
                         }
 
                         // we should not attempt to delete the DealState because it does NOT exist

--- a/vm/actor/src/builtin/miner/bitfield_queue.rs
+++ b/vm/actor/src/builtin/miner/bitfield_queue.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::ActorDowncast;
+use ahash::AHashMap;
 use bitfield::BitField;
 use cid::Cid;
 use clock::ChainEpoch;
@@ -72,19 +73,26 @@ impl<'db, BS: BlockStore> BitFieldQueue<'db, BS> {
     pub fn cut(&mut self, to_cut: &BitField) -> Result<(), Box<dyn StdError>> {
         let mut epochs_to_remove = Vec::<u64>::new();
 
+        let mut updated = AHashMap::new();
         self.amt
-            .for_each_mut(|epoch, bitfield| {
+            .for_each(|epoch, bitfield| {
                 let bf = bitfield.cut(to_cut);
 
                 if bf.is_empty() {
                     epochs_to_remove.push(epoch);
                 } else {
-                    **bitfield = bf;
+                    updated.insert(epoch, bf);
                 }
 
                 Ok(())
             })
             .map_err(|e| e.downcast_wrap("failed to cut from bitfield queue"))?;
+
+        for (i, v) in updated.into_iter() {
+            self.amt
+                .set(i, v)
+                .map_err(|e| e.downcast_wrap("failed to update bitfield queue in cut"))?;
+        }
 
         self.amt
             .batch_delete(epochs_to_remove)

--- a/vm/actor/src/builtin/miner/expiration_queue.rs
+++ b/vm/actor/src/builtin/miner/expiration_queue.rs
@@ -670,6 +670,8 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
             let keep_going = f(epoch, expiration_set)?;
 
             if expiration_set.is_empty() {
+                // Mark expiration set as unchanged, it will be removed after the iteration.
+                expiration_set.mark_unchanged();
                 epochs_emptied.push(epoch);
             }
 

--- a/vm/actor/src/builtin/miner/expiration_queue.rs
+++ b/vm/actor/src/builtin/miner/expiration_queue.rs
@@ -3,6 +3,7 @@
 
 use super::{power_for_sector, PowerPair, SectorOnChainInfo, SECTORS_MAX};
 use crate::ActorDowncast;
+use ahash::AHashMap;
 use bitfield::BitField;
 use cid::Cid;
 use clock::ChainEpoch;
@@ -664,6 +665,7 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
         ) -> Result</* keep going */ bool, Box<dyn StdError>>,
     ) -> Result<(), Box<dyn StdError>> {
         let mut epochs_emptied = Vec::<ChainEpoch>::new();
+        let mut epochs_mutated = AHashMap::new();
 
         self.amt.for_each_while_mut(|e, expiration_set| {
             let epoch = e as ChainEpoch;
@@ -673,10 +675,22 @@ impl<'db, BS: BlockStore> ExpirationQueue<'db, BS> {
                 // Mark expiration set as unchanged, it will be removed after the iteration.
                 expiration_set.mark_unchanged();
                 epochs_emptied.push(epoch);
+            } else if expiration_set.value_changed() {
+                // ! this is not ideal to clone and mark unchanged here, it is only done
+                // because the go-implementation mutates the Amt as they iterate through it,
+                // which we cannot do because it is memory unsafe (and I'm not certain we don't
+                // have side effects from doing this unsafely)
+                expiration_set.mark_unchanged();
+                epochs_mutated.insert(e, expiration_set.clone());
             }
 
             Ok(keep_going)
         })?;
+
+        // ! Once/if the above point is updated, this should be removed, in place mutation is ideal
+        for (i, v) in epochs_mutated.into_iter() {
+            self.amt.set(i, v)?;
+        }
 
         self.amt
             .batch_delete(epochs_emptied.iter().map(|&i| i as u64))?;

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -37,7 +37,7 @@ use vm::{
 
 // This is just used for gas tracing, intentionally 0 and could be removed.
 const ACTOR_EXEC_GAS: GasCharge = GasCharge {
-    name: "on_actor_exec",
+    name: "OnActorExec",
     compute_gas: 0,
     storage_gas: 0,
 };

--- a/vm/interpreter/src/gas_tracker/price_list.rs
+++ b/vm/interpreter/src/gas_tracker/price_list.rs
@@ -154,7 +154,7 @@ impl PriceList {
     #[inline]
     pub fn on_chain_message(&self, msg_size: usize) -> GasCharge {
         GasCharge::new(
-            "on_chain_message",
+            "OnChainMessage",
             self.on_chain_message_compute_base,
             self.on_chain_message_storage_base
                 + self.on_chain_message_storage_per_byte * msg_size as i64,
@@ -164,7 +164,7 @@ impl PriceList {
     #[inline]
     pub fn on_chain_return_value(&self, data_size: usize) -> GasCharge {
         GasCharge::new(
-            "on_chain_return_value",
+            "OnChainReturnValue",
             0,
             data_size as i64 * self.on_chain_return_value_per_byte,
         )
@@ -182,18 +182,18 @@ impl PriceList {
         if method_num != METHOD_SEND {
             ret += self.send_invoke_method;
         }
-        GasCharge::new("on_method_invocation", ret, 0)
+        GasCharge::new("OnMethodInvocation", ret, 0)
     }
     /// Returns the gas required for storing an object
     #[inline]
     pub fn on_ipld_get(&self) -> GasCharge {
-        GasCharge::new("on_ipld_get", self.ipld_get_base, 0)
+        GasCharge::new("OnIpldGet", self.ipld_get_base, 0)
     }
     /// Returns the gas required for storing an object
     #[inline]
     pub fn on_ipld_put(&self, data_size: usize) -> GasCharge {
         GasCharge::new(
-            "on_ipld_put",
+            "OnIpldPut",
             self.ipld_put_base,
             data_size as i64 * self.ipld_put_per_byte,
         )
@@ -202,7 +202,7 @@ impl PriceList {
     #[inline]
     pub fn on_create_actor(&self) -> GasCharge {
         GasCharge::new(
-            "on_create_actor",
+            "OnCreateActor",
             self.create_actor_compute,
             self.create_actor_storage,
         )
@@ -210,7 +210,7 @@ impl PriceList {
     /// Returns the gas required for deleting an actor
     #[inline]
     pub fn on_delete_actor(&self) -> GasCharge {
-        GasCharge::new("on_delete_actor", 0, self.delete_actor)
+        GasCharge::new("OnDeleteActor", 0, self.delete_actor)
     }
     /// Returns gas required for signature verification
     #[inline]
@@ -219,12 +219,12 @@ impl PriceList {
             SignatureType::BLS => self.bls_sig_cost,
             SignatureType::Secp256k1 => self.secp256k1_sig_cost,
         };
-        GasCharge::new("on_verify_signature", val, 0)
+        GasCharge::new("OnVerifySignature", val, 0)
     }
     /// Returns gas required for hashing data
     #[inline]
     pub fn on_hashing(&self, _: usize) -> GasCharge {
-        GasCharge::new("on_hashing", self.hashing_base, 0)
+        GasCharge::new("OnHashing", self.hashing_base, 0)
     }
     /// Returns gas required for computing unsealed sector Cid
     #[inline]
@@ -234,7 +234,7 @@ impl PriceList {
         _pieces: &[PieceInfo],
     ) -> GasCharge {
         GasCharge::new(
-            "on_compute_unsealed_sector_cid",
+            "OnComputeUnsealedSectorCid",
             self.compute_unsealed_sector_cid_base,
             0,
         )
@@ -242,7 +242,7 @@ impl PriceList {
     /// Returns gas required for seal verification
     #[inline]
     pub fn on_verify_seal(&self, _info: &SealVerifyInfo) -> GasCharge {
-        GasCharge::new("on_verify_seal", self.verify_seal_base, 0)
+        GasCharge::new("OnVerifySeal", self.verify_seal_base, 0)
     }
     /// Returns gas required for PoSt verification
     #[inline]
@@ -261,12 +261,12 @@ impl PriceList {
         let mut gas_used = cost.flat + info.challenged_sectors.len() as i64 * cost.scale;
         gas_used /= 2;
 
-        GasCharge::new("on_verify_post", gas_used, 0)
+        GasCharge::new("OnVerifyPost", gas_used, 0)
     }
     /// Returns gas required for verifying consensus fault
     #[inline]
     pub fn on_verify_consensus_fault(&self) -> GasCharge {
-        GasCharge::new("on_verify_consensus_fault", self.verify_consensus_fault, 0)
+        GasCharge::new("OnVerifyConsensusFault", self.verify_consensus_fault, 0)
     }
 }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- We were doing too little reads on one message on height 3080, this solves the issue
  - This just marks the mutated node as unchanged, which would lead to unexpected behaviour, if it wasn't removed directly after (which is the case here)
- Changes gas charge names to match go casing, for a cleaner diff when interop

~This PR does not yet solve the issue of gas diff on mutation instead of removals~, because we do the mutation in place (as it should be if the go implementation was caching and iterating correctly) but they set the value while the amt is being iterated over (memory unsafe). I will find a way around this, but it might involve an inefficient Clone, because we can't exactly pull the element from the amt to set it back into the amt. I will open this PR when I have a functional workaround and tested adequately. 

This now solves the issue marked above. I've documented that it isn't a perfect solution, since the reads and writes are in different order, which could cause a consensus fault if an out of gas error is hit in the middle of this. We cannot match exactly without memory unsafe usage or an extensive implementation of this, so I think this is a good enough solution for now. I will try to make changes upstream/open a FIP to make their caching more efficient or fix this specific issue.

Currently resyncing to check to make sure no regressions

Go equivalent tests: https://github.com/austinabell/go-amt-ipld/commit/747191512a743a88e63456bbb644f3d1a77e4f7d

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->