### PR TITLE
Fix: update balance table

### DIFF
--- a/vm/actor/tests/balance_table_test.rs
+++ b/vm/actor/tests/balance_table_test.rs
@@ -7,22 +7,6 @@ use vm::TokenAmount;
 
 // Ported test from specs-actors
 #[test]
-fn add_create() {
-    let addr = Address::new_id(100);
-    let store = db::MemoryDB::default();
-    let mut bt = BalanceTable::new(&store);
-
-    assert_eq!(bt.has(&addr).unwrap(), false);
-
-    bt.add_create(&addr, TokenAmount::from(10u8)).unwrap();
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(10u8));
-
-    bt.add_create(&addr, TokenAmount::from(20u8)).unwrap();
-    assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(30u8));
-}
-
-// Ported test from specs-actors
-#[test]
 fn total() {
     let addr1 = Address::new_id(100);
     let addr2 = Address::new_id(101);
@@ -60,7 +44,7 @@ fn total() {
     ];
 
     for t in test_vectors.iter() {
-        bt.add_create(t.addr, TokenAmount::from(t.amount)).unwrap();
+        bt.add(t.addr, &TokenAmount::from(t.amount)).unwrap();
 
         assert_eq!(bt.total().unwrap(), TokenAmount::from(t.total));
     }
@@ -72,7 +56,7 @@ fn balance_subtracts() {
     let store = db::MemoryDB::default();
     let mut bt = BalanceTable::new(&store);
 
-    bt.set(&addr, TokenAmount::from(80u8)).unwrap();
+    bt.add(&addr, &TokenAmount::from(80u8)).unwrap();
     assert_eq!(bt.get(&addr).unwrap(), TokenAmount::from(80u8));
     // Test subtracting past minimum only subtracts correct amount
     assert_eq!(


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Balance table had changed in actors, but wasn't noticed because the only difference was that items in the table are now removed when the balance goes back to 0 (somewhat strange as it would incur a large gas cost if not encountered in a cron, but I guess this is just to avoid state bloat)

With #847, syncs past 3388 (still syncing atm)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->