### PR TITLE
Setup mocking panic handling in vm

### DIFF
--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -525,7 +525,7 @@ where
                             Link::Cid { cid, cache } => {
                                 let cache_node = std::mem::take(cache);
 
-                                #[warn(unused_variables)]
+                                #[allow(unused_variables)]
                                 let (mut node, cached) = if let Some(sn) = cache_node.into_inner() {
                                     (sn, true)
                                 } else {

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -654,7 +654,7 @@ impl Actor {
             .compute_unsealed_sector_cid(params.sector_type, &pieces)
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::SysErrorIllegalArgument,
+                    ExitCode::SysErrIllegalArgument,
                     "failed to compute unsealed sector CID",
                 )
             })?;

--- a/vm/actor/tests/common/mod.rs
+++ b/vm/actor/tests/common/mod.rs
@@ -156,7 +156,7 @@ impl MockRuntime {
     }
     fn check_argument(&self, predicate: bool, msg: String) -> Result<(), ActorError> {
         if !predicate {
-            return Err(actor_error!(SysErrorIllegalArgument; msg));
+            return Err(actor_error!(SysErrIllegalArgument; msg));
         }
         Ok(())
     }
@@ -507,7 +507,7 @@ impl Runtime<MemoryDB> for MockRuntime {
 
     fn create<C: Cbor>(&mut self, obj: &C) -> Result<(), ActorError> {
         if self.state.is_some() == true {
-            return Err(actor_error!(SysErrorIllegalActor; "state already constructed"));
+            return Err(actor_error!(SysErrIllegalActor; "state already constructed"));
         }
         self.state = Some(self.store.put(obj, Blake2b256).unwrap());
         Ok(())
@@ -527,7 +527,7 @@ impl Runtime<MemoryDB> for MockRuntime {
         F: FnOnce(&mut C, &mut Self) -> Result<RT, ActorError>,
     {
         if self.in_transaction {
-            return Err(actor_error!(SysErrorIllegalActor; "nested transaction"));
+            return Err(actor_error!(SysErrIllegalActor; "nested transaction"));
         }
         let mut read_only = self.state()?;
         self.in_transaction = true;
@@ -550,7 +550,7 @@ impl Runtime<MemoryDB> for MockRuntime {
     ) -> Result<Serialized, ActorError> {
         self.require_in_call();
         if self.in_transaction {
-            return Err(actor_error!(SysErrorIllegalActor; "side-effect within transaction"));
+            return Err(actor_error!(SysErrIllegalActor; "side-effect within transaction"));
         }
 
         assert!(
@@ -596,7 +596,7 @@ impl Runtime<MemoryDB> for MockRuntime {
     fn create_actor(&mut self, code_id: Cid, address: &Address) -> Result<(), ActorError> {
         self.require_in_call();
         if self.in_transaction {
-            return Err(actor_error!(SysErrorIllegalActor; "side-effect within transaction"));
+            return Err(actor_error!(SysErrIllegalActor; "side-effect within transaction"));
         }
         let expect_create_actor = self
             .expect_create_actor
@@ -610,7 +610,7 @@ impl Runtime<MemoryDB> for MockRuntime {
     fn delete_actor(&mut self, addr: &Address) -> Result<(), ActorError> {
         self.require_in_call();
         if self.in_transaction {
-            return Err(actor_error!(SysErrorIllegalActor; "side-effect within transaction"));
+            return Err(actor_error!(SysErrIllegalActor; "side-effect within transaction"));
         }
         let exp_act = self.expect_delete_actor.take();
         if exp_act.is_none() {

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -203,7 +203,7 @@ where
 
     fn abort_if_already_validated(&mut self) -> Result<(), ActorError> {
         if self.caller_validated {
-            Err(actor_error!(SysErrorIllegalActor;
+            Err(actor_error!(SysErrIllegalActor;
                     "Method must validate caller identity exactly once"))
         } else {
             self.caller_validated = true;
@@ -465,12 +465,12 @@ where
             .get_actor(self.message().receiver())
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::SysErrorIllegalArgument,
+                    ExitCode::SysErrIllegalArgument,
                     "failed to get actor for Readonly state",
                 )
             })?
             .ok_or_else(
-                || actor_error!(SysErrorIllegalArgument; "Actor readonly state does not exist"),
+                || actor_error!(SysErrIllegalArgument; "Actor readonly state does not exist"),
             )?;
 
         // TODO revisit as the go impl doesn't handle not exists and nil cases
@@ -493,12 +493,12 @@ where
             .get_actor(self.message().receiver())
             .map_err(|e| {
                 e.downcast_default(
-                    ExitCode::SysErrorIllegalActor,
+                    ExitCode::SysErrIllegalActor,
                     "failed to get actor for transaction",
                 )
             })?
             .ok_or_else(|| {
-                actor_error!(SysErrorIllegalActor;
+                actor_error!(SysErrIllegalActor;
                 "actor state for transaction doesn't exist")
             })?;
 
@@ -534,7 +534,7 @@ where
         value: TokenAmount,
     ) -> Result<Serialized, ActorError> {
         if !self.allow_internal {
-            return Err(actor_error!(SysErrorIllegalActor; "runtime.send() is not allowed"));
+            return Err(actor_error!(SysErrIllegalActor; "runtime.send() is not allowed"));
         }
 
         let ret = self
@@ -550,7 +550,9 @@ where
         Ok(ret)
     }
     fn new_actor_address(&mut self) -> Result<Address, ActorError> {
-        let oa = resolve_to_key_addr(self.state, self.store.store, &self.origin)?;
+        // ! Go implementation doesn't handle the error for some reason here and will panic
+        let oa = resolve_to_key_addr(self.state, self.store.store, &self.origin)
+            .map_err(|e| e.downcast_fatal("failed to resolve key addr"))?;
         let mut b = to_vec(&oa).map_err(|e| {
             actor_error!(fatal(
                 "Could not serialize address in new_actor_address: {}",
@@ -572,15 +574,15 @@ where
     }
     fn create_actor(&mut self, code_id: Cid, address: &Address) -> Result<(), ActorError> {
         if !is_builtin_actor(&code_id) {
-            return Err(actor_error!(SysErrorIllegalArgument; "Can only create built-in actors."));
+            return Err(actor_error!(SysErrIllegalArgument; "Can only create built-in actors."));
         }
         if is_singleton_actor(&code_id) {
-            return Err(actor_error!(SysErrorIllegalArgument;
+            return Err(actor_error!(SysErrIllegalArgument;
                     "Can only have one instance of singleton actors."));
         }
 
         if let Ok(Some(_)) = self.state.get_actor(address) {
-            return Err(actor_error!(SysErrorIllegalArgument; "Actor address already exists"));
+            return Err(actor_error!(SysErrIllegalArgument; "Actor address already exists"));
         }
 
         self.charge_gas(self.price_list.on_create_actor())?;
@@ -604,7 +606,7 @@ where
             .get_actor(&receiver)
             .map_err(|e| e.downcast_fatal(format!("failed to get actor {}", receiver)))?
             .ok_or_else(
-                || actor_error!(SysErrorIllegalActor; "failed to load actor in delete actor"),
+                || actor_error!(SysErrIllegalActor; "failed to load actor in delete actor"),
             )
             .map(|act| act.balance)?;
         if balance != 0.into() {
@@ -944,14 +946,14 @@ where
         chaos::Actor::invoke_method(rt, method_num, params)
     } else {
         Err(actor_error!(
-            SysErrorIllegalActor,
+            SysErrIllegalActor,
             "no code for actor at address {}",
             to
         ))
     }?;
 
     if !rt.caller_validated {
-        Err(actor_error!(SysErrorIllegalActor; "Caller must be validated during method execution"))
+        Err(actor_error!(SysErrIllegalActor; "Caller must be validated during method execution"))
     } else {
         Ok(ret)
     }
@@ -963,7 +965,7 @@ pub fn resolve_to_key_addr<'st, 'bs, BS, S>(
     st: &'st StateTree<'bs, S>,
     store: &'bs BS,
     addr: &Address,
-) -> Result<Address, ActorError>
+) -> Result<Address, Box<dyn StdError>>
 where
     BS: BlockStore,
     S: BlockStore,
@@ -974,24 +976,17 @@ where
 
     let act = st
         .get_actor(&addr)
-        .map_err(|e| e.downcast_default(ExitCode::SysErrInternal, "Failed to get actor"))?
-        .ok_or_else(|| actor_error!(SysErrInternal; "Failed to retrieve actor: {}", addr))?;
+        .map_err(|e| e.downcast_wrap("Failed to get actor"))?
+        .ok_or_else(|| format!("Failed to retrieve actor: {}", addr))?;
 
+    // TODO this will need to handle multiple actor versions
     if act.code != *ACCOUNT_ACTOR_CODE_ID {
-        return Err(actor_error!(fatal(
-            "Address was not found for an account actor: {}",
-            addr
-        )));
+        return Err(format!("Address was not found for an account actor: {}", addr).into());
     }
     let acc_st: account::State = store
         .get(&act.state)
-        .map_err(|e| e.downcast_fatal(format!("Failed to get account actor state for: {}", addr)))?
-        .ok_or_else(|| {
-            actor_error!(fatal(
-                "Address was not found for an account actor: {}",
-                addr
-            ))
-        })?;
+        .map_err(|e| e.downcast_wrap(format!("Failed to get account actor state for: {}", addr)))?
+        .ok_or_else(|| format!("Address was not found for an account actor: {}", addr))?;
 
     Ok(acc_st.address)
 }

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -605,9 +605,7 @@ where
             .state
             .get_actor(&receiver)
             .map_err(|e| e.downcast_fatal(format!("failed to get actor {}", receiver)))?
-            .ok_or_else(
-                || actor_error!(SysErrIllegalActor; "failed to load actor in delete actor"),
-            )
+            .ok_or_else(|| actor_error!(SysErrIllegalActor; "failed to load actor in delete actor"))
             .map(|act| act.balance)?;
         if balance != 0.into() {
             // Transfer the executing actor's balance to the beneficiary

--- a/vm/src/exit_code.rs
+++ b/vm/src/exit_code.rs
@@ -19,8 +19,8 @@ pub enum ExitCode {
     /// Indicates failure to find a method in an actor.
     SysErrInvalidMethod = 3,
 
-    /// Indicates syntactically invalid parameters for a method.
-    SysErrInvalidParameters = 4,
+    /// Used for catching panics currently. (marked as unused/SysErrReserved1 in go impl though)
+    SysErrActorPanic = 4,
 
     /// Indicates a message sender has insufficient funds for a message's execution.
     SysErrInvalidReceiver = 5,
@@ -38,21 +38,17 @@ pub enum ExitCode {
     /// - mutating state outside of a state acquisition block
     /// - failing to invoke caller validation
     /// - aborting with a reserved exit code (including success or a system error).
-    SysErrorIllegalActor = 9,
+    SysErrIllegalActor = 9,
 
     /// Indicates an invalid argument passed to a runtime method.
-    SysErrorIllegalArgument = 10,
-
-    /// Indicates  an object failed to de/serialize for storage.
-    SysErrSerialization = 11,
+    SysErrIllegalArgument = 10,
 
     /// Reserved exit codes, do not use.
-    SysErrorReserved1 = 12,
-    SysErrorReserved2 = 13,
-    SysErrorReserved3 = 14,
-
-    /// Indicates something broken within the VM.
-    SysErrInternal = 15,
+    SysErrReserved2 = 11,
+    SysErrReserved3 = 12,
+    SysErrReserved4 = 13,
+    SysErrReserved5 = 14,
+    SysErrReserved6 = 15,
 
     // -------Actor Error Codes-------
     /// Indicates a method parameter is invalid.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- In go implementation, they catch any unexpected panic and wrap it with an exit code. We cannot match this (at least currently, but design might be flawed to allow us to safely do) so we just need to handle errors whenever assertions are expected to happen.
  - I've used the added function for the functions I know can and are hit, but there might be others. Until we find a way to match catching panics with other functionality maintained or they change the protocol we will have this vulnerability to our node crashing if anything in actors has a bug

I'll create an issue to detail the issue with actual panic catching. Syncs past 13154 point now

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->