### PR TITLE
Implement chain export functionality and car writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,7 @@ dependencies = [
  "forest_encoding",
  "forest_message",
  "forest_vm",
+ "futures 0.3.8",
  "interpreter",
  "ipld_blockstore",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,6 +2667,7 @@ dependencies = [
  "forest_car",
  "forest_cid",
  "forest_encoding",
+ "futures 0.3.8",
  "ipld_blockstore",
  "log",
  "net_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,6 +2281,7 @@ dependencies = [
 name = "forest_car"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "db",
  "forest_cid",
  "forest_encoding",
@@ -2289,7 +2290,6 @@ dependencies = [
  "ipld_blockstore",
  "serde",
  "thiserror",
- "unsigned-varint 0.5.1",
 ]
 
 [[package]]
@@ -6705,10 +6705,6 @@ name = "unsigned-varint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
-dependencies = [
- "futures-io",
- "futures-util",
-]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,9 +950,11 @@ dependencies = [
  "forest_address",
  "forest_bigint",
  "forest_blocks",
+ "forest_car",
  "forest_cid",
  "forest_crypto",
  "forest_encoding",
+ "forest_ipld",
  "forest_message",
  "futures 0.3.8",
  "interpreter",
@@ -2282,6 +2284,8 @@ dependencies = [
  "db",
  "forest_cid",
  "forest_encoding",
+ "futures 0.3.8",
+ "integer-encoding",
  "ipld_blockstore",
  "serde",
  "thiserror",
@@ -3101,6 +3105,10 @@ name = "integer-encoding"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddae3dfefb8ba2cb7c2bab20594847cea19f0cd0f28d57a4e79a12ddcfa9940"
+dependencies = [
+ "async-trait",
+ "futures-util",
+]
 
 [[package]]
 name = "interpreter"
@@ -6698,8 +6706,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 dependencies = [
- "bytes",
- "futures_codec",
+ "futures-io",
+ "futures-util",
 ]
 
 [[package]]

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -33,6 +33,8 @@ lazy_static = "1.4"
 interpreter = { path = "../../vm/interpreter/" }
 lru = "0.6"
 rayon = "1.3"
+forest_car = { path = "../../ipld/car" }
+forest_ipld = { path = "../../ipld" }
 
 [features]
 json = []

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -4,7 +4,7 @@
 use super::{ChainIndex, Error};
 use actor::{power::State as PowerState, STORAGE_POWER_ACTOR_ADDR};
 use address::Address;
-use async_std::sync::RwLock;
+use async_std::sync::{channel, RwLock};
 use async_std::task;
 use beacon::{BeaconEntry, IGNORE_DRAND_VAR};
 use blake2b_simd::Params;
@@ -16,7 +16,9 @@ use clock::ChainEpoch;
 use crypto::DomainSeparationTag;
 use encoding::{blake2b_256, de::DeserializeOwned, from_slice, Cbor};
 use flo_stream::{MessagePublisher, Publisher, Subscriber};
-use futures::{future, StreamExt};
+use forest_car::CarHeader;
+use forest_ipld::Ipld;
+use futures::{future, AsyncWrite, StreamExt};
 use interpreter::BlockMessages;
 use ipld_amt::Amt;
 use ipld_blockstore::BlockStore;
@@ -28,7 +30,8 @@ use num_traits::Zero;
 use rayon::prelude::*;
 use serde::Serialize;
 use state_tree::StateTree;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::error::Error as StdError;
 use std::io::Write;
 use std::sync::Arc;
 use types::WINNING_POST_SECTOR_SET_LOOKBACK;
@@ -488,6 +491,140 @@ where
         let bmsgs = self.block_msgs_for_tipset(ts)?;
         Ok(bmsgs.into_iter().map(|bm| bm.messages).flatten().collect())
     }
+
+    /// Exports a range of tipsets, as well as the state roots based on the `recent_roots`.
+    pub async fn export<W>(
+        &self,
+        tipset: &Tipset,
+        recent_roots: ChainEpoch,
+        skip_old_msgs: bool,
+        mut writer: W,
+    ) -> Result<(), Error>
+    where
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
+        let (tx, mut rx) = channel(100);
+        let header = CarHeader::from(tipset.key().cids().to_vec());
+        let write_task =
+            task::spawn(async move { header.write_stream_async(&mut writer, &mut rx).await });
+
+        self.walk_snapshot(tipset, recent_roots, skip_old_msgs, |cid| {
+            let block = self
+                .blockstore()
+                .get_bytes(&cid)?
+                .ok_or_else(|| format!("Cid {} not found in blockstore", cid))?;
+
+            // * If cb can return a generic type, deserializing would remove need to clone.
+            task::block_on(tx.send((cid, block.clone())));
+            Ok(block)
+        })
+        .await?;
+
+        // Await on values being written.
+        write_task
+            .await
+            .map_err(|e| Error::Other(format!("Failed to write blocks in export: {}", e)))?;
+        Ok(())
+    }
+
+    pub async fn walk_snapshot<F>(
+        &self,
+        tipset: &Tipset,
+        recent_roots: ChainEpoch,
+        skip_old_msgs: bool,
+        mut cb: F,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(Cid) -> Result<Vec<u8>, Box<dyn StdError>>,
+    {
+        let mut seen = HashSet::<Cid>::new();
+        let mut blocks_to_walk: VecDeque<Cid> = tipset.cids().to_vec().into();
+        let mut current_min_height = tipset.epoch();
+        let incl_roots_epoch = tipset.epoch() - recent_roots;
+
+        // TODO add timer for export
+        info!("chain export started");
+        while let Some(next) = blocks_to_walk.pop_front() {
+            if seen.contains(&next) {
+                continue;
+            }
+
+            let data = cb(next)?;
+
+            let h = BlockHeader::unmarshal_cbor(&data)?;
+
+            if current_min_height > h.epoch() {
+                current_min_height = h.epoch();
+            }
+
+            if (!skip_old_msgs || h.epoch() > incl_roots_epoch) && seen.insert(*h.messages()) {
+                recurse_links(&mut seen, *h.messages(), &mut cb)?;
+            }
+
+            if h.epoch() > 0 {
+                for p in h.parents().cids() {
+                    blocks_to_walk.push_back(*p);
+                }
+            } else {
+                for p in h.parents().cids() {
+                    cb(*p)?;
+                }
+            }
+
+            if (h.epoch() == 0 || h.epoch() > incl_roots_epoch) && seen.insert(*h.state_root()) {
+                recurse_links(&mut seen, *h.state_root(), &mut cb)?;
+            }
+        }
+        info!("export finished");
+        Ok(())
+    }
+}
+
+fn traverse_ipld_links<F>(cb: &mut F, ipld: &Ipld) -> Result<(), Box<dyn StdError>>
+where
+    F: FnMut(Cid) -> Result<Vec<u8>, Box<dyn StdError>>,
+{
+    match ipld {
+        Ipld::Map(m) => {
+            for (_, v) in m.iter() {
+                traverse_ipld_links(cb, v)?;
+            }
+        }
+        Ipld::List(list) => {
+            for v in list.iter() {
+                traverse_ipld_links(cb, v)?;
+            }
+        }
+        Ipld::Link(cid) => {
+            if cid.codec() == cid::DAG_CBOR {
+                let bytes = cb(*cid)?;
+                let ipld = Ipld::unmarshal_cbor(&bytes)?;
+                traverse_ipld_links(cb, &ipld)?;
+            }
+        }
+        _ => (),
+    }
+    Ok(())
+}
+
+fn recurse_links<F>(walked: &mut HashSet<Cid>, root: Cid, cb: &mut F) -> Result<(), Error>
+where
+    F: FnMut(Cid) -> Result<Vec<u8>, Box<dyn StdError>>,
+{
+    if !walked.insert(root) {
+        // Cid has already been traversed
+        return Ok(());
+    }
+    if root.codec() != cid::DAG_CBOR {
+        return Ok(());
+    }
+
+    let bytes = cb(root)?;
+    let ipld = Ipld::unmarshal_cbor(&bytes)?;
+
+    traverse_ipld_links(cb, &ipld)?;
+
+    Ok(())
 }
 
 pub(crate) type TipsetCache = RwLock<LruCache<TipsetKeys, Arc<Tipset>>>;

--- a/blockchain/chain/src/store/errors.rs
+++ b/blockchain/chain/src/store/errors.rs
@@ -6,6 +6,7 @@ use cid::Error as CidErr;
 use db::Error as DbErr;
 use encoding::{error::Error as SerdeErr, Error as EncErr};
 use ipld_amt::Error as AmtErr;
+use std::error::Error as StdError;
 use thiserror::Error;
 
 /// Chain error
@@ -61,5 +62,11 @@ impl From<AmtErr> for Error {
 impl From<String> for Error {
     fn from(e: String) -> Self {
         Error::Other(e)
+    }
+}
+
+impl From<Box<dyn StdError>> for Error {
+    fn from(e: Box<dyn StdError>) -> Self {
+        Error::Other(e.to_string())
     }
 }

--- a/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
+++ b/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
@@ -48,7 +48,7 @@ async fn space_race_full_sync() {
     let (network_send, network_recv) = channel(20);
 
     // Initialize genesis using default (currently space-race) genesis
-    let (genesis, _) = initialize_genesis(None, &state_manager).unwrap();
+    let (genesis, _) = initialize_genesis(None, &state_manager).await.unwrap();
     let genesis = Arc::new(genesis);
 
     let beacon = Arc::new(DrandBeacon::new(
@@ -66,7 +66,9 @@ async fn space_race_full_sync() {
     let network = SyncNetworkContext::new(network_send, Arc::new(peer_manager), db);
 
     let provider_db = Arc::new(MemoryDB::default());
-    let cids: Vec<Cid> = load_car(provider_db.as_ref(), EXPORT_SR_40.as_ref()).unwrap();
+    let cids: Vec<Cid> = load_car(provider_db.as_ref(), EXPORT_SR_40.as_ref())
+        .await
+        .unwrap();
     let prov_cs = ChainStore::new(provider_db);
     let target = prov_cs
         .tipset_from_keys(&TipsetKeys::new(cids))

--- a/blockchain/chain_sync/src/sync_worker/validate_block_test.rs
+++ b/blockchain/chain_sync/src/sync_worker/validate_block_test.rs
@@ -23,13 +23,13 @@ async fn validate_specific_block() {
 
     let db = Arc::new(MemoryDB::default());
 
-    let cids = load_car(db.as_ref(), EXPORT_SR_40.as_ref()).unwrap();
+    let cids = load_car(db.as_ref(), EXPORT_SR_40.as_ref()).await.unwrap();
 
     let chain_store = Arc::new(ChainStore::new(db.clone()));
     let state_manager = Arc::new(StateManager::new(chain_store.clone()));
 
     // Initialize genesis using default (currently space-race) genesis
-    let (genesis, _) = initialize_genesis(None, &state_manager).unwrap();
+    let (genesis, _) = initialize_genesis(None, &state_manager).await.unwrap();
     let genesis = Arc::new(genesis);
 
     let beacon = Arc::new(DrandBeacon::new(

--- a/blockchain/message_pool/src/msgpool/mod.rs
+++ b/blockchain/message_pool/src/msgpool/mod.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-// Copyright 2020 ChainSafe Systems
-// SPDX-License-Identifier: Apache-2.0, MIT
 mod selection;
 use super::config::MpoolConfig;
 use super::errors::Error;

--- a/blockchain/message_pool/src/msgpool/mod.rs
+++ b/blockchain/message_pool/src/msgpool/mod.rs
@@ -1,5 +1,8 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
+
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
 mod selection;
 use super::config::MpoolConfig;
 use super::errors::Error;

--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use super::{allow_negative_chains, create_message_chains, MessagePool, Provider};
 use crate::msg_chain::MsgChain;
 use crate::{run_head_change, Error};

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -72,7 +72,7 @@ pub(super) async fn start(config: Config) {
     // Read Genesis file
     // * When snapshot command implemented, this genesis does not need to be initialized
     let (genesis, network_name) =
-        initialize_genesis(config.genesis_file.as_ref(), &state_manager).unwrap();
+        initialize_genesis(config.genesis_file.as_ref(), &state_manager).await.unwrap();
 
     // Sync from snapshot
     if let Some(path) = &config.snapshot_path {

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -71,8 +71,9 @@ pub(super) async fn start(config: Config) {
 
     // Read Genesis file
     // * When snapshot command implemented, this genesis does not need to be initialized
-    let (genesis, network_name) =
-        initialize_genesis(config.genesis_file.as_ref(), &state_manager).await.unwrap();
+    let (genesis, network_name) = initialize_genesis(config.genesis_file.as_ref(), &state_manager)
+        .await
+        .unwrap();
 
     // Sync from snapshot
     if let Some(path) = &config.snapshot_path {

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
 [dependencies]
-unsigned-varint = { version = "0.5", features = ["futures"] }
 cid = { package = "forest_cid", path = "../cid", features = ["cbor"] }
 forest_encoding = { path = "../../encoding" }
 blockstore = { package = "ipld_blockstore", path = "../blockstore" }
@@ -16,3 +15,4 @@ integer-encoding = { version = "2.1", features = ["futures_async"] }
 
 [dev-dependencies]
 db = { path = "../../node/db" }
+async-std = { version = "1.6.3", features = ["unstable", "attributes"] }

--- a/ipld/car/Cargo.toml
+++ b/ipld/car/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
 [dependencies]
-unsigned-varint = { version = "0.5", features = ["futures-codec"] }
+unsigned-varint = { version = "0.5", features = ["futures"] }
 cid = { package = "forest_cid", path = "../cid", features = ["cbor"] }
 forest_encoding = { path = "../../encoding" }
 blockstore = { package = "ipld_blockstore", path = "../blockstore" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+futures = "0.3.5"
+integer-encoding = { version = "2.1", features = ["futures_async"] }
 
 [dev-dependencies]
 db = { path = "../../node/db" }

--- a/ipld/car/src/error.rs
+++ b/ipld/car/src/error.rs
@@ -10,6 +10,10 @@ pub enum Error {
     ParsingError(String),
     #[error("Invalid CAR file: {0}")]
     InvalidFile(String),
+    #[error("Io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Cbor encoding error: {0}")]
+    Cbor(#[from] forest_encoding::error::Error),
     #[error("CAR error: {0}")]
     Other(String),
 }

--- a/ipld/car/tests/car_file_test.rs
+++ b/ipld/car/tests/car_file_test.rs
@@ -1,16 +1,16 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use async_std::fs::File;
+use async_std::io::BufReader;
 use db::MemoryDB;
 use forest_car::*;
-use std::fs::File;
-use std::io::BufReader;
 
-#[test]
-fn load_into_blockstore() {
-    let file = File::open("tests/test.car").unwrap();
+#[async_std::test]
+async fn load_into_blockstore() {
+    let file = File::open("tests/test.car").await.unwrap();
     let buf_reader = BufReader::new(file);
     let mut bs = MemoryDB::default();
 
-    let _ = load_car(&mut bs, buf_reader).unwrap();
+    let _ = load_car(&mut bs, buf_reader).await.unwrap();
 }

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -48,3 +48,4 @@ forest_address = { path = "../../vm/address" }
 num-bigint = { path = "../../utils/bigint", package = "forest_bigint" }
 crypto = { package = "forest_crypto", path = "../../crypto" }
 genesis = { path = "../../utils/genesis", features = ["testing"] }
+async-std = { version = "1.6.3", features = ["attributes"] }

--- a/tests/conformance_tests/Cargo.toml
+++ b/tests/conformance_tests/Cargo.toml
@@ -25,6 +25,7 @@ submodule_tests = [
     "state_manager",
     "state_tree",
     "forest_message",
+    "futures",
     "crypto"
 ]
 
@@ -53,6 +54,7 @@ fil_types = { path = "../../types", optional = true }
 forest_message = { path = "../../vm/message", features = ["json"], optional = true }
 state_tree = { path = "../../vm/state_tree/", optional = true }
 chain = { path = "../../blockchain/chain", optional = true }
+futures = { version = "0.3.5", optional = true }
 
 [dev-dependencies]
 regex = { version = "1.0" }

--- a/tests/conformance_tests/Cargo.toml
+++ b/tests/conformance_tests/Cargo.toml
@@ -64,7 +64,7 @@ lazy_static = "1.4"
 pretty_env_logger = "0.4.0"
 log = "0.4"
 paramfetch = { path = "../../utils/paramfetch" }
-async-std = "1.6"
+async-std = { version = "1.6", features = ["attributes"] }
 forest_blocks = { path = "../../blockchain/blocks" }
 chain_sync = { path = "../../blockchain/chain_sync" }
 statediff = { path = "../../utils/statediff" }

--- a/utils/genesis/Cargo.toml
+++ b/utils/genesis/Cargo.toml
@@ -20,3 +20,4 @@ fil_types = { path = "../../types" }
 encoding = { path = "../../encoding", package = "forest_encoding" }
 net_utils = { path = "../net_utils" }
 url = "2.1.1"
+futures = "0.3.5"

--- a/utils/genesis/src/lib.rs
+++ b/utils/genesis/src/lib.rs
@@ -1,21 +1,22 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use async_std::fs::File;
+use async_std::io::BufReader;
 use blocks::{BlockHeader, Tipset, TipsetKeys};
 use chain::ChainStore;
 use cid::Cid;
 use encoding::Cbor;
 use fil_types::verifier::ProofVerifier;
 use forest_car::load_car;
+use futures::AsyncRead;
 use ipld_blockstore::BlockStore;
 use log::{debug, info};
 use net_utils::FetchProgress;
 use state_manager::StateManager;
 use std::convert::TryFrom;
 use std::error::Error as StdError;
-use std::fs::File;
 use std::include_bytes;
-use std::io::{BufReader, Read};
 use std::sync::Arc;
 use url::Url;
 
@@ -24,7 +25,7 @@ pub const EXPORT_SR_40: &[u8; 1226395] = include_bytes!("mainnet/export40.car");
 
 /// Uses an optional file path or the default genesis to parse the genesis and determine if
 /// chain store has existing data for the given genesis.
-pub fn initialize_genesis<BS>(
+pub async fn initialize_genesis<BS>(
     genesis_fp: Option<&String>,
     state_manager: &StateManager<BS>,
 ) -> Result<(Tipset, String), Box<dyn StdError>>
@@ -33,15 +34,15 @@ where
 {
     let genesis = match genesis_fp {
         Some(path) => {
-            let file = File::open(path)?;
+            let file = File::open(path).await?;
             let reader = BufReader::new(file);
-            process_car(reader, state_manager.chain_store())?
+            process_car(reader, state_manager.chain_store()).await?
         }
         None => {
             debug!("No specified genesis in config. Using default genesis.");
             let bz = include_bytes!("mainnet/genesis.car");
             let reader = BufReader::<&[u8]>::new(bz.as_ref());
-            process_car(reader, state_manager.chain_store())?
+            process_car(reader, state_manager.chain_store()).await?
         }
     };
 
@@ -54,16 +55,16 @@ where
     Ok((Tipset::new(vec![genesis])?, network_name))
 }
 
-fn process_car<R, BS>(
+async fn process_car<R, BS>(
     reader: R,
     chain_store: &ChainStore<BS>,
 ) -> Result<BlockHeader, Box<dyn StdError>>
 where
-    R: Read,
+    R: AsyncRead + Send + Unpin,
     BS: BlockStore + Send + Sync + 'static,
 {
     // Load genesis state into the database and get the Cid
-    let genesis_cids: Vec<Cid> = load_car(chain_store.blockstore(), reader)?;
+    let genesis_cids: Vec<Cid> = load_car(chain_store.blockstore(), reader).await?;
     if genesis_cids.len() != 1 {
         panic!("Invalid Genesis. Genesis Tipset must have only 1 Block.");
     }
@@ -108,12 +109,14 @@ where
         let url = Url::parse(path).expect("URL is invalid");
         info!("Downloading file...");
         let reader = FetchProgress::try_from(url)?;
-        load_car(sm.blockstore(), reader)?
+        load_car(sm.blockstore(), reader).await?
     } else {
-        let file = File::open(&path).expect("Snapshot file path not found!");
+        let file = File::open(&path)
+            .await
+            .expect("Snapshot file path not found!");
         info!("Reading file...");
         let reader = FetchProgress::try_from(file)?;
-        load_car(sm.blockstore(), reader)?
+        load_car(sm.blockstore(), reader).await?
     };
     let ts = sm
         .chain_store()


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- I made the writer async, because it makes things a lot cleaner, faster and not block the async executor with file io.
  - Essentially, one task is receiving blocks of `(Cid, Vec<u8>)` and writing it, while the other is traversing the chain and passing any unvisited blocks through the channel. Better imo to do in parallel than doing it all in sequence
- There isn't currently any exposed usages of this (although the RPC endpoint can be easily added now) but the main reason I needed it was to be able to export chains and I updated forest-bench https://github.com/austinabell/forest-bench/commit/ad49fb404cef4993c223b55185cce27ac9c352c8

Car read is also async now, to avoid blocking executor on io reads (this is definitely less important, because all of our usages are before we start the node, but this is good to future proof for when we can import a car while the node is running)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->