### PR TITLE
Fix exit code handling in market

### DIFF
--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -1138,14 +1138,14 @@ where
     }
     // Generate unsigned bytes
     let sv_bz = to_vec(&proposal.proposal)
-        .map_err(|_| actor_error!(ErrIllegalArgument; "failed to serialize DealProposal"))?;
+        .map_err(|e| ActorError::from(e).wrap("failed to serialize DealProposal"))?;
 
     rt.verify_signature(
         &proposal.client_signature,
         &proposal.proposal.client,
         &sv_bz,
     )
-    .map_err(|e| actor_error!(ErrIllegalArgument, "signature proposal invalid: {}", e))?;
+    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalArgument, "signature proposal invalid"))?;
 
     Ok(())
 }

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -1462,11 +1462,9 @@ impl Actor {
                     pledge_delta += partition_pledge_delta; // expected to be zero, see note below.
 
                     partitions.set(decl.partition, partition).map_err(|e| {
-                        actor_error!(
-                            ErrIllegalState,
-                            "failed to save partition {:?}: {:?}",
-                            key,
-                            e
+                        e.downcast_default(
+                            ExitCode::ErrIllegalState,
+                            format!("failed to save partition {:?}", key,),
                         )
                     })?;
                 }

--- a/vm/actor/src/builtin/miner/state.rs
+++ b/vm/actor/src/builtin/miner/state.rs
@@ -234,9 +234,12 @@ impl State {
 
         allocated_sectors |= sector_numbers;
 
-        self.allocated_sectors = store.put(&allocated_sectors, Blake2b256).map_err(
-            |e| actor_error!(ErrIllegalArgument; "failed to mask allocated sectors bitfield: {:?}", e),
-        )?;
+        self.allocated_sectors = store.put(&allocated_sectors, Blake2b256).map_err(|e| {
+            e.downcast_default(
+                ExitCode::ErrIllegalArgument,
+                "failed to mask allocated sectors bitfield",
+            )
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Somehow missed this function when doing a pass, I'll do another quick scan to see if any others are still missing

Issue was there was an OOG error, that the go-implementation panics on the spot, and although it seems from looking at the specs-actors code that they overwrite the exit code, they don't if there was a panic internally.

The error message was a bit telling on the transition, so was easy to debug:
```
ActorError(fatal: false, exit_code: ErrIllegalArgument, msg: signature proposal invalid: ActorError(fatal: false, exit_code: SysErrOutOfGas, msg: not enough gas (used=17926312) (available=5045751)))
```

This happened on height: 34263

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->