### PR TITLE
Fork serde_bytes to disallow string and array deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5506,8 +5506,7 @@ dependencies = [
 [[package]]
 name = "serde_bytes"
 version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+source = "git+https://github.com/ChainSafe/serde-bytes?rev=118fa7e1cd0a09f329a86deb3f4e9e27a7319f8e#118fa7e1cd0a09f329a86deb3f4e9e27a7319f8e"
 dependencies = [
  "serde",
 ]

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ChainSafe/forest"
 [dependencies]
 blake2b_simd = "0.5.9"
 serde = { version = "1.0", features = ["derive"] }
-serde_bytes = "0.11.3"
+serde_bytes = { git = "https://github.com/ChainSafe/serde-bytes", rev = "118fa7e1cd0a09f329a86deb3f4e9e27a7319f8e" }
 # TODO remove fork in future (allowing non utf8 strings to be cbor deserialized)
 serde_cbor = { package = "cs_serde_cbor", version = "0.12", features = [
     "tags"

--- a/ipld/cid/Cargo.toml
+++ b/ipld/cid/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_cbor = { package = "cs_serde_cbor", version = "0.12", features = [
     "tags"
 ], optional = true }
-serde_bytes = { version = "0.11.3", optional = true }
+serde_bytes = { git = "https://github.com/ChainSafe/serde-bytes", rev = "118fa7e1cd0a09f329a86deb3f4e9e27a7319f8e", optional = true }
 thiserror = "1.0"
 forest_json_utils = { path = "../../utils/json_utils", optional = true, version = "0.1" }
 generic-array = "0.14.4"

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -12,7 +12,7 @@ cid = { package = "forest_cid", path = "../cid" }
 db = { path = "../../node/db" }
 ipld_blockstore = { path = "../blockstore" }
 forest_ipld = { path = "../" }
-serde_bytes = "0.11.3"
+serde_bytes = { git = "https://github.com/ChainSafe/serde-bytes", rev = "118fa7e1cd0a09f329a86deb3f4e9e27a7319f8e" }
 thiserror = "1.0"
 sha2 = "0.9.1"
 lazycell = "1.2.1"

--- a/utils/bigint/Cargo.toml
+++ b/utils/bigint/Cargo.toml
@@ -13,7 +13,7 @@ features = ["json"]
 [dependencies]
 num-bigint = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_bytes = "0.11.3"
+serde_bytes = { git = "https://github.com/ChainSafe/serde-bytes", rev = "118fa7e1cd0a09f329a86deb3f4e9e27a7319f8e" }
 num-integer = "0.1"
 
 [features]

--- a/utils/bitfield/Cargo.toml
+++ b/utils/bitfield/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 unsigned-varint = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-serde_bytes = "0.11.3"
+serde_bytes = { git = "https://github.com/ChainSafe/serde-bytes", rev = "118fa7e1cd0a09f329a86deb3f4e9e27a7319f8e" }
 ahash = "0.5"
 encoding = { package = "forest_encoding", path = "../../encoding" }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- https://github.com/ChainSafe/serde-bytes/commit/118fa7e1cd0a09f329a86deb3f4e9e27a7319f8e is commit and change on fork

Issue was that we allowed array deserialization (and `str`), and the go implementation restricted to only bytes. Now this is symmetric.

syncs past `36880` now, https://filfox.info/en/message/bafy2bzaceabrez25khsfltuiireeng2p3avoniczz2scfsi54hykltoxjeslk?block=bafy2bzacealjcrqg27r4ny4mos37u3mk7cwxajrwnoi6djodr5d6aqdrlmigs was the message that was the issue

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->