### PR TITLE
Implement Amt fuzzer

### DIFF
--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -22,6 +22,6 @@ criterion = "0.3.1"
 ipld_blockstore = { path = "../blockstore", features = ["tracking"] }
 
 [[bench]]
-name = "amt_beckmark"
+name = "amt_benchmark"
 path = "benches/amt_benchmark.rs"
 harness = false

--- a/ipld/amt/fuzz/.gitignore
+++ b/ipld/amt/fuzz/.gitignore
@@ -1,0 +1,5 @@
+
+target
+corpus
+artifacts
+Cargo.lock

--- a/ipld/amt/fuzz/Cargo.toml
+++ b/ipld/amt/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "ipld_amt-fuzz"
 version = "0.0.0"
-authors = ["Automatically generated"]
+authors = ["ChainSafe Systems <info@chainsafe.io>"]
 publish = false
 edition = "2018"
 

--- a/ipld/amt/fuzz/Cargo.toml
+++ b/ipld/amt/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+
+[package]
+name = "ipld_amt-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+arbitrary = { version = "0.4", features = ["derive"] }
+ahash = "0.5"
+db = { path = "../../../node/db" }
+
+[dependencies.ipld_amt]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "amt_fuzz"
+path = "fuzz_targets/amt_fuzz.rs"
+test = false
+doc = false

--- a/ipld/amt/fuzz/fuzz_targets/amt_fuzz.rs
+++ b/ipld/amt/fuzz/fuzz_targets/amt_fuzz.rs
@@ -1,0 +1,52 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use ipld_amt::{Amt, MAX_INDEX};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Debug, Arbitrary)]
+struct Operation {
+    idx: u64,
+    method: Method,
+}
+
+#[derive(Debug, Arbitrary)]
+enum Method {
+    Insert(u64),
+    Remove,
+    Get,
+}
+
+fuzz_target!(|data: (u8, Vec<Operation>)| {
+    let (flush_rate, operations) = data;
+    let db = db::MemoryDB::default();
+    let mut amt = Amt::new(&db);
+    let mut elements = ahash::AHashMap::new();
+
+    let flush_rate = (flush_rate as usize).saturating_add(5);
+    for (i, Operation { idx, method }) in operations.into_iter().enumerate() {
+        if i % flush_rate == 0 {
+            // Periodic flushing of Amt to fuzz blockstore usage also
+            amt.flush().unwrap();
+        }
+        if idx > MAX_INDEX {
+            continue;
+        }
+
+        match method {
+            Method::Insert(v) => {
+                elements.insert(idx, v);
+                amt.set(idx, v).unwrap();
+            }
+            Method::Remove => {
+                let el = elements.remove(&idx);
+                let amt_deleted = amt.delete(idx).unwrap();
+                assert_eq!(amt_deleted, el.is_some());
+            }
+            Method::Get => {
+                let ev = elements.get(&idx);
+                let av = amt.get(idx).unwrap();
+                assert_eq!(av, ev);
+            }
+        }
+    }
+});

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -72,12 +72,12 @@ where
         Ok(Self { root, block_store })
     }
 
-    // Getter for height
+    /// Gets the height of the `Amt`.
     pub fn height(&self) -> u64 {
         self.root.height
     }
 
-    // Getter for count
+    /// Gets count of elements added in the `Amt`.
     pub fn count(&self) -> u64 {
         self.root.count
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fuzz testing with `cargo-fuzz` for the Amt

What this does is fuzz test the usual operations on the Amt, and also performs the same operations on a map to ensure consistent functionality. This does two things: gives much larger confidence there will be no panics encountered with the Amt, and also gives more confidence of the functionality of the Amt in many different cases.

I ran the fuzzer with the go-interop feature on and off, and found no issues. I just wanted to fuzz the Amt and Hamt before cutting releases/ migrating to v2 actors

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->