### PR TITLE
Fix syncing regressions from #841

### DIFF
--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -594,10 +594,10 @@ where
                 ));
             }
 
-            let hp = sm_c.miner_has_min_power(h.miner_address(), &lbts)?;
+            let hp = sm_c.eligible_to_mine(h.miner_address(), &base_ts_clone, &lbts)?;
             if !hp {
                 return Err(Error::Validation(
-                    "Block's miner does not meet minimum power threshold".to_string(),
+                    "Block's miner is ineligible to mine".to_string(),
                 ));
             }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

Regressions from #841:
- Version getter was broken (I removed the unnecessary parts added to it, since it was very clunky and I don't know how I missed in review)
  - It was checking when the epoch `==` the fork epoch, not `<` or whatever would have been required with that setup
- Incorrect tipsets were being passed back from getting lookback
- If statement was wrong logic
- getting the next tipset was not incrementing epoch by one

Mb for missing these in review and not doing a more thorough test, but this only gets caught when doing a full sync, and we can't have that test run by default on CI because of network calls necessary

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->