### PR TITLE
A bunch of fixes for the RPC

### DIFF
--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -182,6 +182,7 @@ where
 
     /// Returns the currently tracked heaviest tipset
     pub async fn heaviest_tipset(&self) -> Option<Arc<Tipset>> {
+        // TODO: Figure out how to remove optional and return something everytime.
         self.heaviest.read().await.clone()
     }
 

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -180,7 +180,7 @@ where
         genesis(self.blockstore())
     }
 
-    /// Returns heaviest tipset from blockstore
+    /// Returns the currently tracked heaviest tipset
     pub async fn heaviest_tipset(&self) -> Option<Arc<Tipset>> {
         self.heaviest.read().await.clone()
     }
@@ -201,6 +201,9 @@ where
 
     /// Returns Tipset from key-value store from provided cids
     pub async fn tipset_from_keys(&self, tsk: &TipsetKeys) -> Result<Arc<Tipset>, Error> {
+        if tsk.cids().is_empty() {
+            return Ok(self.heaviest_tipset().await.unwrap());
+        }
         tipset_from_keys(&self.ts_cache, self.blockstore(), tsk).await
     }
 

--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -224,7 +224,7 @@ mod test_selection {
 
     #[async_std::test]
     async fn basic_message_selection() {
-        let mut mpool = make_test_mpool();
+        let mpool = make_test_mpool();
 
         let mut w1 = Wallet::new(MemKeyStore::new());
         let a1 = w1.generate_addr(SignatureType::Secp256k1).unwrap();
@@ -371,7 +371,7 @@ mod test_selection {
 
     #[async_std::test]
     async fn message_selection_trimming() {
-        let mut mpool = make_test_mpool();
+        let mpool = make_test_mpool();
 
         let mut w1 = Wallet::new(MemKeyStore::new());
         let a1 = w1.generate_addr(SignatureType::Secp256k1).unwrap();

--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -19,8 +19,8 @@ where
 {
     /// Selects messages for including in a block.
     pub async fn select_messages(
-        &mut self,
-        ts: Tipset,
+        &self,
+        ts: &Tipset,
         _tq: f64,
     ) -> Result<Vec<SignedMessage>, Error> {
         let cur_ts = self.cur_tipset.read().await.clone();
@@ -29,9 +29,9 @@ where
     }
 
     async fn select_messages_greedy(
-        &mut self,
+        &self,
         cur_ts: &Tipset,
-        ts: Tipset,
+        ts: &Tipset,
     ) -> Result<Vec<SignedMessage>, Error> {
         let base_fee = self.api.read().await.chain_compute_base_fee(&ts)?;
 

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -161,9 +161,7 @@ pub(super) async fn start(config: Config) {
                     network_send,
                     network_name,
                     events_pubsub: Arc::new(RwLock::new(Publisher::new(1000))),
-                    beacon: Schedule {
-                        0: vec![BeaconPoint { start: 0, beacon }],
-                    },
+                    beacon: Schedule(vec![BeaconPoint { start: 0, beacon }]),
                     chain_store,
                 },
                 &rpc_listen,

--- a/node/rpc/src/gas_api.rs
+++ b/node/rpc/src/gas_api.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::RpcState;
-use address::Address;
+use super::mpool_api::MessageSendSpec;
+use address::json::AddressJson;
 use beacon::Beacon;
-use blocks::TipsetKeys;
+use blocks::tipset_keys_json::TipsetKeysJson;
 use blockstore::BlockStore;
 use chain::{BASE_FEE_MAX_CHANGE_DENOM, BLOCK_GAS_TARGET, MINIMUM_BASE_FEE};
 use fil_types::{verifier::ProofVerifier, BLOCK_GAS_LIMIT};
@@ -21,7 +22,7 @@ const MAX_SPEND_ON_FEE_DENOM: i64 = 100;
 /// Estimate the fee cap
 pub(crate) async fn gas_estimate_fee_cap<DB, KS, B>(
     data: Data<RpcState<DB, KS, B>>,
-    Params(params): Params<(UnsignedMessageJson, i64, TipsetKeys)>,
+    Params(params): Params<(UnsignedMessageJson, i64, TipsetKeysJson)>,
 ) -> Result<String, JsonRpcError>
 where
     DB: BlockStore + Send + Sync + 'static,
@@ -66,7 +67,7 @@ where
 /// Estimate the fee cap
 pub(crate) async fn gas_estimate_gas_premium<DB, KS, B>(
     data: Data<RpcState<DB, KS, B>>,
-    Params(params): Params<(u64, Address, i64, TipsetKeys)>,
+    Params(params): Params<(u64, AddressJson, i64, TipsetKeysJson)>,
 ) -> Result<String, JsonRpcError>
 where
     DB: BlockStore + Send + Sync + 'static,
@@ -162,7 +163,7 @@ where
 /// Estimate the gas limit
 pub(crate) async fn gas_estimate_gas_limit<DB, KS, B, V>(
     data: Data<RpcState<DB, KS, B>>,
-    Params(params): Params<(UnsignedMessageJson, TipsetKeys)>,
+    Params(params): Params<(UnsignedMessageJson, TipsetKeysJson)>,
 ) -> Result<i64, JsonRpcError>
 where
     DB: BlockStore + Send + Sync + 'static,
@@ -207,4 +208,17 @@ where
         }
         None => Ok(-1),
     }
+}
+
+pub(crate) async fn gas_estimate_message_gas<DB, KS, B, V>(
+    data: Data<RpcState<DB, KS, B>>,
+    Params(params): Params<(UnsignedMessageJson, MessageSendSpec, TipsetKeysJson)>,
+) -> Result<UnsignedMessageJson, JsonRpcError>
+    where
+        DB: BlockStore + Send + Sync + 'static,
+        KS: KeyStore + Send + Sync + 'static,
+        B: Beacon + Send + Sync + 'static,
+        V: ProofVerifier + Send + Sync + 'static,
+{
+    todo!();
 }

--- a/node/rpc/src/gas_api.rs
+++ b/node/rpc/src/gas_api.rs
@@ -90,7 +90,7 @@ where
     KS: KeyStore + Send + Sync + 'static,
     B: Beacon + Send + Sync + 'static,
 {
-    let (mut nblocksincl, AddressJson(sender), gas_limit, TipsetKeysJson(tsk)) = params;
+    let (nblocksincl, AddressJson(sender), gas_limit, TipsetKeysJson(tsk)) = params;
     estimate_gas_premium::<DB, KS, B>(&data, nblocksincl, sender, gas_limit, tsk)
         .await
         .map(|n| BigInt::to_string(&n))
@@ -202,7 +202,7 @@ where
     B: Beacon + Send + Sync + 'static,
     V: ProofVerifier + Send + Sync + 'static,
 {
-    let (UnsignedMessageJson(mut msg), TipsetKeysJson(tsk)) = params;
+    let (UnsignedMessageJson(msg), TipsetKeysJson(tsk)) = params;
     estimate_gas_limit::<DB, KS, B, V>(&data, msg, tsk).await
 }
 
@@ -267,7 +267,7 @@ where
     B: Beacon + Send + Sync + 'static,
     V: ProofVerifier + Send + Sync + 'static,
 {
-    let (UnsignedMessageJson(mut msg), spec, TipsetKeysJson(tsk)) = params;
+    let (UnsignedMessageJson(msg), spec, TipsetKeysJson(tsk)) = params;
     estimate_message_gas::<DB, KS, B, V>(&data, msg, spec, tsk)
         .await
         .map(UnsignedMessageJson::from)

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -153,7 +153,7 @@ where
         .with_method("Filecoin.MpoolPush", mpool_push::<DB, KS, B>, false)
         .with_method(
             "Filecoin.MpoolPushMessage",
-            mpool_push_message::<DB, KS, B>,
+            mpool_push_message::<DB, KS, B, V>,
             false,
         )
         .with_method("Filecoin.MpoolSelect", mpool_select::<DB, KS, B>, false)

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -496,7 +496,9 @@ async fn handle_rpc<KS: KeyStore>(
     if WRITE_ACCESS.contains(&&*call.method) {
         if let Some(header) = authorization_header {
             // let keystore = PersistentKeyStore::new(get_home_dir() + "/.forest")?;
-            let ki = ks.read().await
+            let ki = ks
+                .read()
+                .await
                 .get(JWT_IDENTIFIER)
                 .map_err(|_| AuthError::Other("No JWT private key found".to_owned()))?;
             let key = ki.private_key();

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -206,7 +206,7 @@ where
             false,
         )
         .with_method(
-            "Filecoin.StateSectorInfo",
+            "Filecoin.StateSectorGetInfo",
             state_sector_info::<DB, KS, B>,
             false,
         )
@@ -233,6 +233,11 @@ where
         .with_method(
             "Filecoin.StateMinerRecoveries",
             state_miner_recoveries::<DB, KS, B>,
+            false,
+        )
+        .with_method(
+            "Filecoin.StateMinerPartitions",
+            state_miner_partitions::<DB, KS, B>,
             false,
         )
         .with_method("Filecoin.StateReplay", state_replay::<DB, KS, B>, false)
@@ -263,7 +268,7 @@ where
         )
         .with_method("Filecoin.StateWaitMsg", state_wait_msg::<DB, KS, B>, false)
         .with_method(
-            "Filecoin.NetworkName",
+            "Filecoin.StateNetworkName",
             state_network_name::<DB, KS, B>,
             false,
         )

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -155,6 +155,7 @@ where
             mpool_push_message::<DB, KS, B>,
             false,
         )
+        .with_method("Filecoin.MpoolSelect", mpool_select::<DB, KS, B>, false)
         // Sync API
         .with_method("Filecoin.SyncCheckBad", sync_check_bad::<DB, KS, B>, false)
         .with_method("Filecoin.SyncMarkBad", sync_mark_bad::<DB, KS, B>, false)
@@ -353,7 +354,7 @@ async fn handle_connection_and_log(
                 match message_result {
                     Ok(message) => {
                         let request_text = message.into_text().unwrap();
-                        info!("request senty {:?}", request_text.clone());
+                        info!("RPC Request Received: {:?}", request_text.clone());
                         match serde_json::from_str(&request_text)
                             as Result<RequestObject, serde_json::Error>
                         {

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -40,9 +40,7 @@ use log::{debug, error, info, warn};
 use message_pool::{MessagePool, MpoolRpcProvider};
 use serde::Serialize;
 use state_manager::StateManager;
-use utils::get_home_dir;
 use wallet::KeyStore;
-use wallet::PersistentKeyStore;
 
 type WsSink = SplitSink<WebSocketStream<TcpStream>, async_tungstenite::tungstenite::Message>;
 
@@ -294,6 +292,11 @@ where
         .with_method(
             "Filecoin.GasEstimateFeeCap",
             gas_estimate_fee_cap::<DB, KS, B>,
+            false,
+        )
+        .with_method(
+            "Filecoin.GasEstimateMessageGas",
+            gas_estimate_message_gas::<DB, KS, B, V>,
             false,
         )
         // Common

--- a/node/rpc/src/mpool_api.rs
+++ b/node/rpc/src/mpool_api.rs
@@ -18,7 +18,6 @@ use message::{
     SignedMessage,
 };
 use num_bigint::bigint_ser;
-use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::str::FromStr;

--- a/node/rpc/src/mpool_api.rs
+++ b/node/rpc/src/mpool_api.rs
@@ -10,6 +10,7 @@ use blocks::{tipset_keys_json::TipsetKeysJson, TipsetKeys};
 use blockstore::BlockStore;
 use cid::json::{vec::CidJsonVec, CidJson};
 use encoding::Cbor;
+use fil_types::verifier::FullVerifier;
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
 use message::Message;
 use message::{
@@ -22,7 +23,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::str::FromStr;
 use wallet::KeyStore;
-use fil_types::verifier::FullVerifier;
 
 /// Estimate the gas price for an Address
 pub(crate) async fn estimate_gas_premium<DB, KS, B>(
@@ -170,15 +170,16 @@ where
         .heaviest_tipset()
         .await
         .ok_or_else(|| "Could not get heaviest tipset".to_string())?;
-    let key_addr = data.state_manager
+    let key_addr = data
+        .state_manager
         .resolve_to_key_addr::<FullVerifier>(&from, &heaviest_tipset)
         .await?;
 
     if umsg.sequence() != 0 {
-        return Err("Expected nonce for MpoolPushMessage is 0, and will be calculated for you.".into());
+        return Err(
+            "Expected nonce for MpoolPushMessage is 0, and will be calculated for you.".into(),
+        );
     }
-
-
 
     if from.protocol() == Protocol::ID {
         umsg.from = key_addr;

--- a/node/rpc/src/mpool_api.rs
+++ b/node/rpc/src/mpool_api.rs
@@ -189,7 +189,6 @@ where
     if from.protocol() == Protocol::ID {
         umsg.from = key_addr;
     }
-    println!("Key addr: {}, addr {}", key_addr, from);
     let key = wallet::find_key(&key_addr, &*keystore)?;
     let sig = wallet::sign(
         *key.key_info.key_type(),

--- a/node/rpc/src/mpool_api.rs
+++ b/node/rpc/src/mpool_api.rs
@@ -158,7 +158,6 @@ where
     B: Beacon + Send + Sync + 'static,
     V: ProofVerifier + Send + Sync + 'static,
 {
-    // TODO handle defaults for sequence, gas limit and gas price
     let (UnsignedMessageJson(umsg), spec) = params;
 
     let from = *umsg.from();

--- a/node/rpc/src/state_api.rs
+++ b/node/rpc/src/state_api.rs
@@ -4,8 +4,7 @@
 use crate::RpcState;
 use actor::miner::MinerInfo;
 use actor::miner::{
-    ChainSectorInfo, Fault, SectorOnChainInfo, SectorPreCommitOnChainInfo, State,
-    WorkerKeyChange,
+    ChainSectorInfo, Fault, SectorOnChainInfo, SectorPreCommitOnChainInfo, State, WorkerKeyChange,
 };
 use actor::{DealID, DealWeight, TokenAmount};
 use address::{json::AddressJson, Address};
@@ -48,6 +47,16 @@ use wallet::KeyStore;
 pub struct MessageLookup {
     pub receipt: MessageReceiptJson,
     pub tipset: TipsetJson,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct Partition {
+    all_sectors: BitFieldJson,
+    faulty_sectors: BitFieldJson,
+    recovering_sectors: BitFieldJson,
+    live_sectors: BitFieldJson,
+    active_sectors: BitFieldJson,
 }
 
 /// returns info about the given miner's sectors. If the filter bitfield is nil, all sectors are included.
@@ -312,16 +321,6 @@ pub(crate) async fn state_miner_recoveries<
         .get_miner_recoveries::<FullVerifier>(&tipset, &actor)
         .map(|s| s.into())
         .map_err(|e| e.into())
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub(crate) struct Partition {
-    all_sectors: BitFieldJson,
-    faulty_sectors: BitFieldJson,
-    recovering_sectors: BitFieldJson,
-    live_sectors: BitFieldJson,
-    active_sectors: BitFieldJson,
 }
 
 /// returns a bitfield indicating the recovering sectors of the given miner

--- a/node/rpc/src/state_api.rs
+++ b/node/rpc/src/state_api.rs
@@ -4,9 +4,10 @@
 use crate::RpcState;
 use actor::miner::MinerInfo;
 use actor::miner::{
-    ChainSectorInfo, Deadlines, Fault, SectorOnChainInfo, SectorPreCommitOnChainInfo, State,
+    ChainSectorInfo, Fault, SectorOnChainInfo, SectorPreCommitOnChainInfo, State,
     WorkerKeyChange,
 };
+use actor::{DealID, DealWeight, TokenAmount};
 use address::{json::AddressJson, Address};
 use async_std::task;
 use beacon::{json::BeaconEntryJson, Beacon, BeaconEntry};
@@ -97,6 +98,12 @@ pub(crate) async fn state_call<
         .await?)
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct Deadline {
+    post_submissions: BitFieldJson,
+}
+
 /// returns all the proving deadlines for the given miner
 pub(crate) async fn state_miner_deadlines<
     DB: BlockStore + Send + Sync + 'static,
@@ -105,18 +112,29 @@ pub(crate) async fn state_miner_deadlines<
 >(
     data: Data<RpcState<DB, KS, B>>,
     Params(params): Params<(AddressJson, TipsetKeysJson)>,
-) -> Result<Deadlines, JsonRpcError> {
-    let state_manager = &data.state_manager;
+) -> Result<Vec<Deadline>, JsonRpcError> {
     let (actor, key) = params;
     let actor = actor.into();
-    let tipset = data
+    let mas = data
         .state_manager
         .chain_store()
-        .tipset_from_keys(&key.into())
-        .await?;
-    state_manager
-        .get_miner_deadlines::<FullVerifier>(&tipset, &actor)
-        .map_err(|e| e.into())
+        .miner_load_actor_tsk(&actor, &key.into())
+        .await
+        .map_err(|e| format!("Could not load miner {:?}", e))?;
+    let deadlines = mas
+        .load_deadlines(data.state_manager.chain_store().db.as_ref())
+        .map_err(|e| format!("Could not load deadlines {:?}", e))?;
+    let mut out = Vec::with_capacity(deadlines.due.len());
+    deadlines
+        .for_each(data.state_manager.chain_store().db.as_ref(), |_, dl| {
+            let ps = dl.post_submissions;
+            out.push(Deadline {
+                post_submissions: BitFieldJson(ps),
+            });
+            Ok(())
+        })
+        .map_err(|e| format!("Looping over deadlines failed: {}", e.to_string()))?;
+    Ok(out)
 }
 
 /// returns the PreCommit info for the specified miner's sector
@@ -173,7 +191,7 @@ pub async fn state_sector_info<
 >(
     data: Data<RpcState<DB, KS, B>>,
     Params(params): Params<(AddressJson, SectorNumber, TipsetKeysJson)>,
-) -> Result<Option<SectorOnChainInfo>, JsonRpcError> {
+) -> Result<Option<SectorOnChainInfoJson>, JsonRpcError> {
     let state_manager = &data.state_manager;
     let (address, sector_number, key) = params;
     let address = address.into();
@@ -185,6 +203,7 @@ pub async fn state_sector_info<
     state_manager
         .miner_sector_info::<FullVerifier>(&address, &sector_number, &tipset)
         .map_err(|e| e.into())
+        .map(|e| e.map(SectorOnChainInfoJson::from))
 }
 
 /// calculates the deadline at some epoch for a proving period
@@ -293,6 +312,53 @@ pub(crate) async fn state_miner_recoveries<
         .get_miner_recoveries::<FullVerifier>(&tipset, &actor)
         .map(|s| s.into())
         .map_err(|e| e.into())
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct Partition {
+    all_sectors: BitFieldJson,
+    faulty_sectors: BitFieldJson,
+    recovering_sectors: BitFieldJson,
+    live_sectors: BitFieldJson,
+    active_sectors: BitFieldJson,
+}
+
+/// returns a bitfield indicating the recovering sectors of the given miner
+pub(crate) async fn state_miner_partitions<
+    DB: BlockStore + Send + Sync + 'static,
+    KS: KeyStore + Send + Sync + 'static,
+    B: Beacon + Send + Sync + 'static,
+>(
+    data: Data<RpcState<DB, KS, B>>,
+    Params(params): Params<(AddressJson, u64, TipsetKeysJson)>,
+) -> Result<Vec<Partition>, JsonRpcError> {
+    let (actor, dl_idx, key) = params;
+    let actor = actor.into();
+    let db = data.state_manager.chain_store().db.as_ref();
+    let mas = data
+        .state_manager
+        .chain_store()
+        .miner_load_actor_tsk(&actor, &key.into())
+        .await
+        .map_err(|e| format!("Could not load miner {:?}", e))?;
+    let dl = mas
+        .load_deadlines(db)
+        .map_err(|e| format!("Failed to load deadlines: {:?}", e))?
+        .load_deadline(db, dl_idx)
+        .map_err(|e| format!("Failed to load sector {}: {:?}", dl_idx, e))?;
+    let mut out = Vec::new();
+    dl.for_each(db, |_, part| {
+        out.push(Partition {
+            all_sectors: part.sectors.clone().into(),
+            faulty_sectors: part.faults.clone().into(),
+            recovering_sectors: part.recoveries.clone().into(),
+            live_sectors: part.live_sectors().into(),
+            active_sectors: part.active_sectors().into(),
+        });
+        Ok(())
+    })?;
+    Ok(out)
 }
 
 /// returns the result of executing the indicated message, assuming it was executed in the indicated tipset.
@@ -522,6 +588,54 @@ where
     let (st, _) = task::block_on(state_manager.tipset_state::<FullVerifier>(&ts))?;
     let state_tree = StateTree::new_from_root(block_store, &st)?;
     Ok(state_tree)
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SectorOnChainInfoJson {
+    pub sector_number: SectorNumber,
+    /// The seal proof type implies the PoSt proofs
+    pub seal_proof: RegisteredSealProof,
+    /// CommR
+    pub sealed_cid: CidJson,
+    pub deal_ids: Vec<DealID>,
+    /// Epoch during which the sector proof was accepted
+    pub activation: ChainEpoch,
+    /// Epoch during which the sector expires
+    pub expiration: ChainEpoch,
+    /// Integral of active deals over sector lifetime
+    #[serde(with = "bigint_ser::json")]
+    pub deal_weight: DealWeight,
+    /// Integral of active verified deals over sector lifetime
+    #[serde(with = "bigint_ser::json")]
+    pub verified_deal_weight: DealWeight,
+    /// Pledge collected to commit this sector
+    #[serde(with = "bigint_ser::json")]
+    pub initial_pledge: TokenAmount,
+    /// Expected one day projection of reward for sector computed at activation time
+    #[serde(with = "bigint_ser::json")]
+    pub expected_day_reward: TokenAmount,
+    /// Expected twenty day projection of reward for sector computed at activation time
+    #[serde(with = "bigint_ser::json")]
+    pub expected_storage_pledge: TokenAmount,
+}
+
+impl From<SectorOnChainInfo> for SectorOnChainInfoJson {
+    fn from(info: SectorOnChainInfo) -> Self {
+        Self {
+            sector_number: info.sector_number,
+            seal_proof: info.seal_proof,
+            sealed_cid: CidJson(info.sealed_cid),
+            deal_ids: info.deal_ids,
+            activation: info.activation,
+            expiration: info.expiration,
+            deal_weight: info.deal_weight,
+            verified_deal_weight: info.verified_deal_weight,
+            initial_pledge: info.initial_pledge,
+            expected_day_reward: info.expected_day_reward,
+            expected_storage_pledge: info.expected_storage_pledge,
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/node/rpc/src/sync_api.rs
+++ b/node/rpc/src/sync_api.rs
@@ -167,9 +167,7 @@ mod tests {
             network_name: TEST_NET_NAME.to_owned(),
             events_pubsub: Arc::new(RwLock::new(Publisher::new(1000))),
             chain_store: cs_for_chain,
-            beacon: Schedule {
-                0: vec![BeaconPoint { start: 0, beacon }],
-            },
+            beacon: Schedule(vec![BeaconPoint { start: 0, beacon }]),
         });
         (state, network_rx)
     }

--- a/node/rpc/src/wallet_api.rs
+++ b/node/rpc/src/wallet_api.rs
@@ -211,7 +211,6 @@ where
     let key_addr = state_manager
         .resolve_to_key_addr::<FullVerifier>(&address, &heaviest_tipset)
         .await?;
-    println!("Key addr: {}, addr {}", key_addr, address);
     let msg = Vec::from(msg_string);
     let keystore = &mut *data.keystore.write().await;
     let key = match wallet::find_key(&key_addr, keystore) {

--- a/node/rpc/src/wallet_api.rs
+++ b/node/rpc/src/wallet_api.rs
@@ -6,7 +6,7 @@ use crate::RpcState;
 use address::{json::AddressJson, Address};
 use beacon::Beacon;
 use blockstore::BlockStore;
-use crypto::{signature::json::SignatureJson, SignatureType};
+use crypto::signature::json::{SignatureJson, signature_type::SignatureTypeJson};
 use encoding::Cbor;
 use fil_types::verifier::FullVerifier;
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
@@ -132,22 +132,20 @@ where
 /// List all Addresses in the Wallet
 pub(crate) async fn wallet_list<DB, KS, B>(
     data: Data<RpcState<DB, KS, B>>,
-) -> Result<Vec<String>, JsonRpcError>
+) -> Result<Vec<AddressJson>, JsonRpcError>
 where
     DB: BlockStore + Send + Sync + 'static,
     KS: KeyStore + Send + Sync + 'static,
     B: Beacon + Send + Sync + 'static,
 {
     let keystore = data.keystore.read().await;
-    let addr_vec = wallet::list_addrs(&*keystore)?;
-    let ret = addr_vec.into_iter().map(|a| a.to_string()).collect();
-    Ok(ret)
+    Ok(wallet::list_addrs(&*keystore)?.into_iter().map(AddressJson::from).collect())
 }
 
 /// Generate a new Address that is stored in the Wallet
 pub(crate) async fn wallet_new<DB, KS, B>(
     data: Data<RpcState<DB, KS, B>>,
-    Params(params): Params<(u8,)>,
+    Params(params): Params<(SignatureTypeJson,)>,
 ) -> Result<String, JsonRpcError>
 where
     DB: BlockStore + Send + Sync + 'static,
@@ -155,9 +153,8 @@ where
     B: Beacon + Send + Sync + 'static,
 {
     let (sig_raw,) = params;
-    let sig_type: SignatureType = serde_json::from_str(&sig_raw.to_string())?;
     let mut keystore = data.keystore.write().await;
-    let key = wallet::generate_key(sig_type)?;
+    let key = wallet::generate_key(sig_raw.0)?;
 
     let addr = format!("wallet-{}", key.address.to_string());
     keystore.put(addr, key.key_info.clone())?;
@@ -172,7 +169,7 @@ where
 /// Set the default Address for the Wallet
 pub(crate) async fn wallet_set_default<DB, KS, B>(
     data: Data<RpcState<DB, KS, B>>,
-    Params(params): Params<(String,)>,
+    Params(params): Params<(AddressJson,)>,
 ) -> Result<(), JsonRpcError>
 where
     DB: BlockStore + Send + Sync + 'static,
@@ -182,7 +179,7 @@ where
     let (address,) = params;
     let mut keystore = data.keystore.write().await;
 
-    let addr_string = format!("wallet-{}", address);
+    let addr_string = format!("wallet-{}", address.0);
     let key_info = keystore.get(&addr_string)?;
     keystore.remove("default".to_string())?; // This line should unregister current default key then continue
     keystore.put("default".to_string(), key_info)?;
@@ -211,6 +208,7 @@ where
     let key_addr = state_manager
         .resolve_to_key_addr::<FullVerifier>(&address, &heaviest_tipset)
         .await?;
+    println!("Key addr: {}, addr {}", key_addr, address);
     let msg = Vec::from(msg_string);
     let keystore = &mut *data.keystore.write().await;
     let key = match wallet::find_key(&key_addr, keystore) {

--- a/node/rpc/src/wallet_api.rs
+++ b/node/rpc/src/wallet_api.rs
@@ -6,7 +6,7 @@ use crate::RpcState;
 use address::{json::AddressJson, Address};
 use beacon::Beacon;
 use blockstore::BlockStore;
-use crypto::signature::json::{SignatureJson, signature_type::SignatureTypeJson};
+use crypto::signature::json::{signature_type::SignatureTypeJson, SignatureJson};
 use encoding::Cbor;
 use fil_types::verifier::FullVerifier;
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
@@ -139,7 +139,10 @@ where
     B: Beacon + Send + Sync + 'static,
 {
     let keystore = data.keystore.read().await;
-    Ok(wallet::list_addrs(&*keystore)?.into_iter().map(AddressJson::from).collect())
+    Ok(wallet::list_addrs(&*keystore)?
+        .into_iter()
+        .map(AddressJson::from)
+        .collect())
 }
 
 /// Generate a new Address that is stored in the Wallet

--- a/types/src/build_version/mod.rs
+++ b/types/src/build_version/mod.rs
@@ -18,7 +18,7 @@ const MINOR_ONLY_MASK: u32 = 0x00ff00;
 const PATCH_ONLY_MASK: u32 = 0x0000ff;
 
 //api versions
-const FULL_API_VERSION: Version = new_version(0, 17, 0);
+const FULL_API_VERSION: Version = new_version(1, 0, 0);
 const MINER_API_VERSION: Version = new_version(0, 15, 0);
 const WORKER_API_VERSION: Version = new_version(0, 15, 0);
 

--- a/types/src/deadlines/mod.rs
+++ b/types/src/deadlines/mod.rs
@@ -38,7 +38,6 @@ pub struct DeadlineInfo {
     w_post_challenge_window: ChainEpoch,
     #[serde(rename = "WPoStChallengeLookback")]
     w_post_challenge_lookback: ChainEpoch,
-    #[serde(rename = "FaultDeclarationCutoff")]
     fault_declaration_cutoff: ChainEpoch,
 }
 

--- a/types/src/deadlines/mod.rs
+++ b/types/src/deadlines/mod.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 /// Windows are non-overlapping ranges [Open, Close), but the challenge epoch for a window occurs before
 /// the window opens.
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Copy, Clone)]
+#[serde(rename_all = "PascalCase")]
 pub struct DeadlineInfo {
     /// Epoch at which this info was calculated.
     pub current_epoch: ChainEpoch,
@@ -29,10 +30,15 @@ pub struct DeadlineInfo {
     pub fault_cutoff: ChainEpoch,
 
     // Protocol parameters (This is intentionally included in the JSON response for deadlines)
+    #[serde(rename = "WPoStPeriodDeadlines")]
     w_post_period_deadlines: u64,
+    #[serde(rename = "WPoStProvingPeriod")]
     w_post_proving_period: ChainEpoch,
+    #[serde(rename = "WPoStChallengeWindow")]
     w_post_challenge_window: ChainEpoch,
+    #[serde(rename = "WPoStChallengeLookback")]
     w_post_challenge_lookback: ChainEpoch,
+    #[serde(rename = "FaultDeclarationCutoff")]
     fault_declaration_cutoff: ChainEpoch,
 }
 

--- a/vm/actor/src/builtin/miner/deadline_state.rs
+++ b/vm/actor/src/builtin/miner/deadline_state.rs
@@ -828,6 +828,14 @@ impl Deadline {
         self.post_submissions = BitField::new();
         Ok((new_faulty_power, failed_recovery_power))
     }
+    pub fn for_each<BS: BlockStore>(
+        &self,
+        store: &BS,
+        f: impl FnMut(u64, &Partition) -> Result<(), Box<dyn StdError>>,
+    ) -> Result<(), Box<dyn StdError>> {
+        let parts = self.partitions_amt(store)?;
+        parts.for_each(f)
+    }
 }
 
 pub struct PoStResult {

--- a/vm/message/src/signed_message.rs
+++ b/vm/message/src/signed_message.rs
@@ -146,6 +146,12 @@ pub mod json {
         }
     }
 
+    impl From<SignedMessage> for SignedMessageJson {
+        fn from(msg: SignedMessage) -> Self {
+            SignedMessageJson(msg)
+        }
+    }
+
     pub fn serialize<S>(m: &SignedMessage, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/vm/message/src/unsigned_message.rs
+++ b/vm/message/src/unsigned_message.rs
@@ -215,8 +215,8 @@ impl Cbor for UnsignedMessage {}
 pub mod json {
     use super::*;
     use address::json::AddressJson;
-    use num_bigint::bigint_ser;
     use cid::Cid;
+    use num_bigint::bigint_ser;
     use serde::{de, ser};
 
     /// Wrapper for serializing and deserializing a UnsignedMessage from JSON.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Refactor Gas API so that logic in those methods are reusable.
- Adds gas_estimate_message_gas API call that allows for estimation of gas parameters like the premium, fee cap, etc...

- Fixes some of the JSONRPC method names that have changed since initially implemented
- Fixes Websocket Auth handling. Before a new PersistantKeyStore was created upon every connection and saved to `~./forest`. This is not right, as we pass in the PersistantKeyStore via the RpcState.

- Adds message pool message selection to the RPC.
- Fixes some methods in message pool RPC.

- Fixes a bunch of methods in the state manager RPC.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->

Making this PR before more random fixes come in and PR blows up with too many changes in too many different places. 
There is still some weird issue on when a message gets pushed to the message pool. I believe it has something to do with the VM execution though... 
<!-- Thank you 🔥 -->