### PR TITLE
Remove coverage from CI until fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ commands:
             echo 'export CARGO_INCREMENTAL=0' >> $BASH_ENV
             echo 'export CI_TIMEOUT="timeout 40m"' >> $BASH_ENV
             echo 'export CC=gcc' >> $BASH_ENV
+            echo 'export FIL_PROOFS_PARAMETER_CACHE=$HOME/.proof-params' >> $BASH_ENV
   install_deps:
     steps:
       - run:
@@ -179,7 +180,7 @@ jobs:
           command: make install
 
   ######################################################################################################################
-  #  Testing, linting, code coverage and doc publishing
+  #  Testing, linting and doc publishing
   ######################################################################################################################
   lint:
     executor: test-executor
@@ -187,6 +188,9 @@ jobs:
     steps:
       - build_setup
       - restore_cargo_package_cache
+      - run:
+          name: Check license
+          command: make license
       - run:
           name: cargo clippy
           command: cargo clippy -- -D warnings
@@ -211,54 +215,6 @@ jobs:
       - run:
           name: Run test vectors
           command: make run-vectors
-  # TODO: change executor to ubuntu
-  coverage:
-    executor: mac-executor
-    description: Run coverage reporting using grcov
-    steps:
-      - checkout
-      - when:
-          condition:
-            equal: [main, << pipeline.git.branch >>]
-          steps:
-          - run:
-              name: Install rust toolchain
-              command: |
-                curl https://sh.rustup.rs -sSf -o install_rust.sh
-                chmod +x install_rust.sh
-                ./install_rust.sh -q -y
-                rm install_rust.sh
-                export PATH="${HOME}/.cargo/bin:${PATH}"
-                rustc -V
-          - env_setup
-          - run:
-              name: Set rustc version
-              command: |
-                rustup default nightly
-                rustup update nightly
-          - run:
-              name: Install deps
-              command: |
-                brew install hwloc
-          - run:
-              name: Install grcov
-              command: |
-                cargo install grcov
-          - run:
-              name: Avoid hosts unknown for github
-              command: echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-          - run:
-              name: Run test suite
-              command: |
-                export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Coverflow-checks=off"
-                make build
-                git submodule update --init
-                sudo make test-all
-          - run:
-              name: Upload to codecov
-              command: |
-                grcov ./target/debug -s . -t lcov --llvm --branch --ignore-not-existing --ignore="tests/*" --ignore="target/debug/build/*" --ignore="**/tests/*" -o lcov.info;
-                bash <(curl -s https://codecov.io/bash) -f lcov.info;
   publish-docs:
     executor: test-executor
     description: Publish documentation to GitHub pages
@@ -331,13 +287,6 @@ workflows:
   docs:
     jobs:
       - publish-docs:
-          filters:
-            branches:
-              only:
-                - main
-  coverage:
-    jobs:
-      - coverage:
           filters:
             branches:
               only:

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/filecoin-project/serialization-vectors.git
 [submodule "ipld/tests/ipld-traversal-vectors"]
 	path = ipld/tests/ipld-traversal-vectors
-	url = git@github.com:ChainSafe/ipld-traversal-vectors.git
+	url = https://github.com:ChainSafe/ipld-traversal-vectors.git
 [submodule "tests/conformance_tests/test-vectors"]
 	path = tests/conformance_tests/test-vectors
 	url = https://github.com/filecoin-project/test-vectors.git

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 
 [<img alt="build status" src="https://img.shields.io/circleci/build/gh/ChainSafe/forest/main?style=for-the-badge" height="20">](https://app.circleci.com/pipelines/github/ChainSafe/forest?branch=main)
-[<img alt="Coverage" src="https://img.shields.io/codecov/c/gh/ChainSafe/forest?color=orange&flag=main&style=for-the-badge&token=1OHO2CSD17" height="20">](https://codecov.io/gh/ChainSafe/forest)
 [<img alt="Apache License" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" height="20">](https://opensource.org/licenses/Apache-2.0)
 [<img alt="MIT License" src="https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge" height="20">](https://opensource.org/licenses/MIT)
 [<img alt="Discord" src="https://img.shields.io/discord/593655374469660673.svg?style=for-the-badge&label=Discord&logo=discord" height="20">](https://discord.gg/Q6A3YA2)


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Been wasting CI resources, but I want to make this change to fix a few things:
  - New CI wasn't checking license anymore
  - Fix gitmodules https over git
  - README coverage label broken (will fix in #860 or whatever PR fixes it when we have the time)
  - Use env variable for proofs cache



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->