### PR TITLE
Update CI build checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,8 @@ jobs:
           command: |
             rustup run nightly rustc --version --verbose
             rustup run nightly cargo --version --verbose
-            rustup run nightly cargo build
+            cargo +nightly check -p forest
+            cargo +nightly check
   macos-build-check:
     executor: mac-executor
     description: Check macos build
@@ -168,7 +169,8 @@ jobs:
           command: |
             rustup run stable rustc --version --verbose
             rustup run stable cargo --version --verbose
-            rustup run stable cargo build
+            cargo +stable check -p forest
+            cargo +stable check
   install:
     executor: test-executor
     description: Install forest binary


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Added check for `forest` specific binary. The reason for adding this is that our install check is only run daily on main, but is not checked on PR in. Just trying to avoid our main build breaking again as it did with https://app.circleci.com/pipelines/github/ChainSafe/forest/2927/workflows/68de5cfb-c7e0-4745-88e4-9fde5dcf4a97/jobs/8324
- Switched `build` to `check`. Not sure why it was build



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->