### PR TITLE
Version Hamt, Amt, State tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
  "interpreter",
  "ipld_amt 0.2.0",
  "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_hamt 0.2.0",
+ "ipld_hamt 0.1.1",
  "libp2p",
  "log",
  "lru",
@@ -2256,7 +2256,7 @@ dependencies = [
  "integer-encoding",
  "ipld_amt 0.2.0",
  "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_hamt 0.2.0",
+ "ipld_hamt 0.1.1",
  "lazy_static",
  "libp2p",
  "log",
@@ -2291,7 +2291,7 @@ dependencies = [
  "integer-encoding",
  "ipld_amt 0.1.0",
  "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_hamt 0.1.0",
+ "ipld_hamt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "num-derive",
@@ -2532,6 +2532,24 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
+]
+
+[[package]]
+name = "forest_hash_utils"
+version = "0.1.0"
+dependencies = [
+ "cs_serde_bytes",
+ "serde",
+]
+
+[[package]]
+name = "forest_hash_utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb061ad769411763a5d6ae39d596696657472b25a66387fbb0ba8c133bb6575"
+dependencies = [
+ "cs_serde_bytes",
+ "serde",
 ]
 
 [[package]]
@@ -3428,7 +3446,7 @@ dependencies = [
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "interpreter",
  "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_hamt 0.2.0",
+ "ipld_hamt 0.1.1",
  "lazy_static",
  "log",
  "num-traits 0.2.14",
@@ -3501,26 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "ipld_hamt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4699ac0df58d1d102532125142a13a28940a048434f861e1422bb2b5ce5bf"
-dependencies = [
- "byteorder 1.3.4",
- "cs_serde_bytes",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell",
- "serde",
- "sha2 0.9.2",
- "thiserror",
-]
-
-[[package]]
-name = "ipld_hamt"
-version = "0.2.0"
+version = "0.1.1"
 dependencies = [
  "byteorder 1.3.4",
  "criterion",
@@ -3528,6 +3527,7 @@ dependencies = [
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_db",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_hash_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3536,6 +3536,26 @@ dependencies = [
  "sha2 0.9.2",
  "thiserror",
  "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "ipld_hamt"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3aae17f7905e9a426094aa3fc9f645d0a2028959e6fedbf4840f88c4d9a1a0"
+dependencies = [
+ "byteorder 1.3.4",
+ "cs_serde_bytes",
+ "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_db",
+ "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_hash_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell",
+ "serde",
+ "sha2 0.9.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -6251,7 +6271,7 @@ dependencies = [
  "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_hamt 0.2.0",
+ "ipld_hamt 0.1.1",
 ]
 
 [[package]]
@@ -6266,7 +6286,7 @@ dependencies = [
  "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_hamt 0.2.0",
+ "ipld_hamt 0.1.1",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ name = "actor_interface"
 version = "0.1.0"
 dependencies = [
  "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_actor 0.1.0",
  "forest_actor 0.1.2",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,7 +914,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder 1.3.4",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flo_stream",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
@@ -953,7 +953,7 @@ dependencies = [
  "chain",
  "commcid 0.1.1",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flo_stream",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
@@ -1125,7 +1125,7 @@ dependencies = [
  "chain",
  "chain_sync",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "fil_types"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "async-std",
  "base64 0.13.0",
@@ -2017,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "fil_types"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681278d3761dcbe6097a307caf75fe73af16e31d1b1fccacd289638014f21f1b"
+checksum = "696bd64ef5a2c0cbe463b5d38b542b7a8da1851798b0b6fc6b252c0408721872"
 dependencies = [
  "async-std",
  "base64 0.13.0",
@@ -2199,7 +2199,7 @@ dependencies = [
  "chain",
  "chain_sync",
  "ctrlc",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flo_stream",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
@@ -2241,7 +2241,7 @@ dependencies = [
  "commcid 0.1.1",
  "derive_builder",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2278,7 +2278,7 @@ dependencies = [
  "byteorder 1.3.4",
  "commcid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2392,7 +2392,7 @@ dependencies = [
  "byteorder 1.3.4",
  "derive_builder",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2645,7 +2645,7 @@ version = "0.6.1"
 dependencies = [
  "base64 0.13.0",
  "derive_builder",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2666,7 +2666,7 @@ checksum = "4935036b1da07044b4c50cc7c228517be74f12a66fbbc6661c6f359a05f1dc74"
 dependencies = [
  "base64 0.13.0",
  "derive_builder",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2685,7 +2685,7 @@ dependencies = [
  "base64 0.13.0",
  "commcid 0.1.1",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs-api",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2707,7 +2707,7 @@ dependencies = [
  "base64 0.13.0",
  "commcid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs-api",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2977,7 +2977,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "chain",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_blocks",
  "forest_car",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3434,7 +3434,7 @@ dependencies = [
  "ahash 0.5.9",
  "byteorder 1.3.4",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
  "forest_blocks",
@@ -4304,7 +4304,7 @@ dependencies = [
  "async-trait",
  "blake2b_simd",
  "chain",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flo_stream",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
@@ -4887,7 +4887,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "blake2b_simd",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.8",
  "isahc",
  "log",
@@ -5616,7 +5616,7 @@ dependencies = [
  "chain",
  "chain_sync",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flo_stream",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5968,7 +5968,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
  "bls-signatures",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_blocks",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6232,7 +6232,7 @@ dependencies = [
  "beacon",
  "chain",
  "fil_clock 0.1.0",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs-api",
  "flo_stream",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6264,7 +6264,7 @@ name = "state_tree"
 version = "0.1.0"
 dependencies = [
  "actor_interface",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6281,7 +6281,7 @@ version = "0.1.0"
 dependencies = [
  "colored",
  "difference",
- "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,12 +17,13 @@ dependencies = [
  "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fil_types 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_actor 0.1.0",
- "forest_actor 0.1.1",
+ "forest_actor 0.1.2",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_hash_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p",
@@ -2268,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "forest_actor"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b7dfa6be70718b6013bb0fa5927f1cd587a185071db60358bccbe5442e607"
+checksum = "c957d92ef29bfe3a3b0ffa722233f169442f7880f9cc042461a2fa61ac3984dd"
 dependencies = [
  "ahash 0.5.9",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "utils/genesis",
     "utils/net_utils",
     "utils/statediff",
+    "utils/hash_utils",
     "types",
     "key_management",
 ]

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ clean:
 	@cargo clean -p message_pool
 	@cargo clean -p genesis
 	@cargo clean -p actor_interface
+	@cargo clean -p forest_hash_utils
 	@echo "Done cleaning."
 
 lint: license clean

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ipld_amt"
 description = "Sharded IPLD Array implementation."
+# TODO bump the major version when releasing v2 actors
 version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ipld_hamt"
 description = "Sharded IPLD HashMap implementation."
+# TODO bump the major version when releasing v2 actors
 version = "0.1.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]

--- a/ipld/hamt/Cargo.toml
+++ b/ipld/hamt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ipld_hamt"
 description = "Sharded IPLD HashMap implementation."
-version = "0.2.0"
+version = "0.1.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
@@ -19,6 +19,7 @@ serde_bytes = { package = "cs_serde_bytes", version = "0.12" }
 thiserror = "1.0"
 sha2 = "0.9.1"
 lazycell = "1.2.1"
+forest_hash_utils = "0.1"
 
 [features]
 identity = []

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -1,10 +1,10 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use forest_hash_utils::BytesKey;
 use crate::node::Node;
 use crate::{Error, Hash, HashAlgorithm, Sha256, DEFAULT_BIT_WIDTH};
 use cid::{Cid, Code::Blake2b256};
+use forest_hash_utils::BytesKey;
 use ipld_blockstore::BlockStore;
 use serde::{de::DeserializeOwned, Serialize, Serializer};
 use std::borrow::Borrow;

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::BytesKey;
+use forest_hash_utils::BytesKey;
 use crate::node::Node;
 use crate::{Error, Hash, HashAlgorithm, Sha256, DEFAULT_BIT_WIDTH};
 use cid::{Cid, Code::Blake2b256};

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -23,10 +23,8 @@ pub use self::hamt::Hamt;
 pub use self::hash::*;
 pub use self::hash_algorithm::*;
 
+pub use forest_hash_utils::{BytesKey, Hash};
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
-use std::hash::Hasher;
-use std::ops::Deref;
 
 const MAX_ARRAY_WIDTH: usize = 3;
 
@@ -50,60 +48,5 @@ impl<K, V> KeyValuePair<K, V> {
 impl<K, V> KeyValuePair<K, V> {
     pub fn new(key: K, value: V) -> Self {
         KeyValuePair(key, value)
-    }
-}
-
-/// Key type to be used to isolate usage of unsafe code and allow non utf-8 bytes to be
-/// serialized as a string.
-#[derive(Eq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct BytesKey(#[serde(with = "serde_bytes")] pub Vec<u8>);
-
-impl PartialEq for BytesKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl Hash for BytesKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(&self.0);
-    }
-}
-
-impl Borrow<[u8]> for BytesKey {
-    fn borrow(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl Borrow<Vec<u8>> for BytesKey {
-    fn borrow(&self) -> &Vec<u8> {
-        &self.0
-    }
-}
-
-impl Deref for BytesKey {
-    type Target = Vec<u8>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<Vec<u8>> for BytesKey {
-    fn from(bz: Vec<u8>) -> Self {
-        BytesKey(bz)
-    }
-}
-
-impl From<&[u8]> for BytesKey {
-    fn from(s: &[u8]) -> Self {
-        Self(s.to_vec())
-    }
-}
-
-impl From<&str> for BytesKey {
-    fn from(s: &str) -> Self {
-        Self::from(s.as_bytes())
     }
 }

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -274,10 +274,10 @@ async fn conformance_test_runner() {
                 randomness,
             } => {
                 for variant in preconditions.variants {
-                    // if variant.nv > 3 {
-                    //     // Skip v2 upgrade and above
-                    //     continue;
-                    // }
+                    if variant.nv > 3 {
+                        // Skip v2 upgrade and above
+                        continue;
+                    }
                     if let Err(e) = execute_message_vector(
                         &selector,
                         &car,
@@ -311,10 +311,10 @@ async fn conformance_test_runner() {
                 postconditions,
             } => {
                 for variant in preconditions.variants {
-                    // if variant.nv > 3 {
-                    //     // Skip v2 upgrade and above
-                    //     continue;
-                    // }
+                    if variant.nv > 3 {
+                        // Skip v2 upgrade and above
+                        continue;
+                    }
                     if let Err(e) = execute_tipset_vector(
                         &selector,
                         &car,

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -274,10 +274,10 @@ async fn conformance_test_runner() {
                 randomness,
             } => {
                 for variant in preconditions.variants {
-                    if variant.nv > 3 {
-                        // Skip v2 upgrade and above
-                        continue;
-                    }
+                    // if variant.nv > 3 {
+                    //     // Skip v2 upgrade and above
+                    //     continue;
+                    // }
                     if let Err(e) = execute_message_vector(
                         &selector,
                         &car,
@@ -311,10 +311,10 @@ async fn conformance_test_runner() {
                 postconditions,
             } => {
                 for variant in preconditions.variants {
-                    if variant.nv > 3 {
-                        // Skip v2 upgrade and above
-                        continue;
-                    }
+                    // if variant.nv > 3 {
+                    //     // Skip v2 upgrade and above
+                    //     continue;
+                    // }
                     if let Err(e) = execute_tipset_vector(
                         &selector,
                         &car,

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_types"
 description = "Filecoin types used in Forest."
-version = "0.1.3"
+version = "0.1.5"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -4,9 +4,9 @@
 pub mod build_version;
 pub mod deadlines;
 mod piece;
-mod state;
 mod randomness;
 pub mod sector;
+mod state;
 mod version;
 
 #[cfg(feature = "json")]
@@ -16,9 +16,9 @@ pub mod genesis;
 pub mod verifier;
 
 pub use self::piece::*;
-pub use self::state::*;
 pub use self::randomness::*;
 pub use self::sector::*;
+pub use self::state::*;
 pub use self::version::*;
 
 use clock::{ChainEpoch, EPOCH_DURATION_SECONDS};

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod build_version;
 pub mod deadlines;
 mod piece;
+mod state;
 mod randomness;
 pub mod sector;
 mod version;
@@ -15,6 +16,7 @@ pub mod genesis;
 pub mod verifier;
 
 pub use self::piece::*;
+pub use self::state::*;
 pub use self::randomness::*;
 pub use self::sector::*;
 pub use self::version::*;

--- a/types/src/state.rs
+++ b/types/src/state.rs
@@ -1,7 +1,10 @@
 use cid::Cid;
+use encoding::repr::*;
+use encoding::tuple::*;
+use serde::{Deserialize, Serialize};
 
 /// Specifies the version of the state tree
-#[derive(Debug, PartialEq, Clone, Copy, PartialOrd)]
+#[derive(Debug, PartialEq, Clone, Copy, PartialOrd, Serialize_repr, Deserialize_repr)]
 #[repr(u64)]
 pub enum StateTreeVersion {
     /// Corresponds to actors < v2
@@ -10,6 +13,7 @@ pub enum StateTreeVersion {
     V1,
 }
 
+#[derive(Deserialize_tuple, Serialize_tuple)]
 pub struct StateRoot {
     /// State tree version
     pub version: StateTreeVersion,
@@ -20,3 +24,7 @@ pub struct StateRoot {
     /// Info. The structure depends on the state root version.
     pub info: Cid,
 }
+
+#[derive(Default, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct StateInfo0([(); 0]);

--- a/types/src/state.rs
+++ b/types/src/state.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use cid::Cid;
 use encoding::repr::*;
 use encoding::tuple::*;

--- a/types/src/state.rs
+++ b/types/src/state.rs
@@ -1,0 +1,22 @@
+use cid::Cid;
+
+/// Specifies the version of the state tree
+#[derive(Debug, PartialEq, Clone, Copy, PartialOrd)]
+#[repr(u64)]
+pub enum StateTreeVersion {
+    /// Corresponds to actors < v2
+    V0,
+    /// Corresponds to actors >= v2
+    V1,
+}
+
+pub struct StateRoot {
+    /// State tree version
+    pub version: StateTreeVersion,
+
+    /// Actors tree. The structure depends on the state root version.
+    pub actors: Cid,
+
+    /// Info. The structure depends on the state root version.
+    pub info: Cid,
+}

--- a/utils/hash_utils/Cargo.toml
+++ b/utils/hash_utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "forest_hash_utils"
+description = "Shared hashing utilities used in Ipld Hamt and shared references of it."
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+authors = ["ChainSafe Systems <info@chainsafe.io>"]
+edition = "2018"
+repository = "https://github.com/ChainSafe/forest"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_bytes = { package = "cs_serde_bytes", version = "0.12" }

--- a/utils/hash_utils/src/key.rs
+++ b/utils/hash_utils/src/key.rs
@@ -1,0 +1,61 @@
+use super::Hash;
+use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
+use std::hash::Hasher;
+use std::ops::Deref;
+
+/// Key type to be used to serialize as byte string instead of a `u8` array.
+/// This type is used as a default for the `Hamt` as this is the only allowed type
+/// with the go implementation.
+#[derive(Eq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BytesKey(#[serde(with = "serde_bytes")] pub Vec<u8>);
+
+impl PartialEq for BytesKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Hash for BytesKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(&self.0);
+    }
+}
+
+impl Borrow<[u8]> for BytesKey {
+    fn borrow(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Borrow<Vec<u8>> for BytesKey {
+    fn borrow(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+impl Deref for BytesKey {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for BytesKey {
+    fn from(bz: Vec<u8>) -> Self {
+        BytesKey(bz)
+    }
+}
+
+impl From<&[u8]> for BytesKey {
+    fn from(s: &[u8]) -> Self {
+        Self(s.to_vec())
+    }
+}
+
+impl From<&str> for BytesKey {
+    fn from(s: &str) -> Self {
+        Self::from(s.as_bytes())
+    }
+}

--- a/utils/hash_utils/src/key.rs
+++ b/utils/hash_utils/src/key.rs
@@ -10,15 +10,9 @@ use std::ops::Deref;
 /// Key type to be used to serialize as byte string instead of a `u8` array.
 /// This type is used as a default for the `Hamt` as this is the only allowed type
 /// with the go implementation.
-#[derive(Eq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialOrd, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(transparent)]
 pub struct BytesKey(#[serde(with = "serde_bytes")] pub Vec<u8>);
-
-impl PartialEq for BytesKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
 
 impl Hash for BytesKey {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/utils/hash_utils/src/key.rs
+++ b/utils/hash_utils/src/key.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use super::Hash;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;

--- a/utils/hash_utils/src/lib.rs
+++ b/utils/hash_utils/src/lib.rs
@@ -1,0 +1,166 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+mod key;
+
+pub use self::key::BytesKey;
+use std::hash::Hasher;
+use std::{mem, slice};
+
+/// Custom trait to avoid issues like https://github.com/rust-lang/rust/issues/27108.
+pub trait Hash {
+    fn hash<H: Hasher>(&self, state: &mut H);
+
+    fn hash_slice<H: Hasher>(data: &[Self], state: &mut H)
+    where
+        Self: Sized,
+    {
+        for piece in data {
+            piece.hash(state);
+        }
+    }
+}
+
+macro_rules! impl_write {
+    ($(($ty:ident, $meth:ident),)*) => {$(
+        impl Hash for $ty {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                state.$meth(*self)
+            }
+
+            fn hash_slice<H: Hasher>(data: &[$ty], state: &mut H) {
+                let newlen = data.len() * mem::size_of::<$ty>();
+                let ptr = data.as_ptr() as *const u8;
+                state.write(unsafe { slice::from_raw_parts(ptr, newlen) })
+            }
+        }
+    )*}
+}
+
+impl_write! {
+    (u8, write_u8),
+    (u16, write_u16),
+    (u32, write_u32),
+    (u64, write_u64),
+    (usize, write_usize),
+    (i8, write_i8),
+    (i16, write_i16),
+    (i32, write_i32),
+    (i64, write_i64),
+    (isize, write_isize),
+    (u128, write_u128),
+    (i128, write_i128),
+}
+
+impl Hash for bool {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u8(*self as u8)
+    }
+}
+
+impl Hash for char {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u32(*self as u32)
+    }
+}
+
+impl Hash for str {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.as_bytes());
+    }
+}
+
+impl Hash for String {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.as_bytes());
+    }
+}
+
+macro_rules! impl_hash_tuple {
+    () => (
+        impl Hash for () {
+            fn hash<H: Hasher>(&self, _state: &mut H) {}
+        }
+    );
+
+    ( $($name:ident)+) => (
+        impl<$($name: Hash),*> Hash for ($($name,)*) where last_type!($($name,)+): ?Sized {
+            #[allow(non_snake_case)]
+            fn hash<S: Hasher>(&self, state: &mut S) {
+                let ($(ref $name,)*) = *self;
+                $($name.hash(state);)*
+            }
+        }
+    );
+}
+
+macro_rules! last_type {
+    ($a:ident,) => { $a };
+    ($a:ident, $($rest_a:ident,)+) => { last_type!($($rest_a,)+) };
+}
+
+impl_hash_tuple! {}
+impl_hash_tuple! { A }
+impl_hash_tuple! { A B }
+impl_hash_tuple! { A B C }
+impl_hash_tuple! { A B C D }
+impl_hash_tuple! { A B C D E }
+impl_hash_tuple! { A B C D E F }
+impl_hash_tuple! { A B C D E F G }
+impl_hash_tuple! { A B C D E F G H }
+impl_hash_tuple! { A B C D E F G H I }
+impl_hash_tuple! { A B C D E F G H I J }
+impl_hash_tuple! { A B C D E F G H I J K }
+impl_hash_tuple! { A B C D E F G H I J K L }
+
+impl<T: Hash> Hash for [T] {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash_slice(self, state)
+    }
+}
+
+impl<T: Hash> Hash for Vec<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash_slice(self, state)
+    }
+}
+
+impl<T: ?Sized + Hash> Hash for &T {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (**self).hash(state);
+    }
+}
+
+impl<T: ?Sized + Hash> Hash for &mut T {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (**self).hash(state);
+    }
+}
+
+impl<T: ?Sized> Hash for *const T {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        if mem::size_of::<Self>() == mem::size_of::<usize>() {
+            // Thin pointer
+            state.write_usize(*self as *const () as usize);
+        } else {
+            // Fat pointer
+            let (a, b) = unsafe { *(self as *const Self as *const (usize, usize)) };
+            state.write_usize(a);
+            state.write_usize(b);
+        }
+    }
+}
+
+impl<T: ?Sized> Hash for *mut T {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        if mem::size_of::<Self>() == mem::size_of::<usize>() {
+            // Thin pointer
+            state.write_usize(*self as *const () as usize);
+        } else {
+            // Fat pointer
+            let (a, b) = unsafe { *(self as *const Self as *const (usize, usize)) };
+            state.write_usize(a);
+            state.write_usize(b);
+        }
+    }
+}

--- a/vm/actor/Cargo.toml
+++ b/vm/actor/Cargo.toml
@@ -20,7 +20,7 @@ cid = { package = "forest_cid", version = "0.3", features = ["cbor"] }
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4.0"
 ipld_blockstore = "0.1"
-ipld_hamt = { path = "../../ipld/hamt", features = ["go-interop", "v2"], version = "0.2" }
+ipld_hamt = { path = "../../ipld/hamt", features = ["go-interop", "v2"], version = "0.1" }
 ipld_amt = { path = "../../ipld/amt", features = ["go-interop"], version = "0.2" }
 forest_ipld = "0.1.1"
 unsigned-varint = "0.5"

--- a/vm/actor/src/lib.rs
+++ b/vm/actor/src/lib.rs
@@ -49,7 +49,7 @@ pub fn check_empty_params(params: &Serialized) -> Result<(), ActorError> {
 pub fn make_map<BS, V>(store: &'_ BS) -> Map<'_, BS, V>
 where
     BS: BlockStore,
-    V: DeserializeOwned + Serialize + Clone,
+    V: DeserializeOwned + Serialize,
 {
     Map::<_, V>::new_with_bit_width(store, HAMT_BIT_WIDTH)
 }
@@ -62,7 +62,7 @@ pub fn make_map_with_root<'bs, BS, V>(
 ) -> Result<Map<'bs, BS, V>, HamtError>
 where
     BS: BlockStore,
-    V: DeserializeOwned + Serialize + Clone,
+    V: DeserializeOwned + Serialize,
 {
     Map::<_, V>::load_with_bit_width(root, store, HAMT_BIT_WIDTH)
 }

--- a/vm/actor_interface/Cargo.toml
+++ b/vm/actor_interface/Cargo.toml
@@ -18,3 +18,4 @@ encoding = { package = "forest_encoding", version = "0.2.1" }
 libp2p = { version = "0.24", default-features = false }
 forest_bitfield = "0.1"
 num-bigint = { version = "0.1.1", package = "forest_bigint", features = ["json"] }
+forest_hash_utils = "0.1"

--- a/vm/actor_interface/src/adt/array.rs
+++ b/vm/actor_interface/src/adt/array.rs
@@ -1,0 +1,82 @@
+use crate::ActorVersion;
+use cid::Cid;
+use ipld_blockstore::BlockStore;
+use serde::{de::DeserializeOwned, Serialize};
+use std::error::Error;
+
+pub enum Array<'a, BS, V> {
+    V0(actorv0::ipld_amt::Amt<'a, V, BS>),
+    V2(actorv2::ipld_amt::Amt<'a, V, BS>),
+}
+
+impl<'a, BS, V> Array<'a, BS, V>
+where
+    V: Serialize + DeserializeOwned,
+    BS: BlockStore,
+{
+    pub fn new(store: &'a BS, version: ActorVersion) -> Self {
+        match version {
+            ActorVersion::V0 => Array::V0(actorv0::ipld_amt::Amt::new(store)),
+            ActorVersion::V2 => Array::V2(actorv2::ipld_amt::Amt::new(store)),
+        }
+    }
+
+    /// Load map with root
+    pub fn load(cid: &Cid, store: &'a BS, version: ActorVersion) -> Result<Self, Box<dyn Error>> {
+        match version {
+            ActorVersion::V0 => Ok(Array::V0(actorv0::ipld_amt::Amt::load(cid, store)?)),
+            ActorVersion::V2 => Ok(Array::V2(actorv2::ipld_amt::Amt::load(cid, store)?)),
+        }
+    }
+
+    /// Gets count of elements added in the `Array`.
+    pub fn count(&self) -> u64 {
+        match self {
+            Array::V0(m) => m.count(),
+            Array::V2(m) => m.count(),
+        }
+    }
+
+    /// Get value at index of `Array`
+    pub fn get(&self, i: u64) -> Result<Option<&V>, Box<dyn Error>> {
+        match self {
+            Array::V0(m) => Ok(m.get(i)?),
+            Array::V2(m) => Ok(m.get(i)?),
+        }
+    }
+
+    /// Set value at index
+    pub fn set(&mut self, i: u64, val: V) -> Result<(), Box<dyn Error>> {
+        match self {
+            Array::V0(m) => Ok(m.set(i, val)?),
+            Array::V2(m) => Ok(m.set(i, val)?),
+        }
+    }
+
+    /// Delete item from `Array` at index
+    pub fn delete(&mut self, i: u64) -> Result<bool, Box<dyn Error>> {
+        match self {
+            Array::V0(m) => Ok(m.delete(i)?),
+            Array::V2(m) => Ok(m.delete(i)?),
+        }
+    }
+
+    /// flush root and return Cid used as key in block store
+    pub fn flush(&mut self) -> Result<Cid, Box<dyn Error>> {
+        match self {
+            Array::V0(m) => Ok(m.flush()?),
+            Array::V2(m) => Ok(m.flush()?),
+        }
+    }
+
+    /// Iterates over each value in the `Array` and runs a function on the values.
+    pub fn for_each<F>(&self, f: F) -> Result<(), Box<dyn Error>>
+    where
+        F: FnMut(u64, &V) -> Result<(), Box<dyn Error>>,
+    {
+        match self {
+            Array::V0(m) => m.for_each(f),
+            Array::V2(m) => m.for_each(f),
+        }
+    }
+}

--- a/vm/actor_interface/src/adt/array.rs
+++ b/vm/actor_interface/src/adt/array.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use crate::ActorVersion;
 use cid::Cid;
 use ipld_blockstore::BlockStore;

--- a/vm/actor_interface/src/adt/map.rs
+++ b/vm/actor_interface/src/adt/map.rs
@@ -1,0 +1,106 @@
+use crate::ActorVersion;
+use cid::Cid;
+use forest_hash_utils::{BytesKey, Hash};
+use ipld_blockstore::BlockStore;
+use serde::{de::DeserializeOwned, Serialize};
+use std::borrow::Borrow;
+use std::error::Error;
+
+pub enum Map<'a, BS, V> {
+    V0(actorv0::Map<'a, BS, V>),
+    V2(actorv2::Map<'a, BS, V>),
+}
+
+impl<'a, BS, V> Map<'a, BS, V>
+where
+    V: Serialize + DeserializeOwned,
+    BS: BlockStore,
+{
+    pub fn new(store: &'a BS, version: ActorVersion) -> Self {
+        match version {
+            ActorVersion::V0 => Map::V0(actorv0::make_map(store)),
+            ActorVersion::V2 => Map::V2(actorv2::make_map(store)),
+        }
+    }
+
+    /// Load map with root
+    pub fn load(cid: &Cid, store: &'a BS, version: ActorVersion) -> Result<Self, Box<dyn Error>> {
+        match version {
+            ActorVersion::V0 => Ok(Map::V0(actorv0::make_map_with_root(cid, store)?)),
+            ActorVersion::V2 => Ok(Map::V2(actorv2::make_map_with_root(cid, store)?)),
+        }
+    }
+
+    /// Returns a reference to the underlying store of the `Map`.
+    pub fn store(&self) -> &'a BS {
+        match self {
+            Map::V0(m) => m.store(),
+            Map::V2(m) => m.store(),
+        }
+    }
+
+    /// Inserts a key-value pair into the `Map`.
+    pub fn set(&mut self, key: BytesKey, value: V) -> Result<(), Box<dyn Error>> {
+        match self {
+            Map::V0(m) => Ok(m.set(key, value)?),
+            Map::V2(m) => Ok(m.set(key, value)?),
+        }
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    pub fn get<Q: ?Sized>(&self, k: &BytesKey) -> Result<Option<&V>, Box<dyn Error>>
+    where
+        Q: Hash + Eq,
+        V: DeserializeOwned,
+    {
+        match self {
+            Map::V0(m) => Ok(m.get(k)?),
+            Map::V2(m) => Ok(m.get(k)?),
+        }
+    }
+
+    /// Returns `true` if a value exists for the given key in the `Map`.
+    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> Result<bool, Box<dyn Error>>
+    where
+        BytesKey: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        match self {
+            Map::V0(m) => Ok(m.contains_key(k)?),
+            Map::V2(m) => Ok(m.contains_key(k)?),
+        }
+    }
+
+    /// Removes a key from the `Map`, returning the value at the key if the key
+    /// was previously in the `Map`.
+    pub fn delete<Q: ?Sized>(&mut self, k: &Q) -> Result<Option<(BytesKey, V)>, Box<dyn Error>>
+    where
+        BytesKey: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        match self {
+            Map::V0(m) => Ok(m.delete(k)?),
+            Map::V2(m) => Ok(m.delete(k)?),
+        }
+    }
+
+    /// Flush root and return Cid for `Map`
+    pub fn flush(&mut self) -> Result<Cid, Box<dyn Error>> {
+        match self {
+            Map::V0(m) => Ok(m.flush()?),
+            Map::V2(m) => Ok(m.flush()?),
+        }
+    }
+
+    /// Iterates over each KV in the `Map` and runs a function on the values.
+    pub fn for_each<F>(&self, f: F) -> Result<(), Box<dyn Error>>
+    where
+        V: DeserializeOwned,
+        F: FnMut(&BytesKey, &V) -> Result<(), Box<dyn Error>>,
+    {
+        match self {
+            Map::V0(m) => m.for_each(f),
+            Map::V2(m) => m.for_each(f),
+        }
+    }
+}

--- a/vm/actor_interface/src/adt/map.rs
+++ b/vm/actor_interface/src/adt/map.rs
@@ -48,8 +48,9 @@ where
     }
 
     /// Returns a reference to the value corresponding to the key.
-    pub fn get<Q: ?Sized>(&self, k: &BytesKey) -> Result<Option<&V>, Box<dyn Error>>
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Result<Option<&V>, Box<dyn Error>>
     where
+        BytesKey: Borrow<Q>,
         Q: Hash + Eq,
         V: DeserializeOwned,
     {

--- a/vm/actor_interface/src/adt/map.rs
+++ b/vm/actor_interface/src/adt/map.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use crate::ActorVersion;
 use cid::Cid;
 use forest_hash_utils::{BytesKey, Hash};

--- a/vm/actor_interface/src/adt/mod.rs
+++ b/vm/actor_interface/src/adt/mod.rs
@@ -1,0 +1,5 @@
+mod array;
+mod map;
+
+pub use self::array::*;
+pub use self::map::*;

--- a/vm/actor_interface/src/adt/mod.rs
+++ b/vm/actor_interface/src/adt/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 mod array;
 mod map;
 

--- a/vm/actor_interface/src/lib.rs
+++ b/vm/actor_interface/src/lib.rs
@@ -1,9 +1,9 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+mod adt;
 mod builtin;
 mod policy;
-mod adt;
 
 pub use self::adt::*;
 pub use self::builtin::*;
@@ -11,7 +11,7 @@ pub use self::policy::*;
 pub use actorv0;
 pub use actorv2;
 
-use fil_types::NetworkVersion;
+use fil_types::{NetworkVersion, StateTreeVersion};
 
 pub enum ActorVersion {
     V0,
@@ -27,6 +27,15 @@ impl From<NetworkVersion> for ActorVersion {
             NetworkVersion::V4 | NetworkVersion::V5 | NetworkVersion::V6 | NetworkVersion::V7 => {
                 ActorVersion::V2
             }
+        }
+    }
+}
+
+impl From<StateTreeVersion> for ActorVersion {
+    fn from(version: StateTreeVersion) -> Self {
+        match version {
+            StateTreeVersion::V0 => ActorVersion::V0,
+            StateTreeVersion::V1 => ActorVersion::V2,
         }
     }
 }

--- a/vm/actor_interface/src/lib.rs
+++ b/vm/actor_interface/src/lib.rs
@@ -3,7 +3,9 @@
 
 mod builtin;
 mod policy;
+mod adt;
 
+pub use self::adt::*;
 pub use self::builtin::*;
 pub use self::policy::*;
 pub use actorv0;

--- a/vm/interpreter/tests/transfer_test.rs
+++ b/vm/interpreter/tests/transfer_test.rs
@@ -7,7 +7,7 @@ use cid::Code::{Blake2b256, Identity};
 use clock::ChainEpoch;
 use crypto::DomainSeparationTag;
 use db::MemoryDB;
-use fil_types::{verifier::MockVerifier, NetworkVersion};
+use fil_types::{verifier::MockVerifier, NetworkVersion, StateTreeVersion};
 use interpreter::{vm_send, CircSupplyCalc, DefaultRuntime, LookbackStateGetter, Rand};
 use ipld_blockstore::BlockStore;
 use ipld_hamt::Hamt;
@@ -59,7 +59,7 @@ impl Rand for MockRand {
 fn transfer_test() {
     let store = MemoryDB::default();
 
-    let mut state = StateTree::new(&store);
+    let mut state = StateTree::new(&store, StateTreeVersion::V0).unwrap();
 
     let e_cid = Hamt::<_, String>::new_with_bit_width(&store, 5)
         .flush()

--- a/vm/state_tree/Cargo.toml
+++ b/vm/state_tree/Cargo.toml
@@ -13,7 +13,7 @@ ipld_hamt = { path = "../../ipld/hamt" }
 forest_ipld = "0.1.1"
 ipld_blockstore = "0.1"
 db = { package = "forest_db", version = "0.1" }
-fil_types = "0.1"
+fil_types = { version = "0.1" }
 
 [dev-dependencies]
 num-bigint = { path = "../../utils/bigint", package = "forest_bigint" }

--- a/vm/state_tree/tests/state_tree_tests.rs
+++ b/vm/state_tree/tests/state_tree_tests.rs
@@ -9,6 +9,7 @@ use cid::{
     Cid,
     Code::{Blake2b256, Identity},
 };
+use fil_types::StateTreeVersion;
 use ipld_blockstore::BlockStore;
 use ipld_hamt::Hamt;
 use state_tree::*;
@@ -23,7 +24,7 @@ fn get_set_cache() {
     let act_a = ActorState::new(empty_cid(), empty_cid(), Default::default(), 2);
     let addr = Address::new_id(1);
     let store = db::MemoryDB::default();
-    let mut tree = StateTree::new(&store);
+    let mut tree = StateTree::new(&store, StateTreeVersion::V0).unwrap();
 
     // test address not in cache
     assert_eq!(tree.get_actor(&addr).unwrap(), None);
@@ -40,7 +41,7 @@ fn get_set_cache() {
 #[test]
 fn delete_actor() {
     let store = db::MemoryDB::default();
-    let mut tree = StateTree::new(&store);
+    let mut tree = StateTree::new(&store, StateTreeVersion::V0).unwrap();
 
     let addr = Address::new_id(3);
     let act_s = ActorState::new(empty_cid(), empty_cid(), Default::default(), 1);
@@ -53,7 +54,7 @@ fn delete_actor() {
 #[test]
 fn get_set_non_id() {
     let store = db::MemoryDB::default();
-    let mut tree = StateTree::new(&store);
+    let mut tree = StateTree::new(&store, StateTreeVersion::V0).unwrap();
 
     // Empty hamt Cid used for testing
     let e_cid = Hamt::<_, String>::new_with_bit_width(&store, 5)
@@ -104,7 +105,7 @@ fn get_set_non_id() {
 #[test]
 fn test_snapshots() {
     let store = db::MemoryDB::default();
-    let mut tree = StateTree::new(&store);
+    let mut tree = StateTree::new(&store, StateTreeVersion::V0).unwrap();
     let mut addresses: Vec<Address> = Vec::new();
     use num_bigint::BigInt;
 
@@ -181,7 +182,7 @@ fn test_snapshots() {
 #[test]
 fn revert_snapshot() {
     let store = db::MemoryDB::default();
-    let mut tree = StateTree::new(&store);
+    let mut tree = StateTree::new(&store, StateTreeVersion::V0).unwrap();
     use num_bigint::BigInt;
 
     let addr_str = "f01";


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Moved utils used by hamt into own crate so it can be used in the interface for a cleaner API
- Version `Amt`, `Hamt`, and `StateTree`
  - I was trying to put off doing this for later, but I want to track test vector progress as I update actors


Verified correct because now 1204/1294 test vectors pass (failures due to not all actors being updated, 1255/1294 now pass with the multisig actor update)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->