### PR TITLE
Add syncing configuration options

### DIFF
--- a/blockchain/chain_sync/src/lib.rs
+++ b/blockchain/chain_sync/src/lib.rs
@@ -18,6 +18,6 @@ extern crate serde;
 pub use self::bad_block_cache::BadBlockCache;
 pub use self::errors::Error;
 pub use self::network_context::SyncNetworkContext;
-pub use self::sync::ChainSyncer;
+pub use self::sync::{ChainSyncer, SyncConfig};
 pub use self::sync_state::{SyncStage, SyncState};
 pub use self::sync_worker::compute_msg_meta;

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -46,9 +46,13 @@ enum ChainSyncState {
     /// Following chain with blocks received over gossipsub.
     Follow,
 }
+
+/// Struct that defines syncing configuration options
 #[derive(Debug, Deserialize, Clone)]
 pub struct SyncConfig {
+    /// Request window length for tipsets during chain exchange
     pub req_window: i64,
+    /// Number of tasks spawned for sync workers
     pub worker_tasks: usize,
 }
 
@@ -102,6 +106,7 @@ pub struct ChainSyncer<DB, TBeacon, V, M> {
 
     mpool: Arc<MessagePool<M>>,
 
+    /// Syncing configurations
     sync_config: SyncConfig,
 }
 
@@ -288,6 +293,7 @@ where
 
     /// Spawns a network handler and begins the syncing process.
     pub async fn start(mut self, worker_tx: Sender<Arc<Tipset>>, worker_rx: Receiver<Arc<Tipset>>) {
+        // TODO benchmark (1 is temporary value to avoid overlap)
         for _ in 0..self.sync_config.worker_tasks {
             self.spawn_worker(worker_rx.clone()).await;
         }

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -27,6 +27,7 @@ use libp2p::core::PeerId;
 use log::{debug, info, trace, warn};
 use message::{SignedMessage, UnsignedMessage};
 use message_pool::{MessagePool, Provider};
+use serde::Deserialize;
 use state_manager::StateManager;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -45,7 +46,20 @@ enum ChainSyncState {
     /// Following chain with blocks received over gossipsub.
     Follow,
 }
+#[derive(Debug, Deserialize, Clone)]
+pub struct SyncConfig {
+    pub req_window: i64,
+    pub worker_tasks: usize,
+}
 
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            req_window: 200,
+            worker_tasks: 1,
+        }
+    }
+}
 /// Struct that handles the ChainSync logic. This handles incoming network events such as
 /// gossipsub messages, Hello protocol requests, as well as sending and receiving ChainExchange
 /// messages to be able to do the initial sync.
@@ -87,6 +101,8 @@ pub struct ChainSyncer<DB, TBeacon, V, M> {
     verifier: PhantomData<V>,
 
     mpool: Arc<MessagePool<M>>,
+
+    sync_config: SyncConfig,
 }
 
 impl<DB, TBeacon, V, M> ChainSyncer<DB, TBeacon, V, M>
@@ -103,6 +119,7 @@ where
         network_send: Sender<NetworkMessage>,
         network_rx: Receiver<NetworkEvent>,
         genesis: Arc<Tipset>,
+        cfg: SyncConfig,
     ) -> Result<Self, Error> {
         let network = SyncNetworkContext::new(
             network_send,
@@ -124,6 +141,7 @@ where
             next_sync_target: None,
             verifier: Default::default(),
             mpool,
+            sync_config: cfg,
         })
     }
 
@@ -269,13 +287,8 @@ where
     }
 
     /// Spawns a network handler and begins the syncing process.
-    pub async fn start(
-        mut self,
-        worker_tx: Sender<Arc<Tipset>>,
-        worker_rx: Receiver<Arc<Tipset>>,
-        num_workers: usize,
-    ) {
-        for _ in 0..num_workers {
+    pub async fn start(mut self, worker_tx: Sender<Arc<Tipset>>, worker_rx: Receiver<Arc<Tipset>>) {
+        for _ in 0..self.sync_config.worker_tasks {
             self.spawn_worker(worker_rx.clone()).await;
         }
 
@@ -345,6 +358,7 @@ where
             genesis: self.genesis.clone(),
             bad_blocks: self.bad_blocks.clone(),
             verifier: PhantomData::<V>::default(),
+            req_window: self.sync_config.req_window,
         }
         .spawn(channel)
         .await
@@ -596,6 +610,7 @@ mod tests {
                 local_sender,
                 event_receiver,
                 genesis_ts,
+                SyncConfig::default(),
             )
             .unwrap(),
             event_sender,

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -59,7 +59,7 @@ impl SyncConfig {
     pub fn new(req_window: i64, worker_tasks: usize) -> Self {
         Self {
             req_window,
-            worker_tasks
+            worker_tasks,
         }
     }
 }

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -55,8 +55,16 @@ pub struct SyncConfig {
     /// Number of tasks spawned for sync workers
     pub worker_tasks: usize,
 }
-
+impl SyncConfig {
+    pub fn new(req_window: i64, worker_tasks: usize) -> Self {
+        Self {
+            req_window,
+            worker_tasks
+        }
+    }
+}
 impl Default for SyncConfig {
+    // TODO benchmark (1 is temporary value to avoid overlap)
     fn default() -> Self {
         Self {
             req_window: 200,
@@ -64,6 +72,7 @@ impl Default for SyncConfig {
         }
     }
 }
+
 /// Struct that handles the ChainSync logic. This handles incoming network events such as
 /// gossipsub messages, Hello protocol requests, as well as sending and receiving ChainExchange
 /// messages to be able to do the initial sync.

--- a/blockchain/chain_sync/src/sync/peer_test.rs
+++ b/blockchain/chain_sync/src/sync/peer_test.rs
@@ -54,7 +54,7 @@ fn peer_manager_update() {
         local_sender,
         event_receiver,
         genesis_ts.clone(),
-        SyncConfig::default(),
+        SyncConfig::new(200, 0),
     )
     .unwrap();
 

--- a/blockchain/chain_sync/src/sync/peer_test.rs
+++ b/blockchain/chain_sync/src/sync/peer_test.rs
@@ -54,6 +54,7 @@ fn peer_manager_update() {
         local_sender,
         event_receiver,
         genesis_ts.clone(),
+        SyncConfig::default(),
     )
     .unwrap();
 
@@ -61,7 +62,7 @@ fn peer_manager_update() {
 
     let (worker_tx, worker_rx) = channel(10);
     task::spawn(async {
-        cs.start(worker_tx, worker_rx, 0).await;
+        cs.start(worker_tx, worker_rx).await;
     });
 
     let source = PeerId::random();

--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -1031,7 +1031,7 @@ mod tests {
                 genesis: genesis_ts,
                 bad_blocks: Default::default(),
                 verifier: Default::default(),
-                req_window: Default::default(),
+                req_window: 200,
             },
             test_receiver,
         )

--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -62,6 +62,8 @@ pub(crate) struct SyncWorker<DB, TBeacon, V> {
 
     /// Proof verification implementation.
     pub verifier: PhantomData<V>,
+
+    pub req_window: i64,
 }
 
 impl<DB, TBeacon, V> SyncWorker<DB, TBeacon, V>
@@ -190,11 +192,10 @@ where
                 continue;
             }
 
-            // TODO tweak request window when socket frame is tested
-            const REQUEST_WINDOW: i64 = 200;
             let epoch_diff = cur_ts.epoch() - to.epoch();
             debug!("ChainExchange from: {} to {}", cur_ts.epoch(), to.epoch());
-            let window = min(epoch_diff, REQUEST_WINDOW);
+            // TODO tweak request window when socket frame is tested
+            let window = min(epoch_diff, self.req_window);
 
             // Load blocks from network using chain_exchange
             // TODO consider altering window size before returning error for failed sync.
@@ -1029,6 +1030,7 @@ mod tests {
                 genesis: genesis_ts,
                 bad_blocks: Default::default(),
                 verifier: Default::default(),
+                req_window: Default::default(),
             },
             test_receiver,
         )

--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -63,6 +63,7 @@ pub(crate) struct SyncWorker<DB, TBeacon, V> {
     /// Proof verification implementation.
     pub verifier: PhantomData<V>,
 
+    /// Number of tipsets requested over chain exchange
     pub req_window: i64,
 }
 

--- a/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
+++ b/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
@@ -83,6 +83,7 @@ async fn space_race_full_sync() {
         genesis,
         bad_blocks: Default::default(),
         verifier: PhantomData::<FullVerifier>::default(),
+        req_window: Default::default(),
     };
 
     // Setup process to handle requests from syncer

--- a/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
+++ b/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
@@ -83,7 +83,7 @@ async fn space_race_full_sync() {
         genesis,
         bad_blocks: Default::default(),
         verifier: PhantomData::<FullVerifier>::default(),
-        req_window: Default::default(),
+        req_window: 200,
     };
 
     // Setup process to handle requests from syncer

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use beacon::DrandPublic;
+use chain_sync::SyncConfig;
 use forest_libp2p::Libp2pConfig;
 use serde::Deserialize;
 use utils::get_home_dir;
@@ -18,6 +19,7 @@ pub struct Config {
     /// Otherwise, we validate and compute the states.
     pub snapshot: bool,
     pub snapshot_path: Option<String>,
+    pub sync: SyncConfig,
 }
 
 impl Default for Config {
@@ -31,6 +33,7 @@ impl Default for Config {
             rpc_port: "1234".to_string(),
             snapshot_path: None,
             snapshot: false,
+            sync: SyncConfig::default()
         }
     }
 }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -80,7 +80,7 @@ pub struct DaemonOpts {
     pub worker_tasks: Option<usize>,
     #[structopt(
         long,
-        help = "Number of tipsets exchanged over the network (default is 200)"
+        help = "Number of tipsets requested over chain exchange (default is 200)"
     )]
     pub req_window: Option<i64>,
 }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -76,6 +76,10 @@ pub struct DaemonOpts {
     pub import_snapshot: Option<String>,
     #[structopt(long, help = "Import a chain from a local CAR file or url")]
     pub import_chain: Option<String>,
+    #[structopt(long, help = "Number of worker sync tasks spawned (default is 1")]
+    pub worker_tasks: Option<usize>,
+    #[structopt(long, help = "Number of tipsets exchanged over the network (default is 200)")]
+    pub req_window: Option<i64>,
 }
 
 impl DaemonOpts {
@@ -114,6 +118,13 @@ impl DaemonOpts {
         cfg.network.kademlia = self.kademlia.unwrap_or(cfg.network.kademlia);
         cfg.network.mdns = self.mdns.unwrap_or(cfg.network.mdns);
         // (where to find these flags, should be easy to do with structops)
+
+        if let Some(req_window) = &self.req_window {
+            cfg.sync.req_window = req_window.to_owned();
+        }
+        if let Some(worker_tsk) = &self.worker_tasks {
+            cfg.sync.worker_tasks = worker_tsk.to_owned();
+        }
 
         Ok(cfg)
     }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -78,7 +78,10 @@ pub struct DaemonOpts {
     pub import_chain: Option<String>,
     #[structopt(long, help = "Number of worker sync tasks spawned (default is 1")]
     pub worker_tasks: Option<usize>,
-    #[structopt(long, help = "Number of tipsets exchanged over the network (default is 200)")]
+    #[structopt(
+        long,
+        help = "Number of tipsets exchanged over the network (default is 200)"
+    )]
     pub req_window: Option<i64>,
 }
 
@@ -119,6 +122,8 @@ impl DaemonOpts {
         cfg.network.mdns = self.mdns.unwrap_or(cfg.network.mdns);
         // (where to find these flags, should be easy to do with structops)
 
+        // check and set syncing configurations
+        // TODO add MAX conditions
         if let Some(req_window) = &self.req_window {
             cfg.sync.req_window = req_window.to_owned();
         }

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -26,10 +26,6 @@ use std::sync::Arc;
 use utils::write_to_file;
 use wallet::{KeyStore, PersistentKeyStore};
 
-/// Number of tasks spawned for sync workers.
-// TODO benchmark and/or add this as a config option. (1 is temporary value to avoid overlap)
-const _WORKER_TASKS: usize = 1;
-
 /// Starts daemon process
 pub(super) async fn start(config: Config) {
     info!("Starting Forest daemon");

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -28,7 +28,7 @@ use wallet::{KeyStore, PersistentKeyStore};
 
 /// Number of tasks spawned for sync workers.
 // TODO benchmark and/or add this as a config option. (1 is temporary value to avoid overlap)
-const WORKER_TASKS: usize = 1;
+const _WORKER_TASKS: usize = 1;
 
 /// Starts daemon process
 pub(super) async fn start(config: Config) {
@@ -137,16 +137,15 @@ pub(super) async fn start(config: Config) {
         network_send.clone(),
         network_rx,
         Arc::new(genesis),
+        config.sync,
     )
     .unwrap();
     let bad_blocks = chain_syncer.bad_blocks_cloned();
     let sync_state = chain_syncer.sync_state_cloned();
     let (worker_tx, worker_rx) = channel(20);
     let worker_tx_clone = worker_tx.clone();
-    let sync_task = task::spawn(async {
-        chain_syncer
-            .start(worker_tx_clone, worker_rx, WORKER_TASKS)
-            .await;
+    let sync_task = task::spawn(async move {
+        chain_syncer.start(worker_tx_clone, worker_rx).await;
     });
 
     // Start services

--- a/forest/src/subcommand.rs
+++ b/forest/src/subcommand.rs
@@ -15,7 +15,6 @@ pub(super) async fn process(command: Subcommand) {
         Subcommand::Auth(cmd) => {
             cmd.run().await;
         }
-
         Subcommand::Genesis(cmd) => {
             cmd.run().await;
         }

--- a/forest/src/subcommand.rs
+++ b/forest/src/subcommand.rs
@@ -15,6 +15,7 @@ pub(super) async fn process(command: Subcommand) {
         Subcommand::Auth(cmd) => {
             cmd.run().await;
         }
+
         Subcommand::Genesis(cmd) => {
             cmd.run().await;
         }

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -393,7 +393,7 @@ async fn handle_connection_and_log<KS: KeyStore + Send + Sync + 'static>(
                     match message_result {
                         Ok(message) => {
                             let request_text = message.into_text().unwrap();
-                            if request_text == "" {
+                            if request_text.is_empty() {
                                 return;
                             }
                             info!("RPC Request Received: {:?}", request_text.clone());


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Adds `SyncConfig` to the `ChainSyncer` 
- Options include `worker_tasks` and `req_window`
- Adds sync options to `DaemonOpts` for command-line usage 
- Updates tests accordingly 




**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #801 


**Other information and links**
<!-- Add any other context about the pull request here. -->

Command-line usage:

```
forest --req-window 100 --worker-tasks 1
```

<!-- Thank you 🔥 -->