### PR TITLE
Add a cfg flag to build Forest in Devnet mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,6 +2182,8 @@ dependencies = [
 [[package]]
 name = "forest_actor"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbebfb82ffe7110c2cfd62da6118af0dcd71047c66deda7f5823956237d1be24"
 dependencies = [
  "ahash 0.5.9",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_actor 0.1.0",
- "forest_actor 0.1.2",
+ "forest_actor 0.1.3",
  "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2181,9 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "forest_actor"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c957d92ef29bfe3a3b0ffa722233f169442f7880f9cc042461a2fa61ac3984dd"
+version = "0.1.3"
 dependencies = [
  "ahash 0.5.9",
  "base64 0.13.0",

--- a/forest/Cargo.toml
+++ b/forest/Cargo.toml
@@ -48,3 +48,4 @@ encoding = { package = "forest_encoding", version = "0.2.1" }
 default = ["rocksdb"]
 rocksdb = ["db/rocksdb", "ipld_blockstore/rocksdb"]
 sled = ["db/sled", "ipld_blockstore/sled"]
+devnet = ["actor/devnet"]

--- a/vm/actor/Cargo.toml
+++ b/vm/actor/Cargo.toml
@@ -40,3 +40,6 @@ derive_builder = "0.9"
 db = { package = "forest_db", version = "0.1" }
 hex = "0.4.2"
 libp2p = { version = "0.24", default-features = false }
+
+[features]
+devnet = []

--- a/vm/actor/src/builtin/miner/policy.rs
+++ b/vm/actor/src/builtin/miner/policy.rs
@@ -58,7 +58,17 @@ pub const SEALED_CID_PREFIX: cid::Prefix = cid::Prefix {
 /// List of proof types which can be used when creating new miner actors
 pub fn check_supported_proof_types(proof: RegisteredSealProof) -> bool {
     use RegisteredSealProof::*;
-    matches!(proof, StackedDRG32GiBV1 | StackedDRG64GiBV1)
+    #[cfg(not(feature = "devnet"))]
+    {
+        matches!(proof, StackedDRG32GiBV1 | StackedDRG64GiBV1)
+    }
+    #[cfg(feature = "devnet")]
+    {
+        matches!(
+            proof,
+            StackedDRG2KiBV1 | StackedDRG32GiBV1 | StackedDRG64GiBV1
+        )
+    }
 }
 /// Maximum duration to allow for the sealing process for seal algorithms.
 /// Dependent on algorithm and sector size

--- a/vm/actor/src/builtin/sector.rs
+++ b/vm/actor/src/builtin/sector.rs
@@ -4,6 +4,7 @@
 use fil_types::{RegisteredSealProof, StoragePower};
 
 /// Returns the minimum storage power required for each seal proof types.
+#[cfg(not(feature = "devnet"))]
 pub fn consensus_miner_min_power(p: RegisteredSealProof) -> Result<StoragePower, String> {
     use RegisteredSealProof::*;
     match p {
@@ -14,4 +15,10 @@ pub fn consensus_miner_min_power(p: RegisteredSealProof) -> Result<StoragePower,
         StackedDRG64GiBV1 | StackedDRG64GiBV1P1 => Ok(StoragePower::from(20u64 << 40)),
         Invalid(i) => Err(format!("unsupported proof type: {}", i)),
     }
+}
+
+/// Returns the minimum storage power required for each seal proof types.
+#[cfg(feature = "devnet")]
+pub fn consensus_miner_min_power(_p: RegisteredSealProof) -> Result<StoragePower, String> {
+    Ok(StoragePower::from(2048))
 }

--- a/vm/actor/src/builtin/verifreg/types.rs
+++ b/vm/actor/src/builtin/verifreg/types.rs
@@ -7,8 +7,14 @@ use fil_types::StoragePower;
 use num_bigint::bigint_ser;
 use num_traits::FromPrimitive;
 
+#[cfg(not(feature = "devnet"))]
 lazy_static! {
     pub static ref MINIMUM_VERIFIED_DEAL_SIZE: StoragePower = StoragePower::from_i32(1 << 20).unwrap(); // placeholder
+}
+
+#[cfg(feature = "devnet")]
+lazy_static! {
+    pub static ref MINIMUM_VERIFIED_DEAL_SIZE: StoragePower = StoragePower::from_i32(256).unwrap(); // placeholder
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]

--- a/vm/actor_interface/Cargo.toml
+++ b/vm/actor_interface/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
 [dependencies]
-actorv0 = { package = "forest_actor", version = "0.1", path = "../../../forest-actorv0" }
+actorv0 = { package = "forest_actor", version = "0.1.3" }
 actorv2 = { package = "forest_actor", path = "../actor" }
 fil_types = "0.1"
 vm = { package = "forest_vm", version = "0.3.1" }

--- a/vm/actor_interface/Cargo.toml
+++ b/vm/actor_interface/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 
 [dependencies]
-actorv0 = { package = "forest_actor", version = "0.1" }
+actorv0 = { package = "forest_actor", version = "0.1", path = "../../../forest-actorv0" }
 actorv2 = { package = "forest_actor", path = "../actor" }
 fil_types = "0.1"
 vm = { package = "forest_vm", version = "0.3.1" }
@@ -19,3 +19,6 @@ libp2p = { version = "0.24", default-features = false }
 forest_bitfield = "0.1"
 num-bigint = { version = "0.1.1", package = "forest_bigint", features = ["json"] }
 forest_hash_utils = "0.1"
+
+[features]
+devnet = ["actorv0/devnet", "actorv2/devnet"]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
On enabling the devnet flag,
- Allows for 2k sectors
- Sets the min consensus power to 2048

In draft because I need write access to the actor_v0 repo to add the flag on v0 actors. @austinabell 

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->