### PR TITLE
Add serde annotation for go vec visitor without using wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
  "byteorder 1.3.4",
  "fil_clock 0.1.0",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.0",
+ "forest_json_utils 0.1.1",
  "hex",
  "serde",
  "serde_json",
@@ -1939,7 +1939,7 @@ dependencies = [
  "forest_bigint 0.1.3",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.0",
+ "forest_json_utils 0.1.1",
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "num-derive",
@@ -1964,7 +1964,7 @@ dependencies = [
  "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "num-derive",
@@ -2220,7 +2220,7 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128",
  "num-derive",
  "num-traits 0.2.14",
@@ -2237,7 +2237,7 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128",
  "num-derive",
  "num-traits 0.2.14",
@@ -2310,7 +2310,7 @@ dependencies = [
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.0",
+ "forest_json_utils 0.1.1",
  "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
@@ -2344,7 +2344,7 @@ dependencies = [
  "cid",
  "cs_serde_bytes",
  "cs_serde_cbor",
- "forest_json_utils 0.1.0",
+ "forest_json_utils 0.1.1",
  "generic-array 0.14.4",
  "integer-encoding",
  "multibase 0.9.1",
@@ -2362,7 +2362,7 @@ dependencies = [
  "cid",
  "cs_serde_bytes",
  "cs_serde_cbor",
- "forest_json_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4",
  "integer-encoding",
  "multibase 0.9.1",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "forest_json_utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2509,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "forest_json_utils"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bf972b7dade88cf8524249b2ae9d8e32b5d3ec7dbd3052abbcd1b8c2c29d62"
+checksum = "0da39ba6848c04b22e70520a1339f04f304502a0ebfd4526ea8a566452ea62a8"
 dependencies = [
  "serde",
 ]
@@ -2563,7 +2563,7 @@ dependencies = [
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.0",
+ "forest_json_utils 0.1.1",
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.14",
  "serde",
@@ -2584,7 +2584,7 @@ dependencies = [
  "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.14",
  "serde",

--- a/utils/json_utils/Cargo.toml
+++ b/utils/json_utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "forest_json_utils"
 description = "JSON utilities used to interoperate with default golang JSON defaults"
 license = "MIT OR Apache-2.0"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"
 repository = "https://github.com/ChainSafe/forest"
@@ -11,4 +11,5 @@ repository = "https://github.com/ChainSafe/forest"
 serde = { version = "1.0" }
 
 [dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/utils/json_utils/src/lib.rs
+++ b/utils/json_utils/src/lib.rs
@@ -163,18 +163,22 @@ mod tests {
     #[test]
     fn standard_vec() {
         #[derive(Deserialize)]
-        struct BasicJson(#[serde(with = "go_vec_visitor")] Vec<u8>);
+        #[serde(transparent)]
+        struct BasicJson {
+            #[serde(with = "go_vec_visitor")]
+            ints: Vec<u8>,
+        };
 
         let null_json = r#"null"#;
-        let BasicJson(deserialized) = from_str(null_json).unwrap();
-        assert_eq!(deserialized, [0u8; 0]);
+        let BasicJson { ints } = from_str(null_json).unwrap();
+        assert_eq!(ints, [0u8; 0]);
 
         let empty_array = r#"[]"#;
-        let BasicJson(deserialized) = from_str(empty_array).unwrap();
-        assert_eq!(deserialized, [0u8; 0]);
+        let BasicJson { ints } = from_str(empty_array).unwrap();
+        assert_eq!(ints, [0u8; 0]);
 
         let with_values = r#"[1, 2]"#;
-        let BasicJson(deserialized) = from_str(with_values).unwrap();
-        assert_eq!(deserialized, [1, 2]);
+        let BasicJson { ints } = from_str(with_values).unwrap();
+        assert_eq!(ints, [1, 2]);
     }
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Vectors in rpc are expected to be `nil` or empty array in the go implementation, and we need to match to interop with miner completely

@ec2 let me know if this solves your issue

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->