### PR TITLE
Update randomness for conformance tipsets and update V7 proof verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,7 @@ dependencies = [
  "forest_runtime",
  "forest_vm",
  "futures 0.3.8",
+ "genesis",
  "interpreter",
  "ipld_blockstore",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,19 +14,19 @@ dependencies = [
 name = "actor_interface"
 version = "0.1.0"
 dependencies = [
- "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_clock",
+ "fil_types",
  "forest_actor 0.1.0",
  "forest_actor 0.1.3",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_hash_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_address",
+ "forest_bigint",
+ "forest_bitfield",
+ "forest_cid",
+ "forest_encoding",
+ "forest_hash_utils",
+ "forest_json_utils",
+ "forest_vm",
+ "ipld_blockstore",
  "libp2p",
  "serde",
 ]
@@ -449,7 +449,7 @@ dependencies = [
 name = "auth"
 version = "0.1.0"
 dependencies = [
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_crypto",
  "jsonrpc-v2",
  "jsonwebtoken",
  "key_management",
@@ -522,9 +522,9 @@ dependencies = [
  "base64 0.13.0",
  "bls-signatures",
  "byteorder 1.3.4",
- "fil_clock 0.1.0",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1",
+ "fil_clock",
+ "forest_encoding",
+ "forest_json_utils",
  "hex",
  "serde",
  "serde_json",
@@ -908,23 +908,23 @@ dependencies = [
  "beacon",
  "blake2b_simd",
  "byteorder 1.3.4",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_clock",
+ "fil_types",
  "flo_stream",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
+ "forest_address",
+ "forest_bigint",
  "forest_blocks",
  "forest_car",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_ipld",
+ "forest_message",
  "futures 0.3.8",
  "interpreter",
  "ipld_amt 0.2.0",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "lazy_static",
  "log",
  "lru",
@@ -946,28 +946,28 @@ dependencies = [
  "base64 0.13.0",
  "beacon",
  "chain",
- "commcid 0.1.1",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "commcid",
+ "fil_clock",
+ "fil_types",
  "flo_stream",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
+ "forest_address",
+ "forest_bigint",
  "forest_blocks",
  "forest_car",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
  "forest_libp2p",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_message",
+ "forest_vm",
  "futures 0.3.8",
  "futures-util",
  "genesis",
  "hex",
  "interpreter",
  "ipld_amt 0.2.0",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "ipld_hamt 0.1.1",
  "libp2p",
  "log",
@@ -1076,17 +1076,8 @@ dependencies = [
 name = "commcid"
 version = "0.1.1"
 dependencies = [
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "rand 0.7.3",
-]
-
-[[package]]
-name = "commcid"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e686635f2a492ff38217f2df61700f0d166daebd65ee0d5c1bd26797dbfd98b"
-dependencies = [
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1119,23 +1110,23 @@ dependencies = [
  "base64 0.13.0",
  "chain",
  "chain_sync",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_clock",
+ "fil_types",
  "flate2",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
+ "forest_address",
+ "forest_bigint",
  "forest_blocks",
  "forest_car",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_runtime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_message",
+ "forest_runtime",
+ "forest_vm",
  "futures 0.3.8",
  "interpreter",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "lazy_static",
  "log",
  "paramfetch",
@@ -1907,15 +1898,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fil_clock"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56a516e27ede90cdf852ba9fd40d89bcab385e8c15ebeb2b3b864d4e759fc2"
-dependencies = [
- "chrono",
-]
-
-[[package]]
 name = "fil_logger"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,40 +1915,15 @@ dependencies = [
  "async-std",
  "base64 0.13.0",
  "chrono",
- "commcid 0.1.1",
- "fil_clock 0.1.0",
+ "commcid",
+ "fil_clock",
  "filecoin-proofs-api",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "num-derive",
- "num-traits 0.2.14",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "fil_types"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbaccb5a7e09ae8d86bd3f5677b970a8bc207b2f3eab5597653fabf8f1e3ccc"
-dependencies = [
- "async-std",
- "base64 0.13.0",
- "chrono",
- "commcid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "filecoin-proofs-api",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_address",
+ "forest_bigint",
+ "forest_cid",
+ "forest_encoding",
+ "forest_json_utils",
+ "forest_vm",
  "lazy_static",
  "num-derive",
  "num-traits 0.2.14",
@@ -2112,20 +2069,20 @@ dependencies = [
  "chain",
  "chain_sync",
  "ctrlc",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types",
  "flo_stream",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
+ "forest_address",
+ "forest_bigint",
  "forest_blocks",
  "forest_car",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
  "forest_libp2p",
  "futures 0.3.8",
  "genesis",
  "hex",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "jsonrpc-v2",
  "key_management",
  "libp2p",
@@ -2151,25 +2108,25 @@ dependencies = [
  "ahash 0.5.9",
  "base64 0.13.0",
  "byteorder 1.3.4",
- "commcid 0.1.1",
+ "commcid",
  "derive_builder",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_clock",
+ "fil_types",
+ "forest_address",
+ "forest_bigint",
+ "forest_bitfield",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_runtime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_ipld",
+ "forest_runtime",
+ "forest_vm",
  "hex",
  "indexmap",
  "integer-encoding",
  "ipld_amt 0.2.0",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "ipld_hamt 0.1.1",
  "lazy_static",
  "libp2p",
@@ -2189,22 +2146,22 @@ dependencies = [
  "ahash 0.5.9",
  "base64 0.13.0",
  "byteorder 1.3.4",
- "commcid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_runtime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "commcid",
+ "fil_clock",
+ "fil_types",
+ "forest_address",
+ "forest_bigint",
+ "forest_bitfield",
+ "forest_cid",
+ "forest_crypto",
+ "forest_encoding",
+ "forest_ipld",
+ "forest_runtime",
+ "forest_vm",
  "indexmap",
  "integer-encoding",
  "ipld_amt 0.1.0",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "ipld_hamt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
@@ -2220,25 +2177,8 @@ version = "0.3.1"
 dependencies = [
  "data-encoding",
  "data-encoding-macro",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "leb128",
- "num-derive",
- "num-traits 0.2.14",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "forest_address"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd6b3511082cd6d99581720a6af422fd319bf2e8dead77adc5c17b36ad9e6f6"
-dependencies = [
- "data-encoding",
- "data-encoding-macro",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_json_utils",
  "leb128",
  "num-derive",
  "num-traits 0.2.14",
@@ -2249,18 +2189,6 @@ dependencies = [
 [[package]]
 name = "forest_bigint"
 version = "0.1.3"
-dependencies = [
- "cs_serde_bytes",
- "num-bigint 0.3.1",
- "num-integer",
- "serde",
-]
-
-[[package]]
-name = "forest_bigint"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3613682fb4d6ba3a32c03951696ecee9254171f0593898e45519074a8a2d3814"
 dependencies = [
  "cs_serde_bytes",
  "num-bigint 0.3.1",
@@ -2275,24 +2203,11 @@ dependencies = [
  "ahash 0.5.9",
  "criterion",
  "cs_serde_bytes",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
  "rand 0.7.3",
  "rand_xorshift",
  "serde",
  "serde_json",
- "unsigned-varint 0.5.1",
-]
-
-[[package]]
-name = "forest_bitfield"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9eef8c7b09a4078eb1eb249f46b0894cc3f5a381e57415c70cce6c586d37f9"
-dependencies = [
- "ahash 0.5.9",
- "cs_serde_bytes",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
  "unsigned-varint 0.5.1",
 ]
 
@@ -2304,16 +2219,16 @@ dependencies = [
  "beacon",
  "byteorder 1.3.4",
  "derive_builder",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_clock",
+ "fil_types",
+ "forest_address",
+ "forest_bigint",
+ "forest_cid",
+ "forest_crypto",
+ "forest_encoding",
+ "forest_json_utils",
+ "forest_message",
+ "forest_vm",
  "hex",
  "lazy_static",
  "serde",
@@ -2328,12 +2243,12 @@ name = "forest_car"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
  "futures 0.3.8",
  "integer-encoding",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "serde",
  "thiserror",
 ]
@@ -2345,7 +2260,7 @@ dependencies = [
  "cid",
  "cs_serde_bytes",
  "cs_serde_cbor",
- "forest_json_utils 0.1.1",
+ "forest_json_utils",
  "generic-array 0.14.4",
  "integer-encoding",
  "multibase 0.9.1",
@@ -2355,30 +2270,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "forest_cid"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1a935d7f977a7debbc507de2ab7990b834d85e94c819e5268b1adaefd7d434"
-dependencies = [
- "cid",
- "cs_serde_bytes",
- "cs_serde_cbor",
- "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.14.4",
- "integer-encoding",
- "multibase 0.9.1",
- "multihash 0.13.2",
- "serde",
-]
-
-[[package]]
 name = "forest_crypto"
 version = "0.4.1"
 dependencies = [
  "base64 0.13.0",
  "bls-signatures",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_address",
+ "forest_encoding",
  "libsecp256k1",
  "num-derive",
  "num-traits 0.2.14",
@@ -2389,29 +2287,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "forest_crypto"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40035f5bb36362e9b6200ecdc11a1008169f1d60a01dcd9e1000a808f86cae6f"
-dependencies = [
- "base64 0.13.0",
- "bls-signatures",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsecp256k1",
- "num-derive",
- "num-traits 0.2.14",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "forest_db"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637464246b3f5554e6d7678cf05d8d76a5cbefe3324cd8c5c5a24c62c379af46"
 dependencies = [
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
  "parking_lot 0.11.1",
  "rocksdb",
  "sled",
@@ -2425,23 +2304,7 @@ dependencies = [
  "blake2b_simd",
  "cs_serde_bytes",
  "cs_serde_cbor",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_repr",
- "serde_tuple",
- "thiserror",
-]
-
-[[package]]
-name = "forest_encoding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350965034d9cc9a73dfaaf270851c9486269c36d1c0b18c38ac7151c6cac9060"
-dependencies = [
- "blake2b_simd",
- "cs_serde_bytes",
- "cs_serde_cbor",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "serde",
  "serde_repr",
  "serde_tuple",
@@ -2451,16 +2314,6 @@ dependencies = [
 [[package]]
 name = "forest_hash_utils"
 version = "0.1.0"
-dependencies = [
- "cs_serde_bytes",
- "serde",
-]
-
-[[package]]
-name = "forest_hash_utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb061ad769411763a5d6ae39d596696657472b25a66387fbb0ba8c133bb6575"
 dependencies = [
  "cs_serde_bytes",
  "serde",
@@ -2473,30 +2326,14 @@ dependencies = [
  "async-recursion",
  "async-std",
  "async-trait",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
  "indexmap",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "multibase 0.9.1",
  "serde",
  "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "forest_ipld"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7f6dd22f807768d16d299594f3c4c806d916a1e7461ac1c9bbdd93159272cc"
-dependencies = [
- "async-recursion",
- "async-trait",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap",
- "multibase 0.9.1",
- "serde",
  "thiserror",
 ]
 
@@ -2506,15 +2343,6 @@ version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "forest_json_utils"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da39ba6848c04b22e70520a1339f04f304502a0ebfd4526ea8a566452ea62a8"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2525,22 +2353,22 @@ dependencies = [
  "async-trait",
  "bytes",
  "chain",
- "fil_clock 0.1.0",
+ "fil_clock",
  "fnv",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
+ "forest_address",
+ "forest_bigint",
  "forest_blocks",
  "forest_car",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_message",
  "futures 0.3.8",
  "futures-util",
  "futures_codec",
  "genesis",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "lazy_static",
  "libp2p",
  "libp2p-bitswap",
@@ -2558,76 +2386,36 @@ version = "0.6.1"
 dependencies = [
  "base64 0.13.0",
  "derive_builder",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types",
+ "forest_address",
+ "forest_bigint",
+ "forest_cid",
+ "forest_crypto",
+ "forest_encoding",
+ "forest_json_utils",
+ "forest_vm",
  "num-traits 0.2.14",
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "forest_message"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4935036b1da07044b4c50cc7c228517be74f12a66fbbc6661c6f359a05f1dc74"
-dependencies = [
- "base64 0.13.0",
- "derive_builder",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_json_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.14",
- "serde",
-]
-
-[[package]]
 name = "forest_runtime"
 version = "0.1.1"
 dependencies = [
  "base64 0.13.0",
- "commcid 0.1.1",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "commcid",
+ "fil_clock",
+ "fil_types",
  "filecoin-proofs-api",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_address",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_vm",
  "interpreter",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log",
-]
-
-[[package]]
-name = "forest_runtime"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d377cc52e79171d4576608a54fec9e53a71eecdc62e9a73ca0cb44ed15325d"
-dependencies = [
- "base64 0.13.0",
- "commcid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_clock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "filecoin-proofs-api",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "log",
 ]
 
@@ -2635,27 +2423,10 @@ dependencies = [
 name = "forest_vm"
 version = "0.3.1"
 dependencies = [
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "num-derive",
- "num-traits 0.2.14",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "forest_vm"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee840f104202f76125e6c01063b1ea05cdcc55e2005dbfffb42012f733b1c092"
-dependencies = [
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_address",
+ "forest_bigint",
+ "forest_cid",
+ "forest_encoding",
  "lazy_static",
  "num-derive",
  "num-traits 0.2.14",
@@ -2890,13 +2661,13 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "chain",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types",
  "forest_blocks",
  "forest_car",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_encoding",
  "futures 0.3.8",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "log",
  "net_utils",
  "state_manager",
@@ -3315,20 +3086,20 @@ dependencies = [
  "actor_interface",
  "ahash 0.5.9",
  "byteorder 1.3.4",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
+ "fil_clock",
+ "fil_types",
+ "forest_address",
+ "forest_bigint",
  "forest_blocks",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_runtime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_message",
+ "forest_runtime",
+ "forest_vm",
  "interpreter",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "ipld_hamt 0.1.1",
  "lazy_static",
  "log",
@@ -3353,10 +3124,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc33d3619e6fa8fa8b3ebb0e77650aa33a7e5b276bd2658b1303b2a0fea04c1f"
 dependencies = [
  "ahash 0.5.9",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "ipld_blockstore",
  "lazycell",
  "serde",
  "thiserror",
@@ -3368,10 +3139,10 @@ version = "0.2.0"
 dependencies = [
  "ahash 0.5.9",
  "criterion",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "ipld_blockstore",
  "lazycell",
  "serde",
  "thiserror",
@@ -3381,23 +3152,11 @@ dependencies = [
 name = "ipld_blockstore"
 version = "0.1.1"
 dependencies = [
- "commcid 0.1.1",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "commcid",
+ "forest_cid",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ipld_blockstore"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00297ec82ec490ef38b5f703413d7fb8b3bdf0e64690a459662a1898afcc11b"
-dependencies = [
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_ipld",
 ]
 
 [[package]]
@@ -3407,13 +3166,13 @@ dependencies = [
  "byteorder 1.3.4",
  "criterion",
  "cs_serde_bytes",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_hash_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_hash_utils",
+ "forest_ipld",
  "hex",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "lazycell",
  "serde",
  "sha2 0.9.2",
@@ -3429,12 +3188,12 @@ checksum = "6e3aae17f7905e9a426094aa3fc9f645d0a2028959e6fedbf4840f88c4d9a1a0"
 dependencies = [
  "byteorder 1.3.4",
  "cs_serde_bytes",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_hash_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_hash_utils",
+ "forest_ipld",
+ "ipld_blockstore",
  "lazycell",
  "serde",
  "sha2 0.9.2",
@@ -3620,9 +3379,9 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
  "bls-signatures",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_address",
+ "forest_crypto",
+ "forest_encoding",
  "libsecp256k1",
  "log",
  "rand 0.7.3",
@@ -4186,21 +3945,21 @@ dependencies = [
  "async-trait",
  "blake2b_simd",
  "chain",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types",
  "flo_stream",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
+ "forest_address",
+ "forest_bigint",
  "forest_blocks",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
  "forest_libp2p",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_message",
+ "forest_vm",
  "futures 0.3.8",
  "interpreter",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "key_management",
  "libsecp256k1",
  "log",
@@ -4721,7 +4480,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "blake2b_simd",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types",
  "futures 0.3.8",
  "isahc",
  "log",
@@ -5403,26 +5162,26 @@ dependencies = [
  "bls-signatures",
  "chain",
  "chain_sync",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_clock",
+ "fil_types",
  "flo_stream",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_address",
+ "forest_bigint",
+ "forest_bitfield",
  "forest_blocks",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1",
+ "forest_encoding",
+ "forest_ipld",
  "forest_libp2p",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_message",
+ "forest_vm",
  "futures 0.3.8",
  "hex",
  "interpreter",
  "ipld_amt 0.2.0",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "jsonrpc-v2",
  "jsonwebtoken",
  "key_management",
@@ -5447,9 +5206,9 @@ version = "0.1.0"
 dependencies = [
  "auth",
  "forest_blocks",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
+ "forest_message",
  "jsonrpc-v2",
  "jsonrpsee",
  "key_management",
@@ -5745,14 +5504,14 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
  "bls-signatures",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types",
+ "forest_address",
  "forest_blocks",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
+ "forest_encoding",
+ "forest_message",
+ "forest_vm",
  "hex",
  "num-traits 0.2.14",
  "serde",
@@ -5997,25 +5756,25 @@ dependencies = [
  "async-std",
  "beacon",
  "chain",
- "fil_clock 0.1.0",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_clock",
+ "fil_types",
  "filecoin-proofs-api",
  "flo_stream",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
- "forest_bitfield 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_address",
+ "forest_bigint",
+ "forest_bitfield",
  "forest_blocks",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
  "forest_db",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_runtime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_encoding",
+ "forest_message",
+ "forest_runtime",
+ "forest_vm",
  "futures 0.3.8",
  "interpreter",
  "ipld_amt 0.2.0",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipld_blockstore",
  "lazy_static",
  "lazycell",
  "log",
@@ -6030,14 +5789,14 @@ name = "state_tree"
 version = "0.1.0"
 dependencies = [
  "actor_interface",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types",
+ "forest_address",
+ "forest_bigint",
+ "forest_cid",
  "forest_db",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_ipld",
+ "forest_vm",
+ "ipld_blockstore",
  "ipld_hamt 0.1.1",
 ]
 
@@ -6047,12 +5806,12 @@ version = "0.1.0"
 dependencies = [
  "colored",
  "difference",
- "fil_types 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_ipld 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_vm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil_types",
+ "forest_address",
+ "forest_cid",
+ "forest_ipld",
+ "forest_vm",
+ "ipld_blockstore",
  "ipld_hamt 0.1.1",
  "serde",
  "serde_json",
@@ -6403,15 +6162,15 @@ dependencies = [
  "async-std",
  "base64 0.13.0",
  "chain",
- "forest_address 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_bigint 0.1.3",
+ "forest_address",
+ "forest_bigint",
  "forest_blocks",
- "forest_cid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_crypto 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "forest_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_cid",
+ "forest_crypto",
+ "forest_encoding",
  "forest_libp2p",
- "forest_message 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipld_blockstore 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "forest_message",
+ "ipld_blockstore",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,22 @@ members = [
     "types",
     "key_management",
 ]
+
+[patch.crates-io]
+ipld_blockstore = { path = "./ipld/blockstore" }
+fil_types = { path = "./types" }
+fil_clock = { path = "./node/clock" }
+forest_db = { path = "./node/db" }
+forest_crypto = { path = "./crypto" }
+forest_address = { path = "./vm/address" }
+forest_bigint = { path = "./utils/bigint" }
+forest_bitfield = { path = "./utils/bitfield" }
+forest_cid = { path = "./ipld/cid" }
+forest_ipld = { path = "./ipld" }
+forest_encoding = { path = "./encoding" }
+forest_hash_utils = { path = "./utils/hash_utils" }
+forest_json_utils = { path = "./utils/json_utils" }
+commcid = { path = "./utils/commcid" }
+forest_vm = { path = "./vm" }
+forest_runtime = { path = "./vm/runtime" }
+forest_message = { path = "./vm/message" }

--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -79,7 +79,7 @@ where
 
         let info = mas.info(store)?;
 
-        let spt = RegisteredSealProof::from(info.sector_size);
+        let spt = RegisteredSealProof::from_sector_size(info.sector_size, nv);
 
         let wpt = spt.registered_winning_post_proof()?;
 

--- a/blockchain/state_manager/src/vm_circ_supply.rs
+++ b/blockchain/state_manager/src/vm_circ_supply.rs
@@ -11,7 +11,6 @@ use fil_types::{
     FILECOIN_PRECISION, FIL_RESERVED, UPGRADE_ACTORS_V2_HEIGHT, UPGRADE_IGNITION_HEIGHT,
     UPGRADE_LIFTOFF_HEIGHT,
 };
-use forest_blocks::Tipset;
 use interpreter::CircSupplyCalc;
 use lazycell::AtomicLazyCell;
 use num_bigint::BigInt;
@@ -216,12 +215,10 @@ pub fn get_circulating_supply<'a, DB: BlockStore>(
 fn init_genesis_info<DB: BlockStore>(bs: &DB) -> Result<GenesisInfo, Box<dyn StdError>> {
     let mut ignition = GenesisInfo::default();
 
-    let genesis_block = genesis(bs)?.ok_or_else(|| "Genesis Block doesnt exist".to_string())?;
-
-    let gts = Tipset::new(vec![genesis_block])?;
+    let genesis_block = genesis(bs)?.ok_or_else(|| "Genesis Block doesn't exist".to_string())?;
 
     // Parent state of genesis tipset is tipset state
-    let st = gts.parent_state();
+    let st = genesis_block.state_root();
 
     let state_tree = StateTree::new_from_root(bs, &st)?;
 

--- a/tests/conformance_tests/Cargo.toml
+++ b/tests/conformance_tests/Cargo.toml
@@ -71,4 +71,6 @@ paramfetch = { path = "../../utils/paramfetch" }
 async-std = { version = "1.6", features = ["attributes"] }
 chain_sync = { path = "../../blockchain/chain_sync" }
 statediff = { path = "../../utils/statediff" }
+genesis = { path = "../../utils/genesis" }
+
 

--- a/tests/conformance_tests/src/lib.rs
+++ b/tests/conformance_tests/src/lib.rs
@@ -202,6 +202,9 @@ pub enum TestVector {
         preconditions: PreConditions,
         apply_tipsets: Vec<TipsetVector>,
         postconditions: PostConditions,
+
+        #[serde(default)]
+        randomness: Randomness,
     },
 }
 

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 extern crate lazy_static;
 
+use chain::ChainStore;
 use cid::Cid;
 use clock::ChainEpoch;
 use conformance_tests::*;
@@ -18,6 +19,7 @@ use interpreter::ApplyRet;
 use num_bigint::{BigInt, ToBigInt};
 use paramfetch::{get_params_default, SectorSizeOpt};
 use regex::Regex;
+use state_manager::StateManager;
 use statediff::print_state_diff;
 use std::error::Error as StdError;
 use std::fmt;
@@ -198,16 +200,19 @@ async fn execute_tipset_vector(
     root_cid: Cid,
     tipsets: &[TipsetVector],
     postconditions: &PostConditions,
+    randomness: &Randomness,
     variant: &Variant,
 ) -> Result<(), Box<dyn StdError>> {
     let bs = load_car(car).await?;
     let bs = Arc::new(bs);
+    let sm = Arc::new(StateManager::new(Arc::new(ChainStore::new(bs))));
+    genesis::initialize_genesis(None, &sm).await.unwrap();
 
     let base_epoch = variant.epoch;
     let mut root = root_cid;
 
     let mut receipt_idx = 0;
-    let mut prev_epoch = base_epoch;
+    let mut parent_epoch = base_epoch;
     for (i, ts) in tipsets.into_iter().enumerate() {
         let exec_epoch = base_epoch + ts.epoch_offset;
         let ExecuteTipsetResult {
@@ -215,7 +220,16 @@ async fn execute_tipset_vector(
             post_state_root,
             applied_results,
             ..
-        } = execute_tipset(Arc::clone(&bs), &root, prev_epoch, &ts, exec_epoch)?;
+        } = execute_tipset(
+            Arc::clone(&sm),
+            ExecuteTipsetParams {
+                pre_root: &root,
+                parent_epoch,
+                tipset: &ts,
+                exec_epoch,
+                randomness: ReplayingRand::new(randomness),
+            },
+        )?;
 
         for (j, apply_ret) in applied_results.into_iter().enumerate() {
             check_msg_result(
@@ -228,6 +242,8 @@ async fn execute_tipset_vector(
 
         // Compare receipts root
         let (expected, actual) = (&postconditions.receipts_roots[i], &receipts_root);
+        compare_state_roots(sm.blockstore(), &expected, &actual)?;
+
         if expected != actual {
             return Err(format!(
                 "post receipts did not match; expected: {:?}, got {:?}",
@@ -236,11 +252,11 @@ async fn execute_tipset_vector(
             .into());
         }
 
-        prev_epoch = exec_epoch;
+        parent_epoch = exec_epoch;
         root = post_state_root;
     }
 
-    compare_state_roots(bs.as_ref(), &root, &postconditions.state_tree.root_cid)?;
+    compare_state_roots(sm.blockstore(), &root, &postconditions.state_tree.root_cid)?;
 
     Ok(())
 }
@@ -309,6 +325,7 @@ async fn conformance_test_runner() {
                 preconditions,
                 apply_tipsets,
                 postconditions,
+                randomness,
             } => {
                 for variant in preconditions.variants {
                     if variant.nv > 3 {
@@ -321,6 +338,7 @@ async fn conformance_test_runner() {
                         preconditions.state_tree.root_cid.clone(),
                         &apply_tipsets,
                         &postconditions,
+                        &randomness,
                         &variant,
                     )
                     .await

--- a/types/src/sector/registered_proof.rs
+++ b/types/src/sector/registered_proof.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::SectorSize;
+use crate::NetworkVersion;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "proofs")]
@@ -24,6 +25,28 @@ pub enum RegisteredSealProof {
 }
 
 impl RegisteredSealProof {
+    /// Returns registered seal proof for given sector size
+    pub fn from_sector_size(size: SectorSize, network_version: NetworkVersion) -> Self {
+        if network_version < NetworkVersion::V7 {
+            match size {
+                SectorSize::_2KiB => Self::StackedDRG2KiBV1,
+                SectorSize::_8MiB => Self::StackedDRG8MiBV1,
+                SectorSize::_512MiB => Self::StackedDRG512MiBV1,
+                SectorSize::_32GiB => Self::StackedDRG32GiBV1,
+                SectorSize::_64GiB => Self::StackedDRG64GiBV1,
+            }
+        } else {
+            match size {
+                SectorSize::_2KiB => Self::StackedDRG2KiBV1P1,
+                SectorSize::_8MiB => Self::StackedDRG8MiBV1P1,
+                SectorSize::_512MiB => Self::StackedDRG512MiBV1P1,
+                SectorSize::_32GiB => Self::StackedDRG32GiBV1P1,
+                SectorSize::_64GiB => Self::StackedDRG64GiBV1P1,
+            }
+        }
+    }
+
+    #[deprecated(since = "0.1.10", note = "Logic should exist in actors")]
     /// The maximum duration a sector sealed with this proof may exist between activation and expiration.
     pub fn sector_maximum_lifetime(self) -> clock::ChainEpoch {
         // For all Stacked DRG sectors, the max is 5 years
@@ -217,18 +240,6 @@ impl TryFrom<RegisteredSealProof> for filecoin_proofs_api::RegisteredSealProof {
             StackedDRG8MiBV1P1 => Ok(Self::StackedDrg8MiBV1_1),
             StackedDRG512MiBV1P1 => Ok(Self::StackedDrg512MiBV1_1),
             Invalid(i) => Err(format!("unsupported proof type: {}", i)),
-        }
-    }
-}
-
-impl From<SectorSize> for RegisteredSealProof {
-    fn from(ss: SectorSize) -> Self {
-        match ss {
-            SectorSize::_2KiB => Self::StackedDRG2KiBV1,
-            SectorSize::_8MiB => Self::StackedDRG8MiBV1,
-            SectorSize::_512MiB => Self::StackedDRG512MiBV1,
-            SectorSize::_32GiB => Self::StackedDRG32GiBV1,
-            SectorSize::_64GiB => Self::StackedDRG64GiBV1,
         }
     }
 }

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -2918,7 +2918,10 @@ where
     rt.verify_post(&pv_info).map_err(|e| {
         e.downcast_default(
             ExitCode::ErrIllegalArgument,
-            format!("invalid PoSt: {:?}", pv_info),
+            format!(
+                "invalid PoSt: proofs({:?}), randomness({:?})",
+                pv_info.proofs, pv_info.randomness
+            ),
         )
     })?;
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Converts from sector size to proof type based on network version (part of #910)
- Uses recorded randomness for tipset vectors (is used now with extracted tipset vectors)


This is branching off #907 because it makes a cleaner merge, otherwise would have to break previous version or bump minor version of types and assume this change comes in. Also, somewhat based on #903 because the thing marked as deprecated is removed in that PR (and would only be used in V1 actors, which is why deprecating for now instead of removing)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->