### PR TITLE
Clean up chain exchange responses and peer disconnects

### DIFF
--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -13,6 +13,7 @@ use forest_libp2p::{
         MESSAGES,
     },
     hello::HelloRequest,
+    rpc::RequestResponseError,
     NetworkMessage,
 };
 use futures::channel::oneshot::channel as oneshot_channel;
@@ -24,6 +25,8 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 /// Timeout for response from an RPC request
+// TODO this value can be tweaked, this is just set pretty low to avoid peers timing out
+// requests from slowing the node down. If increase, should create a countermeasure for this.
 const RPC_TIMEOUT: u64 = 5;
 
 /// Context used in chain sync to handle network requests
@@ -242,17 +245,31 @@ where
             .duration_since(req_pre_time)
             .unwrap_or_default();
         match res {
-            Ok(Ok(bs_res)) => {
+            Ok(Ok(Ok(bs_res))) => {
+                // Successful response
                 self.peer_manager.log_success(&peer_id, res_duration).await;
                 Ok(bs_res)
             }
-            Ok(Err(e)) => {
+            Ok(Ok(Err(e))) => {
+                // Internal libp2p error, score failure for peer and potentially disconnect
                 self.peer_manager.log_failure(&peer_id, res_duration).await;
-                Err(format!("RPC error: {}", e.to_string()))
+                match e {
+                    RequestResponseError::ConnectionClosed
+                    | RequestResponseError::DialFailure
+                    | RequestResponseError::UnsupportedProtocols => {
+                        self.peer_manager.remove_peer(&peer_id).await;
+                    }
+                    // Ignore dropping peer on timeout for now. Can't be confident yet that the
+                    // specified timeout is adequate time.
+                    RequestResponseError::Timeout => (),
+                }
+                Err(format!("Internal libp2p error: {:?}", e))
             }
-            Err(_) => {
+            Ok(Err(_)) | Err(_) => {
+                // Sender channel internally dropped or timeout, both should log failure which will
+                // negatively score the peer, but not drop yet.
                 self.peer_manager.log_failure(&peer_id, res_duration).await;
-                Err("Connection timed out".to_string())
+                Err(format!("Chain exchange request timed out"))
             }
         }
     }

--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -269,7 +269,7 @@ where
                 // Sender channel internally dropped or timeout, both should log failure which will
                 // negatively score the peer, but not drop yet.
                 self.peer_manager.log_failure(&peer_id, res_duration).await;
-                Err(format!("Chain exchange request timed out"))
+                Err("Chain exchange request timed out".to_string())
             }
         }
     }

--- a/blockchain/chain_sync/src/peer_manager.rs
+++ b/blockchain/chain_sync/src/peer_manager.rs
@@ -15,7 +15,8 @@ use std::time::Duration;
 /// New peer multiplier slightly less than 1 to incentivize choosing new peers.
 const NEW_PEER_MUL: f64 = 0.9;
 
-pub(crate) const SHUFFLE_PEERS_PREFIX: usize = 5;
+/// Defines max number of peers to send each chain exchange request to.
+pub(crate) const SHUFFLE_PEERS_PREFIX: usize = 16;
 
 /// Local duration multiplier, affects duration delta change.
 const LOCAL_INV_ALPHA: u32 = 5;
@@ -163,10 +164,14 @@ impl PeerManager {
     }
 
     /// Removes a peer from the set and returns true if the value was present previously
-    // TODO peers should only be removed after certain criteria is hit, this doesn't matter as much
-    // because a faulty peer will just be ignored.
-    pub async fn _remove_peer(&self, peer_id: &PeerId) -> bool {
-        self.full_peers.write().await.remove(peer_id).is_some()
+    pub async fn remove_peer(&self, peer_id: &PeerId) -> bool {
+        let mut peers = self.full_peers.write().await;
+        debug!(
+            "removing peer {:?}, remaining chain exchange peers: {}",
+            peer_id,
+            peers.len()
+        );
+        peers.remove(peer_id).is_some()
     }
 
     /// Gets count of full peers managed.

--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -1073,7 +1073,7 @@ mod tests {
                 NetworkMessage::ChainExchangeRequest {
                     response_channel, ..
                 } => {
-                    response_channel.send(rpc_response).unwrap();
+                    response_channel.send(Ok(rpc_response)).unwrap();
                 }
                 _ => unreachable!(),
             }

--- a/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
+++ b/blockchain/chain_sync/src/sync_worker/full_sync_test.rs
@@ -24,7 +24,7 @@ where
                 response_channel,
                 ..
             }) => response_channel
-                .send(make_chain_exchange_response(&db, &request).await)
+                .send(Ok(make_chain_exchange_response(&db, &request).await))
                 .unwrap(),
             Some(event) => log::warn!("Other request sent to network: {:?}", event),
             None => break,

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -354,7 +354,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<ChainExchangeRequest, Cha
 
                 let tx = self.cx_request_table.remove(&request_id);
 
-                // Send error out through channel out.
+                // Send error through channel out.
                 if let Some(tx) = tx {
                     if tx.send(Err(error.into())).is_err() {
                         debug!("RPCResponse receive failed")

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -1,11 +1,14 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::chain_exchange::{
-    ChainExchangeCodec, ChainExchangeProtocolName, ChainExchangeRequest, ChainExchangeResponse,
-};
 use crate::config::Libp2pConfig;
 use crate::hello::{HelloCodec, HelloProtocolName, HelloRequest, HelloResponse};
+use crate::{
+    chain_exchange::{
+        ChainExchangeCodec, ChainExchangeProtocolName, ChainExchangeRequest, ChainExchangeResponse,
+    },
+    rpc::RequestResponseError,
+};
 use forest_cid::Cid;
 use futures::channel::oneshot::{self, Sender as OneShotSender};
 use futures::{prelude::*, stream::FuturesUnordered};
@@ -63,7 +66,8 @@ pub struct ForestBehaviour {
     peers: HashSet<PeerId>,
     /// Keeps track of Chain exchange requests to responses
     #[behaviour(ignore)]
-    cx_request_table: HashMap<RequestId, OneShotSender<ChainExchangeResponse>>,
+    cx_request_table:
+        HashMap<RequestId, OneShotSender<Result<ChainExchangeResponse, RequestResponseError>>>,
     /// Boxed futures of responses for Chain Exchange incoming requests. This needs to be polled
     /// in the behaviour to have access to the `RequestResponse` protocol when sending response.
     ///
@@ -328,9 +332,10 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<ChainExchangeRequest, Cha
                 } => {
                     let tx = self.cx_request_table.remove(&request_id);
 
+                    // Send the sucessful response through channel out.
                     if let Some(tx) = tx {
-                        if tx.send(response).is_err() {
-                            debug!("RPCResponse receive failed")
+                        if tx.send(Ok(response)).is_err() {
+                            debug!("RPCResponse receive timed out")
                         }
                     } else {
                         debug!("RPCResponse receive failed: channel not found");
@@ -341,10 +346,21 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<ChainExchangeRequest, Cha
                 peer,
                 request_id,
                 error,
-            } => warn!(
-                "ChainExchange outbound error (peer: {:?}) (id: {:?}): {:?}",
-                peer, request_id, error
-            ),
+            } => {
+                warn!(
+                    "ChainExchange outbound error (peer: {:?}) (id: {:?}): {:?}",
+                    peer, request_id, error
+                );
+
+                let tx = self.cx_request_table.remove(&request_id);
+
+                // Send error out through channel out.
+                if let Some(tx) = tx {
+                    if tx.send(Err(error.into())).is_err() {
+                        debug!("RPCResponse receive failed")
+                    }
+                }
+            }
             RequestResponseEvent::InboundFailure {
                 peer,
                 error,
@@ -486,7 +502,7 @@ impl ForestBehaviour {
         &mut self,
         peer_id: &PeerId,
         request: ChainExchangeRequest,
-        response_channel: OneShotSender<ChainExchangeResponse>,
+        response_channel: OneShotSender<Result<ChainExchangeResponse, RequestResponseError>>,
     ) {
         let req_id = self.chain_exchange.send_request(peer_id, request);
         self.cx_request_table.insert(req_id, response_channel);

--- a/node/forest_libp2p/src/rpc/mod.rs
+++ b/node/forest_libp2p/src/rpc/mod.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use forest_encoding::{from_slice, to_vec};
 use futures::prelude::*;
 use libp2p::core::ProtocolName;
+use libp2p::request_response::OutboundFailure;
 use libp2p::request_response::RequestResponseCodec;
-pub use libp2p::request_response::{RequestId, ResponseChannel};
 use serde::{de::DeserializeOwned, Serialize};
 use std::io;
 use std::marker::PhantomData;
@@ -24,6 +24,40 @@ impl<P, RQ, RS> Default for CborRequestResponse<P, RQ, RS> {
             protocol: PhantomData::<P>::default(),
             request: PhantomData::<RQ>::default(),
             response: PhantomData::<RS>::default(),
+        }
+    }
+}
+
+/// libp2p request response outbound error type. This indicates a failure sending a request to
+/// a peer. This is different from a failure response from a node, as this is an error that
+/// prevented a response.
+///
+/// This type mirrors the internal libp2p type, but this avoids having to expose that internal type.
+#[derive(Debug)]
+pub enum RequestResponseError {
+    /// The request could not be sent because a dialing attempt failed.
+    DialFailure,
+    /// The request timed out before a response was received.
+    ///
+    /// It is not known whether the request may have been
+    /// received (and processed) by the remote peer.
+    Timeout,
+    /// The connection closed before a response was received.
+    ///
+    /// It is not known whether the request may have been
+    /// received (and processed) by the remote peer.
+    ConnectionClosed,
+    /// The remote supports none of the requested protocols.
+    UnsupportedProtocols,
+}
+
+impl From<OutboundFailure> for RequestResponseError {
+    fn from(err: OutboundFailure) -> Self {
+        match err {
+            OutboundFailure::DialFailure => Self::DialFailure,
+            OutboundFailure::Timeout => Self::Timeout,
+            OutboundFailure::ConnectionClosed => Self::ConnectionClosed,
+            OutboundFailure::UnsupportedProtocols => Self::UnsupportedProtocols,
         }
     }
 }

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -5,7 +5,10 @@ use super::chain_exchange::{
     make_chain_exchange_response, ChainExchangeRequest, ChainExchangeResponse,
 };
 use super::{ForestBehaviour, ForestBehaviourEvent, Libp2pConfig};
-use crate::hello::{HelloRequest, HelloResponse};
+use crate::{
+    hello::{HelloRequest, HelloResponse},
+    rpc::RequestResponseError,
+};
 use async_std::channel::{unbounded, Receiver, Sender};
 use async_std::{stream, task};
 use chain::ChainStore;
@@ -94,7 +97,7 @@ pub enum NetworkMessage {
     ChainExchangeRequest {
         peer_id: PeerId,
         request: ChainExchangeRequest,
-        response_channel: OneShotSender<ChainExchangeResponse>,
+        response_channel: OneShotSender<Result<ChainExchangeResponse, RequestResponseError>>,
     },
     HelloRequest {
         peer_id: PeerId,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Changes chain exchange channel type to be result to pass in internal libp2p errors, was previously leaving to timeout
- Removes peers from cx peer list on error other than timeout
- Update shuffled peers prefix (amount of peers each request is sent to before failing)

With these changes, sync doesn't reset sporatically and duplicate faulty requests don't get sent



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->