### PR TITLE
CBOR Stream Read in LibP2P RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,7 @@ dependencies = [
  "forest_message",
  "futures 0.3.10",
  "futures-util",
+ "futures_cbor_codec",
  "futures_codec",
  "genesis",
  "ipld_blockstore",
@@ -2657,6 +2658,19 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "futures_cbor_codec"
+version = "0.3.0"
+source = "git+https://github.com/najamelan/futures_cbor_codec?rev=de08e31530513f993cbf5efef7311ac5194b2256#de08e31530513f993cbf5efef7311ac5194b2256"
+dependencies = [
+ "bytes 0.5.6",
+ "futures 0.3.10",
+ "futures_codec",
+ "rustc_version 0.2.3",
+ "serde",
+ "serde_cbor",
 ]
 
 [[package]]

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -44,7 +44,6 @@ tiny-cid = "0.2.0"
 ipld_blockstore = "0.1"
 async-trait = "0.1"
 lazy_static = "1.4"
-
 futures_cbor_codec = { git = "https://github.com/najamelan/futures_cbor_codec", rev = "de08e31530513f993cbf5efef7311ac5194b2256" }
 
 [dev-dependencies]

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -45,6 +45,8 @@ ipld_blockstore = "0.1"
 async-trait = "0.1"
 lazy_static = "1.4"
 
+futures_cbor_codec = { git = "https://github.com/najamelan/futures_cbor_codec", rev = "de08e31530513f993cbf5efef7311ac5194b2256" }
+
 [dev-dependencies]
 forest_address = "0.3"
 num-bigint = { path = "../../utils/bigint", package = "forest_bigint" }

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -495,7 +495,8 @@ impl ForestBehaviour {
     /// Adds peer to the peer set.
     pub fn add_peer(&mut self, peer_id: PeerId) {
         self.peers.insert(peer_id.clone());
-        self.bitswap.connect(peer_id);
+        self.bitswap.connect(peer_id.clone());
+        self.events.push(ForestBehaviourEvent::PeerDialed(peer_id));
     }
 
     /// Adds peer to the peer set.

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -25,7 +25,9 @@ use libp2p::{
     core::muxing::StreamMuxerBox,
     core::transport::boxed::Boxed,
     identity::{ed25519, Keypair},
-    mplex, noise, yamux, PeerId, Swarm, Transport,
+    mplex, noise, yamux,
+    yamux::WindowUpdateMode,
+    PeerId, Swarm, Transport,
 };
 use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
@@ -374,7 +376,7 @@ pub fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox), Er
         let mut yamux_config = yamux::Config::default();
         yamux_config.set_max_buffer_size(16 * 1024 * 1024);
         yamux_config.set_receive_window(16 * 1024 * 1024);
-
+        yamux_config.set_window_update_mode(WindowUpdateMode::OnRead);
         core::upgrade::SelectUpgrade::new(yamux_config, mplex_config)
     };
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Before, we read libp2p RPC streams until we see an EOF. This is wrong because we can tell when cbor objects end and lotus doesnt send an EOF after writing to the stream. This PR introduces streams and decodes. 
- Must come in after #931 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->