### PR TITLE
Fix header signing bytes cache bug

### DIFF
--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -655,8 +655,7 @@ where
         let b_cloned = Arc::clone(&block);
         let p_beacon = Arc::clone(&prev_beacon);
         validations.push(task::spawn_blocking(move || {
-            // TODO switch logic to function attached to block header
-            let block_sig_bytes = b_cloned.header().to_signing_bytes()?;
+            let block_sig_bytes = b_cloned.header().to_signing_bytes();
 
             // Can unwrap here because verified to be `Some` in the sanity checks.
             let block_sig = b_cloned.header().signature().as_ref().unwrap();

--- a/node/rpc/src/state_api.rs
+++ b/node/rpc/src/state_api.rs
@@ -720,7 +720,7 @@ pub(crate) async fn miner_create_block<
     let sig = wallet::sign(
         *key.key_info.key_type(),
         key.key_info.private_key(),
-        &next.to_signing_bytes()?,
+        &next.to_signing_bytes(),
     )?;
     next.signature = Some(sig);
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixes bug introduced in #930 where the marshalling is now using the cached bytes, which caused an issue with the header conversion to signing bytes, because it used the cached bytes including the signature encoded


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->