### PR TITLE
Add skip-load flag and cleanup snapshot loading

### DIFF
--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -5,6 +5,7 @@ use chain_sync::SyncConfig;
 use forest_libp2p::Libp2pConfig;
 use serde::Deserialize;
 use utils::get_home_dir;
+
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -17,6 +18,9 @@ pub struct Config {
     /// Otherwise, we validate and compute the states.
     pub snapshot: bool,
     pub snapshot_path: Option<String>,
+    /// Skips loading import CAR file and assumes it's already been loaded.
+    /// Will use the cids in the header of the file to index the chain.
+    pub skip_load: bool,
     pub sync: SyncConfig,
 }
 
@@ -30,6 +34,7 @@ impl Default for Config {
             rpc_port: "1234".to_string(),
             snapshot_path: None,
             snapshot: false,
+            skip_load: false,
             sync: SyncConfig::default(),
         }
     }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -76,6 +76,12 @@ pub struct DaemonOpts {
     pub import_snapshot: Option<String>,
     #[structopt(long, help = "Import a chain from a local CAR file or url")]
     pub import_chain: Option<String>,
+    #[structopt(
+        long,
+        help = "Skips loading CAR file and uses header to index chain.\
+                    Assumes a pre-loaded database"
+    )]
+    pub skip_load: bool,
     #[structopt(long, help = "Number of worker sync tasks spawned (default is 1")]
     pub worker_tasks: Option<usize>,
     #[structopt(
@@ -116,6 +122,8 @@ impl DaemonOpts {
                 cfg.snapshot_path = Some(snapshot_path.to_owned());
                 cfg.snapshot = false;
             }
+
+            cfg.skip_load = self.skip_load;
         }
 
         cfg.network.kademlia = self.kademlia.unwrap_or(cfg.network.kademlia);

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -69,9 +69,10 @@ pub(super) async fn start(config: Config) {
         .await
         .unwrap();
 
+    let validate_height = if config.snapshot { None } else { Some(0) };
     // Sync from snapshot
     if let Some(path) = &config.snapshot_path {
-        import_chain::<FullVerifier, _>(&state_manager, path, Some(0))
+        import_chain::<FullVerifier, _>(&state_manager, path, validate_height, config.skip_load)
             .await
             .unwrap();
     }
@@ -191,7 +192,7 @@ mod test {
         let db = Arc::new(MemoryDB::default());
         let cs = Arc::new(ChainStore::new(db));
         let sm = Arc::new(StateManager::new(cs));
-        import_chain::<FullVerifier, _>(&sm, "test_files/chain4.car", None)
+        import_chain::<FullVerifier, _>(&sm, "test_files/chain4.car", None, false)
             .await
             .expect("Failed to import chain");
     }
@@ -200,7 +201,7 @@ mod test {
         let db = Arc::new(MemoryDB::default());
         let cs = Arc::new(ChainStore::new(db));
         let sm = Arc::new(StateManager::new(cs));
-        import_chain::<FullVerifier, _>(&sm, "test_files/chain4.car", Some(0))
+        import_chain::<FullVerifier, _>(&sm, "test_files/chain4.car", Some(0), false)
             .await
             .expect("Failed to import chain");
     }

--- a/ipld/car/src/lib.rs
+++ b/ipld/car/src/lib.rs
@@ -6,7 +6,7 @@ mod util;
 
 use blockstore::BlockStore;
 use cid::Cid;
-use error::*;
+pub use error::*;
 use forest_encoding::{from_slice, to_vec};
 use futures::{AsyncRead, AsyncWrite, Stream, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -97,8 +97,9 @@ pub struct Block {
 }
 
 /// Loads a CAR buffer into a BlockStore
-pub async fn load_car<R, B: BlockStore>(s: &B, reader: R) -> Result<Vec<Cid>, Error>
+pub async fn load_car<R, B>(s: &B, reader: R) -> Result<Vec<Cid>, Error>
 where
+    B: BlockStore,
     R: AsyncRead + Send + Unpin,
 {
     let mut car_reader = CarReader::new(reader).await?;

--- a/utils/genesis/src/lib.rs
+++ b/utils/genesis/src/lib.rs
@@ -8,16 +8,16 @@ use chain::ChainStore;
 use cid::Cid;
 use encoding::Cbor;
 use fil_types::verifier::ProofVerifier;
-use forest_car::load_car;
+use forest_car::{load_car, CarReader};
 use futures::AsyncRead;
 use ipld_blockstore::BlockStore;
 use log::{debug, info};
 use net_utils::FetchProgress;
 use networks::DEFAULT_GENESIS;
 use state_manager::StateManager;
-use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::sync::Arc;
+use std::{convert::TryFrom, io::Stdout};
 use url::Url;
 
 #[cfg(feature = "testing")]
@@ -96,6 +96,7 @@ pub async fn import_chain<V: ProofVerifier, DB>(
     sm: &Arc<StateManager<DB>>,
     path: &str,
     validate_height: Option<i64>,
+    skip_load: bool,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     DB: BlockStore + Send + Sync + 'static,
@@ -108,14 +109,14 @@ where
         let url = Url::parse(path).expect("URL is invalid");
         info!("Downloading file...");
         let reader = FetchProgress::try_from(url)?;
-        load_car(sm.blockstore(), reader).await?
+        load_and_retrieve_header(sm.blockstore(), reader, skip_load).await?
     } else {
         let file = File::open(&path)
             .await
             .expect("Snapshot file path not found!");
         info!("Reading file...");
         let reader = FetchProgress::try_from(file)?;
-        load_car(sm.blockstore(), reader).await?
+        load_and_retrieve_header(sm.blockstore(), reader, skip_load).await?
     };
     let ts = sm
         .chain_store()
@@ -139,4 +140,23 @@ where
         gen_cid
     );
     Ok(())
+}
+
+/// Loads car file into database, and returns the block header Cids from the CAR header.
+async fn load_and_retrieve_header<DB, R>(
+    store: &DB,
+    mut reader: FetchProgress<R, Stdout>,
+    skip_load: bool,
+) -> Result<Vec<Cid>, Box<dyn StdError>>
+where
+    DB: BlockStore,
+    R: AsyncRead + Send + Unpin,
+{
+    let result = if skip_load {
+        CarReader::new(&mut reader).await?.header.roots
+    } else {
+        load_car(store, &mut reader).await?
+    };
+    reader.finish();
+    Ok(result)
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Adds skip-load flag which allows to skip reloading car file.
- Fix regression which caused loading snapshot to fully validate chain



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->