### PR TITLE
Fix typo in calico winning post validation

### DIFF
--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -62,7 +62,7 @@ where
             let mut proving_sectors = BitField::new();
             mas.for_each_deadline(store, |_, deadline| {
                 deadline.for_each(store, |_, partition: miner::Partition| {
-                    proving_sectors |= &partition.all_sectors();
+                    proving_sectors |= &partition.active_sectors();
                     Ok(())
                 })?;
                 Ok(())


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- #910 Updating sectors for winning post was updated incorrectly



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->