### PR TITLE
Update consensus min power

### DIFF
--- a/vm/actor/src/builtin/power/state.rs
+++ b/vm/actor/src/builtin/power/state.rs
@@ -127,7 +127,7 @@ impl State {
         qa_power: &StoragePower,
     ) -> Result<(), Box<dyn StdError>> {
         let old_claim = get_claim(claims, miner)?
-            .ok_or_else(|| actor_error!(ErrNotFound; "no claim for actor {}", miner))?;
+            .ok_or_else(|| actor_error!(ErrNotFound, "no claim for actor {}", miner))?;
 
         self.total_qa_bytes_committed += qa_power;
         self.total_bytes_committed += power;
@@ -139,8 +139,8 @@ impl State {
         };
 
         let min_power: StoragePower = consensus_miner_min_power(old_claim.seal_proof_type)?;
-        let prev_below: bool = old_claim.quality_adj_power < min_power;
-        let still_below: bool = new_claim.quality_adj_power < min_power;
+        let prev_below: bool = old_claim.raw_byte_power < min_power;
+        let still_below: bool = new_claim.raw_byte_power < min_power;
 
         if prev_below && !still_below {
             // Just passed min miner size

--- a/vm/actor/src/builtin/sector.rs
+++ b/vm/actor/src/builtin/sector.rs
@@ -8,11 +8,10 @@ use fil_types::{RegisteredSealProof, StoragePower};
 pub fn consensus_miner_min_power(p: RegisteredSealProof) -> Result<StoragePower, String> {
     use RegisteredSealProof::*;
     match p {
-        StackedDRG2KiBV1 | StackedDRG2KiBV1P1 => Ok(StoragePower::from(0)),
-        StackedDRG512MiBV1 | StackedDRG512MiBV1P1 => Ok(StoragePower::from(16 << 20)),
-        StackedDRG8MiBV1 | StackedDRG8MiBV1P1 => Ok(StoragePower::from(1 << 30)),
-        StackedDRG32GiBV1 | StackedDRG32GiBV1P1 => Ok(StoragePower::from(10u64 << 40)),
-        StackedDRG64GiBV1 | StackedDRG64GiBV1P1 => Ok(StoragePower::from(20u64 << 40)),
+        // Specs actors defaults to other values, these are the mainnet values put in place
+        StackedDRG2KiBV1 | StackedDRG2KiBV1P1 | StackedDRG512MiBV1 | StackedDRG512MiBV1P1
+        | StackedDRG8MiBV1 | StackedDRG8MiBV1P1 | StackedDRG32GiBV1 | StackedDRG32GiBV1P1
+        | StackedDRG64GiBV1 | StackedDRG64GiBV1P1 => Ok(StoragePower::from(10u64 << 40)),
         Invalid(i) => Err(format!("unsupported proof type: {}", i)),
     }
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

So in v2 they decided to have a hashmap of all proofs to their corresponding minimum consensus power, makes sense. Turns out the function they used to override the single value in v0 was used to iterate over every hashmap value and set it to a static `10 << 40`. Why did they change it to this variably set map if they were just going to overwrite all values to one static? Why would they not alter the setting of consensus minimum to match this change? I don't have the answers

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->