### PR TITLE
Fix to address resolution for chained internal calls

### DIFF
--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -273,13 +273,6 @@ where
         value: TokenAmount,
         params: Serialized,
     ) -> Result<Serialized, ActorError> {
-        // ID must be resolved because otherwise would be done in creation of new runtime.
-        // TODO revisit this later, it's possible there are no code paths this is needed.
-        let from_id = self.resolve_address(&from)?.ok_or_else(|| {
-            actor_error!(SysErrInvalidReceiver;
-            "resolving from address in internal send failed")
-        })?;
-
         let msg = UnsignedMessage {
             from,
             to,
@@ -298,42 +291,7 @@ where
             .snapshot()
             .map_err(|e| actor_error!(fatal("failed to create snapshot: {}", e)))?;
 
-        // Since it is unsafe to share a mutable reference to the state tree by copying
-        // the runtime, all variables must be copied and reset at the end of the transition.
-        let prev_val = self.caller_validated;
-        let prev_depth = self.depth;
-        let prev_msg = self.vm_msg.clone();
-
-        // Ensure receiver is resolved for chained calls (specifically multisig executions)
-        let to = if self.network_version() <= NetworkVersion::V3 {
-            // Don't resolve to address before NV3
-            to
-        } else {
-            self.resolve_address(&to)?.ok_or_else(|| {
-                actor_error!(SysErrInvalidReceiver, "resolve msg.from() address failed")
-            })?
-        };
-
-        self.vm_msg = VMMsg {
-            caller: from_id,
-            receiver: to,
-            value_received: value,
-        };
-        self.caller_validated = false;
-        self.depth += 1;
-        if self.depth > MAX_CALL_DEPTH && self.network_version() >= NetworkVersion::V6 {
-            return Err(actor_error!(
-                SysErrForbidden,
-                "message execution exceeds call depth"
-            ));
-        }
-
-        let send_res = vm_send::<BS, R, C, LB, V, P>(self, &msg, None);
-
-        // Reset values back to their values before the call
-        self.vm_msg = prev_msg;
-        self.caller_validated = prev_val;
-        self.depth = prev_depth;
+        let send_res = self.send(&msg, None);
 
         let ret = send_res.map_err(|e| {
             if let Err(e) = self.state.revert_to_snapshot() {
@@ -347,6 +305,149 @@ where
         }
 
         Ok(ret?)
+    }
+
+    /// Shared logic between the DefaultRuntime and the Interpreter.
+    /// It invokes methods on different Actors based on the Message.
+    /// This function is somewhat equivalent to the go implementation's vm send.
+    pub fn send(
+        &mut self,
+        msg: &UnsignedMessage,
+        gas_cost: Option<GasCharge>,
+    ) -> Result<Serialized, ActorError> {
+        // Since it is unsafe to share a mutable reference to the state tree by copying
+        // the runtime, all variables must be copied and reset at the end of the transition.
+        // This logic is the equivalent to the go implementation creating a new runtime with
+        // shared values.
+        // All other fields will
+        let prev_val = self.caller_validated;
+        let prev_depth = self.depth;
+        let prev_msg = self.vm_msg.clone();
+
+        let res = self.execute_send(msg, gas_cost);
+
+        // Reset values back to their values before the call
+        self.vm_msg = prev_msg;
+        self.caller_validated = prev_val;
+        self.depth = prev_depth;
+
+        res
+    }
+
+    /// Helper function to handle all of the execution logic folded into single result.
+    /// This is necessary to follow to follow the same control flow of the go implementation
+    /// cleanly without doing anything memory unsafe.
+    fn execute_send(
+        &mut self,
+        msg: &UnsignedMessage,
+        gas_cost: Option<GasCharge>,
+    ) -> Result<Serialized, ActorError> {
+        // * Following logic would be called
+        self.caller_validated = false;
+        self.depth += 1;
+        if self.depth > MAX_CALL_DEPTH && self.network_version() >= NetworkVersion::V6 {
+            return Err(actor_error!(
+                SysErrForbidden,
+                "message execution exceeds call depth"
+            ));
+        }
+
+        let caller = self.resolve_address(msg.from())?.ok_or_else(|| {
+            actor_error!(
+                SysErrInvalidReceiver,
+                "resolving from address in internal send failed"
+            )
+        })?;
+
+        let receiver = if self.network_version() <= NetworkVersion::V3 {
+            msg.to
+        } else {
+            if let Some(resolved) = self.resolve_address(msg.to())? {
+                resolved
+            } else {
+                msg.to
+            }
+        };
+
+        self.vm_msg = VMMsg {
+            caller,
+            receiver,
+            value_received: msg.value().clone(),
+        };
+
+        // * End of logic that is performed on go runtime initialization
+
+        if let Some(cost) = gas_cost {
+            self.charge_gas(cost)?;
+        }
+
+        let to_actor = match self
+            .state
+            .get_actor(msg.to())
+            .map_err(|e| e.downcast_fatal("failed to get actor"))?
+        {
+            Some(act) => act,
+            None => {
+                // Try to create actor if not exist
+                let (to_actor, id_addr) = self.try_create_account_actor(msg.to())?;
+                if self.network_version() > NetworkVersion::V3 {
+                    // Update the receiver to the created ID address
+                    self.vm_msg.receiver = id_addr;
+                }
+                to_actor
+            }
+        };
+
+        self.charge_gas(
+            self.price_list()
+                .on_method_invocation(msg.value(), msg.method_num()),
+        )?;
+
+        if !msg.value().is_zero() {
+            transfer(self.state, &msg.from(), &msg.to(), &msg.value())
+                .map_err(|e| e.wrap("failed to transfer funds"))?;
+        }
+
+        if msg.method_num() != METHOD_SEND {
+            self.charge_gas(ACTOR_EXEC_GAS)?;
+            return self.invoke(to_actor.code, msg.method_num(), msg.params(), msg.to());
+        }
+
+        Ok(Serialized::default())
+    }
+
+    /// Calls actor code with method and parameters.
+    fn invoke(
+        &mut self,
+        code: Cid,
+        method_num: MethodNum,
+        params: &Serialized,
+        to: &Address,
+    ) -> Result<Serialized, ActorError> {
+        let ret = if let Some(ret) = {
+            match actor::ActorVersion::from(self.network_version()) {
+                ActorVersion::V0 => actorv0::invoke_code(&code, self, method_num, params),
+                ActorVersion::V2 => actorv2::invoke_code(&code, self, method_num, params),
+            }
+        } {
+            ret
+        } else if code == *actorv2::CHAOS_ACTOR_CODE_ID && self.registered_actors.contains(&code) {
+            actorv2::chaos::Actor::invoke_method(self, method_num, params)
+        } else {
+            Err(actor_error!(
+                SysErrIllegalActor,
+                "no code for actor at address {}",
+                to
+            ))
+        }?;
+
+        if !self.caller_validated {
+            Err(
+                actor_error!(SysErrIllegalActor; "Caller must be validated during method execution"),
+            )
+        } else {
+            Ok(ret)
+        }
     }
 
     /// creates account actors from only BLS/SECP256K1 addresses.
@@ -907,60 +1008,6 @@ where
     }
 }
 
-/// Shared logic between the DefaultRuntime and the Interpreter.
-/// It invokes methods on different Actors based on the Message.
-pub fn vm_send<'db, 'vm, BS, R, C, LB, V, P>(
-    rt: &mut DefaultRuntime<'db, 'vm, BS, R, C, LB, V, P>,
-    msg: &UnsignedMessage,
-    gas_cost: Option<GasCharge>,
-) -> Result<Serialized, ActorError>
-where
-    BS: BlockStore,
-    V: ProofVerifier,
-    P: NetworkParams,
-    R: Rand,
-    C: CircSupplyCalc,
-    LB: LookbackStateGetter<'db, BS>,
-{
-    if let Some(cost) = gas_cost {
-        rt.charge_gas(cost)?;
-    }
-
-    let to_actor = match rt
-        .state
-        .get_actor(msg.to())
-        .map_err(|e| e.downcast_fatal("failed to get actor"))?
-    {
-        Some(act) => act,
-        None => {
-            // Try to create actor if not exist
-            let (to_actor, id_addr) = rt.try_create_account_actor(msg.to())?;
-            if rt.network_version() > NetworkVersion::V3 {
-                // Update the receiver to the created ID address
-                rt.vm_msg.receiver = id_addr;
-            }
-            to_actor
-        }
-    };
-
-    rt.charge_gas(
-        rt.price_list()
-            .on_method_invocation(msg.value(), msg.method_num()),
-    )?;
-
-    if !msg.value().is_zero() {
-        transfer(rt.state, &msg.from(), &msg.to(), &msg.value())
-            .map_err(|e| e.wrap("failed to transfer funds"))?;
-    }
-
-    if msg.method_num() != METHOD_SEND {
-        rt.charge_gas(ACTOR_EXEC_GAS)?;
-        return invoke(rt, to_actor.code, msg.method_num(), msg.params(), msg.to());
-    }
-
-    Ok(Serialized::default())
-}
-
 /// Transfers funds from one Actor to another Actor
 fn transfer<BS: BlockStore>(
     state: &mut StateTree<BS>,
@@ -1021,46 +1068,6 @@ fn transfer<BS: BlockStore>(
         .map_err(|e| e.downcast_fatal("failed to set to actor"))?;
 
     Ok(())
-}
-
-/// Calls actor code with method and parameters.
-fn invoke<'db, 'vm, BS, R, C, LB, V, P>(
-    rt: &mut DefaultRuntime<'db, 'vm, BS, R, C, LB, V, P>,
-    code: Cid,
-    method_num: MethodNum,
-    params: &Serialized,
-    to: &Address,
-) -> Result<Serialized, ActorError>
-where
-    BS: BlockStore,
-    V: ProofVerifier,
-    P: NetworkParams,
-    R: Rand,
-    C: CircSupplyCalc,
-    LB: LookbackStateGetter<'db, BS>,
-{
-    let ret = if let Some(ret) = {
-        match actor::ActorVersion::from(rt.network_version()) {
-            ActorVersion::V0 => actorv0::invoke_code(&code, rt, method_num, params),
-            ActorVersion::V2 => actorv2::invoke_code(&code, rt, method_num, params),
-        }
-    } {
-        ret
-    } else if code == *actorv2::CHAOS_ACTOR_CODE_ID && rt.registered_actors.contains(&code) {
-        actorv2::chaos::Actor::invoke_method(rt, method_num, params)
-    } else {
-        Err(actor_error!(
-            SysErrIllegalActor,
-            "no code for actor at address {}",
-            to
-        ))
-    }?;
-
-    if !rt.caller_validated {
-        Err(actor_error!(SysErrIllegalActor; "Caller must be validated during method execution"))
-    } else {
-        Ok(ret)
-    }
 }
 
 /// returns the public key type of address (`BLS`/`SECP256K1`) of an account actor

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -362,12 +362,10 @@ where
 
         let receiver = if self.network_version() <= NetworkVersion::V3 {
             msg.to
+        } else if let Some(resolved) = self.resolve_address(msg.to())? {
+            resolved
         } else {
-            if let Some(resolved) = self.resolve_address(msg.to())? {
-                resolved
-            } else {
-                msg.to
-            }
+            msg.to
         };
 
         self.vm_msg = VMMsg {

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -319,7 +319,7 @@ where
         // the runtime, all variables must be copied and reset at the end of the transition.
         // This logic is the equivalent to the go implementation creating a new runtime with
         // shared values.
-        // All other fields will
+        // All other fields will be updated from the execution.
         let prev_val = self.caller_validated;
         let prev_depth = self.depth;
         let prev_msg = self.vm_msg.clone();

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -342,7 +342,8 @@ where
         msg: &UnsignedMessage,
         gas_cost: Option<GasCharge>,
     ) -> Result<Serialized, ActorError> {
-        // * Following logic would be called
+        // * Following logic would be called in the go runtime initialization.
+        // * Since We reuse the runtime, all of these things need to happen on each call
         self.caller_validated = false;
         self.depth += 1;
         if self.depth > MAX_CALL_DEPTH && self.network_version() >= NetworkVersion::V6 {

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -277,7 +277,7 @@ where
             from,
             to,
             method_num: method,
-            value: value.clone(),
+            value,
             params,
             gas_limit: self.gas_available(),
             version: Default::default(),

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -303,6 +303,17 @@ where
         let prev_val = self.caller_validated;
         let prev_depth = self.depth;
         let prev_msg = self.vm_msg.clone();
+
+        // Ensure receiver is resolved for chained calls (specifically multisig executions)
+        let to = if self.network_version() <= NetworkVersion::V3 {
+            // Don't resolve to address before NV3
+            to
+        } else {
+            self.resolve_address(&to)?.ok_or_else(|| {
+                actor_error!(SysErrInvalidReceiver, "resolve msg.from() address failed")
+            })?
+        };
+
         self.vm_msg = VMMsg {
             caller: from_id,
             receiver: to,

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -3,7 +3,7 @@
 
 use super::{
     gas_tracker::{price_list_by_epoch, GasCharge},
-    vm_send, DefaultRuntime, Rand,
+    DefaultRuntime, Rand,
 };
 use actor::{
     actorv0::reward::AwardBlockRewardParams, cron, miner, reward, system, BURNT_FUNDS_ACTOR_ADDR,
@@ -523,7 +523,7 @@ where
         );
 
         match res {
-            Ok(mut rt) => match vm_send(&mut rt, msg, gas_cost) {
+            Ok(mut rt) => match rt.send(msg, gas_cost) {
                 Ok(ser) => (ser, Some(rt), None),
                 Err(actor_err) => (Serialized::default(), Some(rt), Some(actor_err)),
             },

--- a/vm/interpreter/tests/transfer_test.rs
+++ b/vm/interpreter/tests/transfer_test.rs
@@ -8,7 +8,7 @@ use clock::ChainEpoch;
 use crypto::DomainSeparationTag;
 use db::MemoryDB;
 use fil_types::{verifier::MockVerifier, NetworkVersion, StateTreeVersion};
-use interpreter::{vm_send, CircSupplyCalc, DefaultRuntime, LookbackStateGetter, Rand};
+use interpreter::{CircSupplyCalc, DefaultRuntime, LookbackStateGetter, Rand};
 use ipld_blockstore::BlockStore;
 use ipld_hamt::Hamt;
 use message::UnsignedMessage;
@@ -153,7 +153,7 @@ fn transfer_test() {
         &lookback,
     )
     .unwrap();
-    let _serialized = vm_send(&mut runtime, &message, None).unwrap();
+    let _serialized = runtime.send(&message, None).unwrap();
 
     let actor_state_result_1 = state.get_actor(&actor_addr_1).unwrap().unwrap();
     let actor_state_result_2 = state.get_actor(&actor_addr_2).unwrap().unwrap();


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Resolution of to address must exist here for chained internal calls. This was caught because a msig execution where the message sends to a non-id address, it wasn't being resolved when executing.
- Refactored vm to handle all cases exactly and for readability (open to suggestions on naming, `send`, `internal_send`, and `execute_send` isn't ideal, but `internal_send` matching Lotus naming and the other two are needed to make interactions cleaner)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->