### PR TITLE
Remove irrelevant spam logs

### DIFF
--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -274,7 +274,7 @@ where
         };
         info!(
             "Received block over GossipSub: {} from {}",
-            block.header.epoch(),
+            block.header.cid(),
             source
         );
 

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -273,8 +273,9 @@ where
             }
         };
         info!(
-            "Received block over GossipSub: {} from {}",
+            "Received block over GossipSub: {} height {} from {}",
             block.header.cid(),
+            block.header.epoch(),
             source
         );
 

--- a/blockchain/message_pool/src/msgpool/mod.rs
+++ b/blockchain/message_pool/src/msgpool/mod.rs
@@ -80,7 +80,7 @@ impl MsgSet {
                     return Err(Error::GasPriceTooLow);
                 }
             } else {
-                (Error::DuplicateSequence);
+                return Err(Error::DuplicateSequence);
             }
         }
         self.msgs.insert(m.sequence(), m);

--- a/blockchain/message_pool/src/msgpool/mod.rs
+++ b/blockchain/message_pool/src/msgpool/mod.rs
@@ -77,12 +77,10 @@ impl MsgSet {
                 let rbf_denom = BigInt::from(RBF_DENOM);
                 let min_price = premium + ((premium * RBF_NUM).div_floor(&rbf_denom)) + 1u8;
                 if m.message().gas_premium() <= &min_price {
-                    warn!("message gas price is below min gas price");
                     return Err(Error::GasPriceTooLow);
                 }
             } else {
-                warn!("try to add message with duplicate sequence increase gas premium");
-                return Err(Error::DuplicateSequence);
+                (Error::DuplicateSequence);
             }
         }
         self.msgs.insert(m.sequence(), m);

--- a/forest/src/logger/mod.rs
+++ b/forest/src/logger/mod.rs
@@ -15,6 +15,7 @@ pub(crate) fn setup_logger() {
         logger_builder.filter(Some("storage_proofs_core"), LevelFilter::Warn);
         logger_builder.filter(Some("surf::middleware"), LevelFilter::Warn);
         logger_builder.filter(Some("tide"), LevelFilter::Warn);
+        logger_builder.filter(Some("libp2p_bitswap"), LevelFilter::Warn);
         logger_builder.filter(None, LevelFilter::Info);
     }
     let logger = logger_builder.build();

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -274,7 +274,7 @@ where
                                                 trace!("Saved Bitswap block with cid {:?}", cid);
                                         }
                                     } else {
-                                        warn!("Received Bitswap response, but response channel cannot be found");
+                                        debug!("Received Bitswap response, but response channel cannot be found");
                                     }
                                     emit_event(&self.network_sender_out, NetworkEvent::BitswapBlock{cid}).await;
                                 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Staying in sync with mainnet, these logs are spammed a lot (mainly the bitswap drop) and it makes it impossible to read things



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->