### PR TITLE
Update Amt API and prep release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
  "forest_message",
  "futures 0.3.10",
  "interpreter",
- "ipld_amt 0.2.0",
+ "ipld_amt 0.2.1",
  "ipld_blockstore",
  "lazy_static",
  "log",
@@ -1029,7 +1029,7 @@ dependencies = [
  "genesis",
  "hex",
  "interpreter",
- "ipld_amt 0.2.0",
+ "ipld_amt 0.2.1",
  "ipld_blockstore",
  "ipld_hamt 0.1.1",
  "libp2p",
@@ -2262,7 +2262,7 @@ dependencies = [
  "hex",
  "indexmap",
  "integer-encoding 3.0.1",
- "ipld_amt 0.2.0",
+ "ipld_amt 0.2.1",
  "ipld_blockstore",
  "ipld_hamt 0.1.1",
  "lazy_static",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "ipld_amt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash 0.6.2",
  "criterion",
@@ -5572,7 +5572,7 @@ dependencies = [
  "futures 0.3.10",
  "hex",
  "interpreter",
- "ipld_amt 0.2.0",
+ "ipld_amt 0.2.1",
  "ipld_blockstore",
  "jsonrpc-v2",
  "jsonwebtoken",
@@ -6215,7 +6215,7 @@ dependencies = [
  "forest_vm",
  "futures 0.3.10",
  "interpreter",
- "ipld_amt 0.2.0",
+ "ipld_amt 0.2.1",
  "ipld_blockstore",
  "lazy_static",
  "log",

--- a/blockchain/chain_sync/src/lib.rs
+++ b/blockchain/chain_sync/src/lib.rs
@@ -18,6 +18,5 @@ extern crate serde;
 pub use self::bad_block_cache::BadBlockCache;
 pub use self::errors::Error;
 pub use self::network_context::SyncNetworkContext;
-pub use self::sync::{ChainSyncer, SyncConfig};
+pub use self::sync::{compute_msg_meta, ChainSyncer, SyncConfig};
 pub use self::sync_state::{SyncStage, SyncState};
-pub use self::sync_worker::compute_msg_meta;

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -639,8 +639,8 @@ pub fn compute_msg_meta<DB: BlockStore>(
     let secp_cids = cids_from_messages(secp_msgs)?;
 
     // generate Amt and batch set message values
-    let bls_root = Amt::new_from_slice(blockstore, &bls_cids)?;
-    let secp_root = Amt::new_from_slice(blockstore, &secp_cids)?;
+    let bls_root = Amt::new_from_iter(blockstore, bls_cids)?;
+    let secp_root = Amt::new_from_iter(blockstore, secp_cids)?;
 
     let meta = TxMeta {
         bls_message_root: bls_root,

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -243,8 +243,7 @@ where
         let receipts = vm.apply_block_messages(messages, parent_epoch, epoch, callback)?;
 
         // Construct receipt root from receipts
-        // TODO this should use an amt relative to the version. This doesn't matter for us yet
-        let rect_root = Amt::new_from_slice(self.blockstore(), &receipts)?;
+        let rect_root = Amt::new_from_iter(self.blockstore(), receipts)?;
 
         // Flush changes to blockstore
         let state_root = vm.flush()?;

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ipld_amt"
 description = "Sharded IPLD Array implementation."
-# TODO bump the major version when releasing v2 actors
 version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]

--- a/ipld/amt/Cargo.toml
+++ b/ipld/amt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ipld_amt"
 description = "Sharded IPLD Array implementation."
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT OR Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2018"

--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -105,14 +105,14 @@ fn from_slice(c: &mut Criterion) {
     c.bench_function("AMT initialization from slice", |b| {
         b.iter(|| {
             let db = db::MemoryDB::default();
-            Amt::new_from_slice(&db, black_box(VALUES)).unwrap();
+            Amt::new_from_iter(&db, black_box(VALUES.iter().copied())).unwrap();
         })
     });
 }
 
 fn for_each(c: &mut Criterion) {
     let db = db::MemoryDB::default();
-    let cid = Amt::new_from_slice(&db, black_box(VALUES)).unwrap();
+    let cid = Amt::new_from_iter(&db, black_box(VALUES.iter().copied())).unwrap();
 
     c.bench_function("AMT for_each function", |b| {
         b.iter(|| {

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -83,10 +83,10 @@ where
     }
 
     /// Generates an AMT with block store and array of cbor marshallable objects and returns Cid
-    pub fn new_from_slice(block_store: &'db BS, vals: &[V]) -> Result<Cid, Error>
-    where
-        V: Clone,
-    {
+    pub fn new_from_iter(
+        block_store: &'db BS,
+        vals: impl IntoIterator<Item = V>,
+    ) -> Result<Cid, Error> {
         let mut t = Self::new(block_store);
 
         t.batch_set(vals)?;
@@ -167,12 +167,9 @@ where
 
     /// Batch set (naive for now)
     // TODO Implement more efficient batch set to not have to traverse tree and keep cache for each
-    pub fn batch_set(&mut self, vals: &[V]) -> Result<(), Error>
-    where
-        V: Clone,
-    {
-        for (i, val) in vals.iter().enumerate() {
-            self.set(i as u64, val.clone())?;
+    pub fn batch_set(&mut self, vals: impl IntoIterator<Item = V>) -> Result<(), Error> {
+        for (i, val) in vals.into_iter().enumerate() {
+            self.set(i as u64, val)?;
         }
 
         Ok(())

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -330,14 +330,14 @@ where
         }
 
         match self {
-            Self::Leaf { bmap, .. } => {
+            Self::Leaf { bmap, vals } => {
                 assert_eq!(
                     height, 0,
                     "Height must be 0 when clearing bit for leaf node"
                 );
 
-                // When deleting from node, should only need to clear bit from bitmap
                 bmap.clear_bit(i);
+                vals[i as usize] = None;
                 Ok(true)
             }
             Self::Link { links, bmap } => {

--- a/node/rpc/src/state_api.rs
+++ b/node/rpc/src/state_api.rs
@@ -669,8 +669,9 @@ pub(crate) async fn miner_create_block<
         }
     }
 
-    let bls_msg_root = Amt::new_from_slice(data.chain_store.blockstore(), &bls_cids)?;
-    let secp_msg_root = Amt::new_from_slice(data.chain_store.blockstore(), &secp_cids)?;
+    let bls_msg_root = Amt::new_from_iter(data.chain_store.blockstore(), bls_cids.iter().copied())?;
+    let secp_msg_root =
+        Amt::new_from_iter(data.chain_store.blockstore(), secp_cids.iter().copied())?;
 
     let mmcid = data.chain_store.blockstore().put(
         &TxMeta {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- API change is pretty needed because v0 is used for receipts and message roots regardless of network version and there is no need to clone.

setup for #978 

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->