### PR TITLE
BufferedBlockstore Flush Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,7 @@ dependencies = [
 name = "ipld_blockstore"
 version = "0.1.1"
 dependencies = [
+ "byteorder 1.4.2",
  "commcid",
  "forest_cid",
  "forest_db",

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -77,7 +77,7 @@ impl Default for SyncConfig {
     fn default() -> Self {
         Self {
             req_window: 200,
-            worker_tasks: 1,
+            worker_tasks: 3,
         }
     }
 }

--- a/blockchain/chain_sync/src/sync.rs
+++ b/blockchain/chain_sync/src/sync.rs
@@ -77,7 +77,7 @@ impl Default for SyncConfig {
     fn default() -> Self {
         Self {
             req_window: 200,
-            worker_tasks: 3,
+            worker_tasks: 1,
         }
     }
 }

--- a/encoding/src/lib.rs
+++ b/encoding/src/lib.rs
@@ -8,7 +8,7 @@ mod hash;
 
 pub use serde::{de, ser};
 pub use serde_bytes;
-pub use serde_cbor::{error, from_reader, from_slice, tags, to_vec, to_writer, value, StreamDeserializer, Deserializer};
+pub use serde_cbor::{error, from_reader, from_slice, tags, to_vec, to_writer};
 
 pub use self::bytes::*;
 pub use self::cbor::*;

--- a/encoding/src/lib.rs
+++ b/encoding/src/lib.rs
@@ -8,7 +8,7 @@ mod hash;
 
 pub use serde::{de, ser};
 pub use serde_bytes;
-pub use serde_cbor::{error, from_reader, from_slice, tags, to_vec, to_writer, value};
+pub use serde_cbor::{error, from_reader, from_slice, tags, to_vec, to_writer, value, StreamDeserializer, Deserializer};
 
 pub use self::bytes::*;
 pub use self::cbor::*;

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -10,9 +10,12 @@ repository = "https://github.com/ChainSafe/forest"
 [dependencies]
 cid = { package = "forest_cid", features = ["cbor"], version = "0.3" }
 db = { package = "forest_db", version = "0.1" }
-encoding = { package = "forest_encoding", version = "0.2.1" }
+encoding = { package = "forest_encoding", version = "0.2.1", path = "../../encoding" }
+ahash = "0.6"
+# encoding = { package = "forest_encoding", version = "0.2.1" }
 forest_ipld = { optional = true, version = "0.1" }
-
+byteorder = "1.3.2"
+pprof = { version = "0.4", features = ["flamegraph"] } 
 [dev-dependencies]
 commcid = { path = "../../utils/commcid" }
 

--- a/ipld/blockstore/Cargo.toml
+++ b/ipld/blockstore/Cargo.toml
@@ -10,12 +10,9 @@ repository = "https://github.com/ChainSafe/forest"
 [dependencies]
 cid = { package = "forest_cid", features = ["cbor"], version = "0.3" }
 db = { package = "forest_db", version = "0.1" }
-encoding = { package = "forest_encoding", version = "0.2.1", path = "../../encoding" }
-ahash = "0.6"
-# encoding = { package = "forest_encoding", version = "0.2.1" }
+encoding = { package = "forest_encoding", version = "0.2.1" }
 forest_ipld = { optional = true, version = "0.1" }
 byteorder = "1.3.2"
-pprof = { version = "0.4", features = ["flamegraph"] } 
 [dev-dependencies]
 commcid = { path = "../../utils/commcid" }
 

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -7,7 +7,7 @@ use super::BlockStore;
 use cid::{Cid, Code, DAG_CBOR};
 use db::{Error, Store};
 use std::{cell::RefCell, convert::TryFrom, io::Cursor};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::error::Error as StdError;
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use std::io::Seek;

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -7,7 +7,7 @@ use super::BlockStore;
 use cid::{Cid, Code, DAG_CBOR};
 use db::{Error, Store};
 use std::{cell::RefCell, convert::TryFrom, io::Cursor};
-use std::collections::{BTreeMap,HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error as StdError;
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use std::io::Seek;
@@ -71,7 +71,6 @@ fn cbor_read_header_buf<'a, B: std::io::BufRead>(br: &mut B, scratch: &'a mut [u
             return Err(format!("cbor input was not canonical (lval 26 with value <= MaxUint16)").into());
         }
         return Ok((maj, val as u64))
-
     } else if low == 27 {
         br.read_exact(&mut scratch[..8])?;
         let val = BigEndian::read_u64(&scratch[..8]);
@@ -79,7 +78,6 @@ fn cbor_read_header_buf<'a, B: std::io::BufRead>(br: &mut B, scratch: &'a mut [u
             return Err(format!("cbor input was not canonical (lval 27 with value <= MaxUint32)").into());
         }
         return Ok((maj, val))
-
     } else {
         return Err(format!("invalid header cbor_read_header_buf").into());
     }
@@ -163,6 +161,7 @@ BS: BlockStore,
         if !cache.contains_key(&link) && base.exists(link.to_bytes())? {
             continue;
         }
+        // Recursively find more links under the links we're iterating over.
         copy_rec(base,cache, *link)?;
     }
     base.write(&root.to_bytes(), block)?;

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -41,7 +41,7 @@ where
     /// This will recursively traverse the cache and write all data connected by links to this
     /// root Cid.
     pub fn flush(&mut self, root: &Cid) -> Result<(), Box<dyn StdError>> {
-        let guard = pprof::ProfilerGuard::new(100).unwrap();
+        // let guard = pprof::ProfilerGuard::new(100).unwrap();
         let now = SystemTime::now();
         println!("--------------- The cache has: {} items -----------------", self.write.borrow().len());
 
@@ -63,26 +63,23 @@ where
 
 
         println!("------- Start DB write START: {:?}", now.elapsed());
-        let mut counter = 0;
-        for (raw_cid_bz, raw_bz) in self.buffer1.borrow().iter() {
-            // if self.base.exists(raw_cid_bz)? {
-            //     continue;
-            // }
-            counter += 1;
-            self.base.write(raw_cid_bz, raw_bz)?;
-        }
+        // let mut counter = 0;
+        // for (raw_cid_bz, raw_bz) in self.buffer1.borrow().iter() {
+        //     counter += 1;
+        //     self.base.write(raw_cid_bz, raw_bz)?;
+        // }
         self.write = Default::default();
 
-        match guard.report().build() {
-            Ok(report) => {
-                let file = File::create("flamegraph.svg").unwrap();
-                report.flamegraph(file).unwrap();
+        // match guard.report().build() {
+        //     Ok(report) => {
+        //         let file = File::create("flamegraph.svg").unwrap();
+        //         report.flamegraph(file).unwrap();
     
-                // println!("report: {:?}", &report);
-            }
-            Err(_) => {}
-        };
-        println!("------- Ended up writing: {} iterms", counter);
+        //         // println!("report: {:?}", &report);
+        //     }
+        //     Err(_) => {}
+        // };
+        // println!("------- Ended up writing: {} iterms", counter);
 
         println!("--------------- FLUSH TOTAL TOOK: {:?} ---------------------------------", now.elapsed());
         Ok(())
@@ -206,9 +203,9 @@ BS: BlockStore,
         }
         copy_rec(base,cache,buffer, *link)?;
     }
-    // base.write(&root.to_bytes(), block)?;
+    base.write(&root.to_bytes(), block)?;
     // cb(&root.to_bytes(), block)?;
-    buffer.insert(root.to_bytes(), block.to_vec());
+    // buffer.insert(root.to_bytes(), block.to_vec());
     Ok(())
 }
 

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -6,11 +6,13 @@
 use super::BlockStore;
 use cid::{Cid, Code, DAG_CBOR};
 use db::{Error, Store};
-use encoding::from_slice;
+use encoding::{StreamDeserializer, from_slice, to_vec};
 use forest_ipld::Ipld;
-use std::cell::RefCell;
-use std::collections::HashMap;
+use std::{borrow::Borrow, cell::{RefCell, RefMut}, convert::TryFrom, fs::File, io::{Cursor, Read}, time::SystemTime};
+use std::collections::{BTreeMap,HashMap};
 use std::error::Error as StdError;
+use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
+use std::io::Seek;
 
 /// Wrapper around `BlockStore` to limit and have control over when values are written.
 /// This type is not threadsafe and can only be used in synchronous contexts.
@@ -18,6 +20,9 @@ use std::error::Error as StdError;
 pub struct BufferedBlockStore<'bs, BS> {
     base: &'bs BS,
     write: RefCell<HashMap<Cid, Vec<u8>>>,
+    buffer1: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
+    buffer2: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
+
 }
 
 impl<'bs, BS> BufferedBlockStore<'bs, BS>
@@ -28,23 +33,242 @@ where
         Self {
             base,
             write: Default::default(),
+            buffer1: Default::default(),
+            buffer2: Default::default(),
         }
     }
     /// Flushes the buffered cache based on the root node.
     /// This will recursively traverse the cache and write all data connected by links to this
     /// root Cid.
     pub fn flush(&mut self, root: &Cid) -> Result<(), Box<dyn StdError>> {
-        write_recursive(self.base, &self.write.borrow(), root)?;
+        let guard = pprof::ProfilerGuard::new(100).unwrap();
+        let now = SystemTime::now();
+        println!("--------------- The cache has: {} items -----------------", self.write.borrow().len());
 
+
+        println!("REC 2 START: {:?}", now.elapsed());
+        match copy_rec(self.base, &self.write.borrow(), &mut self.buffer1.borrow_mut(), *root) {
+            Ok(_) => {}
+            Err(e) => {println!("REC 2 FAILED!: {}", e);}
+        }
+         println!("----------------- WE 2 GOT: {:?} items --------------------", self.buffer1.borrow().len());
+ 
+ 
+ 
+
+        // println!("REC 1 START: {:?}", now.elapsed());
+        // write_recursive(self.base, &self.write.borrow(), &mut self.buffer1.borrow_mut(), root)?;
+        // println!("----------------- WE 1 GOT: {:?} items --------------------", self.buffer1.borrow().len());
+
+
+
+        println!("------- Start DB write START: {:?}", now.elapsed());
+        let mut counter = 0;
+        for (raw_cid_bz, raw_bz) in self.buffer1.borrow().iter() {
+            // if self.base.exists(raw_cid_bz)? {
+            //     continue;
+            // }
+            counter += 1;
+            self.base.write(raw_cid_bz, raw_bz)?;
+        }
         self.write = Default::default();
+
+        match guard.report().build() {
+            Ok(report) => {
+                let file = File::create("flamegraph.svg").unwrap();
+                report.flamegraph(file).unwrap();
+    
+                // println!("report: {:?}", &report);
+            }
+            Err(_) => {}
+        };
+        println!("------- Ended up writing: {} iterms", counter);
+
+        println!("--------------- FLUSH TOTAL TOOK: {:?} ---------------------------------", now.elapsed());
         Ok(())
     }
 }
+
+fn cbor_read_header_buf<'a, B: std::io::BufRead>(br: &mut B, scratch: &'a mut [u8]) -> Result<(u8, u64), Box<dyn StdError>> 
+{
+    let first = br.read_u8()?;
+    let maj = (first & 0xe0) >> 5;
+    let low = first & 0x1f;
+
+    if low < 24 {
+        return Ok((maj, low as u64));
+    } else if low == 24 {
+        let next = br.read_u8()?;
+        if next < 24 {
+            return Err(format!("cbor input was not canonical (lval 24 with value < 24)").into());
+        }
+        return Ok((maj, next as u64));
+    } else if low == 25 {
+        br.read_exact(&mut scratch[..2])?;
+        let val = BigEndian::read_u16(&scratch[..2]);
+        if val <= u8::MAX as u16 {
+            return Err(format!("cbor input was not canonical (lval 25 with value <= MaxUint8)").into());
+        }
+        return Ok((maj, val as u64))
+    } else if low == 26 {
+        br.read_exact(&mut scratch[..4])?;
+        let val = BigEndian::read_u32(&scratch[..4]);
+        if val <= u16::MAX as u32 {
+            return Err(format!("cbor input was not canonical (lval 26 with value <= MaxUint16)").into());
+        }
+        return Ok((maj, val as u64))
+
+    } else if low == 27 {
+        br.read_exact(&mut scratch[..8])?;
+        let val = BigEndian::read_u64(&scratch[..8]);
+        if val <= u32::MAX as u64 {
+            return Err(format!("cbor input was not canonical (lval 27 with value <= MaxUint32)").into());
+        }
+        return Ok((maj, val))
+
+    } else {
+        return Err(format!("invalid header cbor_read_header_buf").into());
+    }
+}
+
+fn new_scan_for_linkz<B: std::io::BufRead + Seek>(br: &mut B) -> Result<Vec<Cid>, Box<dyn StdError>> {
+    let mut scratch : [u8; 100] = [0;100];
+    let mut remaining = 1;
+    let mut ret = Vec::new();
+    while remaining > 0 {
+        let (maj, extra) = cbor_read_header_buf(br, &mut scratch)?;
+        match maj {
+            0 | 1 | 7 => {},
+            2 | 3 => {
+                br.seek(std::io::SeekFrom::Current(extra as i64))?;
+            }
+            6 => {
+                if extra == 42 {
+                    let (maj, extra) = cbor_read_header_buf(br, &mut scratch)?;
+                    if maj != 2 {
+                        return Err(format!("expected cbor type byte string in input").into());
+                    }
+                    if extra > 100 {
+                        return Err(format!("string in cbor input too long").into());
+                    }
+                    br.read_exact(&mut scratch[..extra as usize])?;
+                    let c = Cid::try_from(&scratch[1..extra as usize])?;
+                    ret.push(c);
+                } else {
+                    remaining += 1;
+                }
+            }
+            4 => {
+                remaining += extra;
+            }
+            5 => {
+                remaining += extra * 2;
+            }
+            _ => {
+                return Err(format!("unhandled cbor type: {}", maj).into());
+            }
+        }
+        remaining -= 1;
+    }
+    Ok(ret)
+}
+
+fn copy_rec<BS>(
+    base: &BS,
+    cache: &HashMap<Cid, Vec<u8>>,
+    buffer: &mut RefMut<HashMap<Vec<u8>, Vec<u8>>>,
+
+    root: Cid,
+    // cb: &mut F,
+) -> Result<(), Box<dyn StdError>> 
+where 
+// F: FnMut(&Vec<u8>, &Vec<u8>) -> Result<(), Box<dyn StdError>>,
+BS: BlockStore,
+{
+    if root.codec() != DAG_CBOR {
+        return Ok(());
+    }
+    let block = cache.get(&root).ok_or_else(|| format!("Invalid link ({}) in flushing buffered store", root))?;
+    let links = new_scan_for_linkz(&mut std::io::BufReader::new(Cursor::new(block)))?;
+    // println!("Got {} links!", links.len());
+
+    for link in links.iter() {
+        if link.codec() != DAG_CBOR {
+            continue;
+        }
+        // if base.exists(link.to_bytes())? {
+        //     continue;
+        // }
+        // DB reads are expensive. Often times, if the cache doesnt have the key, then the DB will have it. 
+        // And if the DB doesnt have it, the cache will.
+        if !cache.contains_key(&link) && base.exists(link.to_bytes())? {
+            continue;
+        }
+        copy_rec(base,cache,buffer, *link)?;
+    }
+    // base.write(&root.to_bytes(), block)?;
+    // cb(&root.to_bytes(), block)?;
+    buffer.insert(root.to_bytes(), block.to_vec());
+    Ok(())
+}
+
+// fn scan_for_links(r: &[u8]) -> Result<Vec<Cid>, Box<dyn StdError>>
+// {
+//     let mut br = encoding::Deserializer::from_slice(&r).into_iter::<encoding::value::Value>();
+
+//     let mut ret = Vec::new();
+//         // println!("majjj: {:?}", maj);
+//         while let Some (maj) = br.next() {
+//             match maj {
+//             Ok(v) => {
+//                 match v {
+//                     encoding::value::Value::Null | encoding::value::Value::Bool(_) | encoding::value::Value::Float(_) | encoding::value::Value::Integer(_) => {},
+//                     encoding::value::Value::Text(_) | encoding::value::Value::Bytes(_)  => {}
+//                     encoding::value::Value::Array(v) => {
+//                         // let mut k: Vec<_> = v.par_iter().map(|val| {
+//                         //     scan_for_links(&to_vec(&val).unwrap()).unwrap()
+//                         // }).flatten().collect();
+//                         // // println!("wow we got k: {}", k.len());
+//                         // ret.append(&mut k);
+//                         for val in v.iter() {
+//                             ret.append(&mut scan_for_links(&to_vec(&val)?)?);
+//                         }
+//                     },
+//                     encoding::value::Value::Map(v) => {
+//                         for val in v.values() {
+//                             ret.append(&mut scan_for_links(&to_vec(&val)?)?);
+//                         }
+//                     },
+//                     encoding::value::Value::Tag(tag, value) => {
+//                             if let encoding::value::Value::Bytes(b) = value.borrow() {
+//                                 let c: Cid = Cid::try_from(&b[1..])?;
+//                                 ret.push(c);
+//                             }
+//                     },
+//                     _ => {
+//                         // println!("finally hit unrech");
+//                         unreachable!("0")
+//                         // throw error her
+//                     }
+//                 }
+//             },
+//             Err(e) => {
+//                 // println!("finally hit err {}", e.to_string());
+//                 unreachable!("1")
+//             }
+//         }
+//     }
+        
+    
+
+//     Ok(ret)
+// }
 
 /// Recursively traverses cache through Cid links.
 fn write_recursive<BS>(
     base: &BS,
     cache: &HashMap<Cid, Vec<u8>>,
+    buffer: &mut RefMut<HashMap<Vec<u8>, Vec<u8>>>,
     cid: &Cid,
 ) -> Result<(), Box<dyn StdError>>
 where
@@ -58,7 +282,9 @@ where
     let raw_cid_bz = cid.to_bytes();
 
     // If root exists in base store already, can skip
-    if base.exists(&raw_cid_bz)? {
+    // DB reads are expensive. Often times, if the cache doesnt have the key, then the DB will have it. 
+    // And if the DB doesnt have it, the cache will.
+    if base.exists(cid.to_bytes())? {
         return Ok(());
     }
 
@@ -69,36 +295,41 @@ where
     // Deserialize the bytes to Ipld to traverse links.
     // This is safer than finding links in place,
     // but slightly slower to copy and potentially allocate non Cid data.
-    let block: Ipld = from_slice(raw_bz)?;
+    let block = from_slice(raw_bz)?;
 
     // Traverse and write linked data recursively
-    for_each_link(&block, &|c| write_recursive(base, cache, c))?;
+    let links = for_each_link(&block, &mut |c| write_recursive(base, cache, buffer, c))?;
+    for link in links {
+        write_recursive(base, cache, buffer, &link)?;
+    }
 
     // Write the root node to base storage
-    base.write(&raw_cid_bz, raw_bz)?;
+    // base.write(&raw_cid_bz, raw_bz)?;
+    buffer.insert(raw_cid_bz, raw_bz.to_vec());
     Ok(())
 }
 
 /// Recursively explores Ipld for links and calls a function with a reference to the Cid.
-fn for_each_link<F>(ipld: &Ipld, cb: &F) -> Result<(), Box<dyn StdError>>
+fn for_each_link<F>(ipld: &Ipld, cb: &mut F) -> Result<Vec<Cid>, Box<dyn StdError>>
 where
-    F: Fn(&Cid) -> Result<(), Box<dyn StdError>>,
+    F: FnMut(&Cid) -> Result<(), Box<dyn StdError>>,
 {
+    let mut ret = Vec::new();
     match ipld {
-        Ipld::Link(c) => cb(&c)?,
+        Ipld::Link(c) => ret.push(*c),
         Ipld::List(arr) => {
             for item in arr {
-                for_each_link(item, cb)?
+                ret.append(&mut for_each_link(item, cb)?);
             }
         }
         Ipld::Map(map) => {
             for v in map.values() {
-                for_each_link(v, cb)?
+                ret.append(&mut for_each_link(v, cb)?);
             }
         }
         _ => (),
     }
-    Ok(())
+    Ok(ret)
 }
 
 impl<BS> BlockStore for BufferedBlockStore<'_, BS>

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -280,7 +280,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<HelloRequest, HelloRespon
                 request_id,
                 error,
             } => {
-                warn!(
+                debug!(
                     "Hello outbound error (peer: {:?}) (id: {:?}): {:?}",
                     peer, request_id, error
                 );
@@ -402,7 +402,7 @@ impl ForestBehaviour {
                 Some(outcome) => outcome,
                 // The response builder was too busy and thus the request was dropped. This is
                 // later on reported as a `InboundFailure::Omission`.
-                None => continue,
+                None => break,
             };
 
             if self


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Flushing the buffered store is one of the slowest parts of our VM and therefore Syncing.
- This PR improves upon that by doing less recursion and deserializing by scanning for links while the IPLD object is still serialized. 
- This significantly improves our total Tipset processing time by ~50% on my local environment


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->