### PR TITLE
Fix ExitCode Handling in load_deadline

### DIFF
--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -31,7 +31,7 @@ use forest_libp2p::chain_exchange::TipsetBundle;
 use futures::stream::{FuturesUnordered, StreamExt};
 use interpreter::price_list_by_epoch;
 use ipld_blockstore::BlockStore;
-use log::{debug, info, warn};
+use log::{debug, info, warn, error};
 use message::{Message, UnsignedMessage};
 use networks::{get_network_version_default, BLOCK_DELAY_SECS, UPGRADE_SMOKE_HEIGHT};
 use state_manager::StateManager;
@@ -94,7 +94,7 @@ where
                     Ok(()) => *state.lock().await = ChainSyncState::Follow,
                     Err(e) => {
                         let err = e.to_string();
-                        warn!("failed to sync tipset: {}", &err);
+                        error!("failed to sync tipset: {}", &err);
                         self.state.write().await.error(err);
                     }
                 }

--- a/blockchain/chain_sync/src/sync_worker.rs
+++ b/blockchain/chain_sync/src/sync_worker.rs
@@ -31,7 +31,7 @@ use forest_libp2p::chain_exchange::TipsetBundle;
 use futures::stream::{FuturesUnordered, StreamExt};
 use interpreter::price_list_by_epoch;
 use ipld_blockstore::BlockStore;
-use log::{debug, info, warn, error};
+use log::{debug, error, info, warn};
 use message::{Message, UnsignedMessage};
 use networks::{get_network_version_default, BLOCK_DELAY_SECS, UPGRADE_SMOKE_HEIGHT};
 use state_manager::StateManager;

--- a/vm/actor/src/builtin/miner/deadline_state.rs
+++ b/vm/actor/src/builtin/miner/deadline_state.rs
@@ -46,26 +46,24 @@ impl Deadlines {
         &self,
         store: &BS,
         deadline_idx: usize,
-    ) -> Result<Deadline, ActorError> {
+    ) -> Result<Deadline, Box <dyn StdError>> {
         if deadline_idx >= WPOST_PERIOD_DEADLINES as usize {
-            return Err(actor_error!(
+            return Err(Box::new(actor_error!(
                 ErrIllegalArgument,
                 "invalid deadline {}",
                 deadline_idx
-            ));
+            )));
         }
 
-        store
-            .get(&self.due[deadline_idx])
-            .ok()
-            .flatten()
+        Ok(store
+            .get(&self.due[deadline_idx])?
             .ok_or_else(|| {
-                actor_error!(
+                Box::new(actor_error!(
                     ErrIllegalState,
                     "failed to lookup deadline {}",
                     deadline_idx
-                )
-            })
+                ))
+            })?)
     }
 
     pub fn for_each<BS: BlockStore>(

--- a/vm/actor/src/builtin/miner/deadline_state.rs
+++ b/vm/actor/src/builtin/miner/deadline_state.rs
@@ -46,7 +46,7 @@ impl Deadlines {
         &self,
         store: &BS,
         deadline_idx: usize,
-    ) -> Result<Deadline, Box <dyn StdError>> {
+    ) -> Result<Deadline, Box<dyn StdError>> {
         if deadline_idx >= WPOST_PERIOD_DEADLINES as usize {
             return Err(Box::new(actor_error!(
                 ErrIllegalArgument,
@@ -55,15 +55,13 @@ impl Deadlines {
             )));
         }
 
-        Ok(store
-            .get(&self.due[deadline_idx])?
-            .ok_or_else(|| {
-                Box::new(actor_error!(
-                    ErrIllegalState,
-                    "failed to lookup deadline {}",
-                    deadline_idx
-                ))
-            })?)
+        Ok(store.get(&self.due[deadline_idx])?.ok_or_else(|| {
+            Box::new(actor_error!(
+                ErrIllegalState,
+                "failed to lookup deadline {}",
+                deadline_idx
+            ))
+        })?)
     }
 
     pub fn for_each<BS: BlockStore>(

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -568,7 +568,7 @@ impl Actor {
 
             let mut deadline = deadlines
                 .load_deadline(rt.store(), params.deadline)
-                .map_err(|e| e.wrap(format!("failed to load deadline {}", params.deadline)))?;
+                .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", params.deadline)))?;
 
             // Record proven sectors/partitions, returning updates to power and the final set of sectors
             // proven/skipped.
@@ -734,7 +734,7 @@ impl Actor {
 
                 let mut dl_current = deadlines_current
                     .load_deadline(rt.store(), params.deadline)
-                    .map_err(|e| e.wrap("failed to load deadline"))?;
+                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,"failed to load deadline"))?;
 
                 // Take the post from the snapshot for dispute.
                 // This operation REMOVES the PoSt from the snapshot so
@@ -1723,7 +1723,7 @@ impl Actor {
             for deadline_idx in deadlines_to_load {
                 let mut deadline = deadlines
                     .load_deadline(store, deadline_idx)
-                    .map_err(|e| e.wrap(format!("failed to load deadline {}", deadline_idx)))?;
+                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", deadline_idx)))?;
 
                 let mut partitions = deadline.partitions_amt(store).map_err(|e| {
                     e.downcast_default(
@@ -2006,7 +2006,7 @@ impl Actor {
                 let quant = state.quant_spec_for_deadline(deadline_idx);
                 let mut deadline = deadlines
                     .load_deadline(store, deadline_idx)
-                    .map_err(|e| e.wrap(format!("failed to load deadline {}", deadline_idx)))?;
+                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", deadline_idx)))?;
 
                 let removed_power = deadline
                     .terminate_sectors(
@@ -2159,7 +2159,7 @@ impl Actor {
 
                 let mut deadline = deadlines
                     .load_deadline(store, deadline_idx)
-                    .map_err(|e| e.wrap(format!("failed to load deadline {}", deadline_idx)))?;
+                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", deadline_idx)))?;
 
                 let fault_expiration_epoch = target_deadline.last() + FAULT_MAX_AGE;
 
@@ -2310,9 +2310,9 @@ impl Actor {
 
                 let mut deadline = deadlines
                     .load_deadline(store, deadline_idx)
-                    .map_err(|e| e.wrap(format!("failed to load deadline {}", deadline_idx)))?;
+                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, format!("failed to load deadline {}", deadline_idx)))?;
 
-                deadline
+                    deadline
                     .declare_faults_recovered(store, &sectors, info.sector_size, partition_map)
                     .map_err(|e| {
                         e.downcast_default(
@@ -2430,7 +2430,7 @@ impl Actor {
 
             let mut deadline = deadlines
                 .load_deadline(store, params_deadline)
-                .map_err(|e| e.wrap(format!("failed to load deadline {}", params_deadline)))?;
+                .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", params_deadline)))?;
 
             let (live, dead, removed_power) = deadline
                 .remove_partitions(store, partitions, quant)

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -568,7 +568,12 @@ impl Actor {
 
             let mut deadline = deadlines
                 .load_deadline(rt.store(), params.deadline)
-                .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", params.deadline)))?;
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load deadline {}", params.deadline),
+                    )
+                })?;
 
             // Record proven sectors/partitions, returning updates to power and the final set of sectors
             // proven/skipped.
@@ -734,7 +739,9 @@ impl Actor {
 
                 let mut dl_current = deadlines_current
                     .load_deadline(rt.store(), params.deadline)
-                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,"failed to load deadline"))?;
+                    .map_err(|e| {
+                        e.downcast_default(ExitCode::ErrIllegalState, "failed to load deadline")
+                    })?;
 
                 // Take the post from the snapshot for dispute.
                 // This operation REMOVES the PoSt from the snapshot so
@@ -1721,9 +1728,12 @@ impl Actor {
             let mut pledge_delta = TokenAmount::zero();
 
             for deadline_idx in deadlines_to_load {
-                let mut deadline = deadlines
-                    .load_deadline(store, deadline_idx)
-                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", deadline_idx)))?;
+                let mut deadline = deadlines.load_deadline(store, deadline_idx).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load deadline {}", deadline_idx),
+                    )
+                })?;
 
                 let mut partitions = deadline.partitions_amt(store).map_err(|e| {
                     e.downcast_default(
@@ -2004,9 +2014,12 @@ impl Actor {
                 }
 
                 let quant = state.quant_spec_for_deadline(deadline_idx);
-                let mut deadline = deadlines
-                    .load_deadline(store, deadline_idx)
-                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", deadline_idx)))?;
+                let mut deadline = deadlines.load_deadline(store, deadline_idx).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load deadline {}", deadline_idx),
+                    )
+                })?;
 
                 let removed_power = deadline
                     .terminate_sectors(
@@ -2157,9 +2170,12 @@ impl Actor {
                     )
                 })?;
 
-                let mut deadline = deadlines
-                    .load_deadline(store, deadline_idx)
-                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", deadline_idx)))?;
+                let mut deadline = deadlines.load_deadline(store, deadline_idx).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load deadline {}", deadline_idx),
+                    )
+                })?;
 
                 let fault_expiration_epoch = target_deadline.last() + FAULT_MAX_AGE;
 
@@ -2308,11 +2324,14 @@ impl Actor {
                     )
                 })?;
 
-                let mut deadline = deadlines
-                    .load_deadline(store, deadline_idx)
-                    .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, format!("failed to load deadline {}", deadline_idx)))?;
+                let mut deadline = deadlines.load_deadline(store, deadline_idx).map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load deadline {}", deadline_idx),
+                    )
+                })?;
 
-                    deadline
+                deadline
                     .declare_faults_recovered(store, &sectors, info.sector_size, partition_map)
                     .map_err(|e| {
                         e.downcast_default(
@@ -2430,7 +2449,12 @@ impl Actor {
 
             let mut deadline = deadlines
                 .load_deadline(store, params_deadline)
-                .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState,format!("failed to load deadline {}", params_deadline)))?;
+                .map_err(|e| {
+                    e.downcast_default(
+                        ExitCode::ErrIllegalState,
+                        format!("failed to load deadline {}", params_deadline),
+                    )
+                })?;
 
             let (live, dead, removed_power) = deadline
                 .remove_partitions(store, partitions, quant)


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- https://filfox.info/en/message/bafy2bzacebtrbhmisd4wulj44qkn6v4vlopvdj3xgopjzh5vrwzlq6j22xjq2
- The above message was returning ErrIllegalState as opposed to ErrOutOfGas. This was due to improper handling of ExitCodes when loading deadlines. 


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->