### PR TITLE
Libp2p Connection Limits

### DIFF
--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -133,8 +133,8 @@ impl DaemonOpts {
 
         cfg.network.kademlia = self.kademlia.unwrap_or(cfg.network.kademlia);
         cfg.network.mdns = self.mdns.unwrap_or(cfg.network.mdns);
-        if let Some(target_peer_count) = &self.target_peer_count {
-            cfg.network.target_peer_count = *target_peer_count;
+        if let Some(target_peer_count) = self.target_peer_count {
+            cfg.network.target_peer_count = target_peer_count;
         }
         // (where to find these flags, should be easy to do with structops)
 

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -89,6 +89,8 @@ pub struct DaemonOpts {
         help = "Number of tipsets requested over chain exchange (default is 200)"
     )]
     pub req_window: Option<i64>,
+    #[structopt(long, help = "Amount of Peers we want to be connected to (default is 75)")]
+    pub target_peer_count: Option<u32>,
 }
 
 impl DaemonOpts {
@@ -128,6 +130,9 @@ impl DaemonOpts {
 
         cfg.network.kademlia = self.kademlia.unwrap_or(cfg.network.kademlia);
         cfg.network.mdns = self.mdns.unwrap_or(cfg.network.mdns);
+        if let Some(target_peer_count) = &self.target_peer_count {
+            cfg.network.target_peer_count = *target_peer_count;
+        }
         // (where to find these flags, should be easy to do with structops)
 
         // check and set syncing configurations

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -89,7 +89,10 @@ pub struct DaemonOpts {
         help = "Number of tipsets requested over chain exchange (default is 200)"
     )]
     pub req_window: Option<i64>,
-    #[structopt(long, help = "Amount of Peers we want to be connected to (default is 75)")]
+    #[structopt(
+        long,
+        help = "Amount of Peers we want to be connected to (default is 75)"
+    )]
     pub target_peer_count: Option<u32>,
 }
 

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -13,6 +13,7 @@ use crate::{
     discovery::DiscoveryConfig,
     hello::{HelloCodec, HelloProtocolName, HelloRequest, HelloResponse},
 };
+use crate::gossip_params::{build_peer_score_params, build_peer_score_threshold};
 use forest_cid::Cid;
 use futures::channel::oneshot::{self, Sender as OneShotSender};
 use futures::{prelude::*, stream::FuturesUnordered};
@@ -426,6 +427,14 @@ impl ForestBehaviour {
         gs_config_builder.validation_mode(ValidationMode::Strict);
 
         let gossipsub_config = gs_config_builder.build().unwrap();
+        let gossipsub = Gossipsub::new(
+            MessageAuthenticity::Signed(local_key.clone()),
+            gossipsub_config,
+        )
+        .unwrap();
+
+        // TODO: Figure out why this delays incoming blocks. See gossip_params.rs for the params settings.
+        // gossipsub.with_peer_score(build_peer_score_params(network_name), build_peer_score_threshold()).unwrap();
 
         let bitswap = Bitswap::new();
 
@@ -445,11 +454,7 @@ impl ForestBehaviour {
         req_res_config.set_connection_keep_alive(Duration::from_secs(20));
 
         ForestBehaviour {
-            gossipsub: Gossipsub::new(
-                MessageAuthenticity::Signed(local_key.clone()),
-                gossipsub_config,
-            )
-            .unwrap(),
+            gossipsub,
             discovery: discovery_config.finish(),
             ping: Ping::default(),
             identify: Identify::new(

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -443,7 +443,7 @@ impl ForestBehaviour {
             .with_kademlia(config.kademlia)
             .with_user_defined(config.bootstrap_peers.clone())
             // TODO allow configuring this through config.
-            .discovery_limit(50);
+            .discovery_limit(config.target_peer_count as u64);
 
         let hp = std::iter::once((HelloProtocolName, ProtocolSupport::Full));
         let cp = std::iter::once((ChainExchangeProtocolName, ProtocolSupport::Full));

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -13,7 +13,6 @@ use crate::{
     discovery::DiscoveryConfig,
     hello::{HelloCodec, HelloProtocolName, HelloRequest, HelloResponse},
 };
-use crate::gossip_params::{build_peer_score_params, build_peer_score_threshold};
 use forest_cid::Cid;
 use futures::channel::oneshot::{self, Sender as OneShotSender};
 use futures::{prelude::*, stream::FuturesUnordered};

--- a/node/forest_libp2p/src/config.rs
+++ b/node/forest_libp2p/src/config.rs
@@ -17,6 +17,8 @@ pub struct Libp2pConfig {
     pub mdns: bool,
     /// Kademlia discovery enabled.
     pub kademlia: bool,
+    /// Target peer count.
+    pub target_peer_count: u32,
 }
 
 impl Default for Libp2pConfig {
@@ -30,6 +32,7 @@ impl Default for Libp2pConfig {
             bootstrap_peers,
             mdns: false,
             kademlia: true,
+            target_peer_count: 75,
         }
     }
 }

--- a/node/forest_libp2p/src/gossip_params.rs
+++ b/node/forest_libp2p/src/gossip_params.rs
@@ -1,12 +1,15 @@
-use libp2p::gossipsub::{PeerScoreParams, IdentTopic, PeerScoreThresholds, TopicScoreParams, score_parameter_decay};
-use std::{collections::HashMap, time::Duration};
 use crate::{PUBSUB_BLOCK_STR, PUBSUB_MSG_STR};
+use libp2p::gossipsub::{
+    score_parameter_decay, IdentTopic, PeerScoreParams, PeerScoreThresholds, TopicScoreParams,
+};
+use std::{collections::HashMap, time::Duration};
 
-// All these parameters are copied from what Lotus has set for their Topic scores. 
-// They are currently unused because enabling them causes GossipSub blocks to come 
+// All these parameters are copied from what Lotus has set for their Topic scores.
+// They are currently unused because enabling them causes GossipSub blocks to come
 // delayed usually by 1 second compared to when we have these parameters disabled.
 // Leaving these here so that we can enable and fix these parameters when they are needed.
 
+#[allow(dead_code)]
 fn build_msg_topic_config() -> TopicScoreParams {
     let mut t_params = TopicScoreParams::default();
     // expected 10 blocks/min
@@ -20,15 +23,15 @@ fn build_msg_topic_config() -> TopicScoreParams {
     // deliveries decay after 10min, cap at 100 tx
     t_params.first_message_deliveries_weight = 5.0;
     t_params.first_message_deliveries_decay = score_parameter_decay(Duration::from_secs(10 * 60)); // 10mins
-    // 100 blocks in an hour
+                                                                                                   // 100 blocks in an hour
     t_params.first_message_deliveries_cap = 100.0;
     // invalid messages decay after 1 hour
     t_params.invalid_message_deliveries_weight = -1000.0;
-    t_params.invalid_message_deliveries_decay = score_parameter_decay(Duration::from_secs(60*60));
+    t_params.invalid_message_deliveries_decay = score_parameter_decay(Duration::from_secs(60 * 60));
     t_params
 }
 
-
+#[allow(dead_code)]
 fn build_block_topic_config() -> TopicScoreParams {
     let mut t_params = TopicScoreParams::default();
     t_params.topic_weight = 0.1;
@@ -41,47 +44,49 @@ fn build_block_topic_config() -> TopicScoreParams {
     // deliveries decay after 10min, cap at 100 tx
     t_params.first_message_deliveries_weight = 0.5;
     t_params.first_message_deliveries_decay = score_parameter_decay(Duration::from_secs(10 * 60)); // 10mins
-    // 100 messages in 10 minutes
+                                                                                                   // 100 messages in 10 minutes
     t_params.first_message_deliveries_cap = 100.0;
     // invalid messages decay after 1 hour
     t_params.invalid_message_deliveries_weight = -1000.0;
-    t_params.invalid_message_deliveries_decay = score_parameter_decay(Duration::from_secs(60*60));
+    t_params.invalid_message_deliveries_decay = score_parameter_decay(Duration::from_secs(60 * 60));
     t_params
 }
 
-pub(crate)fn build_peer_score_params(network_name: &str) -> PeerScoreParams {
+#[allow(dead_code)]
+pub(crate) fn build_peer_score_params(network_name: &str) -> PeerScoreParams {
     let mut psp = PeerScoreParams::default();
     psp.app_specific_weight = 1.0;
 
     psp.ip_colocation_factor_threshold = 5.0;
     psp.ip_colocation_factor_weight = -100.0;
 
-
     psp.behaviour_penalty_threshold = 6.0;
     psp.behaviour_penalty_weight = -10.0;
-    psp.behaviour_penalty_decay = score_parameter_decay(Duration::from_secs(60*60));
+    psp.behaviour_penalty_decay = score_parameter_decay(Duration::from_secs(60 * 60));
 
-    psp.retain_score = Duration::from_secs(6 *60 * 60);
+    psp.retain_score = Duration::from_secs(6 * 60 * 60);
 
     psp.topics = HashMap::new();
 
     // msg topic
     let msg_topic = IdentTopic::new(format!("{}/{}", PUBSUB_MSG_STR, network_name));
-    psp.topics.insert(msg_topic.hash(), build_msg_topic_config());
+    psp.topics
+        .insert(msg_topic.hash(), build_msg_topic_config());
     // block topic
     let block_topic = IdentTopic::new(format!("{}/{}", PUBSUB_BLOCK_STR, network_name));
-    psp.topics.insert(block_topic.hash(), build_block_topic_config());
+    psp.topics
+        .insert(block_topic.hash(), build_block_topic_config());
 
     psp
 }
 
-pub(crate)fn build_peer_score_threshold() -> PeerScoreThresholds {
+#[allow(dead_code)]
+pub(crate) fn build_peer_score_threshold() -> PeerScoreThresholds {
     PeerScoreThresholds {
         gossip_threshold: -500.0,
         publish_threshold: -1000.0,
         graylist_threshold: -2500.0,
         accept_px_threshold: 1000.0,
         opportunistic_graft_threshold: 3.5,
-        
     }
 }

--- a/node/forest_libp2p/src/gossip_params.rs
+++ b/node/forest_libp2p/src/gossip_params.rs
@@ -11,73 +11,74 @@ use std::{collections::HashMap, time::Duration};
 
 #[allow(dead_code)]
 fn build_msg_topic_config() -> TopicScoreParams {
-    let mut t_params = TopicScoreParams::default();
-    // expected 10 blocks/min
-    t_params.topic_weight = 0.1;
+    TopicScoreParams {
+        // expected 10 blocks/min
+        topic_weight: 0.1,
 
-    // 1 tick per second, maxes at 1 after 1 hour
-    t_params.time_in_mesh_weight = 0.00027;
-    t_params.time_in_mesh_quantum = Duration::from_secs(1);
-    t_params.time_in_mesh_cap = 1.0;
+        // 1 tick per second, maxes at 1 after 1 hour
+        time_in_mesh_weight: 0.00027,
+        time_in_mesh_quantum: Duration::from_secs(1),
+        time_in_mesh_cap: 1.0,
 
-    // deliveries decay after 10min, cap at 100 tx
-    t_params.first_message_deliveries_weight = 5.0;
-    t_params.first_message_deliveries_decay = score_parameter_decay(Duration::from_secs(10 * 60)); // 10mins
-                                                                                                   // 100 blocks in an hour
-    t_params.first_message_deliveries_cap = 100.0;
-    // invalid messages decay after 1 hour
-    t_params.invalid_message_deliveries_weight = -1000.0;
-    t_params.invalid_message_deliveries_decay = score_parameter_decay(Duration::from_secs(60 * 60));
-    t_params
+        // deliveries decay after 10min, cap at 100 tx
+        first_message_deliveries_weight: 5.0,
+        first_message_deliveries_decay: score_parameter_decay(Duration::from_secs(10 * 60)), // 10mins
+        // 100 blocks in an hour
+        first_message_deliveries_cap: 100.0,
+        // invalid messages decay after 1 hour
+        invalid_message_deliveries_weight: -1000.0,
+        invalid_message_deliveries_decay: score_parameter_decay(Duration::from_secs(60 * 60)),
+        ..Default::default()
+    }
 }
 
 #[allow(dead_code)]
 fn build_block_topic_config() -> TopicScoreParams {
-    let mut t_params = TopicScoreParams::default();
-    t_params.topic_weight = 0.1;
+    TopicScoreParams {
+        topic_weight: 0.1,
 
-    // 1 tick per second, maxes at 1 hours (-1/3600)
-    t_params.time_in_mesh_weight = 0.0002778;
-    t_params.time_in_mesh_quantum = Duration::from_secs(1);
-    t_params.time_in_mesh_cap = 1.0;
+        // 1 tick per second, maxes at 1 hours (-1/3600)
+        time_in_mesh_weight: 0.0002778,
+        time_in_mesh_quantum: Duration::from_secs(1),
+        time_in_mesh_cap: 1.0,
 
-    // deliveries decay after 10min, cap at 100 tx
-    t_params.first_message_deliveries_weight = 0.5;
-    t_params.first_message_deliveries_decay = score_parameter_decay(Duration::from_secs(10 * 60)); // 10mins
-                                                                                                   // 100 messages in 10 minutes
-    t_params.first_message_deliveries_cap = 100.0;
-    // invalid messages decay after 1 hour
-    t_params.invalid_message_deliveries_weight = -1000.0;
-    t_params.invalid_message_deliveries_decay = score_parameter_decay(Duration::from_secs(60 * 60));
-    t_params
+        // deliveries decay after 10min, cap at 100 tx
+        first_message_deliveries_weight: 0.5,
+        first_message_deliveries_decay: score_parameter_decay(Duration::from_secs(10 * 60)), // 10mins
+        // 100 messages in 10 minutes
+        first_message_deliveries_cap: 100.0,
+        // invalid messages decay after 1 hour
+        invalid_message_deliveries_weight: -1000.0,
+        invalid_message_deliveries_decay: score_parameter_decay(Duration::from_secs(60 * 60)),
+        ..Default::default()
+    }
 }
 
 #[allow(dead_code)]
 pub(crate) fn build_peer_score_params(network_name: &str) -> PeerScoreParams {
-    let mut psp = PeerScoreParams::default();
-    psp.app_specific_weight = 1.0;
-
-    psp.ip_colocation_factor_threshold = 5.0;
-    psp.ip_colocation_factor_weight = -100.0;
-
-    psp.behaviour_penalty_threshold = 6.0;
-    psp.behaviour_penalty_weight = -10.0;
-    psp.behaviour_penalty_decay = score_parameter_decay(Duration::from_secs(60 * 60));
-
-    psp.retain_score = Duration::from_secs(6 * 60 * 60);
-
-    psp.topics = HashMap::new();
+    let mut psp_topics = HashMap::new();
 
     // msg topic
     let msg_topic = IdentTopic::new(format!("{}/{}", PUBSUB_MSG_STR, network_name));
-    psp.topics
-        .insert(msg_topic.hash(), build_msg_topic_config());
+    psp_topics.insert(msg_topic.hash(), build_msg_topic_config());
     // block topic
     let block_topic = IdentTopic::new(format!("{}/{}", PUBSUB_BLOCK_STR, network_name));
-    psp.topics
-        .insert(block_topic.hash(), build_block_topic_config());
+    psp_topics.insert(block_topic.hash(), build_block_topic_config());
 
-    psp
+    PeerScoreParams {
+        app_specific_weight: 1.0,
+
+        ip_colocation_factor_threshold: 5.0,
+        ip_colocation_factor_weight: -100.0,
+
+        behaviour_penalty_threshold: 6.0,
+        behaviour_penalty_weight: -10.0,
+        behaviour_penalty_decay: score_parameter_decay(Duration::from_secs(60 * 60)),
+
+        retain_score: Duration::from_secs(6 * 60 * 60),
+        topics: psp_topics,
+        ..Default::default()
+    }
 }
 
 #[allow(dead_code)]

--- a/node/forest_libp2p/src/gossip_params.rs
+++ b/node/forest_libp2p/src/gossip_params.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use crate::{PUBSUB_BLOCK_STR, PUBSUB_MSG_STR};
 use libp2p::gossipsub::{
     score_parameter_decay, IdentTopic, PeerScoreParams, PeerScoreThresholds, TopicScoreParams,

--- a/node/forest_libp2p/src/gossip_params.rs
+++ b/node/forest_libp2p/src/gossip_params.rs
@@ -1,0 +1,87 @@
+use libp2p::gossipsub::{PeerScoreParams, IdentTopic, PeerScoreThresholds, TopicScoreParams, score_parameter_decay};
+use std::{collections::HashMap, time::Duration};
+use crate::{PUBSUB_BLOCK_STR, PUBSUB_MSG_STR};
+
+// All these parameters are copied from what Lotus has set for their Topic scores. 
+// They are currently unused because enabling them causes GossipSub blocks to come 
+// delayed usually by 1 second compared to when we have these parameters disabled.
+// Leaving these here so that we can enable and fix these parameters when they are needed.
+
+fn build_msg_topic_config() -> TopicScoreParams {
+    let mut t_params = TopicScoreParams::default();
+    // expected 10 blocks/min
+    t_params.topic_weight = 0.1;
+
+    // 1 tick per second, maxes at 1 after 1 hour
+    t_params.time_in_mesh_weight = 0.00027;
+    t_params.time_in_mesh_quantum = Duration::from_secs(1);
+    t_params.time_in_mesh_cap = 1.0;
+
+    // deliveries decay after 10min, cap at 100 tx
+    t_params.first_message_deliveries_weight = 5.0;
+    t_params.first_message_deliveries_decay = score_parameter_decay(Duration::from_secs(10 * 60)); // 10mins
+    // 100 blocks in an hour
+    t_params.first_message_deliveries_cap = 100.0;
+    // invalid messages decay after 1 hour
+    t_params.invalid_message_deliveries_weight = -1000.0;
+    t_params.invalid_message_deliveries_decay = score_parameter_decay(Duration::from_secs(60*60));
+    t_params
+}
+
+
+fn build_block_topic_config() -> TopicScoreParams {
+    let mut t_params = TopicScoreParams::default();
+    t_params.topic_weight = 0.1;
+
+    // 1 tick per second, maxes at 1 hours (-1/3600)
+    t_params.time_in_mesh_weight = 0.0002778;
+    t_params.time_in_mesh_quantum = Duration::from_secs(1);
+    t_params.time_in_mesh_cap = 1.0;
+
+    // deliveries decay after 10min, cap at 100 tx
+    t_params.first_message_deliveries_weight = 0.5;
+    t_params.first_message_deliveries_decay = score_parameter_decay(Duration::from_secs(10 * 60)); // 10mins
+    // 100 messages in 10 minutes
+    t_params.first_message_deliveries_cap = 100.0;
+    // invalid messages decay after 1 hour
+    t_params.invalid_message_deliveries_weight = -1000.0;
+    t_params.invalid_message_deliveries_decay = score_parameter_decay(Duration::from_secs(60*60));
+    t_params
+}
+
+pub(crate)fn build_peer_score_params(network_name: &str) -> PeerScoreParams {
+    let mut psp = PeerScoreParams::default();
+    psp.app_specific_weight = 1.0;
+
+    psp.ip_colocation_factor_threshold = 5.0;
+    psp.ip_colocation_factor_weight = -100.0;
+
+
+    psp.behaviour_penalty_threshold = 6.0;
+    psp.behaviour_penalty_weight = -10.0;
+    psp.behaviour_penalty_decay = score_parameter_decay(Duration::from_secs(60*60));
+
+    psp.retain_score = Duration::from_secs(6 *60 * 60);
+
+    psp.topics = HashMap::new();
+
+    // msg topic
+    let msg_topic = IdentTopic::new(format!("{}/{}", PUBSUB_MSG_STR, network_name));
+    psp.topics.insert(msg_topic.hash(), build_msg_topic_config());
+    // block topic
+    let block_topic = IdentTopic::new(format!("{}/{}", PUBSUB_BLOCK_STR, network_name));
+    psp.topics.insert(block_topic.hash(), build_block_topic_config());
+
+    psp
+}
+
+pub(crate)fn build_peer_score_threshold() -> PeerScoreThresholds {
+    PeerScoreThresholds {
+        gossip_threshold: -500.0,
+        publish_threshold: -1000.0,
+        graylist_threshold: -2500.0,
+        accept_px_threshold: 1000.0,
+        opportunistic_graft_threshold: 3.5,
+        
+    }
+}

--- a/node/forest_libp2p/src/lib.rs
+++ b/node/forest_libp2p/src/lib.rs
@@ -10,10 +10,10 @@ mod behaviour;
 pub mod chain_exchange;
 mod config;
 mod discovery;
+mod gossip_params;
 pub mod hello;
 pub mod rpc;
 mod service;
-mod gossip_params;
 
 pub(crate) use self::behaviour::*;
 pub use self::config::*;

--- a/node/forest_libp2p/src/lib.rs
+++ b/node/forest_libp2p/src/lib.rs
@@ -13,6 +13,7 @@ mod discovery;
 pub mod hello;
 pub mod rpc;
 mod service;
+mod gossip_params;
 
 pub(crate) use self::behaviour::*;
 pub use self::config::*;

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -138,13 +138,13 @@ where
         let limits = ConnectionLimits::default()
             .with_max_pending_incoming(Some(5))
             .with_max_pending_outgoing(Some(16))
-            .with_max_established_incoming(Some((30 as f64 * 1.2) as u32))
-            .with_max_established_outgoing(Some((30 as f64 * 1.2) as u32))
+            .with_max_established_incoming(Some(config.target_peer_count))
+            .with_max_established_outgoing(Some(config.target_peer_count))
             .with_max_established_per_peer(Some(3));
 
         let mut swarm = SwarmBuilder::new(transport, ForestBehaviour::new(&net_keypair, &config, network_name), peer_id)
             .connection_limits(limits)
-            .notify_handler_buffer_size(std::num::NonZeroUsize::new(7).expect("Not zero"))
+            .notify_handler_buffer_size(std::num::NonZeroUsize::new(15).expect("Not zero"))
             .connection_event_buffer_size(64)
             .build();
 
@@ -155,6 +155,7 @@ where
             let t = Topic::new(format!("{}/{}", topic, network_name));
             swarm.subscribe(&t).unwrap();
         }
+
 
         // Bootstrap with Kademlia
         if let Err(e) = swarm.bootstrap() {

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -20,7 +20,6 @@ use futures::channel::oneshot::Sender as OneShotSender;
 use futures::select;
 use futures_util::stream::StreamExt;
 use ipld_blockstore::BlockStore;
-use libp2p::{core::Multiaddr, swarm::SwarmBuilder};
 pub use libp2p::gossipsub::IdentTopic;
 pub use libp2p::gossipsub::Topic;
 use libp2p::request_response::ResponseChannel;
@@ -32,6 +31,7 @@ use libp2p::{
     identity::{ed25519, Keypair},
     mplex, noise, yamux, PeerId, Swarm, Transport,
 };
+use libp2p::{core::Multiaddr, swarm::SwarmBuilder};
 use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -142,11 +142,15 @@ where
             .with_max_established_outgoing(Some(config.target_peer_count))
             .with_max_established_per_peer(Some(3));
 
-        let mut swarm = SwarmBuilder::new(transport, ForestBehaviour::new(&net_keypair, &config, network_name), peer_id)
-            .connection_limits(limits)
-            .notify_handler_buffer_size(std::num::NonZeroUsize::new(15).expect("Not zero"))
-            .connection_event_buffer_size(64)
-            .build();
+        let mut swarm = SwarmBuilder::new(
+            transport,
+            ForestBehaviour::new(&net_keypair, &config, network_name),
+            peer_id,
+        )
+        .connection_limits(limits)
+        .notify_handler_buffer_size(std::num::NonZeroUsize::new(15).expect("Not zero"))
+        .connection_event_buffer_size(64)
+        .build();
 
         Swarm::listen_on(&mut swarm, config.listening_multiaddr).unwrap();
 
@@ -155,7 +159,6 @@ where
             let t = Topic::new(format!("{}/{}", topic, network_name));
             swarm.subscribe(&t).unwrap();
         }
-
 
         // Bootstrap with Kademlia
         if let Err(e) = swarm.bootstrap() {

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -136,11 +136,11 @@ where
         let transport = build_transport(net_keypair.clone());
 
         let limits = ConnectionLimits::default()
-            .with_max_pending_incoming(Some(5))
-            .with_max_pending_outgoing(Some(16))
+            .with_max_pending_incoming(Some(10))
+            .with_max_pending_outgoing(Some(30))
             .with_max_established_incoming(Some(config.target_peer_count))
             .with_max_established_outgoing(Some(config.target_peer_count))
-            .with_max_established_per_peer(Some(3));
+            .with_max_established_per_peer(Some(5));
 
         let mut swarm = SwarmBuilder::new(
             transport,
@@ -148,7 +148,7 @@ where
             peer_id,
         )
         .connection_limits(limits)
-        .notify_handler_buffer_size(std::num::NonZeroUsize::new(15).expect("Not zero"))
+        .notify_handler_buffer_size(std::num::NonZeroUsize::new(20).expect("Not zero"))
         .connection_event_buffer_size(64)
         .build();
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Add new flag `--target-peer-count` to have a sort of bound on the number of peers we should be connected to with a default of 75. 
- Added Topic scoring to Gossipsub topics. They are currently disabled because I don't think were using them properly, but they aren't important for now, but might be in the future, so just leaving it in for posterity. 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
#798 

**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->