### PR TITLE
Clippy "Fix"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 
 lint: license clean
 	cargo fmt --all
-	cargo clippy --all-features -- -D warnings
+	cargo clippy --all-features -- -D warnings -A clippy::upper_case_acronyms
 
 build:
 	cargo build --bin forest

--- a/tests/conformance_tests/src/lib.rs
+++ b/tests/conformance_tests/src/lib.rs
@@ -37,7 +37,7 @@ mod base64_bytes {
         D: Deserializer<'de>,
     {
         let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
-        Ok(base64::decode(s.as_ref()).map_err(de::Error::custom)?)
+        base64::decode(s.as_ref()).map_err(de::Error::custom)
     }
 
     pub mod vec {
@@ -48,10 +48,10 @@ mod base64_bytes {
             D: Deserializer<'de>,
         {
             let v: Vec<Cow<'de, str>> = Deserialize::deserialize(deserializer)?;
-            Ok(v.into_iter()
+            v.into_iter()
                 .map(|s| base64::decode(s.as_ref()))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(de::Error::custom)?)
+                .map_err(de::Error::custom)
         }
     }
 }

--- a/tests/conformance_tests/src/tipset.rs
+++ b/tests/conformance_tests/src/tipset.rs
@@ -26,8 +26,7 @@ mod block_messages_json {
         D: Deserializer<'de>,
     {
         let bm: Vec<BlockMessageJson> = Deserialize::deserialize(deserializer)?;
-        Ok(bm
-            .into_iter()
+        bm.into_iter()
             .map(|m| {
                 let mut secpk_messages = Vec::new();
                 let mut bls_messages = Vec::new();
@@ -51,7 +50,7 @@ mod block_messages_json {
                     messages: bls_messages,
                 })
             })
-            .collect::<Result<Vec<BlockMessages>, _>>()?)
+            .collect::<Result<Vec<BlockMessages>, _>>()
     }
 }
 

--- a/vm/address/src/lib.rs
+++ b/vm/address/src/lib.rs
@@ -295,7 +295,7 @@ pub(crate) fn to_leb_bytes(id: u64) -> Result<Vec<u8>, Error> {
 }
 
 pub(crate) fn from_leb_bytes(bz: &[u8]) -> Result<u64, Error> {
-    let mut readable = &bz[..];
+    let mut readable = bz;
 
     // write id to buffer in leb128 format
     Ok(leb128::read::unsigned(&mut readable)?)


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- upper-case-acronyms is disabled in `make lint`. We could fix it, but it would require releasing a bunch of crates, so we should do it the next time we do a round of releases. 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->