### PR TITLE
Add Prometheus server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,10 +2117,12 @@ dependencies = [
  "libp2p 0.35.1",
  "log",
  "message_pool",
+ "metrics",
  "net_utils",
  "networks",
  "paramfetch",
  "pretty_env_logger",
+ "prometheus",
  "rpassword",
  "rpc",
  "rpc-client",
@@ -4289,6 +4291,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.1.0"
+dependencies = [
+ "async-std",
+ "log",
+ "prometheus",
+ "thiserror",
+ "tide",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5136,6 +5149,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.11.1",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "utils/net_utils",
     "utils/statediff",
     "utils/test_utils",
+    "utils/metrics",
 ]
 resolver = "2"
 

--- a/blockchain/chain_sync/src/chain_muxer.rs
+++ b/blockchain/chain_sync/src/chain_muxer.rs
@@ -140,7 +140,7 @@ pub struct ChainMuxer<DB, TBeacon, V, M> {
     /// Will mark any invalid blocks and all childen as bad in this bounded cache
     bad_blocks: Arc<BadBlockCache>,
 
-    ///  incoming network events to be handled by syncer
+    /// Incoming network events to be handled by syncer
     net_handler: Receiver<NetworkEvent>,
 
     /// Proof verification implementation.

--- a/blockchain/message_pool/src/msg_chain.rs
+++ b/blockchain/message_pool/src/msg_chain.rs
@@ -166,10 +166,9 @@ impl Chains {
 
     /// Removes messages from the given index and resets effective perfs
     pub(crate) fn trim_msgs_at(&mut self, idx: usize, gas_limit: i64, base_fee: &BigInt) {
-        let prev = match self.get_at(if idx == 0 { return } else { idx - 1 }) {
-            Some(prev) => Some((prev.eff_perf, prev.gas_limit)),
-            None => None,
-        };
+        let prev = self
+            .get_at(if idx == 0 { return } else { idx - 1 })
+            .map(|prev| (prev.eff_perf, prev.gas_limit));
         let chain_node = self.get_mut_at(idx).unwrap();
         let mut i = chain_node.msgs.len() as i64 - 1;
 

--- a/forest/Cargo.toml
+++ b/forest/Cargo.toml
@@ -38,12 +38,14 @@ wallet = { package = "key_management", path = "../key_management" }
 uuid = { version = "0.8.2", features = ["v4"] }
 auth = { path = "../utils/auth" }
 net_utils = { path = "../utils/net_utils" }
+metrics = { path = "../utils/metrics" }
 actor = { package = "actor_interface", path = "../vm/actor_interface" }
 genesis = { path = "../utils/genesis" }
 paramfetch = { path = "../utils/paramfetch" }
 encoding = { package = "forest_encoding", version = "0.2.1" }
 networks = { path = "../types/networks" }
 rpassword = "0.0.4"
+prometheus =  { version = "0.12.0", default-features = false }
 
 [dependencies.jsonrpc-v2]
 version = "0.10.0"

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -23,7 +23,7 @@ pub struct Config {
     pub skip_load: bool,
     pub sync: SyncConfig,
     pub encrypt_keystore: bool,
-    pub prometheus_port: u16,
+    pub metrics_port: u16,
 }
 
 impl Default for Config {
@@ -39,7 +39,7 @@ impl Default for Config {
             skip_load: false,
             sync: SyncConfig::default(),
             encrypt_keystore: false,
-            prometheus_port: 6116,
+            metrics_port: 6116,
         }
     }
 }

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub skip_load: bool,
     pub sync: SyncConfig,
     pub encrypt_keystore: bool,
+    pub prometheus_port: u16,
 }
 
 impl Default for Config {
@@ -38,6 +39,7 @@ impl Default for Config {
             skip_load: false,
             sync: SyncConfig::default(),
             encrypt_keystore: false,
+            prometheus_port: 6116,
         }
     }
 }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -68,12 +68,8 @@ pub struct DaemonOpts {
     pub rpc: Option<bool>,
     #[structopt(short, long, help = "The port used for communication")]
     pub port: Option<String>,
-    #[structopt(
-        short,
-        long,
-        help = "Port used for Prometheus metric collection server"
-    )]
-    pub prometheus_port: Option<u16>,
+    #[structopt(short, long, help = "Port used for metrics collection server")]
+    pub metrics_port: Option<u16>,
     #[structopt(short, long, help = "Allow Kademlia (default = true)")]
     pub kademlia: Option<bool>,
     #[structopt(short, long, help = "Allow MDNS (default = false)")]
@@ -125,8 +121,8 @@ impl DaemonOpts {
         } else {
             cfg.enable_rpc = false;
         }
-        if let Some(prometheus_port) = self.prometheus_port {
-            cfg.prometheus_port = prometheus_port;
+        if let Some(metrics_port) = self.metrics_port {
+            cfg.metrics_port = metrics_port;
         }
         if self.import_snapshot.is_some() && self.import_chain.is_some() {
             panic!("Can't set import_snapshot and import_chain at the same time!");

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -68,6 +68,12 @@ pub struct DaemonOpts {
     pub rpc: Option<bool>,
     #[structopt(short, long, help = "The port used for communication")]
     pub port: Option<String>,
+    #[structopt(
+        short,
+        long,
+        help = "Port used for Prometheus metric collection server"
+    )]
+    pub prometheus_port: Option<u16>,
     #[structopt(short, long, help = "Allow Kademlia (default = true)")]
     pub kademlia: Option<bool>,
     #[structopt(short, long, help = "Allow MDNS (default = false)")]
@@ -118,6 +124,9 @@ impl DaemonOpts {
             cfg.rpc_port = self.port.to_owned().unwrap_or(cfg.rpc_port);
         } else {
             cfg.enable_rpc = false;
+        }
+        if let Some(prometheus_port) = self.prometheus_port {
+            cfg.prometheus_port = prometheus_port;
         }
         if self.import_snapshot.is_some() && self.import_chain.is_some() {
             panic!("Can't set import_snapshot and import_chain at the same time!");

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -2,26 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::cli::{block_until_sigint, Config};
-use async_std::{channel::bounded, sync::RwLock, task};
 use auth::{generate_priv_key, JWT_IDENTIFIER};
 use chain::ChainStore;
 use chain_sync::ChainMuxer;
 use fil_types::verifier::FullVerifier;
 use forest_libp2p::{get_keypair, Libp2pService};
 use genesis::{import_chain, initialize_genesis};
-use libp2p::identity::{ed25519, Keypair};
-use log::{debug, info, trace};
 use message_pool::{MessagePool, MpoolConfig, MpoolRpcProvider};
 use paramfetch::{get_params_default, SectorSizeOpt};
-use rpassword::read_password;
 use rpc::{start_rpc, RpcState};
 use state_manager::StateManager;
-use std::io::prelude::*;
-use std::path::PathBuf;
-use std::sync::Arc;
 use utils::write_to_file;
 use wallet::ENCRYPTED_KEYSTORE_NAME;
 use wallet::{KeyStore, KeyStoreConfig};
+
+use async_std::{channel::bounded, sync::RwLock, task};
+use libp2p::identity::{ed25519, Keypair};
+use log::{debug, info, trace};
+use rpassword::read_password;
+
+use std::io::prelude::*;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 /// Starts daemon process
 pub(super) async fn start(config: Config) {
@@ -52,6 +54,8 @@ pub(super) async fn start(config: Config) {
             };
             Keypair::Ed25519(gen_keypair)
         });
+
+    let prometheus_registry = prometheus::Registry::new();
 
     // Initialize keystore
     let mut ks = if config.encrypt_keystore {
@@ -206,6 +210,14 @@ pub(super) async fn start(config: Config) {
         None
     };
 
+    // Start Prometheus server port
+    let prometheus_server_task = task::spawn(metrics::init_prometheus(
+        (format!("127.0.0.1:{}", config.prometheus_port))
+            .parse()
+            .unwrap(),
+        prometheus_registry,
+    ));
+
     // Block until ctrl-c is hit
     block_until_sigint().await;
 
@@ -214,6 +226,7 @@ pub(super) async fn start(config: Config) {
     });
 
     // Cancel all async services
+    prometheus_server_task.cancel().await;
     sync_task.cancel().await;
     p2p_task.cancel().await;
     if let Some(task) = rpc_task {

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -212,7 +212,7 @@ pub(super) async fn start(config: Config) {
 
     // Start Prometheus server port
     let prometheus_server_task = task::spawn(metrics::init_prometheus(
-        (format!("127.0.0.1:{}", config.prometheus_port))
+        (format!("127.0.0.1:{}", config.metrics_port))
             .parse()
             .unwrap(),
         prometheus_registry,

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -187,9 +187,9 @@ where
     /// Flushes cache for node, replacing any cached values with a Cid variant
     pub(super) fn flush<DB: BlockStore>(&mut self, bs: &DB) -> Result<(), Error> {
         if let Node::Link { links } = self {
-            for link in links.iter_mut() {
+            for link in links.iter_mut().flatten() {
                 // links should only be flushed if the bitmap is set.
-                if let Some(Link::Dirty(n)) = link {
+                if let Link::Dirty(n) = link {
                     // flush sub node to clear caches
                     n.flush(bs)?;
 
@@ -201,7 +201,7 @@ where
 
                     // Can keep the flushed node in link cache
                     let cache = OnceCell::from(existing);
-                    *link = Some(Link::Cid { cid, cache });
+                    *link = Link::Cid { cid, cache };
                 }
             }
         }

--- a/utils/metrics/Cargo.toml
+++ b/utils/metrics/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "metrics"
+version = "0.1.0"
+authors = ["jorge <jorgeaolivero@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+prometheus =  { version = "0.12.0", default-features = false }
+tide = "0.16.0"
+log = "0.4.8"
+thiserror = "1.0"
+async-std = { version = "1.9", features = ["tokio1", "unstable"] }

--- a/utils/metrics/src/lib.rs
+++ b/utils/metrics/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
 use log::info;
 use prometheus::{Encoder, Registry, TextEncoder};
 use thiserror::Error;

--- a/utils/metrics/src/lib.rs
+++ b/utils/metrics/src/lib.rs
@@ -1,0 +1,42 @@
+use log::info;
+use prometheus::{Encoder, Registry, TextEncoder};
+use thiserror::Error;
+
+use std::net::SocketAddr;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Tide internal error.
+    #[error("Tide error: {0}")]
+    Tide(tide::Error),
+    /// I/O error.
+    #[error("IO error: {0}")]
+    Io(std::io::Error),
+    /// Prometheus port is already in use.
+    #[error("Prometheus port {0} is already in use.")]
+    PortInUse(SocketAddr),
+}
+
+pub async fn init_prometheus(prometheus_addr: SocketAddr, registry: Registry) -> Result<(), Error> {
+    info!("Prometheus server started at {}", prometheus_addr);
+
+    // Create an configure HTTP server
+    let mut server = tide::with_state(registry);
+    server.at("/metrics").get(collect_metrics);
+
+    // Wait for server to exit
+    server.listen(prometheus_addr).await.map_err(Error::Io)
+}
+
+async fn collect_metrics(req: tide::Request<Registry>) -> tide::Result {
+    let metric_families = req.state().gather();
+    let mut metrics = vec![];
+
+    let encoder = TextEncoder::new();
+    encoder
+        .encode(&metric_families, &mut metrics)
+        .expect("Encoding Prometheus metrics must succeed.");
+    Ok(tide::Response::builder(tide::StatusCode::Ok)
+        .body(metrics)
+        .build())
+}


### PR DESCRIPTION
**Summary of changes**

Adds a Prometheus HTTP server to the `forest` process to support the collection of metrics. 
This PR does _not_ add metrics to `forest`, it only sets up the metrics scaffolding. 

**Reference issue to close (if applicable)**

Closes #1095 

**Other information and links**