### PR TITLE
Improve CLI printing and RPC error handling

### DIFF
--- a/forest/src/cli/auth_cmd.rs
+++ b/forest/src/cli/auth_cmd.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::stringify_rpc_err;
+use super::print_rpc_res;
 use rpc_client::auth_new;
 use structopt::StructOpt;
 
@@ -23,8 +23,7 @@ impl AuthCommands {
         match self {
             Self::CreateToken { perm } => {
                 let perm: String = perm.parse().unwrap();
-                let obj = auth_new(perm).await.map_err(stringify_rpc_err).unwrap();
-                println!("{}", &obj);
+                print_rpc_res(auth_new(perm).await);
             }
         }
     }

--- a/forest/src/cli/chain_cmd.rs
+++ b/forest/src/cli/chain_cmd.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::stringify_rpc_err;
+use super::{print_rpc_res_cids, print_rpc_res_pretty};
 use cid::Cid;
 use rpc_client::{block, genesis, head, messages, read_obj};
 use structopt::StructOpt;
@@ -45,37 +45,21 @@ impl ChainCommands {
         match self {
             Self::Block { cid } => {
                 let cid: Cid = cid.parse().unwrap();
-                let blk = block(cid).await.map_err(stringify_rpc_err).unwrap();
-                println!("{}", serde_json::to_string_pretty(&blk).unwrap());
+                print_rpc_res_pretty(block(cid).await);
             }
             Self::Genesis => {
-                let gen = genesis().await.map_err(stringify_rpc_err).unwrap();
-                println!("{}", serde_json::to_string_pretty(&gen).unwrap());
+                print_rpc_res_pretty(genesis().await);
             }
             Self::Head => {
-                let canonical = head().await.map_err(stringify_rpc_err).unwrap();
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(
-                        &canonical
-                            .0
-                            .cids()
-                            .iter()
-                            .map(|cid: &Cid| cid.to_string())
-                            .collect::<Vec<_>>()
-                    )
-                    .unwrap()
-                );
+                print_rpc_res_cids(head().await);
             }
             Self::Message { cid } => {
                 let cid: Cid = cid.parse().unwrap();
-                let msg = messages(cid).await.map_err(stringify_rpc_err).unwrap();
-                println!("{}", serde_json::to_string_pretty(&msg).unwrap());
+                print_rpc_res_pretty(messages(cid).await);
             }
             Self::ReadObj { cid } => {
                 let cid: Cid = cid.parse().unwrap();
-                let obj = read_obj(cid).await.map_err(stringify_rpc_err).unwrap();
-                println!("{}", serde_json::to_string_pretty(&obj).unwrap());
+                print_rpc_res_pretty(read_obj(cid).await);
             }
         }
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- JSON-RPC response parsed as untagged enum
- Improved CLI error handling (printing and exit codes)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
N/A


**Other information and links**
<!-- Add any other context about the pull request here. -->
Related to discussion in https://github.com/kardeiz/jsonrpc-v2/issues/18


<!-- Thank you 🔥 -->