### PR TITLE
[Audit fixes] FOR-02: Inconsistent Deserialization of Address ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,7 @@ dependencies = [
  "forest_encoding",
  "forest_json_utils",
  "leb128",
+ "log",
  "num-derive",
  "num-traits",
  "once_cell",

--- a/vm/address/Cargo.toml
+++ b/vm/address/Cargo.toml
@@ -13,6 +13,7 @@ num-derive = "0.3.0"
 data-encoding = "2.1.2"
 data-encoding-macro = "0.1.7"
 leb128 = "0.2.1"
+log = "0.4.8"
 encoding = { package = "forest_encoding", version = "0.2.1" }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/vm/address/src/errors.rs
+++ b/vm/address/src/errors.rs
@@ -30,6 +30,8 @@ pub enum Error {
     Base32Decoding(#[from] DecodeError),
     #[error("Cannot get id from non id address")]
     NonIDAddress,
+    #[error("Invalid address ID payload")]
+    InvalidAddressIDPayload,
 }
 
 impl From<num::ParseIntError> for Error {

--- a/vm/address/src/errors.rs
+++ b/vm/address/src/errors.rs
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("Cannot get id from non id address")]
     NonIDAddress,
     #[error("Invalid address ID payload")]
-    InvalidAddressIDPayload,
+    InvalidAddressIDPayload(Vec<u8>),
 }
 
 impl From<num::ParseIntError> for Error {

--- a/vm/address/src/lib.rs
+++ b/vm/address/src/lib.rs
@@ -14,7 +14,6 @@ use data_encoding::Encoding;
 #[allow(unused_imports)]
 use data_encoding_macro::{internal_new_encoding, new_encoding};
 use encoding::{blake2b_variable, serde_bytes, Cbor};
-use log::error;
 use once_cell::sync::OnceCell;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::hash::Hash;
@@ -309,12 +308,7 @@ pub(crate) fn from_leb_bytes(bz: &[u8]) -> Result<u64, Error> {
     if to_leb_bytes(id)? == bz {
         Ok(id)
     } else {
-        error!(
-            "Invalid address ID payload, input does not match output. Input: {:?}; Output: {:?}",
-            bz,
-            &to_leb_bytes(id)?,
-        );
-        Err(Error::InvalidAddressIDPayload)
+        Err(Error::InvalidAddressIDPayload(bz.to_owned()))
     }
 }
 
@@ -345,7 +339,7 @@ mod tests {
                 panic!();
             }
             Err(e) => {
-                assert_eq!(e, Error::InvalidAddressIDPayload);
+                assert_eq!(e, Error::InvalidAddressIDPayload(extra_bytes));
             }
         }
     }
@@ -363,7 +357,7 @@ mod tests {
                 panic!();
             }
             Err(e) => {
-                assert_eq!(e, Error::InvalidAddressIDPayload);
+                assert_eq!(e, Error::InvalidAddressIDPayload(minimal_encoding));
             }
         }
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Compares serialized leb128 bytes to deserialized bytes.
- Adds a passing test case, in addition to 2 test cases for encodings meant to fail, as recommended in the audit document.
- These changes should not alter behavior in release build; it will only make the node behavior more consistent with that of the Lotus node.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1134 


**Other information and links**
<!-- Add any other context about the pull request here. -->
- Explanation of changes: `from_leb_128` is too permissive of how leb128 bytes are deserialized, resulting in inconsistent behavior from how Lotus deserializes bytes. Lotus throws an error if there byte encodings are inconsistent.


<!-- Thank you 🔥 -->