### PR TITLE
[Audit fixes] FOR-16: Unnecessary Extensive Permissions for Private Keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,6 +3484,7 @@ dependencies = [
  "serde_json",
  "sodiumoxide",
  "thiserror",
+ "utils",
 ]
 
 [[package]]
@@ -6836,6 +6837,7 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "libc 0.2.91",
  "serde",
  "serde_derive",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6838,6 +6838,7 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "libc 0.2.91",
+ "log",
  "serde",
  "serde_derive",
  "toml",

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -56,10 +56,10 @@ pub(super) async fn start(config: Config) {
                 &format!("{}{}", &config.data_dir, "/libp2p/"),
                 "keypair",
             ) {
-                Ok(_) => {
+                Ok(file) => {
                     // Restrict permissions on files containing private keys
-                    #[cfg(linux)]
-                    utils::set_user_perm(file)?;
+                    #[cfg(unix)]
+                    utils::set_user_perm(&file).expect("Set user perms on unix systems");
                 }
                 Err(e) => {
                     info!("Could not write keystore to disk!");

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -51,13 +51,20 @@ pub(super) async fn start(config: Config) {
             let gen_keypair = ed25519::Keypair::generate();
             // Save Ed25519 keypair to file
             // TODO rename old file to keypair.old(?)
-            if let Err(e) = write_to_file(
+            match write_to_file(
                 &gen_keypair.encode(),
                 &format!("{}{}", &config.data_dir, "/libp2p/"),
                 "keypair",
             ) {
-                info!("Could not write keystore to disk!");
-                trace!("Error {:?}", e);
+                Ok(_) => {
+                    // Restrict permissions on files containing private keys
+                    #[cfg(linux)]
+                    utils::set_user_perm(file)?;
+                }
+                Err(e) => {
+                    info!("Could not write keystore to disk!");
+                    trace!("Error {:?}", e);
+                }
             };
             Keypair::Ed25519(gen_keypair)
         });

--- a/key_management/Cargo.toml
+++ b/key_management/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.57"
 serde_cbor = "0.11.1"
 log = "0.4.8"
 sodiumoxide = "0.2.6"
+utils = { path = "../node/utils" }
 
 [features]
 json = ["base64", "crypto/json"]

--- a/key_management/src/keystore.rs
+++ b/key_management/src/keystore.rs
@@ -326,6 +326,11 @@ impl KeyStore {
                     .ok_or_else(|| Error::Other("Invalid Path".to_string()))?;
                 fs::create_dir_all(dir)?;
                 let file = File::create(&persistent_keystore.file_path)?;
+
+                // Restrict permissions on files containing private keys
+                #[cfg(linux)]
+                utils::set_user_perm(file)?;
+
                 let mut writer = BufWriter::new(file);
 
                 match &self.encryption {

--- a/key_management/src/keystore.rs
+++ b/key_management/src/keystore.rs
@@ -328,8 +328,8 @@ impl KeyStore {
                 let file = File::create(&persistent_keystore.file_path)?;
 
                 // Restrict permissions on files containing private keys
-                #[cfg(linux)]
-                utils::set_user_perm(file)?;
+                #[cfg(unix)]
+                utils::set_user_perm(&file)?;
 
                 let mut writer = BufWriter::new(file);
 

--- a/node/utils/Cargo.toml
+++ b/node/utils/Cargo.toml
@@ -9,6 +9,7 @@ dirs = "3.0"
 toml = "0.5.5"
 libc = "0.2"
 serde = "1.0"
+log = "0.4.8"
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/node/utils/Cargo.toml
+++ b/node/utils/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 dirs = "3.0"
 toml = "0.5.5"
+libc = "0.2"
 serde = "1.0"
 
 [dev-dependencies]

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -9,13 +9,15 @@ use std::path::Path;
 /// Restricts permissions on a file to user-only: 0600
 #[cfg(unix)]
 pub fn set_user_perm(file: &File) -> Result<()> {
+    use log::info;
     use std::os::unix::fs::PermissionsExt;
 
     let mut perm = file.metadata()?.permissions();
     perm.set_mode((libc::S_IWUSR | libc::S_IRUSR) as u32);
     file.set_permissions(perm)?;
-    println!("Permissions on {:?} set to 600", file);
-    // log::info!("Permissions on {} set to 600", file);
+
+    info!("Permissions set to 0600 on {:?}", file);
+
     Ok(())
 }
 

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -6,6 +6,19 @@ use std::fs::{create_dir_all, File};
 use std::io::{prelude::*, Result};
 use std::path::Path;
 
+/// Restricts permissions on a file to user-only: 0600
+#[cfg(linux)]
+pub fn set_user_perm(file: File) -> Result<()> {
+    use std::os::linux::fs::PermissionsExt;
+
+    let mut perm = file.metadata()?.permissions();
+    perm.set_mode((libc::S_IWUSR | libc::S_IRUSR) as u32);
+    file.set_permissions(perm)?;
+    println!("Permissions on {} set to 600", file);
+    // log::info!("Permissions on {} set to 600", file);
+    Ok(())
+}
+
 /// Writes a string to a specified file. Creates the desired path if it does not exist.
 /// Note: `path` and `filename` are appended to produce the resulting file path.
 pub fn write_to_file(message: &[u8], path: &str, file_name: &str) -> Result<()> {

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -7,27 +7,27 @@ use std::io::{prelude::*, Result};
 use std::path::Path;
 
 /// Restricts permissions on a file to user-only: 0600
-#[cfg(linux)]
-pub fn set_user_perm(file: File) -> Result<()> {
-    use std::os::linux::fs::PermissionsExt;
+#[cfg(unix)]
+pub fn set_user_perm(file: &File) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
 
     let mut perm = file.metadata()?.permissions();
     perm.set_mode((libc::S_IWUSR | libc::S_IRUSR) as u32);
     file.set_permissions(perm)?;
-    println!("Permissions on {} set to 600", file);
+    println!("Permissions on {:?} set to 600", file);
     // log::info!("Permissions on {} set to 600", file);
     Ok(())
 }
 
 /// Writes a string to a specified file. Creates the desired path if it does not exist.
 /// Note: `path` and `filename` are appended to produce the resulting file path.
-pub fn write_to_file(message: &[u8], path: &str, file_name: &str) -> Result<()> {
+pub fn write_to_file(message: &[u8], path: &str, file_name: &str) -> Result<File> {
     // Create path if it doesn't exist
     create_dir_all(Path::new(path))?;
     let join = format!("{}{}", path, file_name);
     let mut file = File::create(join)?;
     file.write_all(message)?;
-    Ok(())
+    Ok(file)
 }
 
 /// Read file as a `Vec<u8>`


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Restrict to only user permissions both libp2p keypair and forest keystore files


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1148 


**Other information and links**
<!-- Add any other context about the pull request here. -->
Makes full use of the outstanding Unix permission implementation so helpfully recommended by our simply delightful auditors... Capital! Most capital.
https://github.com/sigp/lighthouse/pull/551/files

<!-- Thank you 🔥 -->