### PR TITLE
hotfix:metrics:change prometheus response type

### DIFF
--- a/utils/metrics/src/lib.rs
+++ b/utils/metrics/src/lib.rs
@@ -40,6 +40,7 @@ async fn collect_metrics(req: tide::Request<Registry>) -> tide::Result {
         .encode(&metric_families, &mut metrics)
         .expect("Encoding Prometheus metrics must succeed.");
     Ok(tide::Response::builder(tide::StatusCode::Ok)
+        .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
         .body(metrics)
         .build())
 }

--- a/utils/metrics/src/lib.rs
+++ b/utils/metrics/src/lib.rs
@@ -40,7 +40,7 @@ async fn collect_metrics(req: tide::Request<Registry>) -> tide::Result {
         .encode(&metric_families, &mut metrics)
         .expect("Encoding Prometheus metrics must succeed.");
     Ok(tide::Response::builder(tide::StatusCode::Ok)
-        .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
+        .content_type("text/plain; version=0.0.4; charset=utf-8")
         .body(metrics)
         .build())
 }


### PR DESCRIPTION

**Summary of changes**
Changes introduced in this pull request:
Change prometheus response body type to text/format (default is application/octet-stream)

More detail see https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md#text-based-format

Signed-off-by: detailyang <detailyang@gmail.com>

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->