### PR TITLE
fix wallet verify

### DIFF
--- a/forest/src/cli/wallet_cmd.rs
+++ b/forest/src/cli/wallet_cmd.rs
@@ -11,7 +11,6 @@ use forest_crypto::{
     },
     Signature,
 };
-use futures::TryFutureExt;
 use rpc_client::*;
 use structopt::StructOpt;
 use wallet::json::KeyInfoJson;

--- a/forest/src/cli/wallet_cmd.rs
+++ b/forest/src/cli/wallet_cmd.rs
@@ -200,14 +200,16 @@ impl WalletCommands {
                 };
 
                 let response = wallet_verify((
-                    message.to_string(),
                     address.to_string(),
+                    message.to_string(),
                     SignatureJson(signature),
                 ))
-                .await
-                .map_err(handle_rpc_err)
-                .unwrap();
-                println!("{}", response);
+                .await;
+
+                match response {
+                    Ok(value) => println!("{}", value),
+                    Err(error) => handle_rpc_err(error),
+                }
             }
         };
     }

--- a/forest/src/cli/wallet_cmd.rs
+++ b/forest/src/cli/wallet_cmd.rs
@@ -11,6 +11,7 @@ use forest_crypto::{
     },
     Signature,
 };
+use futures::TryFutureExt;
 use rpc_client::*;
 use structopt::StructOpt;
 use wallet::json::KeyInfoJson;
@@ -204,12 +205,11 @@ impl WalletCommands {
                     message.to_string(),
                     SignatureJson(signature),
                 ))
-                .await;
+                .await
+                .map_err(handle_rpc_err)
+                .unwrap();
 
-                match response {
-                    Ok(value) => println!("{}", value),
-                    Err(error) => handle_rpc_err(error),
-                }
+                println!("{}", response);
             }
         };
     }

--- a/node/rpc/src/wallet_api.rs
+++ b/node/rpc/src/wallet_api.rs
@@ -259,7 +259,7 @@ where
 {
     let (addr_str, msg_str, SignatureJson(sig)) = params;
     let address = Address::from_str(&addr_str)?;
-    let msg = hex::decode(&msg_str).map_err(|_| JsonRpcError::INVALID_PARAMS)?;
+    let msg = hex::decode(&msg_str)?;
 
     let ret = sig.verify(&msg, &address).is_ok();
     Ok(ret)

--- a/node/rpc/src/wallet_api.rs
+++ b/node/rpc/src/wallet_api.rs
@@ -259,7 +259,8 @@ where
 {
     let (addr_str, msg_str, SignatureJson(sig)) = params;
     let address = Address::from_str(&addr_str)?;
-    let msg = hex::decode(msg_str).unwrap();
+    let msg = hex::decode(&msg_str).map_err(|_| JsonRpcError::INVALID_PARAMS)?;
+
     let ret = sig.verify(&msg, &address).is_ok();
     Ok(ret)
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- This is more of a bugfix. When refactoring the wallet cli when that PR was in review, a tuple construction was moved to another module to clean up the original file. The first two parameters of that tuple were strings and messed with the API. The address was actually a message, and a message was actually an address. All fixed now



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->