### PR TITLE
Reference files with PathBuf instead of Strings

### DIFF
--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -23,6 +23,7 @@ use jsonrpc_v2::Error as JsonRpcError;
 use serde::Serialize;
 use std::cell::RefCell;
 use std::io::{self, Write};
+use std::path::PathBuf;
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -132,7 +133,7 @@ impl CLIOpts {
         let mut cfg: Config = match &self.config {
             Some(config_file) => {
                 // Read from config file
-                let toml = read_file_to_string(&*config_file)?;
+                let toml = read_file_to_string(&PathBuf::from(&config_file))?;
                 // Parse and return the configuration file
                 read_toml(&toml)?
             }
@@ -140,7 +141,7 @@ impl CLIOpts {
                 // Check ENV VAR for config file
                 if let Ok(config_file) = std::env::var("FOREST_CONFIG_PATH") {
                     // Read from config file
-                    let toml = read_file_to_string(&*config_file)?;
+                    let toml = read_file_to_string(&PathBuf::from(&config_file))?;
                     // Parse and return the configuration file
                     read_toml(&toml)?
                 } else {

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -45,29 +45,26 @@ pub(super) async fn start(config: Config) {
         .expect("Failed to create global Rayon ThreadPool");
 
     info!("Starting Forest daemon");
-    let net_keypair = get_keypair(&format!("{}{}", &config.data_dir, "/libp2p/keypair"))
-        .unwrap_or_else(|| {
-            // Keypair not found, generate and save generated keypair
-            let gen_keypair = ed25519::Keypair::generate();
-            // Save Ed25519 keypair to file
-            // TODO rename old file to keypair.old(?)
-            match write_to_file(
-                &gen_keypair.encode(),
-                &format!("{}{}", &config.data_dir, "/libp2p/"),
-                "keypair",
-            ) {
-                Ok(file) => {
-                    // Restrict permissions on files containing private keys
-                    #[cfg(unix)]
-                    utils::set_user_perm(&file).expect("Set user perms on unix systems");
-                }
-                Err(e) => {
-                    info!("Could not write keystore to disk!");
-                    trace!("Error {:?}", e);
-                }
-            };
-            Keypair::Ed25519(gen_keypair)
-        });
+
+    let path: PathBuf = [&config.data_dir, "libp2p"].iter().collect();
+    let net_keypair = get_keypair(&path.join("keypair")).unwrap_or_else(|| {
+        // Keypair not found, generate and save generated keypair
+        let gen_keypair = ed25519::Keypair::generate();
+        // Save Ed25519 keypair to file
+        // TODO rename old file to keypair.old(?)
+        match write_to_file(&gen_keypair.encode(), &path, "keypair") {
+            Ok(file) => {
+                // Restrict permissions on files containing private keys
+                #[cfg(unix)]
+                utils::set_user_perm(&file).expect("Set user perms on unix systems");
+            }
+            Err(e) => {
+                info!("Could not write keystore to disk!");
+                trace!("Error {:?}", e);
+            }
+        };
+        Keypair::Ed25519(gen_keypair)
+    });
 
     let mut ks = if config.encrypt_keystore {
         loop {

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -36,6 +36,7 @@ use libp2p::{core::Multiaddr, swarm::SwarmBuilder};
 use log::{debug, error, info, trace, warn};
 use multihash::Multihash;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use utils::read_file_to_vec;
@@ -428,7 +429,7 @@ pub fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
 }
 
 /// Fetch keypair from disk, returning none if it cannot be decoded.
-pub fn get_keypair(path: &str) -> Option<Keypair> {
+pub fn get_keypair(path: &PathBuf) -> Option<Keypair> {
     match read_file_to_vec(&path) {
         Err(e) => {
             info!("Networking keystore not found!");

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -36,7 +36,7 @@ use libp2p::{core::Multiaddr, swarm::SwarmBuilder};
 use log::{debug, error, info, trace, warn};
 use multihash::Multihash;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use utils::read_file_to_vec;
@@ -429,7 +429,7 @@ pub fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
 }
 
 /// Fetch keypair from disk, returning none if it cannot be decoded.
-pub fn get_keypair(path: &PathBuf) -> Option<Keypair> {
+pub fn get_keypair(path: &Path) -> Option<Keypair> {
     match read_file_to_vec(&path) {
         Err(e) => {
             info!("Networking keystore not found!");

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -4,7 +4,7 @@
 use dirs::home_dir;
 use std::fs::{create_dir_all, File};
 use std::io::{prelude::*, Result};
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Restricts permissions on a file to user-only: 0600
 #[cfg(unix)]
@@ -23,7 +23,7 @@ pub fn set_user_perm(file: &File) -> Result<()> {
 
 /// Writes a string to a specified file. Creates the desired path if it does not exist.
 /// Note: `path` and `filename` are appended to produce the resulting file path.
-pub fn write_to_file(message: &[u8], path: &PathBuf, file_name: &str) -> Result<File> {
+pub fn write_to_file(message: &[u8], path: &Path, file_name: &str) -> Result<File> {
     // Create path if it doesn't exist
     create_dir_all(&path)?;
     let mut file = File::create(path.join(file_name))?;
@@ -32,7 +32,7 @@ pub fn write_to_file(message: &[u8], path: &PathBuf, file_name: &str) -> Result<
 }
 
 /// Read file as a `Vec<u8>`
-pub fn read_file_to_vec(path: &PathBuf) -> Result<Vec<u8>> {
+pub fn read_file_to_vec(path: &Path) -> Result<Vec<u8>> {
     let mut file = File::open(path)?;
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer)?;
@@ -40,7 +40,7 @@ pub fn read_file_to_vec(path: &PathBuf) -> Result<Vec<u8>> {
 }
 
 /// Read file as a `String`.
-pub fn read_file_to_string(path: &PathBuf) -> Result<String> {
+pub fn read_file_to_string(path: &Path) -> Result<String> {
     let mut file = File::open(path)?;
     let mut string = String::new();
     file.read_to_string(&mut string)?;

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -4,7 +4,7 @@
 use dirs::home_dir;
 use std::fs::{create_dir_all, File};
 use std::io::{prelude::*, Result};
-use std::path::Path;
+use std::path::PathBuf;
 
 /// Restricts permissions on a file to user-only: 0600
 #[cfg(unix)]
@@ -23,17 +23,16 @@ pub fn set_user_perm(file: &File) -> Result<()> {
 
 /// Writes a string to a specified file. Creates the desired path if it does not exist.
 /// Note: `path` and `filename` are appended to produce the resulting file path.
-pub fn write_to_file(message: &[u8], path: &str, file_name: &str) -> Result<File> {
+pub fn write_to_file(message: &[u8], path: &PathBuf, file_name: &str) -> Result<File> {
     // Create path if it doesn't exist
-    create_dir_all(Path::new(path))?;
-    let join = format!("{}{}", path, file_name);
-    let mut file = File::create(join)?;
+    create_dir_all(&path)?;
+    let mut file = File::create(path.join(file_name))?;
     file.write_all(message)?;
     Ok(file)
 }
 
 /// Read file as a `Vec<u8>`
-pub fn read_file_to_vec(path: &str) -> Result<Vec<u8>> {
+pub fn read_file_to_vec(path: &PathBuf) -> Result<Vec<u8>> {
     let mut file = File::open(path)?;
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer)?;
@@ -41,7 +40,7 @@ pub fn read_file_to_vec(path: &str) -> Result<Vec<u8>> {
 }
 
 /// Read file as a `String`.
-pub fn read_file_to_string(path: &str) -> Result<String> {
+pub fn read_file_to_string(path: &PathBuf) -> Result<String> {
     let mut file = File::open(path)?;
     let mut string = String::new();
     file.read_to_string(&mut string)?;

--- a/node/utils/tests/files.rs
+++ b/node/utils/tests/files.rs
@@ -4,22 +4,23 @@
 use utils::{read_file_to_string, read_file_to_vec, read_toml, write_to_file};
 
 use serde_derive::Deserialize;
-use std::fs::remove_dir_all;
+use std::{fs::remove_dir_all, path::PathBuf};
 
 // Please use with caution, remove_dir_all will completely delete a directory
-fn cleanup_file(path: &str) {
+fn cleanup_file(path: &PathBuf) {
     remove_dir_all(path).expect("cleanup_file() path: {:?} failed: {:?}");
 }
 
 #[test]
 fn write_to_file_to_path() {
     let msg = "Hello World!".as_bytes();
-    let path = "./test-write/";
+    let path = PathBuf::from("./test-write");
     let file = "test.txt";
+
     match write_to_file(&msg, &path, file) {
-        Ok(_) => cleanup_file(path),
+        Ok(_) => cleanup_file(&path),
         Err(e) => {
-            cleanup_file(path);
+            cleanup_file(&path);
             panic!("{}", e);
         }
     }
@@ -28,12 +29,12 @@ fn write_to_file_to_path() {
 #[test]
 fn write_to_file_nested_dir() {
     let msg = "Hello World!".as_bytes();
-    let root = "./test_missing";
-    let path = format!("{}{}", root, "/test_write_string/");
-    match write_to_file(&msg, &path, "test-file") {
-        Ok(_) => cleanup_file(root),
+    let root = PathBuf::from("./test_missing");
+
+    match write_to_file(&msg, &root.join("test_write_string"), "test-file") {
+        Ok(_) => cleanup_file(&root),
         Err(e) => {
-            cleanup_file(root);
+            cleanup_file(&root);
             panic!("{}", e);
         }
     }
@@ -42,16 +43,17 @@ fn write_to_file_nested_dir() {
 #[test]
 fn read_from_file_vec() {
     let msg = "Hello World!".as_bytes();
-    let path = "./test_read_file/";
+    let path = PathBuf::from("./test_read_file");
     let file_name = "out.keystore";
     write_to_file(&msg, &path, file_name).unwrap();
-    match read_file_to_vec(&format!("{}{}", path, file_name)) {
+
+    match read_file_to_vec(&path.join(file_name)) {
         Ok(contents) => {
-            cleanup_file(path);
+            cleanup_file(&path);
             assert_eq!(contents, msg)
         }
         Err(e) => {
-            cleanup_file(path);
+            cleanup_file(&path);
             panic!("{}", e);
         }
     }
@@ -60,16 +62,17 @@ fn read_from_file_vec() {
 #[test]
 fn read_from_file_string() {
     let msg = "Hello World!";
-    let path = "./test_string_read_file/";
+    let path = PathBuf::from("./test_string_read_file");
     let file_name = "out.keystore";
+
     write_to_file(&msg.as_bytes(), &path, file_name).unwrap();
-    match read_file_to_string(&format!("{}{}", path, file_name)) {
+    match read_file_to_string(&path.join(file_name)) {
         Ok(contents) => {
-            cleanup_file(path);
+            cleanup_file(&path);
             assert_eq!(contents, msg)
         }
         Err(e) => {
-            cleanup_file(path);
+            cleanup_file(&path);
             panic!("{}", e);
         }
     }

--- a/utils/paramfetch/src/lib.rs
+++ b/utils/paramfetch/src/lib.rs
@@ -129,8 +129,7 @@ async fn fetch_verify_params(
     info: Arc<ParameterData>,
     mb: Option<Arc<MultiBar<Stdout>>>,
 ) -> Result<(), Box<dyn StdError>> {
-    let mut path: PathBuf = param_dir().into();
-    path.push(name);
+    let path: PathBuf = [&param_dir(), name].iter().collect();
     let path: Arc<Path> = Arc::from(path.as_path());
 
     match check_file(path.clone(), info.clone()).await {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- switched to PathBuf instead of &str at places where Files and Folders are referenced
- refactored few places for more idiomatic use of PathBufs



**Reference issue to close (if applicable)**
Closes #1158