### PR TITLE
Generate actor names for actor_name_by_code

### DIFF
--- a/vm/actor/src/builtin/codes.rs
+++ b/vm/actor/src/builtin/codes.rs
@@ -3,6 +3,8 @@
 
 use cid::{multihash::MultihashDigest, Cid, Code::Identity, RAW};
 
+pub const CURRENT_ACTOR_VERSION: u32 = 4;
+
 lazy_static! {
     pub static ref SYSTEM_ACTOR_CODE_ID: Cid = make_builtin(b"fil/4/system");
     pub static ref INIT_ACTOR_CODE_ID: Cid = make_builtin(b"fil/4/init");


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Adds a way to build actor names for lookup by CID
- Resolves issue where extra methods in previous actor versions were needed. With this, maintenance is required when new actor versions are added; However, is much easier and does not need to invoke different actor functions within the builtins.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1220 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->