### PR TITLE
scripts: fix copyright header years

### DIFF
--- a/blockchain/beacon/src/beacon_entries.rs
+++ b/blockchain/beacon/src/beacon_entries.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::{serde_bytes, tuple::*};

--- a/blockchain/beacon/src/drand.rs
+++ b/blockchain/beacon/src/drand.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::beacon_entries::BeaconEntry;

--- a/blockchain/beacon/src/lib.rs
+++ b/blockchain/beacon/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod beacon_entries;

--- a/blockchain/beacon/src/mock_beacon.rs
+++ b/blockchain/beacon/src/mock_beacon.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{Beacon, BeaconEntry};

--- a/blockchain/beacon/tests/drand.rs
+++ b/blockchain/beacon/tests/drand.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use beacon::{Beacon, ChainInfo, DrandBeacon, DrandConfig};

--- a/blockchain/blocks/src/block.rs
+++ b/blockchain/blocks/src/block.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::BlockHeader;

--- a/blockchain/blocks/src/election_proof.rs
+++ b/blockchain/blocks/src/election_proof.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crypto::VRFProof;

--- a/blockchain/blocks/src/errors.rs
+++ b/blockchain/blocks/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::time::SystemTimeError as TimeErr;

--- a/blockchain/blocks/src/gossip_block.rs
+++ b/blockchain/blocks/src/gossip_block.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::BlockHeader;

--- a/blockchain/blocks/src/header/json.rs
+++ b/blockchain/blocks/src/header/json.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;

--- a/blockchain/blocks/src/header/mod.rs
+++ b/blockchain/blocks/src/header/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{ElectionProof, Error, Ticket, TipsetKeys};

--- a/blockchain/blocks/src/lib.rs
+++ b/blockchain/blocks/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 // workaround for a compiler bug, see https://github.com/rust-lang/rust/issues/55779

--- a/blockchain/blocks/src/ticket.rs
+++ b/blockchain/blocks/src/ticket.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crypto::VRFProof;

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{Block, BlockHeader, Error, Ticket};

--- a/blockchain/blocks/tests/header_json_test.rs
+++ b/blockchain/blocks/tests/header_json_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "json")]

--- a/blockchain/blocks/tests/ticket_test.rs
+++ b/blockchain/blocks/tests/ticket_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::{from_slice, to_vec};

--- a/blockchain/chain/src/lib.rs
+++ b/blockchain/chain/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[macro_use]

--- a/blockchain/chain/src/store/base_fee.rs
+++ b/blockchain/chain/src/store/base_fee.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use blocks::Tipset;

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{index::ChainIndex, tipset_tracker::TipsetTracker, Error};

--- a/blockchain/chain/src/store/errors.rs
+++ b/blockchain/chain/src/store/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use blocks::Error as BlkErr;

--- a/blockchain/chain/src/store/index.rs
+++ b/blockchain/chain/src/store/index.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{tipset_from_keys, Error, TipsetCache};

--- a/blockchain/chain/src/store/mod.rs
+++ b/blockchain/chain/src/store/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod base_fee;

--- a/blockchain/chain/src/store/tipset_tracker.rs
+++ b/blockchain/chain/src/store/tipset_tracker.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::sync::RwLock;

--- a/blockchain/chain_sync/src/bad_block_cache.rs
+++ b/blockchain/chain_sync/src/bad_block_cache.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::sync::RwLock;

--- a/blockchain/chain_sync/src/chain_muxer.rs
+++ b/blockchain/chain_sync/src/chain_muxer.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::bad_block_cache::BadBlockCache;

--- a/blockchain/chain_sync/src/lib.rs
+++ b/blockchain/chain_sync/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![recursion_limit = "1024"]

--- a/blockchain/chain_sync/src/metrics.rs
+++ b/blockchain/chain_sync/src/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use lazy_static::lazy_static;

--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::peer_manager::PeerManager;

--- a/blockchain/chain_sync/src/peer_manager.rs
+++ b/blockchain/chain_sync/src/peer_manager.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashMap;

--- a/blockchain/chain_sync/src/sync/peer_test.rs
+++ b/blockchain/chain_sync/src/sync/peer_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;

--- a/blockchain/chain_sync/src/sync_state.rs
+++ b/blockchain/chain_sync/src/sync_state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use blocks::{tipset::tipset_json::TipsetJsonRef, Tipset};

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::cmp::min;

--- a/blockchain/chain_sync/src/validation.rs
+++ b/blockchain/chain_sync/src/validation.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::bad_block_cache::BadBlockCache;

--- a/blockchain/message_pool/src/block_prob.rs
+++ b/blockchain/message_pool/src/block_prob.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use statrs::function::gamma::ln_gamma;

--- a/blockchain/message_pool/src/config.rs
+++ b/blockchain/message_pool/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/blockchain/message_pool/src/errors.rs
+++ b/blockchain/message_pool/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use chain::Error as ChainError;

--- a/blockchain/message_pool/src/lib.rs
+++ b/blockchain/message_pool/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod block_prob;

--- a/blockchain/message_pool/src/msg_chain.rs
+++ b/blockchain/message_pool/src/msg_chain.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::errors::Error;

--- a/blockchain/message_pool/src/msgpool/mod.rs
+++ b/blockchain/message_pool/src/msgpool/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub(crate) mod msg_pool;

--- a/blockchain/message_pool/src/msgpool/msg_pool.rs
+++ b/blockchain/message_pool/src/msgpool/msg_pool.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 // Contains the implementation of Message Pool component.

--- a/blockchain/message_pool/src/msgpool/provider.rs
+++ b/blockchain/message_pool/src/msgpool/provider.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::errors::Error;

--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! Contains routines for message selection APIs.

--- a/blockchain/message_pool/src/msgpool/test_provider.rs
+++ b/blockchain/message_pool/src/msgpool/test_provider.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! Contains mock implementations for testing internal MessagePool APIs

--- a/blockchain/message_pool/src/msgpool/utils.rs
+++ b/blockchain/message_pool/src/msgpool/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::Error;

--- a/blockchain/state_manager/src/chain_rand.rs
+++ b/blockchain/state_manager/src/chain_rand.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::task;

--- a/blockchain/state_manager/src/errors.rs
+++ b/blockchain/state_manager/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use db::Error as DbErr;

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[macro_use]

--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::errors::*;

--- a/blockchain/state_manager/src/vm_circ_supply.rs
+++ b/blockchain/state_manager/src/vm_circ_supply.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use actor::*;

--- a/crypto/src/errors.rs
+++ b/crypto/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Error as AddressError;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod errors;

--- a/crypto/src/randomness.rs
+++ b/crypto/src/randomness.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::repr::*;

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::errors::Error;

--- a/crypto/src/signer.rs
+++ b/crypto/src/signer.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::signature::Signature;

--- a/crypto/src/vrf.rs
+++ b/crypto/src/vrf.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::signature::verify_bls_sig;

--- a/encoding/src/bytes.rs
+++ b/encoding/src/bytes.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};

--- a/encoding/src/cbor.rs
+++ b/encoding/src/cbor.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::errors::Error;

--- a/encoding/src/errors.rs
+++ b/encoding/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Error as CidError;

--- a/encoding/src/hash.rs
+++ b/encoding/src/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use blake2b_simd::Params;

--- a/encoding/src/lib.rs
+++ b/encoding/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod bytes;

--- a/forest/src/cli/auth_cmd.rs
+++ b/forest/src/cli/auth_cmd.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{handle_rpc_err, print_rpc_res_bytes, Config};

--- a/forest/src/cli/chain_cmd.rs
+++ b/forest/src/cli/chain_cmd.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use structopt::StructOpt;

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use chain_sync::SyncConfig;

--- a/forest/src/cli/fetch_params_cmd.rs
+++ b/forest/src/cli/fetch_params_cmd.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use structopt::StructOpt;

--- a/forest/src/cli/genesis_cmd.rs
+++ b/forest/src/cli/genesis_cmd.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use log::{info, warn};

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod auth_cmd;

--- a/forest/src/cli/net_cmd.rs
+++ b/forest/src/cli/net_cmd.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_libp2p::{Multiaddr, Protocol};

--- a/forest/src/cli/sync_cmd.rs
+++ b/forest/src/cli/sync_cmd.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::{

--- a/forest/src/cli/wallet_cmd.rs
+++ b/forest/src/cli/wallet_cmd.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use rpassword::read_password;

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::cli::{block_until_sigint, Config};

--- a/forest/src/logger/mod.rs
+++ b/forest/src/logger/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use log::LevelFilter;

--- a/forest/src/main.rs
+++ b/forest/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod cli;

--- a/forest/src/subcommand.rs
+++ b/forest/src/subcommand.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use auth::{create_token, ADMIN, JWT_IDENTIFIER};

--- a/ipld/amt/benches/amt_benchmark.rs
+++ b/ipld/amt/benches/amt_benchmark.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};

--- a/ipld/amt/fuzz/fuzz_targets/amt_fuzz.rs
+++ b/ipld/amt/fuzz/fuzz_targets/amt_fuzz.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![no_main]

--- a/ipld/amt/src/amt.rs
+++ b/ipld/amt/src/amt.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::ValueMut;

--- a/ipld/amt/src/error.rs
+++ b/ipld/amt/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Error as CidError;

--- a/ipld/amt/src/lib.rs
+++ b/ipld/amt/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! AMT crate for use as rust IPLD data structure

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::ValueMut;

--- a/ipld/amt/src/root.rs
+++ b/ipld/amt/src/root.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{init_sized_vec, node::CollapsedNode, Node};

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::ops::{Deref, DerefMut};

--- a/ipld/amt/tests/amt_tests.rs
+++ b/ipld/amt/tests/amt_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::{de::DeserializeOwned, ser::Serialize, BytesDe};

--- a/ipld/blockstore/src/buffered.rs
+++ b/ipld/blockstore/src/buffered.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "buffered")]

--- a/ipld/blockstore/src/lib.rs
+++ b/ipld/blockstore/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[cfg(feature = "buffered")]

--- a/ipld/blockstore/src/resolve.rs
+++ b/ipld/blockstore/src/resolve.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::BlockStore;

--- a/ipld/blockstore/src/sled.rs
+++ b/ipld/blockstore/src/sled.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::BlockStore;

--- a/ipld/blockstore/src/tracking.rs
+++ b/ipld/blockstore/src/tracking.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "tracking")]

--- a/ipld/car/src/error.rs
+++ b/ipld/car/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use thiserror::Error;

--- a/ipld/car/src/lib.rs
+++ b/ipld/car/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod error;

--- a/ipld/car/src/util.rs
+++ b/ipld/car/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::error::Error;

--- a/ipld/car/tests/car_file_test.rs
+++ b/ipld/car/tests/car_file_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::fs::File;

--- a/ipld/cid/src/json.rs
+++ b/ipld/cid/src/json.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::Cid;

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod mh_code;

--- a/ipld/cid/src/mh_code.rs
+++ b/ipld/cid/src/mh_code.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use multihash::{derive::Multihash, U32};

--- a/ipld/cid/src/prefix.rs
+++ b/ipld/cid/src/prefix.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{Cid, Error, Version};

--- a/ipld/cid/src/to_cid.rs
+++ b/ipld/cid/src/to_cid.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{Cid, Error};

--- a/ipld/cid/tests/base_cid_tests.rs
+++ b/ipld/cid/tests/base_cid_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_cid::{Cid, Code, Error, Prefix, Version, DAG_CBOR};

--- a/ipld/cid/tests/json_tests.rs
+++ b/ipld/cid/tests/json_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "json")]

--- a/ipld/cid/tests/serde_tests.rs
+++ b/ipld/cid/tests/serde_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "cbor")]

--- a/ipld/graphsync/build.rs
+++ b/ipld/graphsync/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 extern crate protoc_rust;

--- a/ipld/graphsync/src/lib.rs
+++ b/ipld/graphsync/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 // TODO evaluate exporting from libp2p mod

--- a/ipld/graphsync/src/libp2p/behaviour.rs
+++ b/ipld/graphsync/src/libp2p/behaviour.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::config::GraphSyncConfig;

--- a/ipld/graphsync/src/libp2p/codec.rs
+++ b/ipld/graphsync/src/libp2p/codec.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{proto, GraphSyncMessage};

--- a/ipld/graphsync/src/libp2p/config.rs
+++ b/ipld/graphsync/src/libp2p/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::borrow::Cow;

--- a/ipld/graphsync/src/libp2p/handler.rs
+++ b/ipld/graphsync/src/libp2p/handler.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::codec::GraphSyncCodec;

--- a/ipld/graphsync/src/libp2p/mod.rs
+++ b/ipld/graphsync/src/libp2p/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod behaviour;

--- a/ipld/graphsync/src/libp2p/protocol.rs
+++ b/ipld/graphsync/src/libp2p/protocol.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::GraphSyncCodec;

--- a/ipld/graphsync/src/message/mod.rs
+++ b/ipld/graphsync/src/message/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod proto;

--- a/ipld/graphsync/src/message/proto/mod.rs
+++ b/ipld/graphsync/src/message/proto/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[rustfmt::skip]

--- a/ipld/graphsync/src/response_manager/link_tracker.rs
+++ b/ipld/graphsync/src/response_manager/link_tracker.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::RequestID;

--- a/ipld/graphsync/src/response_manager/mod.rs
+++ b/ipld/graphsync/src/response_manager/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![allow(dead_code)]

--- a/ipld/graphsync/src/response_manager/peer_response_sender.rs
+++ b/ipld/graphsync/src/response_manager/peer_response_sender.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{LinkTracker, ResponseBuilder};

--- a/ipld/graphsync/src/response_manager/response_builder.rs
+++ b/ipld/graphsync/src/response_manager/response_builder.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{

--- a/ipld/graphsync/src/test_utils.rs
+++ b/ipld/graphsync/src/test_utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;

--- a/ipld/graphsync/tests/proto_roundtrip.rs
+++ b/ipld/graphsync/tests/proto_roundtrip.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::{Code::Blake2b256, Cid};

--- a/ipld/hamt/benches/hamt_benchmark.rs
+++ b/ipld/hamt/benches/hamt_benchmark.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 extern crate serde;

--- a/ipld/hamt/fuzz/fuzz_targets/hamt_fuzz.rs
+++ b/ipld/hamt/fuzz/fuzz_targets/hamt_fuzz.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![no_main]

--- a/ipld/hamt/src/bitfield.rs
+++ b/ipld/hamt/src/bitfield.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use byteorder::{BigEndian, ByteOrder};

--- a/ipld/hamt/src/error.rs
+++ b/ipld/hamt/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_encoding::Error as EncodingError;

--- a/ipld/hamt/src/hamt.rs
+++ b/ipld/hamt/src/hamt.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::node::Node;

--- a/ipld/hamt/src/hash.rs
+++ b/ipld/hamt/src/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::hash::Hasher;

--- a/ipld/hamt/src/hash_algorithm.rs
+++ b/ipld/hamt/src/hash_algorithm.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{Hash, HashedKey};

--- a/ipld/hamt/src/hash_bits.rs
+++ b/ipld/hamt/src/hash_bits.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{Error, HashedKey};

--- a/ipld/hamt/src/lib.rs
+++ b/ipld/hamt/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! HAMT crate for use as rust IPLD data structure

--- a/ipld/hamt/src/node.rs
+++ b/ipld/hamt/src/node.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::bitfield::Bitfield;

--- a/ipld/hamt/src/pointer.rs
+++ b/ipld/hamt/src/pointer.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::node::Node;

--- a/ipld/hamt/tests/hamt_tests.rs
+++ b/ipld/hamt/tests/hamt_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Code::Blake2b256;

--- a/ipld/src/de.rs
+++ b/ipld/src/de.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::Ipld;

--- a/ipld/src/error.rs
+++ b/ipld/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::error::Error as CborError;

--- a/ipld/src/json.rs
+++ b/ipld/src/json.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{ipld, Ipld};

--- a/ipld/src/lib.rs
+++ b/ipld/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod de;

--- a/ipld/src/macros.rs
+++ b/ipld/src/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 /// Construct a `forest_ipld::Ipld` roughly matching JSON format. This code is a modified version

--- a/ipld/src/path.rs
+++ b/ipld/src/path.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::PathSegment;

--- a/ipld/src/path_segment.rs
+++ b/ipld/src/path_segment.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use serde::de;

--- a/ipld/src/selector/empty_map.rs
+++ b/ipld/src/selector/empty_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/ipld/src/selector/mod.rs
+++ b/ipld/src/selector/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod empty_map;

--- a/ipld/src/selector/walk.rs
+++ b/ipld/src/selector/walk.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::super::{Error, Ipld, Path, PathSegment};

--- a/ipld/src/ser.rs
+++ b/ipld/src/ser.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 // Copyright 2017 Serde Developers

--- a/ipld/src/util.rs
+++ b/ipld/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::collections::HashSet;

--- a/ipld/tests/cbor_test.rs
+++ b/ipld/tests/cbor_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::{

--- a/ipld/tests/json_tests.rs
+++ b/ipld/tests/json_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "json")]

--- a/ipld/tests/selector_explore.rs
+++ b/ipld/tests/selector_explore.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "submodule_tests")]

--- a/ipld/tests/selector_gen_tests.rs
+++ b/ipld/tests/selector_gen_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_ipld::selector::{RecursionLimit, Selector};

--- a/ipld/tests/walk_tests.rs
+++ b/ipld/tests/walk_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "submodule_tests")]

--- a/key_management/src/errors.rs
+++ b/key_management/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::io;

--- a/key_management/src/keystore.rs
+++ b/key_management/src/keystore.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use log::{error, warn};

--- a/key_management/src/lib.rs
+++ b/key_management/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod errors;

--- a/key_management/src/wallet.rs
+++ b/key_management/src/wallet.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::errors::Error;

--- a/key_management/src/wallet_helpers.rs
+++ b/key_management/src/wallet_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::errors::Error;

--- a/node/clock/src/lib.rs
+++ b/node/clock/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 const _ISO_FORMAT: &str = "%FT%X.%.9F";

--- a/node/db/src/errors.rs
+++ b/node/db/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::error::Error as CborError;

--- a/node/db/src/lib.rs
+++ b/node/db/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod errors;

--- a/node/db/src/memory.rs
+++ b/node/db/src/memory.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{Error, Store};

--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::errors::Error;

--- a/node/db/src/sled.rs
+++ b/node/db/src/sled.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::errors::Error;

--- a/node/db/tests/db_utils/mod.rs
+++ b/node/db/tests/db_utils/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "rocksdb")]

--- a/node/db/tests/mem_test.rs
+++ b/node/db/tests/mem_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod subtests;

--- a/node/db/tests/rocks_test.rs
+++ b/node/db/tests/rocks_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "rocksdb")]

--- a/node/db/tests/sled_test.rs
+++ b/node/db/tests/sled_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "sled")]

--- a/node/db/tests/subtests/mod.rs
+++ b/node/db/tests/subtests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_db::Store;

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{

--- a/node/forest_libp2p/src/chain_exchange/message.rs
+++ b/node/forest_libp2p/src/chain_exchange/message.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_blocks::{Block, BlockHeader, FullTipset, Tipset, BLOCK_MESSAGE_LIMIT};

--- a/node/forest_libp2p/src/chain_exchange/mod.rs
+++ b/node/forest_libp2p/src/chain_exchange/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod message;

--- a/node/forest_libp2p/src/chain_exchange/provider.rs
+++ b/node/forest_libp2p/src/chain_exchange/provider.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use chain::{ChainStore, Error as ChainError};

--- a/node/forest_libp2p/src/config.rs
+++ b/node/forest_libp2p/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use libp2p::Multiaddr;

--- a/node/forest_libp2p/src/discovery.rs
+++ b/node/forest_libp2p/src/discovery.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::stream::{self, Interval};

--- a/node/forest_libp2p/src/gossip_params.rs
+++ b/node/forest_libp2p/src/gossip_params.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{PUBSUB_BLOCK_STR, PUBSUB_MSG_STR};

--- a/node/forest_libp2p/src/hello/message.rs
+++ b/node/forest_libp2p/src/hello/message.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clock::ChainEpoch;

--- a/node/forest_libp2p/src/hello/mod.rs
+++ b/node/forest_libp2p/src/hello/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod message;

--- a/node/forest_libp2p/src/lib.rs
+++ b/node/forest_libp2p/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![recursion_limit = "1024"]

--- a/node/forest_libp2p/src/rpc/mod.rs
+++ b/node/forest_libp2p/src/rpc/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_trait::async_trait;

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::chain_exchange::{

--- a/node/forest_libp2p/tests/decode_test.rs
+++ b/node/forest_libp2p/tests/decode_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crypto::{Signature, Signer};

--- a/node/rpc-api/build.rs
+++ b/node/rpc-api/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::cmp;

--- a/node/rpc-api/src/data_types.rs
+++ b/node/rpc-api/src/data_types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::channel::Sender;

--- a/node/rpc-api/src/lib.rs
+++ b/node/rpc-api/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use once_cell::sync::Lazy;

--- a/node/rpc-client/src/auth_ops.rs
+++ b/node/rpc-client/src/auth_ops.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::Error as JsonRpcError;

--- a/node/rpc-client/src/chain_ops.rs
+++ b/node/rpc-client/src/chain_ops.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::call;

--- a/node/rpc-client/src/client.rs
+++ b/node/rpc-client/src/client.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::{Error, Id, RequestObject, V2};

--- a/node/rpc-client/src/lib.rs
+++ b/node/rpc-client/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 /// Filecoin RPC client interface methods

--- a/node/rpc-client/src/net_ops.rs
+++ b/node/rpc-client/src/net_ops.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::call;

--- a/node/rpc-client/src/sync_ops.rs
+++ b/node/rpc-client/src/sync_ops.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::call;

--- a/node/rpc-client/src/wallet_ops.rs
+++ b/node/rpc-client/src/wallet_ops.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::call;

--- a/node/rpc/src/auth_api.rs
+++ b/node/rpc/src/auth_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};

--- a/node/rpc/src/beacon_api.rs
+++ b/node/rpc/src/beacon_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};

--- a/node/rpc/src/chain_api.rs
+++ b/node/rpc/src/chain_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::{Data, Error as JsonRpcError, Id, Params};

--- a/node/rpc/src/common_api.rs
+++ b/node/rpc/src/common_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::Error as JsonRpcError;

--- a/node/rpc/src/gas_api.rs
+++ b/node/rpc/src/gas_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod auth_api;

--- a/node/rpc/src/mpool_api.rs
+++ b/node/rpc/src/mpool_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::gas_api::estimate_message_gas;

--- a/node/rpc/src/net_api.rs
+++ b/node/rpc/src/net_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use futures::channel::oneshot;

--- a/node/rpc/src/rpc_http_handler.rs
+++ b/node/rpc/src/rpc_http_handler.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::RequestObject as JsonRpcRequestObject;

--- a/node/rpc/src/rpc_util.rs
+++ b/node/rpc/src/rpc_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use log::{debug, error};

--- a/node/rpc/src/rpc_ws_handler.rs
+++ b/node/rpc/src/rpc_ws_handler.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::sync::Arc;

--- a/node/rpc/src/state_api.rs
+++ b/node/rpc/src/state_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};

--- a/node/rpc/src/sync_api.rs
+++ b/node/rpc/src/sync_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use beacon::Beacon;

--- a/node/rpc/src/wallet_api.rs
+++ b/node/rpc/src/wallet_api.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};

--- a/node/utils/src/lib.rs
+++ b/node/utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use dirs::home_dir;

--- a/node/utils/tests/files.rs
+++ b/node/utils/tests/files.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use utils::{read_file_to_string, read_file_to_vec, read_toml, write_to_file};

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PAT_APA="^// Copyright 2019-2021 ChainSafe Systems // SPDX-License-Identifier: Apache-2.0, MIT$"
+PAT_APA="^// Copyright 2019-2022 ChainSafe Systems // SPDX-License-Identifier: Apache-2.0, MIT$"
 
 valid=true
 for file in $(find . -type f -not -path "./target/*" -not -path "./blockchain/beacon/src/drand_api/*" -not -path "./ipld/graphsync/src/message/proto/message.rs" | egrep '\.(rs)$'); do

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PAT_APA="^// Copyright 2020 ChainSafe Systems // SPDX-License-Identifier: Apache-2.0, MIT$"
+PAT_APA="^// Copyright 2019-2021 ChainSafe Systems // SPDX-License-Identifier: Apache-2.0, MIT$"
 
 valid=true
 for file in $(find . -type f -not -path "./target/*" -not -path "./blockchain/beacon/src/drand_api/*" -not -path "./ipld/graphsync/src/message/proto/message.rs" | egrep '\.(rs)$'); do

--- a/scripts/copyright.txt
+++ b/scripts/copyright.txt
@@ -1,2 +1,2 @@
-// Copyright 2019-2021 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT

--- a/scripts/copyright.txt
+++ b/scripts/copyright.txt
@@ -1,3 +1,2 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2021 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
-

--- a/tests/conformance_tests/src/lib.rs
+++ b/tests/conformance_tests/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "submodule_tests")]

--- a/tests/conformance_tests/src/message.rs
+++ b/tests/conformance_tests/src/message.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;

--- a/tests/conformance_tests/src/rand_replay.rs
+++ b/tests/conformance_tests/src/rand_replay.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;

--- a/tests/conformance_tests/src/stubs.rs
+++ b/tests/conformance_tests/src/stubs.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;

--- a/tests/conformance_tests/src/tipset.rs
+++ b/tests/conformance_tests/src/tipset.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "submodule_tests")]

--- a/tests/serialization_tests/src/lib.rs
+++ b/tests/serialization_tests/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "submodule_tests")]

--- a/tests/serialization_tests/tests/block_header_ser.rs
+++ b/tests/serialization_tests/tests/block_header_ser.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "submodule_tests")]

--- a/tests/serialization_tests/tests/signing_ser.rs
+++ b/tests/serialization_tests/tests/signing_ser.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 // Doesn't run these unless feature specified

--- a/tests/serialization_tests/tests/u_message_ser.rs
+++ b/tests/serialization_tests/tests/u_message_ser.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 // Doesn't run these unless feature specified

--- a/types/networks/src/devnet/mod.rs
+++ b/types/networks/src/devnet/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{drand::DRAND_MAINNET, DrandPoint};

--- a/types/networks/src/drand.rs
+++ b/types/networks/src/drand.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use beacon::DrandConfig;

--- a/types/networks/src/interopnet/mod.rs
+++ b/types/networks/src/interopnet/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{drand::DRAND_MAINNET, DrandPoint};

--- a/types/networks/src/lib.rs
+++ b/types/networks/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[macro_use]

--- a/types/networks/src/mainnet/mod.rs
+++ b/types/networks/src/mainnet/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{

--- a/types/src/build_version/mod.rs
+++ b/types/src/build_version/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::sync::RwLock;

--- a/types/src/deadlines/mod.rs
+++ b/types/src/deadlines/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod quantize;

--- a/types/src/deadlines/quantize.rs
+++ b/types/src/deadlines/quantize.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clock::ChainEpoch;

--- a/types/src/genesis/mod.rs
+++ b/types/src/genesis/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::SectorSize;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod build_version;

--- a/types/src/piece/mod.rs
+++ b/types/src/piece/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[cfg(feature = "proofs")]

--- a/types/src/piece/zero.rs
+++ b/types/src/piece/zero.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::PaddedPieceSize;

--- a/types/src/randomness.rs
+++ b/types/src/randomness.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::{Byte32De, BytesSer};

--- a/types/src/sector/mod.rs
+++ b/types/src/sector/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod post;

--- a/types/src/sector/post.rs
+++ b/types/src/sector/post.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{ActorID, Randomness, RegisteredPoStProof, RegisteredSealProof, SectorNumber};

--- a/types/src/sector/registered_proof.rs
+++ b/types/src/sector/registered_proof.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::SectorSize;

--- a/types/src/sector/seal.rs
+++ b/types/src/sector/seal.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{

--- a/types/src/state.rs
+++ b/types/src/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;

--- a/types/src/verifier/mock.rs
+++ b/types/src/verifier/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::ProofVerifier;

--- a/types/src/verifier/mod.rs
+++ b/types/src/verifier/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod mock;

--- a/types/src/version.rs
+++ b/types/src/version.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::repr::Serialize_repr;

--- a/utils/auth/src/lib.rs
+++ b/utils/auth/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use jsonrpc_v2::Error as JsonRpcError;

--- a/utils/bigint/src/bigint_ser.rs
+++ b/utils/bigint/src/bigint_ser.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use num_bigint::{BigInt, Sign};

--- a/utils/bigint/src/biguint_ser.rs
+++ b/utils/bigint/src/biguint_ser.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use num_bigint::BigUint;

--- a/utils/bigint/src/lib.rs
+++ b/utils/bigint/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod bigint_ser;

--- a/utils/bitfield/benches/benchmarks/examples.rs
+++ b/utils/bitfield/benches/benchmarks/examples.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_bitfield::BitField;

--- a/utils/bitfield/benches/benchmarks/main.rs
+++ b/utils/bitfield/benches/benchmarks/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod examples;

--- a/utils/bitfield/src/iter/combine.rs
+++ b/utils/bitfield/src/iter/combine.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! Combining two range iterators into a single new range iterator.

--- a/utils/bitfield/src/iter/mod.rs
+++ b/utils/bitfield/src/iter/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod combine;

--- a/utils/bitfield/src/lib.rs
+++ b/utils/bitfield/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod iter;

--- a/utils/bitfield/src/rleplus/mod.rs
+++ b/utils/bitfield/src/rleplus/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! # RLE+ Bitset Encoding

--- a/utils/bitfield/src/rleplus/reader.rs
+++ b/utils/bitfield/src/rleplus/reader.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::Result;

--- a/utils/bitfield/src/rleplus/writer.rs
+++ b/utils/bitfield/src/rleplus/writer.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[derive(Default, Clone, Debug)]

--- a/utils/bitfield/src/unvalidated.rs
+++ b/utils/bitfield/src/unvalidated.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{BitField, Result};

--- a/utils/bitfield/tests/bitfield_tests.rs
+++ b/utils/bitfield/tests/bitfield_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use ahash::AHashSet;

--- a/utils/commcid/src/lib.rs
+++ b/utils/commcid/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::{

--- a/utils/commcid/tests/commcid_tests.rs
+++ b/utils/commcid/tests/commcid_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::{multihash::MultihashDigest, Cid, Code};

--- a/utils/genesis/src/lib.rs
+++ b/utils/genesis/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::fs::File;

--- a/utils/hash_utils/src/key.rs
+++ b/utils/hash_utils/src/key.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::Hash;

--- a/utils/hash_utils/src/lib.rs
+++ b/utils/hash_utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod key;

--- a/utils/json_utils/src/lib.rs
+++ b/utils/json_utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use serde::de::{self, SeqAccess, Visitor};

--- a/utils/metrics/src/db.rs
+++ b/utils/metrics/src/db.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use log::error;

--- a/utils/metrics/src/lib.rs
+++ b/utils/metrics/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod db;

--- a/utils/net_utils/src/download.rs
+++ b/utils/net_utils/src/download.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::fs::File;

--- a/utils/net_utils/src/lib.rs
+++ b/utils/net_utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod download;

--- a/utils/paramfetch/src/lib.rs
+++ b/utils/paramfetch/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use async_std::{

--- a/utils/statediff/src/lib.rs
+++ b/utils/statediff/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/utils/test_utils/src/chain_structures.rs
+++ b/utils/test_utils/src/chain_structures.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "test_constructors")]

--- a/utils/test_utils/src/lib.rs
+++ b/utils/test_utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[cfg(feature = "test_constructors")]

--- a/vm/actor/src/builtin/account/mod.rs
+++ b/vm/actor/src/builtin/account/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod state;

--- a/vm/actor/src/builtin/account/state.rs
+++ b/vm/actor/src/builtin/account/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/src/builtin/codes.rs
+++ b/vm/actor/src/builtin/codes.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::{multihash::MultihashDigest, Cid, Code::Identity, RAW};

--- a/vm/actor/src/builtin/cron/mod.rs
+++ b/vm/actor/src/builtin/cron/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod state;

--- a/vm/actor/src/builtin/cron/state.rs
+++ b/vm/actor/src/builtin/cron/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/src/builtin/init/mod.rs
+++ b/vm/actor/src/builtin/init/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod state;

--- a/vm/actor/src/builtin/init/state.rs
+++ b/vm/actor/src/builtin/init/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{make_empty_map, make_map_with_root_and_bitwidth, FIRST_NON_SINGLETON_ADDR};

--- a/vm/actor/src/builtin/init/types.rs
+++ b/vm/actor/src/builtin/init/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/src/builtin/market/deal.rs
+++ b/vm/actor/src/builtin/market/deal.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::DealWeight;

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod deal;

--- a/vm/actor/src/builtin/market/policy.rs
+++ b/vm/actor/src/builtin/market/policy.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::deal::DealProposal;

--- a/vm/actor/src/builtin/market/state.rs
+++ b/vm/actor/src/builtin/market/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{policy::*, types::*, DealProposal, DealState, DEAL_UPDATES_INTERVAL};

--- a/vm/actor/src/builtin/market/types.rs
+++ b/vm/actor/src/builtin/market/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::deal::{ClientDealProposal, DealProposal, DealState};

--- a/vm/actor/src/builtin/miner/bitfield_queue.rs
+++ b/vm/actor/src/builtin/miner/bitfield_queue.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::ActorDowncast;

--- a/vm/actor/src/builtin/miner/deadline_assignment.rs
+++ b/vm/actor/src/builtin/miner/deadline_assignment.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{Deadline, SectorOnChainInfo};

--- a/vm/actor/src/builtin/miner/deadline_state.rs
+++ b/vm/actor/src/builtin/miner/deadline_state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{

--- a/vm/actor/src/builtin/miner/deadlines.rs
+++ b/vm/actor/src/builtin/miner/deadlines.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::policy::*;

--- a/vm/actor/src/builtin/miner/expiration_queue.rs
+++ b/vm/actor/src/builtin/miner/expiration_queue.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{power_for_sector, PowerPair, SectorOnChainInfo};

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use log::{error, info, warn};

--- a/vm/actor/src/builtin/miner/monies.rs
+++ b/vm/actor/src/builtin/miner/monies.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{VestSpec, REWARD_VESTING_SPEC};

--- a/vm/actor/src/builtin/miner/partition_state.rs
+++ b/vm/actor/src/builtin/miner/partition_state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{

--- a/vm/actor/src/builtin/miner/policy.rs
+++ b/vm/actor/src/builtin/miner/policy.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{types::SectorOnChainInfo, PowerPair, BASE_REWARD_FOR_DISPUTED_WINDOW_POST};

--- a/vm/actor/src/builtin/miner/sector_map.rs
+++ b/vm/actor/src/builtin/miner/sector_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::WPOST_PERIOD_DEADLINES;

--- a/vm/actor/src/builtin/miner/sectors.rs
+++ b/vm/actor/src/builtin/miner/sectors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::SectorOnChainInfo;

--- a/vm/actor/src/builtin/miner/state.rs
+++ b/vm/actor/src/builtin/miner/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{

--- a/vm/actor/src/builtin/miner/termination.rs
+++ b/vm/actor/src/builtin/miner/termination.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use bitfield::BitField;

--- a/vm/actor/src/builtin/miner/types.rs
+++ b/vm/actor/src/builtin/miner/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::DealWeight;

--- a/vm/actor/src/builtin/miner/vesting_state.rs
+++ b/vm/actor/src/builtin/miner/vesting_state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::VestSpec;

--- a/vm/actor/src/builtin/mod.rs
+++ b/vm/actor/src/builtin/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod account;

--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod state;

--- a/vm/actor/src/builtin/multisig/state.rs
+++ b/vm/actor/src/builtin/multisig/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{types::Transaction, TxnID};

--- a/vm/actor/src/builtin/multisig/types.rs
+++ b/vm/actor/src/builtin/multisig/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::BytesKey;

--- a/vm/actor/src/builtin/network.rs
+++ b/vm/actor/src/builtin/network.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub use clock::EPOCH_DURATION_SECONDS;

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod state;

--- a/vm/actor/src/builtin/paych/state.rs
+++ b/vm/actor/src/builtin/paych/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/src/builtin/paych/types.rs
+++ b/vm/actor/src/builtin/paych/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::Merge;

--- a/vm/actor/src/builtin/power/mod.rs
+++ b/vm/actor/src/builtin/power/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod policy;

--- a/vm/actor/src/builtin/power/policy.rs
+++ b/vm/actor/src/builtin/power/policy.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 /// Minimum power of an individual miner to meet the threshold for leader election.

--- a/vm/actor/src/builtin/power/state.rs
+++ b/vm/actor/src/builtin/power/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{CONSENSUS_MINER_MIN_MINERS, CRON_QUEUE_AMT_BITWIDTH, CRON_QUEUE_HAMT_BITWIDTH};

--- a/vm/actor/src/builtin/power/types.rs
+++ b/vm/actor/src/builtin/power/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::smooth::FilterEstimate;

--- a/vm/actor/src/builtin/reward/expneg.rs
+++ b/vm/actor/src/builtin/reward/expneg.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::math::{poly_parse, poly_val, PRECISION};

--- a/vm/actor/src/builtin/reward/logic.rs
+++ b/vm/actor/src/builtin/reward/logic.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::expneg::expneg;

--- a/vm/actor/src/builtin/reward/mod.rs
+++ b/vm/actor/src/builtin/reward/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub(crate) mod expneg;

--- a/vm/actor/src/builtin/reward/state.rs
+++ b/vm/actor/src/builtin/reward/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::logic::*;

--- a/vm/actor/src/builtin/reward/types.rs
+++ b/vm/actor/src/builtin/reward/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::smooth::FilterEstimate;

--- a/vm/actor/src/builtin/sector.rs
+++ b/vm/actor/src/builtin/sector.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use fil_types::{RegisteredPoStProof, StoragePower};

--- a/vm/actor/src/builtin/shared.rs
+++ b/vm/actor/src/builtin/shared.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::miner::{GetControlAddressesReturn, Method};

--- a/vm/actor/src/builtin/singletons.rs
+++ b/vm/actor/src/builtin/singletons.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/src/builtin/system/mod.rs
+++ b/vm/actor/src/builtin/system/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::SYSTEM_ACTOR_ADDR;

--- a/vm/actor/src/builtin/verifreg/mod.rs
+++ b/vm/actor/src/builtin/verifreg/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod state;

--- a/vm/actor/src/builtin/verifreg/state.rs
+++ b/vm/actor/src/builtin/verifreg/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::error::Error as StdError;

--- a/vm/actor/src/builtin/verifreg/types.rs
+++ b/vm/actor/src/builtin/verifreg/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/src/lib.rs
+++ b/vm/actor/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[macro_use]

--- a/vm/actor/src/util/balance_table.rs
+++ b/vm/actor/src/util/balance_table.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{make_empty_map, make_map_with_root_and_bitwidth, Map};

--- a/vm/actor/src/util/chaos/mod.rs
+++ b/vm/actor/src/util/chaos/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod state;

--- a/vm/actor/src/util/chaos/state.rs
+++ b/vm/actor/src/util/chaos/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::util::unmarshallable::UnmarshallableCBOR;

--- a/vm/actor/src/util/chaos/types.rs
+++ b/vm/actor/src/util/chaos/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::state::State;

--- a/vm/actor/src/util/downcast.rs
+++ b/vm/actor/src/util/downcast.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::{error::Error as CborError, Error as EncodingError};

--- a/vm/actor/src/util/math.rs
+++ b/vm/actor/src/util/math.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use num_bigint::{BigInt, ParseBigIntError};

--- a/vm/actor/src/util/mod.rs
+++ b/vm/actor/src/util/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod balance_table;

--- a/vm/actor/src/util/multimap.rs
+++ b/vm/actor/src/util/multimap.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{make_empty_map, make_map_with_root_and_bitwidth, BytesKey, Map};

--- a/vm/actor/src/util/set.rs
+++ b/vm/actor/src/util/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{make_empty_map, make_map_with_root, BytesKey, Map};

--- a/vm/actor/src/util/set_multimap.rs
+++ b/vm/actor/src/util/set_multimap.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::Set;

--- a/vm/actor/src/util/smooth/alpha_beta_filter.rs
+++ b/vm/actor/src/util/smooth/alpha_beta_filter.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::util::math::PRECISION;

--- a/vm/actor/src/util/smooth/mod.rs
+++ b/vm/actor/src/util/smooth/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod alpha_beta_filter;

--- a/vm/actor/src/util/smooth/smooth_func.rs
+++ b/vm/actor/src/util/smooth/smooth_func.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::alpha_beta_filter::*;

--- a/vm/actor/src/util/unmarshallable.rs
+++ b/vm/actor/src/util/unmarshallable.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::Cbor;

--- a/vm/actor/tests/account_actor_test.rs
+++ b/vm/actor/tests/account_actor_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod common;

--- a/vm/actor/tests/alpha_beta_filter_test.rs
+++ b/vm/actor/tests/alpha_beta_filter_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clock::ChainEpoch;

--- a/vm/actor/tests/balance_table_test.rs
+++ b/vm/actor/tests/balance_table_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/tests/common/mod.rs
+++ b/vm/actor/tests/common/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/tests/cron_actor_test.rs
+++ b/vm/actor/tests/cron_actor_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod common;

--- a/vm/actor/tests/init_actor_test.rs
+++ b/vm/actor/tests/init_actor_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod common;

--- a/vm/actor/tests/market_actor_test.rs
+++ b/vm/actor/tests/market_actor_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod common;

--- a/vm/actor/tests/multimap_test.rs
+++ b/vm/actor/tests/multimap_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor/tests/paych_actor_test.rs
+++ b/vm/actor/tests/paych_actor_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod common;

--- a/vm/actor/tests/reward_actor_test.rs
+++ b/vm/actor/tests/reward_actor_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[macro_use]

--- a/vm/actor/tests/set_multimap_test.rs
+++ b/vm/actor/tests/set_multimap_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clock::ChainEpoch;

--- a/vm/actor/tests/set_test.rs
+++ b/vm/actor/tests/set_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_actor::Set;

--- a/vm/actor_interface/src/adt/array.rs
+++ b/vm/actor_interface/src/adt/array.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::ActorVersion;

--- a/vm/actor_interface/src/adt/map.rs
+++ b/vm/actor_interface/src/adt/map.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::ActorVersion;

--- a/vm/actor_interface/src/adt/mod.rs
+++ b/vm/actor_interface/src/adt/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod array;

--- a/vm/actor_interface/src/builtin/account/mod.rs
+++ b/vm/actor_interface/src/builtin/account/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor_interface/src/builtin/cron/mod.rs
+++ b/vm/actor_interface/src/builtin/cron/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use ipld_blockstore::BlockStore;

--- a/vm/actor_interface/src/builtin/init/mod.rs
+++ b/vm/actor_interface/src/builtin/init/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor_interface/src/builtin/market/mod.rs
+++ b/vm/actor_interface/src/builtin/market/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor_interface/src/builtin/miner/mod.rs
+++ b/vm/actor_interface/src/builtin/miner/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/actor_interface/src/builtin/mod.rs
+++ b/vm/actor_interface/src/builtin/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod account;

--- a/vm/actor_interface/src/builtin/multisig/mod.rs
+++ b/vm/actor_interface/src/builtin/multisig/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use ipld_blockstore::BlockStore;

--- a/vm/actor_interface/src/builtin/power/mod.rs
+++ b/vm/actor_interface/src/builtin/power/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::FilterEstimate;

--- a/vm/actor_interface/src/builtin/reward/mod.rs
+++ b/vm/actor_interface/src/builtin/reward/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::FilterEstimate;

--- a/vm/actor_interface/src/builtin/system/mod.rs
+++ b/vm/actor_interface/src/builtin/system/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use ipld_blockstore::BlockStore;

--- a/vm/actor_interface/src/lib.rs
+++ b/vm/actor_interface/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod adt;

--- a/vm/actor_interface/src/policy.rs
+++ b/vm/actor_interface/src/policy.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clock::ChainEpoch;

--- a/vm/address/src/errors.rs
+++ b/vm/address/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{BLS_PUB_LEN, PAYLOAD_HASH_LEN, SECP_PUB_LEN};

--- a/vm/address/src/lib.rs
+++ b/vm/address/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod errors;

--- a/vm/address/src/network.rs
+++ b/vm/address/src/network.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{MAINNET_PREFIX, TESTNET_PREFIX};

--- a/vm/address/src/payload.rs
+++ b/vm/address/src/payload.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{from_leb_bytes, to_leb_bytes, Error, Protocol, BLS_PUB_LEN, PAYLOAD_HASH_LEN};

--- a/vm/address/src/protocol.rs
+++ b/vm/address/src/protocol.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use num_derive::FromPrimitive;

--- a/vm/address/tests/address_test.rs
+++ b/vm/address/tests/address_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use data_encoding::{DecodeError, DecodeKind};

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::gas_block_store::GasBlockStore;

--- a/vm/interpreter/src/gas_block_store.rs
+++ b/vm/interpreter/src/gas_block_store.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::gas_tracker::{GasTracker, PriceList};

--- a/vm/interpreter/src/gas_tracker/gas_charge.rs
+++ b/vm/interpreter/src/gas_tracker/gas_charge.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 /// Single gas charge in the VM. Contains information about what gas was for, as well

--- a/vm/interpreter/src/gas_tracker/mod.rs
+++ b/vm/interpreter/src/gas_tracker/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod gas_charge;

--- a/vm/interpreter/src/gas_tracker/price_list.rs
+++ b/vm/interpreter/src/gas_tracker/price_list.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::GasCharge;

--- a/vm/interpreter/src/lib.rs
+++ b/vm/interpreter/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[macro_use]

--- a/vm/interpreter/src/rand.rs
+++ b/vm/interpreter/src/rand.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use clock::ChainEpoch;

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{

--- a/vm/interpreter/tests/transfer_test.rs
+++ b/vm/interpreter/tests/transfer_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use actor::actorv0::{account, init, ACCOUNT_ACTOR_CODE_ID, INIT_ACTOR_ADDR, INIT_ACTOR_CODE_ID};

--- a/vm/message/src/chain_message.rs
+++ b/vm/message/src/chain_message.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::Message;

--- a/vm/message/src/lib.rs
+++ b/vm/message/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 // workaround for a compiler bug, see https://github.com/rust-lang/rust/issues/55779

--- a/vm/message/src/message_receipt.rs
+++ b/vm/message/src/message_receipt.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::tuple::*;

--- a/vm/message/src/signed_message.rs
+++ b/vm/message/src/signed_message.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::{Message, UnsignedMessage};

--- a/vm/message/src/unsigned_message.rs
+++ b/vm/message/src/unsigned_message.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::Message;

--- a/vm/message/tests/builder_test.rs
+++ b/vm/message/tests/builder_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;

--- a/vm/message/tests/message_json_test.rs
+++ b/vm/message/tests/message_json_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #![cfg(feature = "json")]

--- a/vm/runtime/src/actor_code.rs
+++ b/vm/runtime/src/actor_code.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::Runtime;

--- a/vm/runtime/src/lib.rs
+++ b/vm/runtime/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod actor_code;

--- a/vm/src/actor_state.rs
+++ b/vm/src/actor_state.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::TokenAmount;

--- a/vm/src/deal_id.rs
+++ b/vm/src/deal_id.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 /// Deal identifier used in market and miner actors

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::ExitCode;

--- a/vm/src/exit_code.rs
+++ b/vm/src/exit_code.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::repr::*;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 // workaround for a compiler bug, see https://github.com/rust-lang/rust/issues/55779

--- a/vm/src/method.rs
+++ b/vm/src/method.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::{de, from_slice, ser, serde_bytes, to_vec, Cbor, Error as EncodingError};

--- a/vm/src/token.rs
+++ b/vm/src/token.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use num_bigint::BigInt;

--- a/vm/state_migration/src/lib.rs
+++ b/vm/state_migration/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! Common code that's shared across all migration code.

--- a/vm/state_migration/src/nv12/miner.rs
+++ b/vm/state_migration/src/nv12/miner.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 //! This module implements network version 12 or actorv4 state migration

--- a/vm/state_migration/src/nv12/mod.rs
+++ b/vm/state_migration/src/nv12/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 pub mod miner;

--- a/vm/state_tree/src/lib.rs
+++ b/vm/state_tree/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use actor::{init, ActorVersion, Map};

--- a/vm/state_tree/tests/state_tree_tests.rs
+++ b/vm/state_tree/tests/state_tree_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use actor::actorv0::{

--- a/vm/tests/params_test.rs
+++ b/vm/tests/params_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 ChainSafe Systems
+// Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use address::Address;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- fix copyright header years (was 2020; should be 2019-2021)

**Other information and links**
`❯ grep -rl "// Copyright 2020 ChainSafe Systems" . | xargs sed -i 's/Copyright\ 2020/Copyright\ 2019-2022/g'`

Bonus: bumped it to 2022, so we don't have to bother next year ;)