### PR TITLE
fix stable clippy::needless_borrow

### DIFF
--- a/blockchain/blocks/src/election_proof.rs
+++ b/blockchain/blocks/src/election_proof.rs
@@ -78,7 +78,7 @@ fn poly_val(poly: &[BigInt], x: &BigInt) -> BigInt {
 /// computes lambda in Q.256
 #[inline]
 fn lambda(power: &BigInt, total_power: &BigInt) -> BigInt {
-    ((power * BLOCKS_PER_EPOCH) << PRECISION).div_floor(&total_power)
+    ((power * BLOCKS_PER_EPOCH) << PRECISION).div_floor(total_power)
 }
 
 /// Poisson inverted CDF

--- a/blockchain/blocks/src/header/mod.rs
+++ b/blockchain/blocks/src/header/mod.rs
@@ -326,7 +326,7 @@ impl BlockHeader {
             .ok_or_else(|| Error::InvalidSignature("Signature is nil in header".to_owned()))?;
 
         signature
-            .verify(&self.to_signing_bytes(), &addr)
+            .verify(&self.to_signing_bytes(), addr)
             .map_err(|e| Error::InvalidSignature(format!("Block signature invalid: {}", e)))?;
 
         // Set validated cache to true
@@ -420,7 +420,7 @@ impl BlockHeader {
         let mut prev = prev_entry;
         for curr in &self.beacon_entries {
             if !curr_beacon
-                .verify_entry(&curr, &prev)
+                .verify_entry(curr, prev)
                 .await
                 .map_err(|e| Error::Validation(e.to_string()))?
             {
@@ -429,7 +429,7 @@ impl BlockHeader {
                     curr, prev
                 )));
             }
-            prev = &curr;
+            prev = curr;
         }
         Ok(())
     }

--- a/blockchain/chain/src/store/base_fee.rs
+++ b/blockchain/chain/src/store/base_fee.rs
@@ -74,7 +74,7 @@ where
 
     // Add all unique messages' gas limit to get the total for the Tipset.
     for b in ts.blocks() {
-        let (msg1, msg2) = crate::block_messages(db, &b)?;
+        let (msg1, msg2) = crate::block_messages(db, b)?;
         for m in msg1 {
             let m_cid = m.cid()?;
             if !seen.contains(&m_cid) {

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -920,7 +920,7 @@ where
 
         for message in unsigned_box.chain(signed_box) {
             let from_address = message.from();
-            if applied.contains_key(&from_address) {
+            if applied.contains_key(from_address) {
                 let actor_state = state
                     .get_actor(from_address)
                     .map_err(|e| Error::Other(e.to_string()))?

--- a/blockchain/chain/src/store/tipset_tracker.rs
+++ b/blockchain/chain/src/store/tipset_tracker.rs
@@ -75,7 +75,7 @@ impl<DB: BlockStore> TipsetTracker<DB> {
                 // TODO: maybe cache the parents tipset keys to avoid having to do a blockstore lookup here
                 let h = self
                     .db
-                    .get::<BlockHeader>(&cid)
+                    .get::<BlockHeader>(cid)
                     .ok()
                     .flatten()
                     .ok_or_else(|| {

--- a/blockchain/chain_sync/src/chain_muxer.rs
+++ b/blockchain/chain_sync/src/chain_muxer.rs
@@ -238,7 +238,7 @@ where
         let ts = chain_store.tipset_from_keys(&tipset_keys).await?;
         for header in ts.blocks() {
             // Retrieve bls and secp messages from specified BlockHeader
-            let (bls_msgs, secp_msgs) = chain::block_messages(chain_store.blockstore(), &header)?;
+            let (bls_msgs, secp_msgs) = chain::block_messages(chain_store.blockstore(), header)?;
             // Construct a full block
             blocks.push(Block {
                 header: header.clone(),

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -179,7 +179,7 @@ impl TipsetGroup {
         if !self.epoch.eq(&tipset.epoch()) || !self.parents.eq(tipset.parents()) {
             return Some(tipset);
         }
-        if self.tipsets.iter().any(|ts| tipset.key().eq(&ts.key())) {
+        if self.tipsets.iter().any(|ts| tipset.key().eq(ts.key())) {
             return Some(tipset);
         }
         self.tipsets.push(tipset);
@@ -434,7 +434,7 @@ where
                             if ns.is_mergeable(&heaviest_tipset_group) {
                                 // Both tipsets groups have the same epoch & parents, so merge them
                                 ns.merge(heaviest_tipset_group);
-                            } else if heaviest_tipset_group.is_heavier_than(&ns) {
+                            } else if heaviest_tipset_group.is_heavier_than(ns) {
                                 // The tipset group received is heavier than the one saved, replace it.
                                 *next_sync = Some(heaviest_tipset_group);
                             }
@@ -481,7 +481,7 @@ where
                             if ns.is_mergeable(&heaviest_tipset_group) {
                                 // Both tipsets groups have the same epoch & parents, so merge them
                                 ns.merge(heaviest_tipset_group);
-                            } else if heaviest_tipset_group.is_heavier_than(&ns) {
+                            } else if heaviest_tipset_group.is_heavier_than(ns) {
                                 // The tipset group received is heavier than the one saved, replace it.
                                 *next_sync = Some(heaviest_tipset_group);
                             } else {
@@ -881,7 +881,7 @@ async fn sync_headers_in_reverse<DB: BlockStore + Sync + Send + 'static>(
             if tipset.epoch() < current_head.epoch() {
                 break 'sync;
             }
-            validate_tipset_against_cache(bad_block_cache.clone(), &tipset.key(), &parent_blocks)
+            validate_tipset_against_cache(bad_block_cache.clone(), tipset.key(), &parent_blocks)
                 .await?;
             parent_blocks.extend_from_slice(tipset.cids());
             tracker.write().await.set_epoch(tipset.epoch());
@@ -1196,7 +1196,7 @@ async fn validate_block<
     let header = block.header();
 
     // Check to ensure all optional values exist
-    block_sanity_checks(&header).map_err(|e| (*block_cid, e))?;
+    block_sanity_checks(header).map_err(|e| (*block_cid, e))?;
 
     let base_tipset = chain_store
         .tipset_from_keys(header.parents())
@@ -1386,7 +1386,7 @@ async fn validate_block<
         verify_election_post_vrf(&work_addr, &vrf_base, election_proof.vrfproof.as_bytes())?;
 
         if v_state_manager
-            .is_miner_slashed(header.miner_address(), &v_base_tipset.parent_state())?
+            .is_miner_slashed(header.miner_address(), v_base_tipset.parent_state())?
         {
             return Err(TipsetRangeSyncerError::InvalidOrSlashedMiner);
         }
@@ -1577,9 +1577,9 @@ fn verify_winning_post_proof<DB: BlockStore + Send + Sync + 'static, V: ProofVer
     })?;
     let sectors = state_manager
         .get_sectors_for_winning_post::<V>(
-            &lookback_state,
+            lookback_state,
             network_version,
-            &header.miner_address(),
+            header.miner_address(),
             Randomness(rand.to_vec()),
         )
         .map_err(|e| {
@@ -1638,7 +1638,7 @@ fn check_block_messages<
                 .map(|x| &x[..])
                 .collect::<Vec<&[u8]>>()
                 .as_slice(),
-            &sig,
+            sig,
         ) {
             return Err(TipsetRangeSyncerError::BlsAggregateSignatureInvalid(
                 format!("{:?}", sig),
@@ -1695,7 +1695,7 @@ fn check_block_messages<
     let mut account_sequences: HashMap<Address, u64> = HashMap::default();
     let block_store = state_manager.blockstore();
     let (state_root, _) =
-        task::block_on(state_manager.tipset_state::<V>(&base_tipset)).map_err(|e| {
+        task::block_on(state_manager.tipset_state::<V>(base_tipset)).map_err(|e| {
             TipsetRangeSyncerError::Calculation(format!("Could not update state: {}", e))
         })?;
     let tree = StateTree::new_from_root(block_store, &state_root).map_err(|e| {

--- a/blockchain/message_pool/src/msg_chain.rs
+++ b/blockchain/message_pool/src/msg_chain.rs
@@ -55,9 +55,9 @@ impl Chains {
             let a = self.map.get(*a).unwrap();
             let b = self.map.get(*b).unwrap();
             if rev {
-                b.compare(&a)
+                b.compare(a)
             } else {
-                a.compare(&b)
+                a.compare(b)
             }
         });
         let _ = mem::replace(&mut self.key_vec, chains);
@@ -81,7 +81,7 @@ impl Chains {
             self.map
                 .get(*a)
                 .unwrap()
-                .cmp_effective(&self.map.get(*b).unwrap())
+                .cmp_effective(self.map.get(*b).unwrap())
         });
         let _ = mem::replace(&mut self.key_vec, chains);
     }
@@ -356,7 +356,7 @@ where
     //   cannot exceed the block limit; drop all messages that exceed the limit
     // - the total gasReward cannot exceed the actor's balance; drop all messages that exceed
     //   the balance
-    let actor_state = api.read().await.get_actor_after(&actor, &ts)?;
+    let actor_state = api.read().await.get_actor_after(actor, ts)?;
     let mut cur_seq = actor_state.sequence;
     let mut balance = actor_state.balance;
 
@@ -405,7 +405,7 @@ where
         let value = m.value();
         balance -= value;
 
-        let gas_reward = get_gas_reward(&m, base_fee);
+        let gas_reward = get_gas_reward(m, base_fee);
         rewards.push(gas_reward);
         i += 1;
     }

--- a/blockchain/message_pool/src/msgpool/mod.rs
+++ b/blockchain/message_pool/src/msgpool/mod.rs
@@ -49,7 +49,7 @@ async fn get_state_sequence<T>(
 where
     T: Provider,
 {
-    let actor = api.read().await.get_actor_after(&addr, cur_ts)?;
+    let actor = api.read().await.get_actor_after(addr, cur_ts)?;
     let base_sequence = actor.sequence;
 
     Ok(base_sequence)
@@ -94,7 +94,7 @@ where
 
     let mut chains = Chains::new();
     for (actor, mset) in pending_map.iter() {
-        create_message_chains(&api, actor, mset, &base_fee_lower_bound, &ts, &mut chains).await?;
+        create_message_chains(api, actor, mset, &base_fee_lower_bound, &ts, &mut chains).await?;
     }
 
     if chains.is_empty() {
@@ -198,7 +198,7 @@ where
 
         let mut msgs: Vec<SignedMessage> = Vec::new();
         for block in ts.blocks() {
-            let (umsg, smsgs) = api.read().await.messages_for_block(&block)?;
+            let (umsg, smsgs) = api.read().await.messages_for_block(block)?;
             msgs.extend(smsgs);
             for msg in umsg {
                 let mut bls_sig_cache = bls_sig_cache.write().await;
@@ -242,7 +242,7 @@ where
     for (_, hm) in rmsgs {
         for (_, msg) in hm {
             let sequence =
-                get_state_sequence(api, &msg.from(), &cur_tipset.read().await.clone()).await?;
+                get_state_sequence(api, msg.from(), &cur_tipset.read().await.clone()).await?;
             if let Err(e) = add_helper(api, bls_sig_cache, pending, msg, sequence).await {
                 error!("Failed to readd message from reorg to mpool: {}", e);
             }

--- a/blockchain/message_pool/src/msgpool/msg_pool.rs
+++ b/blockchain/message_pool/src/msgpool/msg_pool.rs
@@ -237,7 +237,7 @@ where
                             repub_trigger.clone(),
                             republished.as_ref(),
                             pending.as_ref(),
-                            &cur.as_ref(),
+                            cur.as_ref(),
                             rev,
                             app,
                         )
@@ -374,7 +374,7 @@ where
             return Err(Error::SequenceTooLow);
         }
 
-        let publish = verify_msg_before_add(&msg, &cur_ts, local)?;
+        let publish = verify_msg_before_add(&msg, cur_ts, local)?;
 
         let balance = self.get_state_balance(msg.from(), cur_ts).await?;
 
@@ -425,14 +425,14 @@ where
 
     /// Get the state of the sequence for a given address in cur_ts.
     async fn get_state_sequence(&self, addr: &Address, cur_ts: &Tipset) -> Result<u64, Error> {
-        let actor = self.api.read().await.get_actor_after(&addr, cur_ts)?;
+        let actor = self.api.read().await.get_actor_after(addr, cur_ts)?;
         Ok(actor.sequence)
     }
 
     /// Get the state balance for the actor that corresponds to the supplied address and tipset,
     /// if this actor does not exist, return an error.
     async fn get_state_balance(&self, addr: &Address, ts: &Tipset) -> Result<BigInt, Error> {
-        let actor = self.api.read().await.get_actor_after(&addr, &ts)?;
+        let actor = self.api.read().await.get_actor_after(addr, ts)?;
         Ok(actor.balance)
     }
 
@@ -447,20 +447,20 @@ where
             Protocol::ID => {
                 let api = self.api.read().await;
 
-                api.state_account_key::<V>(&addr, &self.cur_tipset.read().await.clone())
+                api.state_account_key::<V>(addr, &self.cur_tipset.read().await.clone())
                     .await?
             }
             _ => *addr,
         };
 
-        let sequence = self.get_sequence(&addr).await?;
+        let sequence = self.get_sequence(addr).await?;
         let msg = cb(from_key, sequence)?;
         self.check_message(&msg).await?;
         if *self.cur_tipset.read().await != cur_ts {
             return Err(Error::TryAgain);
         }
 
-        if self.get_sequence(&addr).await? != sequence {
+        if self.get_sequence(addr).await? != sequence {
             return Err(Error::TryAgain);
         }
 
@@ -483,7 +483,7 @@ where
     }
 
     async fn check_balance(&self, m: &SignedMessage, cur_ts: &Tipset) -> Result<(), Error> {
-        let bal = self.get_state_balance(m.from(), &cur_ts).await?;
+        let bal = self.get_state_balance(m.from(), cur_ts).await?;
         let mut required_funds = m.required_funds();
         if bal < required_funds {
             return Err(Error::NotEnoughFunds);
@@ -555,7 +555,7 @@ where
         let mut msg_vec: Vec<SignedMessage> = Vec::new();
 
         for block in blks {
-            let (umsg, mut smsgs) = self.api.read().await.messages_for_block(&block)?;
+            let (umsg, mut smsgs) = self.api.read().await.messages_for_block(block)?;
 
             msg_vec.append(smsgs.as_mut());
             for msg in umsg {
@@ -607,9 +607,9 @@ where
         if local {
             let local_addrs = self.local_addrs.read().await;
             for a in local_addrs.iter() {
-                if let Some(mset) = self.pending.read().await.get(&a) {
+                if let Some(mset) = self.pending.read().await.get(a) {
                     for m in mset.msgs.values() {
-                        if !self.local_msgs.write().await.remove(&m) {
+                        if !self.local_msgs.write().await.remove(m) {
                             warn!("error deleting local message");
                         }
                     }
@@ -620,7 +620,7 @@ where
         } else {
             let mut pending = self.pending.write().await;
             let local_addrs = self.local_addrs.read().await;
-            pending.retain(|a, _| local_addrs.contains(&a));
+            pending.retain(|a, _| local_addrs.contains(a));
         }
     }
     pub fn get_config(&self) -> &MpoolConfig {

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -322,7 +322,7 @@ where
             } else {
                 // generic constants are not implemented yet this is a lowcost method for now
                 let no_func = None::<fn(&Cid, &ChainMessage, &ApplyRet) -> Result<(), String>>;
-                self.compute_tipset_state::<V, _>(&tipset, no_func).await?
+                self.compute_tipset_state::<V, _>(tipset, no_func).await?
             };
 
             // Fill entry with calculated cid pair
@@ -456,7 +456,7 @@ where
         )?;
 
         for msg in prior_messages {
-            vm.apply_message(&msg)?;
+            vm.apply_message(msg)?;
         }
         let from_actor = vm
             .state()
@@ -465,7 +465,7 @@ where
             .ok_or_else(|| Error::Other("cant find actor in state tree".to_string()))?;
         message.set_sequence(from_actor.sequence);
 
-        let ret = vm.apply_message(&message)?;
+        let ret = vm.apply_message(message)?;
 
         Ok(InvocResult {
             msg: message.message().clone(),
@@ -499,7 +499,7 @@ where
 
             Ok(())
         };
-        let result = self.compute_tipset_state::<V, _>(&ts, Some(callback)).await;
+        let result = self.compute_tipset_state::<V, _>(ts, Some(callback)).await;
 
         if let Err(error_message) = result {
             if error_message.to_string() != "halt" {
@@ -604,7 +604,7 @@ where
 
         // Non-empty power claim.
         let claim = power_state
-            .miner_power(self.blockstore(), &address)?
+            .miner_power(self.blockstore(), address)?
             .ok_or_else(|| Error::Other("Could not get claim".to_string()))?;
         if claim.quality_adj_power <= BigInt::zero() {
             return Ok(false);
@@ -691,7 +691,7 @@ where
 
         let worker_key = resolve_to_key_addr(&state, self.blockstore(), &info.worker())?;
 
-        let eligible = self.eligible_to_mine(&address, &tipset.as_ref(), &lbts)?;
+        let eligible = self.eligible_to_mine(&address, tipset.as_ref(), &lbts)?;
 
         Ok(Some(MiningBaseInfo {
             miner_power: Some(mpow.quality_adj_power),
@@ -1174,7 +1174,7 @@ where
         Ok(interpreter::resolve_to_key_addr(
             &state,
             self.blockstore(),
-            &addr,
+            addr,
         )?)
     }
 
@@ -1239,7 +1239,7 @@ where
                 ts.epoch(),
                 ts.cids()
             );
-            let (st, msg_root) = self.tipset_state::<V>(&ts).await?;
+            let (st, msg_root) = self.tipset_state::<V>(ts).await?;
             last_state = st;
             last_receipt = msg_root;
         }

--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -50,8 +50,8 @@ where
                 mas.for_each_deadline(store, |_, deadline| {
                     let mut fault_sectors = BitField::new();
                     deadline.for_each(store, |_, partition: miner::Partition| {
-                        proving_sectors |= &partition.all_sectors();
-                        fault_sectors |= &partition.faulty_sectors();
+                        proving_sectors |= partition.all_sectors();
+                        fault_sectors |= partition.faulty_sectors();
                         Ok(())
                     })?;
 
@@ -231,7 +231,7 @@ where
         let mut out = BitField::new();
 
         self.for_each_deadline_partition::<V, _>(tipset, address, |part| {
-            out |= &part.faulty_sectors();
+            out |= part.faulty_sectors();
             Ok(())
         })?;
 
@@ -250,7 +250,7 @@ where
         let mut out = BitField::new();
 
         self.for_each_deadline_partition::<V, _>(tipset, address, |part| {
-            out |= &part.recovering_sectors();
+            out |= part.recovering_sectors();
             Ok(())
         })?;
 

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -187,7 +187,7 @@ pub fn verify_bls_aggregate(data: &[&[u8]], pub_keys: &[&[u8]], aggregate_sig: &
 pub fn ecrecover(hash: &[u8; 32], signature: &[u8; SECP_SIG_LEN]) -> Result<Address, Error> {
     // generate types to recover key from
     let rec_id = RecoveryId::parse(signature[64])?;
-    let message = Message::parse(&hash);
+    let message = Message::parse(hash);
 
     // Signature value without recovery byte
     let mut s = [0u8; 64];

--- a/forest/src/cli/fetch_params_cmd.rs
+++ b/forest/src/cli/fetch_params_cmd.rs
@@ -24,7 +24,7 @@ impl FetchCommands {
         let sizes = if self.all {
             SectorSizeOpt::All
         } else if let Some(size) = &self.params_size {
-            let sector_size = ram_to_int(&size).unwrap();
+            let sector_size = ram_to_int(size).unwrap();
             SectorSizeOpt::Size(sector_size)
         } else if self.keys {
             SectorSizeOpt::Keys

--- a/forest/src/cli/wallet_cmd.rs
+++ b/forest/src/cli/wallet_cmd.rs
@@ -155,7 +155,7 @@ impl WalletCommands {
                 let key_str = str::from_utf8(&decoded_key).unwrap();
 
                 let key_result: Result<KeyInfoJson, serde_json::error::Error> =
-                    serde_json::from_str(&key_str);
+                    serde_json::from_str(key_str);
 
                 if key_result.is_err() {
                     cli_error_and_die(&format!("{} is not a valid key to import", key), 1);

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -34,7 +34,7 @@ impl<V> Deref for ValueMut<'_, V> {
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
-        &self.value
+        self.value
     }
 }
 

--- a/ipld/cid/src/lib.rs
+++ b/ipld/cid/src/lib.rs
@@ -81,7 +81,7 @@ impl Cid {
 
     /// Returns the cid multihash.
     pub fn hash(&self) -> &Multihash {
-        &self.0.hash()
+        self.0.hash()
     }
 
     /// Reads the bytes from a byte stream.

--- a/ipld/src/json.rs
+++ b/ipld/src/json.rs
@@ -28,7 +28,7 @@ where
         Ipld::Bool(bool) => serializer.serialize_bool(*bool),
         Ipld::Integer(i128) => serializer.serialize_i128(*i128),
         Ipld::Float(f64) => serializer.serialize_f64(*f64),
-        Ipld::String(string) => serializer.serialize_str(&string),
+        Ipld::String(string) => serializer.serialize_str(string),
         Ipld::Bytes(bytes) => serialize(
             &ipld!({ "/": { BYTES_JSON_KEY: multibase::encode(Base::Base64, bytes) } }),
             serializer,

--- a/ipld/src/ser.rs
+++ b/ipld/src/ser.rs
@@ -25,8 +25,8 @@ impl serde::Serialize for Ipld {
     {
         match self {
             Ipld::Integer(v) => serializer.serialize_i128(*v),
-            Ipld::Bytes(v) => serializer.serialize_bytes(&v),
-            Ipld::String(v) => serializer.serialize_str(&v),
+            Ipld::Bytes(v) => serializer.serialize_bytes(v),
+            Ipld::String(v) => serializer.serialize_str(v),
             Ipld::List(v) => v.serialize(serializer),
             Ipld::Map(v) => v.serialize(serializer),
             Ipld::Link(cid) => cid.serialize(serializer),

--- a/key_management/src/keystore.rs
+++ b/key_management/src/keystore.rs
@@ -459,7 +459,7 @@ impl EncryptedKeyStore {
         let nonce = secretbox::Nonce::from_slice(&msg[msg.len() - 24..])
             .ok_or(EncryptedKeyStoreError::DecryptionError)?;
 
-        let plaintext = secretbox::open(&ciphertext, &nonce, &encryption_key)
+        let plaintext = secretbox::open(ciphertext, &nonce, &encryption_key)
             .map_err(|_| EncryptedKeyStoreError::DecryptionError)?;
 
         Ok(plaintext)

--- a/key_management/src/wallet.rs
+++ b/key_management/src/wallet.rs
@@ -65,7 +65,7 @@ impl Wallet {
     /// If this key does not exist in the keys hashmap, check if this key is in
     /// the keystore, if it is, then add it to keys, otherwise return Error
     pub fn find_key(&mut self, addr: &Address) -> Result<Key, Error> {
-        if let Some(k) = self.keys.get(&addr) {
+        if let Some(k) = self.keys.get(addr) {
             return Ok(k.clone());
         }
         let key_string = format!("wallet-{}", addr.to_string());

--- a/key_management/src/wallet_helpers.rs
+++ b/key_management/src/wallet_helpers.rs
@@ -12,7 +12,7 @@ use secp256k1::{Message as SecpMessage, PublicKey as SecpPublic, SecretKey as Se
 /// Return the public key for a given private_key and SignatureType
 pub fn to_public(sig_type: SignatureType, private_key: &[u8]) -> Result<Vec<u8>, Error> {
     match sig_type {
-        SignatureType::BLS => Ok(BlsPrivate::from_bytes(&private_key)
+        SignatureType::BLS => Ok(BlsPrivate::from_bytes(private_key)
             .map_err(|err| Error::Other(err.to_string()))?
             .public_key()
             .as_bytes()),

--- a/node/forest_libp2p/src/chain_exchange/message.rs
+++ b/node/forest_libp2p/src/chain_exchange/message.rs
@@ -231,8 +231,8 @@ fn fts_from_bundle_parts(
                     i, message_count, BLOCK_MESSAGE_LIMIT
                 ));
             }
-            let bls_messages = values_from_indexes(&bls_msg_includes[i], &bls_msgs)?;
-            let secp_messages = values_from_indexes(&secp_msg_includes[i], &secp_msgs)?;
+            let bls_messages = values_from_indexes(&bls_msg_includes[i], bls_msgs)?;
+            let secp_messages = values_from_indexes(&secp_msg_includes[i], secp_msgs)?;
 
             Ok(Block {
                 header,

--- a/node/forest_libp2p/src/discovery.rs
+++ b/node/forest_libp2p/src/discovery.rs
@@ -130,7 +130,7 @@ impl<'a> DiscoveryConfig<'a> {
         let kademlia_opt = if enable_kademlia {
             let mut kademlia = Kademlia::with_config(local_peer_id, store, kad_config);
             for (peer_id, addr) in user_defined.iter() {
-                kademlia.add_address(&peer_id, addr.clone());
+                kademlia.add_address(peer_id, addr.clone());
                 peers.insert(*peer_id);
             }
             if let Err(e) = kademlia.bootstrap() {

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -430,7 +430,7 @@ pub fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
 
 /// Fetch keypair from disk, returning none if it cannot be decoded.
 pub fn get_keypair(path: &Path) -> Option<Keypair> {
-    match read_file_to_vec(&path) {
+    match read_file_to_vec(path) {
         Err(e) => {
             info!("Networking keystore not found!");
             trace!("Error {:?}", e);

--- a/node/rpc/src/auth_api.rs
+++ b/node/rpc/src/auth_api.rs
@@ -37,6 +37,6 @@ where
     let (header_raw,) = params;
     let token = header_raw.trim_start_matches("Bearer ");
     let ki = ks.get(JWT_IDENTIFIER)?;
-    let perms = verify_token(&token, ki.private_key())?;
+    let perms = verify_token(token, ki.private_key())?;
     Ok(perms)
 }

--- a/node/rpc/src/chain_api.rs
+++ b/node/rpc/src/chain_api.rs
@@ -101,7 +101,7 @@ where
         .ok_or("can't find block with that cid")?;
     let blk_msgs = blk.messages();
     let (unsigned_cids, signed_cids) =
-        chain::read_msg_cids(data.state_manager.blockstore(), &blk_msgs)?;
+        chain::read_msg_cids(data.state_manager.blockstore(), blk_msgs)?;
     let (bls_msg, secp_msg) = chain::block_messages_from_cids(
         data.state_manager.blockstore(),
         &unsigned_cids,

--- a/node/rpc/src/gas_api.rs
+++ b/node/rpc/src/gas_api.rs
@@ -269,15 +269,15 @@ where
 {
     let mut msg = msg;
     if msg.gas_limit() == 0 {
-        let gl = estimate_gas_limit::<DB, B, V>(&data, msg.clone(), tsk.clone()).await?;
+        let gl = estimate_gas_limit::<DB, B, V>(data, msg.clone(), tsk.clone()).await?;
         msg.gas_limit = gl;
     }
     if msg.gas_premium().is_zero() {
-        let gp = estimate_gas_premium(&data, 10).await?;
+        let gp = estimate_gas_premium(data, 10).await?;
         msg.gas_premium = gp;
     }
     if msg.gas_fee_cap().is_zero() {
-        let gfp = estimate_fee_cap(&data, msg.clone(), 20, tsk).await?;
+        let gfp = estimate_fee_cap(data, msg.clone(), 20, tsk).await?;
         msg.gas_fee_cap = gfp;
     }
     // TODO: Cap Gas Fee https://github.com/ChainSafe/forest/issues/901

--- a/node/rpc/src/state_api.rs
+++ b/node/rpc/src/state_api.rs
@@ -207,7 +207,7 @@ pub(crate) async fn state_miner_proving_deadline<
         .await?;
 
     let actor = state_manager
-        .get_actor(&addr, &tipset.parent_state())?
+        .get_actor(&addr, tipset.parent_state())?
         .ok_or_else(|| format!("Address {} not found", addr))?;
 
     let mas = miner::State::load(state_manager.blockstore(), &actor)?;
@@ -401,7 +401,7 @@ pub(crate) async fn state_get_actor<
         .chain_store()
         .tipset_from_keys(&key.into())
         .await?;
-    let state = state_for_ts::<DB, V>(&state_manager, tipset).await?;
+    let state = state_for_ts::<DB, V>(state_manager, tipset).await?;
     Ok(state.get_actor(&actor)?.map(ActorStateJson::from))
 }
 
@@ -422,7 +422,7 @@ pub(crate) async fn state_account_key<
         .chain_store()
         .tipset_from_keys(&key.into())
         .await?;
-    let state = state_for_ts::<DB, V>(&state_manager, tipset).await?;
+    let state = state_for_ts::<DB, V>(state_manager, tipset).await?;
     let address = interpreter::resolve_to_key_addr(&state, state_manager.blockstore(), &actor)?;
     Ok(Some(address.into()))
 }
@@ -443,7 +443,7 @@ pub(crate) async fn state_lookup_id<
         .chain_store()
         .tipset_from_keys(&key.into())
         .await?;
-    let state = state_for_ts::<DB, V>(&state_manager, tipset).await?;
+    let state = state_for_ts::<DB, V>(state_manager, tipset).await?;
     state.lookup_id(&address).map_err(|e| e.into())
 }
 
@@ -635,8 +635,8 @@ pub(crate) async fn miner_create_block<
             .as_bytes(),
         ))
     };
-    let pweight = chain::weight(data.chain_store.blockstore(), &pts.as_ref())?;
-    let base_fee = chain::compute_base_fee(data.chain_store.blockstore(), &pts.as_ref())?;
+    let pweight = chain::weight(data.chain_store.blockstore(), pts.as_ref())?;
+    let base_fee = chain::compute_base_fee(data.chain_store.blockstore(), pts.as_ref())?;
 
     let mut next = BlockHeader::builder()
         .messages(mmcid)

--- a/node/rpc/src/wallet_api.rs
+++ b/node/rpc/src/wallet_api.rs
@@ -40,7 +40,7 @@ where
         .ok_or("No heaviest tipset")?;
     let cid = heaviest_ts.parent_state();
 
-    let state = StateTree::new_from_root(data.state_manager.blockstore(), &cid)?;
+    let state = StateTree::new_from_root(data.state_manager.blockstore(), cid)?;
     match state.get_actor(&address) {
         Ok(act) => {
             if let Some(actor) = act {

--- a/types/src/verifier/mod.rs
+++ b/types/src/verifier/mod.rs
@@ -132,7 +132,7 @@ pub trait ProofVerifier {
         randomness[31] &= 0x3f;
 
         // Convert sector info into public replica
-        let replicas = to_fil_public_replica_infos(&challenge_sectors, ProofType::Winning)?;
+        let replicas = to_fil_public_replica_infos(challenge_sectors, ProofType::Winning)?;
 
         // Convert PoSt proofs into proofs-api format
         let proof_bytes = proofs.iter().fold(Vec::new(), |mut proof, p| {
@@ -164,7 +164,7 @@ pub trait ProofVerifier {
         randomness[31] &= 0x3f;
 
         // Convert sector info into public replica
-        let replicas = to_fil_public_replica_infos(&challenge_sectors, ProofType::Window)?;
+        let replicas = to_fil_public_replica_infos(challenge_sectors, ProofType::Window)?;
 
         // Convert PoSt proofs into proofs-api format
         let proofs: Vec<(proofs::RegisteredPoStProof, _)> = proofs

--- a/utils/bitfield/src/unvalidated.rs
+++ b/utils/bitfield/src/unvalidated.rs
@@ -40,7 +40,7 @@ impl UnvalidatedBitField {
     /// reference to the decoded bit field.
     pub fn validate_mut(&mut self) -> Result<&mut BitField> {
         if let Self::Unvalidated(bytes) = self {
-            *self = Self::Validated(BitField::from_bytes(&bytes)?);
+            *self = Self::Validated(BitField::from_bytes(bytes)?);
         }
 
         match self {

--- a/utils/statediff/src/lib.rs
+++ b/utils/statediff/src/lib.rs
@@ -131,8 +131,8 @@ where
             "Could not resolve actor states: {}\nUsing default resolution:",
             e
         );
-        let expected = resolve_cids_recursive(bs, &expected_root, depth)?;
-        let actual = resolve_cids_recursive(bs, &root, depth)?;
+        let expected = resolve_cids_recursive(bs, expected_root, depth)?;
+        let actual = resolve_cids_recursive(bs, root, depth)?;
 
         let expected_json = serde_json::to_string_pretty(&IpldJsonRef(&expected))?;
         let actual_json = serde_json::to_string_pretty(&IpldJsonRef(&actual))?;

--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -264,7 +264,7 @@ impl Actor {
                 })?;
 
             for deal in &mut params.deals {
-                validate_deal(rt, &deal, &network_raw_power, &baseline_power)?;
+                validate_deal(rt, deal, &network_raw_power, &baseline_power)?;
 
                 if deal.proposal.provider != provider && deal.proposal.provider != provider_raw {
                     return Err(actor_error!(
@@ -440,7 +440,7 @@ impl Actor {
         // Update deal states
         rt.transaction(|st: &mut State, rt| {
             validate_deals_for_activation(
-                &st,
+                st,
                 rt.store(),
                 &params.deal_ids,
                 &miner_addr,
@@ -1074,11 +1074,11 @@ where
             .get(*deal_id as usize)?
             .ok_or_else(|| actor_error!(ErrNotFound, "no such deal {}", deal_id))?;
 
-        validate_deal_can_activate(&proposal, miner_addr, sector_expiry, sector_activation)
+        validate_deal_can_activate(proposal, miner_addr, sector_expiry, sector_activation)
             .map_err(|e| e.wrap(&format!("cannot activate deal {}", deal_id)))?;
 
         total_deal_space += proposal.piece_size.0;
-        let deal_space_time = deal_weight(&proposal);
+        let deal_space_time = deal_weight(proposal);
         if proposal.verified_deal {
             total_verified_space_time += deal_space_time;
         } else {

--- a/vm/actor/src/builtin/market/state.rs
+++ b/vm/actor/src/builtin/market/state.rs
@@ -403,7 +403,7 @@ where
 
         if ever_slashed {
             // unlock client collateral and locked storage fee
-            let payment_remaining = deal_get_payment_remaining(&deal, state.slash_epoch)?;
+            let payment_remaining = deal_get_payment_remaining(deal, state.slash_epoch)?;
 
             // Unlock remaining storage fee
             self.unlock_balance(&deal.client, &payment_remaining, Reason::ClientStorageFee)
@@ -436,7 +436,7 @@ where
         }
 
         if epoch >= deal.end_epoch {
-            self.process_deal_expired(&deal, state)?;
+            self.process_deal_expired(deal, state)?;
             return Ok((TokenAmount::zero(), EPOCH_UNDEFINED, true));
         }
 
@@ -664,17 +664,17 @@ where
         self.escrow_table
             .as_mut()
             .unwrap()
-            .must_subtract(from_addr, &amount)
+            .must_subtract(from_addr, amount)
             .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "subtract from escrow"))?;
 
-        self.unlock_balance(from_addr, &amount, Reason::ClientStorageFee)
+        self.unlock_balance(from_addr, amount, Reason::ClientStorageFee)
             .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "subtract from locked"))?;
 
         // Add subtracted amount to the recipient
         self.escrow_table
             .as_mut()
             .unwrap()
-            .add(to_addr, &amount)
+            .add(to_addr, amount)
             .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "add to escrow"))?;
 
         Ok(())
@@ -698,7 +698,7 @@ where
         self.escrow_table
             .as_mut()
             .unwrap()
-            .must_subtract(addr, &amount)?;
+            .must_subtract(addr, amount)?;
         self.unlock_balance(addr, amount, lock_reason)
     }
 }

--- a/vm/actor/src/builtin/miner/expiration_queue.rs
+++ b/vm/actor/src/builtin/miner/expiration_queue.rs
@@ -909,7 +909,7 @@ fn group_new_sectors_by_declared_expiration<'a>(
 
             for sector in epoch_sectors {
                 sector_numbers.push(sector.sector_number);
-                total_power += &power_for_sector(sector_size, &sector);
+                total_power += &power_for_sector(sector_size, sector);
                 total_pledge += &sector.initial_pledge;
             }
 

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -282,7 +282,7 @@ impl Actor {
         RT: Runtime<BS>,
     {
         rt.transaction(|state: &mut State, rt| {
-            let mut info = get_miner_info(rt.store(), &state)?;
+            let mut info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(std::iter::once(&info.owner))?;
 
@@ -313,7 +313,7 @@ impl Actor {
         }
 
         rt.transaction(|state: &mut State, rt| {
-            let mut info = get_miner_info(rt.store(), &state)?;
+            let mut info = get_miner_info(rt.store(), state)?;
 
             if rt.message().caller() == &info.owner || info.pending_owner_address.is_none() {
                 rt.validate_immediate_caller_is(std::iter::once(&info.owner))?;
@@ -1265,7 +1265,7 @@ impl Actor {
                 .map_err(|_e|
                     actor_error!(
                         ErrIllegalArgument,
-                        "failed to lookup Window PoSt proof type for sector seal proof {}", 
+                        "failed to lookup Window PoSt proof type for sector seal proof {}",
                         i64::from(precommit.seal_proof)
                     ))?;
                 if sector_wpost_proof != info.window_post_proof_type {
@@ -1281,7 +1281,7 @@ impl Actor {
                     return Err(actor_error!(ErrIllegalArgument, "deals too large to fit in sector {} > {}", deal_weight.deal_space, info.sector_size));
                 }
                 if precommit.replace_capacity {
-                    validate_replace_sector(state, store, &precommit)?
+                    validate_replace_sector(state, store, precommit)?
                 }
                 // Estimate the sector weight using the current epoch as an estimate for activation,
             	// and compute the pre-commit deposit using that weight.
@@ -2028,7 +2028,7 @@ impl Actor {
             })?;
 
         let power_delta = rt.transaction(|state: &mut State, rt| {
-            let info = get_miner_info(rt.store(), &state)?;
+            let info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
                 info.control_addresses
@@ -2177,7 +2177,7 @@ impl Actor {
             // and repay fee debt now.
             let fee_to_burn = repay_debts_or_abort(rt, state)?;
 
-            let info = get_miner_info(rt.store(), &state)?;
+            let info = get_miner_info(rt.store(), state)?;
 
             rt.validate_immediate_caller_is(
                 info.control_addresses
@@ -2629,7 +2629,7 @@ impl Actor {
         let mut pledge_delta = TokenAmount::from(0);
 
         let (burn_amount, reward_amount) = rt.transaction(|st: &mut State, rt| {
-            let mut info = get_miner_info(rt.store(), &st)?;
+            let mut info = get_miner_info(rt.store(), st)?;
 
             // Verify miner hasn't already been faulted
             if fault.epoch < info.consensus_fault_elapsed {
@@ -3020,7 +3020,7 @@ where
         pledge_delta_total -= newly_vested;
 
         // Process pending worker change if any
-        let mut info = get_miner_info(rt.store(), &state)?;
+        let mut info = get_miner_info(rt.store(), state)?;
         process_pending_worker(&mut info, rt, state)?;
 
         let deposit_to_burn = state
@@ -3513,7 +3513,7 @@ where
             *STORAGE_MARKET_ACTOR_ADDR,
             MarketMethod::ComputeDataCommitment as u64,
             Serialized::serialize(ComputeDataCommitmentParamsRef {
-                inputs: &data_commitment_inputs,
+                inputs: data_commitment_inputs,
             })?,
             TokenAmount::zero(),
         )?
@@ -3879,7 +3879,7 @@ where
     info.pending_worker_key = None;
 
     state
-        .save_info(rt.store(), &info)
+        .save_info(rt.store(), info)
         .map_err(|e| e.downcast_default(ExitCode::ErrIllegalState, "failed to save miner info"))
 }
 

--- a/vm/actor/src/builtin/miner/partition_state.rs
+++ b/vm/actor/src/builtin/miner/partition_state.rs
@@ -217,7 +217,7 @@ impl Partition {
         sector_size: SectorSize,
         quant: QuantSpec,
     ) -> Result<(BitField, PowerPair, PowerPair), Box<dyn StdError>> {
-        validate_partition_contains_sectors(&self, sector_numbers)
+        validate_partition_contains_sectors(self, sector_numbers)
             .map_err(|e| actor_error!(ErrIllegalArgument; "failed fault declaration: {}", e))?;
 
         let sector_numbers = sector_numbers
@@ -744,7 +744,7 @@ impl Partition {
         }
 
         // Check that the declared sectors are actually in the partition.
-        if !self.sectors.contains_all(&skipped) {
+        if !self.sectors.contains_all(skipped) {
             return Err(actor_error!(
                 ErrIllegalArgument,
                 "skipped faults contains sectors outside partition"

--- a/vm/actor/src/builtin/miner/state.rs
+++ b/vm/actor/src/builtin/miner/state.rs
@@ -429,7 +429,7 @@ impl State {
         F: FnMut(&SectorOnChainInfo) -> Result<(), Box<dyn StdError>>,
     {
         let sectors = Sectors::load(store, &self.sectors)?;
-        sectors.amt.for_each(|_, v| f(&v))
+        sectors.amt.for_each(|_, v| f(v))
     }
 
     /// Returns the deadline and partition index for a sector number.

--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -654,7 +654,7 @@ where
         })?;
 
     if check_hash {
-        let calculated_hash = compute_proposal_hash(&txn, rt).map_err(|e| {
+        let calculated_hash = compute_proposal_hash(txn, rt).map_err(|e| {
             e.downcast_default(
                 ExitCode::ErrIllegalState,
                 format!("failed to compute proposal hash for (tx: {:?})", txn_id),

--- a/vm/actor/src/builtin/paych/mod.rs
+++ b/vm/actor/src/builtin/paych/mod.rs
@@ -136,7 +136,7 @@ impl Actor {
             .map_err(|e| ActorError::from(e).wrap("failed to serialized SignedVoucher"))?;
 
         // Validate signature
-        rt.verify_signature(&sig, &signer, &sv_bz).map_err(|e| {
+        rt.verify_signature(sig, &signer, &sv_bz).map_err(|e| {
             e.downcast_default(ExitCode::ErrIllegalArgument, "voucher signature invalid")
         })?;
 

--- a/vm/actor/src/builtin/power/state.rs
+++ b/vm/actor/src/builtin/power/state.rs
@@ -305,7 +305,7 @@ impl State {
         miner: &Address,
     ) -> Result<(), Box<dyn StdError>> {
         let (rbp, qap) =
-            match get_claim(&claims, &miner).map_err(|e| e.downcast_wrap("failed to get claim"))? {
+            match get_claim(claims, miner).map_err(|e| e.downcast_wrap("failed to get claim"))? {
                 None => {
                     return Ok(());
                 }
@@ -316,7 +316,7 @@ impl State {
             };
 
         // Subtract from stats to remove power
-        self.add_to_claim(claims, &miner, &rbp.neg(), &qap.neg())
+        self.add_to_claim(claims, miner, &rbp.neg(), &qap.neg())
             .map_err(|e| e.downcast_wrap("failed to subtract miner power before deleting claim"))?;
 
         claims

--- a/vm/actor/src/builtin/reward/logic.rs
+++ b/vm/actor/src/builtin/reward/logic.rs
@@ -57,7 +57,7 @@ pub(crate) fn compute_r_theta(
     if effective_network_time != 0 {
         let reward_theta = BigInt::from(effective_network_time) << PRECISION;
         let diff = ((cumsum_baseline - cumsum_realized) << PRECISION)
-            .div_floor(&baseline_power_at_effective_network_time);
+            .div_floor(baseline_power_at_effective_network_time);
 
         reward_theta - diff
     } else {

--- a/vm/actor/src/util/balance_table.rs
+++ b/vm/actor/src/util/balance_table.rs
@@ -49,7 +49,7 @@ where
 
     /// Adds token amount to previously initialized account.
     pub fn add(&mut self, key: &Address, value: &TokenAmount) -> Result<(), Box<dyn StdError>> {
-        let prev = self.get(&key)?;
+        let prev = self.get(key)?;
         let sum = &prev + value;
         if sum.is_negative() {
             Err(format!("New balance in table cannot be negative: {}", sum).into())

--- a/vm/actor/src/util/multimap.rs
+++ b/vm/actor/src/util/multimap.rs
@@ -70,7 +70,7 @@ where
         V: DeserializeOwned + Serialize,
     {
         match self.0.get(key)? {
-            Some(cid) => Ok(Some(Amt::load(&cid, self.0.store())?)),
+            Some(cid) => Ok(Some(Amt::load(cid, self.0.store())?)),
             None => Ok(None),
         }
     }
@@ -106,7 +106,7 @@ where
         F: FnMut(&BytesKey, &Amt<V, BS>) -> Result<(), Box<dyn StdError>>,
     {
         self.0.for_each::<_>(|key, arr_root| {
-            let arr = Amt::load(&arr_root, self.0.store())?;
+            let arr = Amt::load(arr_root, self.0.store())?;
             f(key, &arr)
         })?;
 

--- a/vm/actor/src/util/set_multimap.rs
+++ b/vm/actor/src/util/set_multimap.rs
@@ -74,7 +74,7 @@ where
     #[inline]
     pub fn get(&self, key: ChainEpoch) -> Result<Option<Set<'a, BS>>, Box<dyn StdError>> {
         match self.0.get(&u64_key(key as u64))? {
-            Some(cid) => Ok(Some(Set::from_root(self.0.store(), &cid)?)),
+            Some(cid) => Ok(Some(Set::from_root(self.0.store(), cid)?)),
             None => Ok(None),
         }
     }
@@ -117,7 +117,7 @@ where
         };
 
         set.for_each(|k| {
-            let v = parse_uint_key(&k)
+            let v = parse_uint_key(k)
                 .map_err(|e| format!("Could not parse key: {:?}, ({})", &k.0, e))?;
 
             // Run function on all parsed keys

--- a/vm/actor/src/util/smooth/smooth_func.rs
+++ b/vm/actor/src/util/smooth/smooth_func.rs
@@ -73,7 +73,7 @@ pub fn extrapolated_cum_sum_of_ratio(
     let mut x1m: BigInt = velo_1 * (t0 + half_delta);
     x1m = (x1m >> PRECISION) + pos_1;
 
-    (x1m * delta_t).div_floor(&pos_2)
+    (x1m * delta_t).div_floor(pos_2)
 }
 
 /// The natural log of Q.128 x.

--- a/vm/actor_interface/src/builtin/market/mod.rs
+++ b/vm/actor_interface/src/builtin/market/mod.rs
@@ -204,7 +204,7 @@ impl State {
     {
         match self {
             State::V0(st) => actorv0::market::validate_deals_for_activation(
-                &st,
+                st,
                 store,
                 deal_ids,
                 miner_addr,
@@ -212,7 +212,7 @@ impl State {
                 curr_epoch,
             ),
             State::V2(st) => actorv2::market::validate_deals_for_activation(
-                &st,
+                st,
                 store,
                 deal_ids,
                 miner_addr,
@@ -221,7 +221,7 @@ impl State {
             )
             .map(|(deal_st, verified_st, _)| (deal_st, verified_st)),
             State::V3(st) => actorv3::market::validate_deals_for_activation(
-                &st,
+                st,
                 store,
                 deal_ids,
                 miner_addr,
@@ -230,7 +230,7 @@ impl State {
             )
             .map(|(deal_st, verified_st, _)| (deal_st, verified_st)),
             State::V4(st) => actorv4::market::validate_deals_for_activation(
-                &st,
+                st,
                 store,
                 deal_ids,
                 miner_addr,
@@ -239,7 +239,7 @@ impl State {
             )
             .map(|(deal_st, verified_st, _)| (deal_st, verified_st)),
             State::V5(st) => actorv5::market::validate_deals_for_activation(
-                &st,
+                st,
                 store,
                 deal_ids,
                 miner_addr,

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -145,7 +145,7 @@ where
         };
 
         let caller_id = state
-            .lookup_id(&message.from())
+            .lookup_id(message.from())
             .map_err(|e| e.downcast_fatal("failed to lookup id"))?
             .ok_or_else(|| {
                 actor_error!(SysErrInvalidReceiver, "resolve msg from address failed")
@@ -155,7 +155,7 @@ where
             *message.to()
         } else {
             state
-                .lookup_id(&message.to())
+                .lookup_id(message.to())
                 .map_err(|e| e.downcast_fatal("failed to lookup id"))?
                 // * Go implementation changes this to undef address. To avoid using optional
                 // * value here, the non-id address is kept here (should never be used)
@@ -217,7 +217,7 @@ where
     fn get_balance(&self, addr: &Address) -> Result<BigInt, ActorError> {
         Ok(self
             .state
-            .get_actor(&addr)
+            .get_actor(addr)
             .map_err(|e| e.downcast_fatal("failed to get actor in get balance"))?
             .map(|act| act.balance)
             .unwrap_or_default())
@@ -412,7 +412,7 @@ where
         )?;
 
         if !msg.value().is_zero() {
-            transfer(self.state, &msg.from(), &msg.to(), &msg.value())
+            transfer(self.state, msg.from(), msg.to(), msg.value())
                 .map_err(|e| e.wrap("failed to transfer funds"))?;
         }
 
@@ -533,7 +533,7 @@ where
 
         let worker = ms.info(&self.store)?.worker;
 
-        resolve_to_key_addr(&self.state, &self.store, &worker)
+        resolve_to_key_addr(self.state, &self.store, &worker)
     }
 }
 
@@ -598,14 +598,14 @@ where
 
     fn resolve_address(&self, address: &Address) -> Result<Option<Address>, ActorError> {
         self.state
-            .lookup_id(&address)
+            .lookup_id(address)
             .map_err(|e| e.downcast_fatal("failed to look up id"))
     }
 
     fn get_actor_code_cid(&self, addr: &Address) -> Result<Option<Cid>, ActorError> {
         Ok(self
             .state
-            .get_actor(&addr)
+            .get_actor(addr)
             .map_err(|e| e.downcast_fatal("failed to get actor"))?
             .map(|act| act.code))
     }
@@ -784,7 +784,7 @@ where
         self.charge_gas(self.price_list.on_create_actor())?;
         self.state
             .set_actor(
-                &address,
+                address,
                 ActorState::new(code_id, *EMPTY_ARR_CID, 0.into(), 0),
             )
             .map_err(|e| e.downcast_fatal("creating actor entry"))
@@ -805,7 +805,7 @@ where
             .map(|act| act.balance)?;
         if balance != 0.into() {
             if self.version >= NetworkVersion::V7 {
-                let beneficiary_id = self.resolve_address(&beneficiary)?.ok_or_else(|| {
+                let beneficiary_id = self.resolve_address(beneficiary)?.ok_or_else(|| {
                     actor_error!(SysErrIllegalArgument, "beneficiary doesn't exist")
                 })?;
 
@@ -1048,7 +1048,7 @@ where
     ) -> Result<(), Box<dyn StdError>> {
         self.gas_tracker
             .borrow_mut()
-            .charge_gas(self.price_list.on_verify_aggregate_seals(&aggregate))?;
+            .charge_gas(self.price_list.on_verify_aggregate_seals(aggregate))?;
         V::verify_aggregate_seals(aggregate)
     }
 }
@@ -1099,11 +1099,11 @@ fn transfer<BS: BlockStore>(
             ))
         })?;
 
-    f.deduct_funds(&value).map_err(|e| {
+    f.deduct_funds(value).map_err(|e| {
         actor_error!(SysErrInsufficientFunds;
         "transfer failed when deducting funds ({}): {}", value, e)
     })?;
-    t.deposit_funds(&value);
+    t.deposit_funds(value);
 
     state
         .set_actor(from, f)
@@ -1131,7 +1131,7 @@ where
     }
 
     let act = st
-        .get_actor(&addr)
+        .get_actor(addr)
         .map_err(|e| e.downcast_wrap("Failed to get actor"))?
         .ok_or_else(|| format!("Failed to retrieve actor: {}", addr))?;
 

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -519,7 +519,7 @@ where
 
             self.state
                 .mutate_actor(addr, |act| {
-                    act.deposit_funds(&amt);
+                    act.deposit_funds(amt);
                     Ok(())
                 })
                 .map_err(|e| e.to_string())?;
@@ -570,7 +570,7 @@ where
             self.store,
             0,
             self.base_fee.clone(),
-            &msg,
+            msg,
             self.epoch,
             *msg.from(),
             msg.sequence(),

--- a/vm/message/src/chain_message.rs
+++ b/vm/message/src/chain_message.rs
@@ -21,8 +21,8 @@ pub enum ChainMessage {
 impl ChainMessage {
     pub fn message(&self) -> &UnsignedMessage {
         match self {
-            Self::Unsigned(m) => &m,
-            Self::Signed(sm) => &sm.message(),
+            Self::Unsigned(m) => m,
+            Self::Signed(sm) => sm.message(),
         }
     }
 }

--- a/vm/message/src/signed_message.rs
+++ b/vm/message/src/signed_message.rs
@@ -98,10 +98,10 @@ impl Message for SignedMessage {
         self.message.required_funds()
     }
     fn gas_fee_cap(&self) -> &TokenAmount {
-        &self.message.gas_fee_cap()
+        self.message.gas_fee_cap()
     }
     fn gas_premium(&self) -> &TokenAmount {
-        &self.message.gas_premium()
+        self.message.gas_premium()
     }
 
     fn set_gas_fee_cap(&mut self, cap: TokenAmount) {


### PR DESCRIPTION
This fixes Clippy warnings for the latest Rust stable (1.55), where the compiler immediately dereferences borrowed references.

See: https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

After #1228 is merged.