### PR TITLE
fix stable clippy::needless_collect

### DIFF
--- a/blockchain/message_pool/src/msgpool/msg_pool.rs
+++ b/blockchain/message_pool/src/msgpool/msg_pool.rs
@@ -588,9 +588,7 @@ where
     /// Loads local messages to the message pool to be applied.
     pub async fn load_local(&mut self) -> Result<(), Error> {
         let mut local_msgs = self.local_msgs.write().await;
-        let msg_vec: Vec<SignedMessage> = local_msgs.iter().cloned().collect();
-
-        for k in msg_vec.into_iter() {
+        for k in local_msgs.iter().cloned().collect::<Vec<SignedMessage>>() {
             self.add(k.clone()).await.unwrap_or_else(|err| {
                 if err == Error::SequenceTooLow {
                     warn!("error adding message: {:?}", err);


### PR DESCRIPTION
This fixes Clippy warnings for the latest Rust stable (1.55), where functions collect an iterator when `collect()` is unnecessary.

See: https://rust-lang.github.io/rust-clippy/master/index.html#needless_collect

After #1228 is merged.

**However,** this specific fix might not be optimal, and we should just consider to ignore Clippy here. Ref https://github.com/rust-lang/rust-clippy/issues/6164 and https://github.com/rust-lang/rust-clippy/issues/6909; especially in this instance, as we are collecting the iterator straight into a loop.