### PR TITLE
fix stable clippy::upper_case_acronyms

### DIFF
--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -41,9 +41,9 @@ use utils::{read_file_to_string, read_toml};
     about = "Filecoin implementation in Rust. This command will start the daemon process",
     author = "ChainSafe Systems <info@chainsafe.io>"
 )]
-pub struct CLI {
+pub struct Cli {
     #[structopt(flatten)]
-    pub opts: CLIOpts,
+    pub opts: CliOpts,
     #[structopt(subcommand)]
     pub cmd: Option<Subcommand>,
 }
@@ -78,7 +78,7 @@ pub enum Subcommand {
 
 /// CLI options
 #[derive(StructOpt, Debug)]
-pub struct CLIOpts {
+pub struct CliOpts {
     #[structopt(short, long, help = "A toml file containing relevant configurations")]
     pub config: Option<String>,
     #[structopt(short, long, help = "The genesis CAR file")]
@@ -128,7 +128,7 @@ pub struct CLIOpts {
     pub encrypt_keystore: Option<bool>,
 }
 
-impl CLIOpts {
+impl CliOpts {
     pub fn to_config(&self) -> Result<Config, io::Error> {
         let mut cfg: Config = match &self.config {
             Some(config_file) => {

--- a/forest/src/main.rs
+++ b/forest/src/main.rs
@@ -6,14 +6,14 @@ mod daemon;
 mod logger;
 mod subcommand;
 
-use cli::{cli_error_and_die, CLI};
+use cli::{cli_error_and_die, Cli};
 use structopt::StructOpt;
 
 #[async_std::main]
 async fn main() {
     logger::setup_logger();
-    // Capture CLI inputs
-    let CLI { opts, cmd } = CLI::from_args();
+    // Capture Cli inputs
+    let Cli { opts, cmd } = Cli::from_args();
 
     // Run forest as a daemon if no other subcommands are used. Otherwise, run the subcommand.
     match opts.to_config() {

--- a/node/rpc-client/src/lib.rs
+++ b/node/rpc-client/src/lib.rs
@@ -76,17 +76,17 @@ pub enum JsonRpcResponse<R> {
     },
 }
 
-struct URL {
+struct Url {
     protocol: String,
     port: String,
     host: String,
 }
 
-/// Parses a multiaddress into a URL
+/// Parses a multiaddress into a Url
 fn multiaddress_to_url(multiaddr: Multiaddr) -> String {
-    // Fold Multiaddress into a URL struct
+    // Fold Multiaddress into a Url struct
     let addr = multiaddr.into_iter().fold(
-        URL {
+        Url {
             protocol: DEFAULT_PROTOCOL.to_owned(),
             port: DEFAULT_PORT.to_owned(),
             host: DEFAULT_HOST.to_owned(),


### PR DESCRIPTION
Fix Clippy stable for situations, where two acronyms could become contiguous.

See: https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

After #1228 is merged.

I know you had this in place for a reason, but honestly, I don't think it really matters for `URL` vs. `Url` or `CLI` vs. `Cli`. I would slightly lean towards fixing the lint and renaming the acronyms to strict camel case.