### PR TITLE
acotrs v6: fip 0020, add withdrawn amount to WithdrawBalance return

### DIFF
--- a/vm/actor/src/builtin/market/mod.rs
+++ b/vm/actor/src/builtin/market/mod.rs
@@ -126,7 +126,7 @@ impl Actor {
     fn withdraw_balance<BS, RT>(
         rt: &mut RT,
         params: WithdrawBalanceParams,
-    ) -> Result<(), ActorError>
+    ) -> Result<WithdrawBalanceReturn, ActorError>
     where
         BS: BlockStore,
         RT: Runtime<BS>,
@@ -183,14 +183,14 @@ impl Actor {
 
             Ok(ex)
         })?;
-
+        let amount_withdrawn = amount_extracted.clone();
         rt.send(
             recipient,
             METHOD_SEND,
             Serialized::default(),
             amount_extracted,
         )?;
-        Ok(())
+        Ok(WithdrawBalanceReturn{amount_withdrawn: amount_withdrawn})
     }
 
     /// Publish a new set of storage deals (not yet included in a sector).

--- a/vm/actor/src/builtin/market/types.rs
+++ b/vm/actor/src/builtin/market/types.rs
@@ -23,6 +23,12 @@ pub struct WithdrawBalanceParams {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct WithdrawBalanceReturn {
+    #[serde(with = "bigint_ser")]
+    pub amount_withdrawn: TokenAmount,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct OnMinerSectorsTerminateParams {
     pub epoch: ChainEpoch,
     pub deal_ids: Vec<DealID>,

--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -2692,7 +2692,7 @@ impl Actor {
     fn withdraw_balance<BS, RT>(
         rt: &mut RT,
         params: WithdrawBalanceParams,
-    ) -> Result<(), ActorError>
+    ) -> Result<WithdrawBalanceReturn, ActorError>
     where
         BS: BlockStore,
         RT: Runtime<BS>,
@@ -2755,7 +2755,7 @@ impl Actor {
                 ))
             })?;
 
-        let amount_withdrawn = std::cmp::min(&available_balance, &params.amount_requested);
+        let amount_withdrawn = std::cmp::min(&available_balance, &params.amount_requested).clone();
         assert!(!amount_withdrawn.is_negative());
         if amount_withdrawn.is_negative() {
             return Err(actor_error!(
@@ -2764,7 +2764,7 @@ impl Actor {
                 amount_withdrawn
             ));
         }
-        if amount_withdrawn > &available_balance {
+        if amount_withdrawn > available_balance {
             return Err(actor_error!(
                 ErrIllegalState,
                 "amount to withdraw {} < available {}",
@@ -2793,7 +2793,7 @@ impl Actor {
                     format!("balance invariants broken: {}", e),
                 )
             })?;
-        Ok(())
+        Ok(WithdrawBalanceReturn{amount_withdrawn: amount_withdrawn})
     }
 
     fn repay_debt<BS, RT>(rt: &mut RT) -> Result<(), ActorError>

--- a/vm/actor/src/builtin/miner/types.rs
+++ b/vm/actor/src/builtin/miner/types.rs
@@ -197,6 +197,12 @@ pub struct WithdrawBalanceParams {
     pub amount_requested: TokenAmount,
 }
 
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct WithdrawBalanceReturn {
+    #[serde(with = "bigint_ser")]
+    pub amount_withdrawn: TokenAmount,
+}
+
 #[derive(Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct WorkerKeyChange {
     /// Must be an ID address


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Implement [FIP 0020](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0020.md) adding a return value to miner and market withdraw balance calls.
- [spec-actors PR ](https://github.com/filecoin-project/specs-actors/pull/1476)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->
While I hope this helps with getting forest ready for mainnet syncing post v14 I'm mostly filing this change to start getting familiar with rust actors code base. If it makes things easier for you to close this and do the change yourself please do.


<!-- Thank you 🔥 -->