### PR TITLE
Elmattic/actors review F1

### DIFF
--- a/vm/actor/src/builtin/multisig/mod.rs
+++ b/vm/actor/src/builtin/multisig/mod.rs
@@ -596,6 +596,9 @@ where
                 out = ser;
             }
             Err(e) => {
+                if e.is_recovered() {
+                    return Err(e);
+                }
                 code = e.exit_code();
             }
         }

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -356,10 +356,10 @@ where
         self.caller_validated = false;
         self.depth += 1;
         if self.depth > MAX_CALL_DEPTH && self.network_version() >= NetworkVersion::V6 {
-            return Err(actor_error!(
+            return Err(actor_error!(recovered(
                 SysErrForbidden,
                 "message execution exceeds call depth"
-            ));
+            )));
         }
 
         let caller = self.resolve_address(msg.from())?.ok_or_else(|| {
@@ -727,7 +727,7 @@ where
         value: TokenAmount,
     ) -> Result<Serialized, ActorError> {
         if !self.allow_internal {
-            return Err(actor_error!(SysErrIllegalActor; "runtime.send() is not allowed"));
+            return Err(actor_error!(recovered(SysErrIllegalActor, "runtime.send() is not allowed")));
         }
 
         let ret = self

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -727,7 +727,10 @@ where
         value: TokenAmount,
     ) -> Result<Serialized, ActorError> {
         if !self.allow_internal {
-            return Err(actor_error!(recovered(SysErrIllegalActor, "runtime.send() is not allowed")));
+            return Err(actor_error!(recovered(
+                SysErrIllegalActor,
+                "runtime.send() is not allowed"
+            )));
         }
 
         let ret = self

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -16,6 +16,8 @@ pub struct ActorError {
     exit_code: ExitCode,
     /// Message for debugging purposes,
     msg: String,
+    /// Is this a recovered error.
+    recovered: bool,
 }
 
 impl ActorError {
@@ -24,6 +26,7 @@ impl ActorError {
             fatal: false,
             exit_code,
             msg,
+            recovered: false,
         }
     }
 
@@ -32,12 +35,27 @@ impl ActorError {
             fatal: true,
             exit_code: ExitCode::ErrPlaceholder,
             msg,
+            recovered: false,
+        }
+    }
+
+    pub fn new_recovered(exit_code: ExitCode, msg: String) -> Self {
+        Self {
+            fatal: false,
+            exit_code,
+            msg,
+            recovered: true,
         }
     }
 
     /// Returns true if error is fatal.
     pub fn is_fatal(&self) -> bool {
         self.fatal
+    }
+
+    /// Returns true if error is recovered.
+    pub fn is_recovered(&self) -> bool {
+        self.recovered
     }
 
     /// Returns the exit code of the error.
@@ -68,6 +86,7 @@ impl From<EncodingError> for ActorError {
             fatal: false,
             exit_code: ExitCode::ErrSerialization,
             msg: e.to_string(),
+            recovered: false,
         }
     }
 }
@@ -78,6 +97,7 @@ impl From<CborError> for ActorError {
             fatal: false,
             exit_code: ExitCode::ErrSerialization,
             msg: e.to_string(),
+            recovered: false,
         }
     }
 }
@@ -89,6 +109,11 @@ macro_rules! actor_error {
     ( fatal($msg:expr) ) => { ActorError::new_fatal($msg.to_string()) };
     ( fatal($msg:literal $(, $ex:expr)+) ) => {
         ActorError::new_fatal(format!($msg, $($ex,)*))
+    };
+
+    // Recovered Errors
+    ( recovered($code:ident, $msg:expr ) ) => {
+        ActorError::new_recovered(ExitCode::$code, $msg.to_string())
     };
 
     // Error with only one stringable expression


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Add a new way to create errors that are equivalently catched via `recover` in Lotus
- Still need to confirm if this design is working (create conformance tests?)

This PR introduces a way to distinguish between errors that are directly returned (in an Actor or Runtime code) and errors that are indirectly returned via the Lotus Runtime [Abortf](https://github.com/filecoin-project/lotus/blob/1d2f84322d4fc1c0d5357476aa693c309097a8c8/chain/vm/runtime.go#L358) function.

In Lotus these latter are recovered in the [shimCall](https://github.com/filecoin-project/lotus/blob/1d2f84322d4fc1c0d5357476aa693c309097a8c8/chain/vm/runtime.go#L147) that protects a method from panicking when [invoked](https://github.com/filecoin-project/lotus/blob/1d2f84322d4fc1c0d5357476aa693c309097a8c8/chain/vm/invoker.go#L246).

Note that this PR only fixes following errors for the multisig actor as a starting point:

  - [max call depth](https://github.com/chainsafe/forest/blob/ccf1ac118aefe7143b0a97a671f241e052f79343/vm/interpreter/src/default_runtime.rs#L358-L363)
  - [invalid send call](https://github.com/chainsafe/forest/blob/ccf1ac118aefe7143b0a97a671f241e052f79343/vm/interpreter/src/default_runtime.rs#L729-L731)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 

https://github.com/ChainSafe/forest/issues/1265

**Other information and links**
<!-- Add any other context about the pull request here. -->

See also:
https://github.com/ChainSafe/forest/pull/857

<!-- Thank you 🔥 -->