### PR TITLE
Elmattic/actors review F10

### DIFF
--- a/vm/actor/src/builtin/miner/mod.rs
+++ b/vm/actor/src/builtin/miner/mod.rs
@@ -190,14 +190,7 @@ impl Actor {
             params.peer_id,
             params.multi_addresses,
             params.window_post_proof_type,
-        )
-        .map_err(|e| {
-            actor_error!(
-                ErrIllegalState,
-                "failed to construct initial miner info: {}",
-                e
-            )
-        })?;
+        )?;
         let info_cid = rt.store().put(&info, Blake2b256).map_err(|e| {
             e.downcast_default(
                 ExitCode::ErrIllegalState,

--- a/vm/actor/src/builtin/miner/state.rs
+++ b/vm/actor/src/builtin/miner/state.rs
@@ -1237,7 +1237,7 @@ impl MinerInfo {
 
         let window_post_partition_sectors = window_post_proof_type
             .window_post_partitions_sector()
-            .map_err(|e| actor_error!(ErrIllegalArgument, "invalid sector size: {}", e))?;
+            .map_err(|e| actor_error!(ErrIllegalArgument, "invalid partition sectors: {}", e))?;
 
         Ok(Self {
             owner,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- fix error message
- change code to unwrap directly after call to ctor

By construction there is no way that [ConstructMinerInfo](https://github.com/filecoin-project/specs-actors/blob/97fc4480cbc9b7078c67276d8c3394e3423ef513/actors/builtin/miner/miner_state.go#L238) will return an error code other than `ErrIllegalArgument`.

So my proposal is just to unwrap directly on our side. As the Forest Rust actors will be the ones used in the future FVM this should not make much difference.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1274


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->