### PR TITLE
Fix clippy errors for the new cargo 1.57.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,19 @@
+name: Publish docs
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-docs:
+    name: publish docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+      - run: |
+          cargo install mdbook
+          mdbook build ./documentation
+          bash ./scripts/build-rust-docs.sh

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,151 @@
+on: [push, pull_request]
+
+name: MSRV
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.57.0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.57.0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/toolchain@v1
+        run: make test
+
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.31.0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: check license
+        run: make license
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.31.0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+
+  test-vectors:
+    name: test-vectors
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.57.0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: build
+        uses: actions-rs/toolchain@v1
+        run: |
+          git submodule update --init
+          make run-vectors
+
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.57.0
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: build
+        uses: actions-rs/toolchain@v1
+        run: |
+          cargo install cargo-audit
+          cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,10 +1,10 @@
 on: [pull_request]
 
-name: MSRV
+name: msrv
 
 jobs:
   check:
-    name: Check
+    name: check
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -78,7 +78,7 @@ jobs:
           args: --all -- --check
 
   clippy:
-    name: Clippy
+    name: clippy
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.31.0
+          - 1.57.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -84,7 +84,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.31.0
+          - 1.57.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 
 name: MSRV
 

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -45,7 +45,6 @@ jobs:
           override: true
 
       - name: Run cargo test
-        uses: actions-rs/toolchain@v1
         run: make test
 
   fmt:
@@ -123,7 +122,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: build
-        uses: actions-rs/toolchain@v1
         run: |
           git submodule update --init
           make run-vectors
@@ -145,7 +143,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: build
-        uses: actions-rs/toolchain@v1
         run: |
           cargo install cargo-audit
           cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071

--- a/blockchain/blocks/src/election_proof.rs
+++ b/blockchain/blocks/src/election_proof.rs
@@ -229,7 +229,7 @@ pub mod json {
             S: Serializer,
         {
             v.as_ref()
-                .map(|s| ElectionProofJsonRef(s))
+                .map(ElectionProofJsonRef)
                 .serialize(serializer)
         }
 

--- a/blockchain/blocks/src/election_proof.rs
+++ b/blockchain/blocks/src/election_proof.rs
@@ -228,9 +228,7 @@ pub mod json {
         where
             S: Serializer,
         {
-            v.as_ref()
-                .map(ElectionProofJsonRef)
-                .serialize(serializer)
+            v.as_ref().map(ElectionProofJsonRef).serialize(serializer)
         }
 
         pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<ElectionProof>, D::Error>

--- a/blockchain/blocks/src/ticket.rs
+++ b/blockchain/blocks/src/ticket.rs
@@ -67,7 +67,7 @@ pub mod json {
         where
             S: Serializer,
         {
-            v.as_ref().map(|s| TicketJsonRef(s)).serialize(serializer)
+            v.as_ref().map(TicketJsonRef).serialize(serializer)
         }
 
         pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Ticket>, D::Error>

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -319,7 +319,7 @@ pub mod json {
             S: Serializer,
         {
             v.as_ref()
-                .map(|s| SignatureJsonRef(s))
+                .map(SignatureJsonRef)
                 .serialize(serializer)
         }
 

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -318,9 +318,7 @@ pub mod json {
         where
             S: Serializer,
         {
-            v.as_ref()
-                .map(SignatureJsonRef)
-                .serialize(serializer)
+            v.as_ref().map(SignatureJsonRef).serialize(serializer)
         }
 
         pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Signature>, D::Error>

--- a/ipld/amt/src/node.rs
+++ b/ipld/amt/src/node.rs
@@ -353,7 +353,7 @@ where
         let sub_i = i / nodes_for_height(bit_width, height);
 
         match self {
-            Self::Leaf { vals } => Ok(vals.get_mut(i).map(|v| std::mem::take(v)).flatten()),
+            Self::Leaf { vals } => Ok(vals.get_mut(i).map(std::mem::take).flatten()),
             Self::Link { links } => {
                 let (deleted, replace) = match &mut links[sub_i] {
                     Some(Link::Dirty(n)) => {

--- a/ipld/amt/src/value_mut.rs
+++ b/ipld/amt/src/value_mut.rs
@@ -41,6 +41,6 @@ impl<V> Deref for ValueMut<'_, V> {
 impl<V> DerefMut for ValueMut<'_, V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.value_mutated = true;
-        &mut self.value
+        self.value
     }
 }

--- a/ipld/cid/src/json.rs
+++ b/ipld/cid/src/json.rs
@@ -84,7 +84,7 @@ pub mod opt {
     where
         S: Serializer,
     {
-        v.as_ref().map(|s| CidJsonRef(s)).serialize(serializer)
+        v.as_ref().map(CidJsonRef).serialize(serializer)
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Cid>, D::Error>

--- a/ipld/src/json.rs
+++ b/ipld/src/json.rs
@@ -34,7 +34,7 @@ where
             serializer,
         ),
         Ipld::List(list) => {
-            let wrapped = list.iter().map(|ipld| IpldJsonRef(ipld));
+            let wrapped = list.iter().map(IpldJsonRef);
             serializer.collect_seq(wrapped)
         }
         Ipld::Map(map) => {

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -50,6 +50,7 @@ pub const PUBSUB_MSG_STR: &str = "/fil/msgs";
 const PUBSUB_TOPICS: [&str; 2] = [PUBSUB_BLOCK_STR, PUBSUB_MSG_STR];
 
 /// Events emitted by this Service.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum NetworkEvent {
     PubsubMessage {
@@ -72,6 +73,7 @@ pub enum NetworkEvent {
 }
 
 /// Message types that can come over GossipSub
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum PubsubMessage {
     /// Messages that come over the block topic

--- a/vm/interpreter/src/gas_tracker/price_list.rs
+++ b/vm/interpreter/src/gas_tracker/price_list.rs
@@ -15,7 +15,7 @@ use vm::{MethodNum, TokenAmount, METHOD_SEND};
 
 lazy_static! {
     static ref BASE_PRICES: PriceList = PriceList {
-        compute_gas_multiplier: 1,
+        _compute_gas_multiplier: 1,
         storage_gas_multiplier: 1000,
 
         on_chain_message_compute_base: 38863,
@@ -44,7 +44,7 @@ lazy_static! {
         compute_unsealed_sector_cid_base: 98647,
         verify_seal_base: 2000, // TODO revisit potential removal of this
 
-        verify_aggregate_seal_base: 0,
+        _verify_aggregate_seal_base: 0,
         verify_aggregate_seal_per: [
             (
                 RegisteredSealProof::StackedDRG32GiBV1P1,
@@ -121,7 +121,7 @@ lazy_static! {
     };
 
     static ref CALICO_PRICES: PriceList = PriceList {
-        compute_gas_multiplier: 1,
+        _compute_gas_multiplier: 1,
         storage_gas_multiplier: 1300,
 
         on_chain_message_compute_base: 38863,
@@ -150,7 +150,7 @@ lazy_static! {
         compute_unsealed_sector_cid_base: 98647,
         verify_seal_base: 2000, // TODO revisit potential removal of this
 
-        verify_aggregate_seal_base: 0,
+        _verify_aggregate_seal_base: 0,
         verify_aggregate_seal_per: [
             (
                 RegisteredSealProof::StackedDRG32GiBV1P1,
@@ -264,7 +264,7 @@ pub struct PriceList {
     /// Compute gas charge multiplier
     // * This multiplier is not currently applied to anything, but is matching lotus.
     // * If the possible values are non 1 or if Lotus adds, we should change also.
-    pub(crate) compute_gas_multiplier: i64,
+    pub(crate) _compute_gas_multiplier: i64,
     /// Storage gas charge multiplier
     pub(crate) storage_gas_multiplier: i64,
 
@@ -335,7 +335,7 @@ pub struct PriceList {
 
     pub(crate) compute_unsealed_sector_cid_base: i64,
     pub(crate) verify_seal_base: i64,
-    pub(crate) verify_aggregate_seal_base: i64,
+    pub(crate) _verify_aggregate_seal_base: i64,
     pub(crate) verify_aggregate_seal_per: AHashMap<RegisteredSealProof, i64>,
     pub(crate) verify_aggregate_seal_steps: AHashMap<RegisteredSealProof, StepCost>,
 

--- a/vm/message/src/message_receipt.rs
+++ b/vm/message/src/message_receipt.rs
@@ -110,7 +110,7 @@ pub mod json {
             S: Serializer,
         {
             v.as_ref()
-                .map(|s| MessageReceiptJsonRef(s))
+                .map(MessageReceiptJsonRef)
                 .serialize(serializer)
         }
 

--- a/vm/message/src/message_receipt.rs
+++ b/vm/message/src/message_receipt.rs
@@ -109,9 +109,7 @@ pub mod json {
         where
             S: Serializer,
         {
-            v.as_ref()
-                .map(MessageReceiptJsonRef)
-                .serialize(serializer)
+            v.as_ref().map(MessageReceiptJsonRef).serialize(serializer)
         }
 
         pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<MessageReceipt>, D::Error>


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix a few clippy errors

Note that two have been allowed via `#[allow(clippy::large_enum_variant)]`.

But they should be fixed (in the foreseeable future) as it's a potential CPU Caches Hog issue.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
N/A


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->