### PR TITLE
Elmattic/actors review f25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
  "lazy_static",
  "lockfree",
  "log",
- "lru 0.6.5",
+ "lru 0.7.2",
  "multihash 0.13.2",
  "networks",
  "num-traits",
@@ -1060,7 +1060,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "log",
- "lru 0.6.5",
+ "lru 0.7.2",
  "message_pool",
  "networks",
  "num-traits",
@@ -4030,7 +4030,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru 0.7.0",
+ "lru 0.7.2",
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.0",
@@ -4266,9 +4266,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
  "hashbrown 0.11.2",
 ]
@@ -4382,7 +4382,7 @@ dependencies = [
  "key_management",
  "libsecp256k1",
  "log",
- "lru 0.6.5",
+ "lru 0.7.2",
  "networks",
  "num-rational 0.3.2",
  "num-traits",

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -31,7 +31,7 @@ async-std = { version = "1.9", features = ["tokio1"] }
 types = { package = "fil_types", version = "0.2" }
 lazy_static = "1.4"
 interpreter = { path = "../../vm/interpreter/" }
-lru = "0.6"
+lru = "0.7.2"
 forest_car = { path = "../../ipld/car" }
 forest_ipld = "0.1.1"
 networks = { path = "../../types/networks" }

--- a/blockchain/chain_sync/Cargo.toml
+++ b/blockchain/chain_sync/Cargo.toml
@@ -27,7 +27,7 @@ async-std = { version = "1.9", features = ["tokio1", "unstable"] }
 forest_libp2p = { path = "../../node/forest_libp2p" }
 futures = "0.3.5"
 futures-util = "0.3.5"
-lru = "0.6"
+lru = "0.7.2"
 thiserror = "1.0"
 num-traits = "0.2"
 fil_types = "0.2"

--- a/blockchain/message_pool/Cargo.toml
+++ b/blockchain/message_pool/Cargo.toml
@@ -14,7 +14,7 @@ cid = { package = "forest_cid", version = "0.3" }
 encoding = { package = "forest_encoding", version = "0.2.1" }
 blockstore = { package = "ipld_blockstore", version = "0.1" }
 num-bigint = { path = "../../utils/bigint", package = "forest_bigint" }
-lru = "0.6"
+lru = "0.7.2"
 crypto = { package = "forest_crypto", version = "0.5", features = ["blst"] }
 chain = { path = "../chain" }
 state_tree = { path = "../../vm/state_tree/" }

--- a/vm/interpreter/src/default_runtime.rs
+++ b/vm/interpreter/src/default_runtime.rs
@@ -314,9 +314,10 @@ where
                 e
             }
         });
-        if let Err(e) = self.state.borrow_mut().clear_snapshot() {
-            actor_error!(fatal("failed to clear snapshot: {}", e));
-        }
+        self.state
+            .borrow_mut()
+            .clear_snapshot()
+            .map_err(|e| actor_error!(fatal("failed to clear snapshot: {}", e)))?;
 
         ret
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix `clear_snapshot` error propagation

Note that [ClearSnapshot](https://github.com/filecoin-project/lotus/blob/baa1ec098dff9898ec4f9e45eb86abd9cdea8cdd/chain/vm/runtime.go#L426-L430) in Lotus can lead to an error too. An out of bounds error [here](https://github.com/filecoin-project/lotus/blob/baa1ec098dff9898ec4f9e45eb86abd9cdea8cdd/chain/state/statetree.go#L86-L87) will result in a panic that is recovered in the [shimCall](https://github.com/filecoin-project/lotus/blob/1bc987772c21c714997f09757d55a7e12ca0672b/chain/vm/runtime.go#L157).

On Forest side we need to handle those programmer errors by bubbling them up.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1302


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->