### PR TITLE
docs: fix snapshot retrieval command

### DIFF
--- a/documentation/src/basic_usage.md
+++ b/documentation/src/basic_usage.md
@@ -48,8 +48,10 @@ Before running `forest` in the normal mode you must seed the database with the F
 Download the latest snapshot provided by Protocol Labs:
 
 ```bash
-wget https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car > /destination/for/snapshot/file
+curl -sI https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car | perl -ne '/x-amz-website-redirect-location:\s(.+)\.car/ && print "$1.sha256sum\n$1.car"' | xargs wget
 ```
+
+If desired, you can check the checksum using the instructions [here](https://lotus.filecoin.io/docs/set-up/chain-management/#lightweight-snapshot).
 
 Import the snapshot using `forest`:
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- with the previous command I was getting an error 403
```
$ wget https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_jan-6-2022.car
--2022-01-06 16:22:32--  https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_jan-6-2022.car
Resolving fil-chain-snapshots-fallback.s3.amazonaws.com (fil-chain-snapshots-fallback.s3.amazonaws.com)... 52.218.183.121
Connecting to fil-chain-snapshots-fallback.s3.amazonaws.com (fil-chain-snapshots-fallback.s3.amazonaws.com)|52.218.183.121|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2022-01-06 16:22:32 ERROR 403: Forbidden.
```

so I updated it to be the same as lotus, which works: https://lotus.filecoin.io/docs/set-up/chain-management/#lightweight-snapshot

also added a line mentioning the checksum verification.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->