### PR TITLE
The 'base64' dependency for key_management is no longer optional.

### DIFF
--- a/key_management/Cargo.toml
+++ b/key_management/Cargo.toml
@@ -16,7 +16,7 @@ libsecp256k1 = "0.6"
 rand = "0.7.3"
 encoding = { package = "forest_encoding", version = "0.2.1" }
 serde = { version = "1.0", features = ["derive"] }
-base64 = { version = "0.13", optional = true }
+base64 = { version = "0.13" }
 serde_json = "1.0.57"
 serde_cbor = "0.11.1"
 log = "0.4.8"
@@ -24,4 +24,4 @@ sodiumoxide = "0.2.6"
 utils = { path = "../node/utils" }
 
 [features]
-json = ["base64", "crypto/json"]
+json = ["crypto/json"]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- `base64` is now a required rather than optional dependency of `key_management`.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes nothing.


**Other information and links**
<!-- Add any other context about the pull request here. -->
At some point in the past, `base64` was only used with the `json` feature flag but that is no longer true.


<!-- Thank you 🔥 -->