### PR TITLE
networks: Show an informative error message if the selected feature set is invalid.

### DIFF
--- a/types/networks/src/lib.rs
+++ b/types/networks/src/lib.rs
@@ -15,7 +15,9 @@ mod drand;
     not(feature = "devnet"),
     not(feature = "mainnet")
 ))]
-compile_error!("Either feature \"mainnet\", \"devnet\", or \"interopnet\" must be enabled for this crate.");
+compile_error!(
+    "Either feature \"mainnet\", \"devnet\", or \"interopnet\" must be enabled for this crate."
+);
 
 #[cfg(feature = "mainnet")]
 mod mainnet;

--- a/types/networks/src/lib.rs
+++ b/types/networks/src/lib.rs
@@ -13,46 +13,59 @@ mod drand;
 #[cfg(all(
     not(feature = "interopnet"),
     not(feature = "devnet"),
-    not(feature = "mainnet")
+    not(feature = "mainnet"),
+    not(feature = "conformance"),
 ))]
 compile_error!(
-    "Either feature \"mainnet\", \"devnet\", or \"interopnet\" must be enabled for this crate."
+    "No network feature selected. Exactly one of \"mainnet\", \"devnet\", \"interopnet\", or \"conformance\" must be enabled for this crate."
 );
 
-#[cfg(feature = "mainnet")]
-mod mainnet;
-#[cfg(feature = "mainnet")]
-pub use self::mainnet::*;
+#[cfg(all(
+    feature = "mainnet",
+    any(feature = "interopnet", feature = "devnet", feature = "conformance",)
+))]
+compile_error!(
+    "\"mainnet\" feature cannot be combined with \"devnet\", \"interopnet\", or \"conformance\"."
+);
 
-#[cfg(feature = "conformance")]
-mod mainnet;
-#[cfg(feature = "conformace")]
-pub use self::mainnet::*;
+#[cfg(all(
+    feature = "conformance",
+    any(feature = "interopnet", feature = "devnet", feature = "mainnet",)
+))]
+compile_error!(
+    "\"conformance\" feature cannot be combined with \"devnet\", \"interopnet\", or \"mainnet\"."
+);
+
+#[cfg(all(
+    feature = "devnet",
+    any(feature = "interopnet", feature = "conformance", feature = "mainnet",)
+))]
+compile_error!(
+    "\"devnet\" feature cannot be combined with \"conformance\", \"interopnet\", or \"mainnet\"."
+);
 
 #[cfg(all(
     feature = "interopnet",
-    not(feature = "devnet"),
-    not(feature = "mainnet")
+    any(feature = "conformance", feature = "devnet", feature = "mainnet",)
 ))]
+compile_error!(
+    "\"interopnet\" feature cannot be combined with \"devnet\", \"conformance\", or \"mainnet\"."
+);
+
+// Both mainnet and conformance parameters are kept in the 'mainnet' module.
+#[cfg(any(feature = "mainnet", feature = "conformance"))]
+mod mainnet;
+#[cfg(any(feature = "mainnet", feature = "conformance"))]
+pub use self::mainnet::*;
+
+#[cfg(feature = "interopnet")]
 mod interopnet;
-#[cfg(all(
-    feature = "interopnet",
-    not(feature = "devnet"),
-    not(feature = "mainnet")
-))]
+#[cfg(feature = "interopnet")]
 pub use self::interopnet::*;
 
-#[cfg(all(
-    feature = "devnet",
-    not(feature = "interopnet"),
-    not(feature = "mainnet")
-))]
+#[cfg(feature = "devnet")]
 mod devnet;
-#[cfg(all(
-    feature = "devnet",
-    not(feature = "interopnet"),
-    not(feature = "mainnet")
-))]
+#[cfg(feature = "devnet")]
 pub use self::devnet::*;
 
 /// Defines the different hard fork parameters.

--- a/types/networks/src/lib.rs
+++ b/types/networks/src/lib.rs
@@ -10,6 +10,13 @@ use fil_types::NetworkVersion;
 use std::{error::Error, sync::Arc};
 mod drand;
 
+#[cfg(all(
+    not(feature = "interopnet"),
+    not(feature = "devnet"),
+    not(feature = "mainnet")
+))]
+compile_error!("Either feature \"mainnet\", \"devnet\", or \"interopnet\" must be enabled for this crate.");
+
 #[cfg(feature = "mainnet")]
 mod mainnet;
 #[cfg(feature = "mainnet")]
@@ -19,7 +26,6 @@ pub use self::mainnet::*;
 mod mainnet;
 #[cfg(feature = "conformace")]
 pub use self::mainnet::*;
-pub use crate::mainnet::*;
 
 #[cfg(all(
     feature = "interopnet",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- In the `networks` crate, emit an informative error message if none of the required feature flags are selected.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes nothing.


**Other information and links**
<!-- Add any other context about the pull request here. -->
This improves the error message if one tries to build `networks` without any feature flags set.


<!-- Thank you 🔥 -->