### PR TITLE
docs: Set required GITHUB_TOKEN for pushing documentation to gh-pages.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ jobs:
   publish-docs:
     name: publish docs
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix the authentication error when trying to upload docs to gh-pages.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->

I am not certain that this PR is enough. We might have to change the username from `git` to `ChainSafe`. Not sure.

<!-- Thank you 🔥 -->