### PR TITLE
Use pre-made action to deploy documentation to gh-pages.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,5 @@
-name: Publish docs
+name: Documentation
+
 on:
   push:
     branches:
@@ -6,14 +7,24 @@ on:
 
 jobs:
   publish-docs:
-    name: publish docs
+    name: Publish Docs
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
+      - name: Checkout Sources
         uses: actions/checkout@v2
-      - name: Install toolchain
+      - name: Install Toolchain
         uses: actions-rs/toolchain@v1
-      - run: |
+      - name: Install MDBook
+        run: |
           cargo install mdbook
-          mdbook build ./documentation
+      - name: Execute MDBook
+        run: |
+          mdbook build ./documentation/
+      - name: Build Rust Docs
+        run: |
           bash ./scripts/build-rust-docs.sh
+      - name: Deploy GH Pages
+        uses: JamesIves/github-pages-deploy-action@4.2.2
+        with:
+            branch: gh-pages
+            folder: ./documentation/book/

--- a/scripts/build-rust-docs.sh
+++ b/scripts/build-rust-docs.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-cd documentation/book
-git init
-git add .
-git config --global -l
-git -c user.name='ci' -c user.email='ci' commit -m 'Deploy documentation'
-git push -f -q https://git:${GITHUB_TOKEN}@github.com/ChainSafe/forest HEAD:gh-pages


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use `JamesIves/github-pages-deploy-action` to deploy documentation to gh-pages rather than a custom shell script.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->