### PR TITLE
Disable test 'test_optimal_message_selection3' because it is inconsistent

### DIFF
--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -1230,6 +1230,7 @@ mod test_selection {
     }
 
     #[async_std::test]
+    #[ignore = "This test fails inconsistently. See issue #1369"]
     async fn test_optimal_message_selection3() {
         // this test uses 10 actors sending a block of messages to each other, with the the first
         // actors paying higher gas premium than the subsequent actors.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Disable `msgpool::selection::test_selection::test_optimal_message_selection3` until #1369 has been resolved.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->

**Other information and links**
<!-- Add any other context about the pull request here. -->

<!-- Thank you 🔥 -->