### PR TITLE
fix 1369

### DIFF
--- a/blockchain/message_pool/src/msg_chain.rs
+++ b/blockchain/message_pool/src/msg_chain.rs
@@ -166,9 +166,12 @@ impl Chains {
 
     /// Removes messages from the given index and resets effective perfs
     pub(crate) fn trim_msgs_at(&mut self, idx: usize, gas_limit: i64, base_fee: &BigInt) {
-        let prev = self
-            .get_at(if idx == 0 { return } else { idx - 1 })
-            .map(|prev| (prev.eff_perf, prev.gas_limit));
+        let prev = match idx {
+            0 => None,
+            _ => self
+                .get_at(idx - 1)
+                .map(|prev| (prev.eff_perf, prev.gas_limit)),
+        };
         let chain_node = self.get_mut_at(idx).unwrap();
         let mut i = chain_node.msgs.len() as i64 - 1;
 

--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -1230,7 +1230,6 @@ mod test_selection {
     }
 
     #[async_std::test]
-    #[ignore = "This test fails inconsistently. See issue #1369"]
     async fn test_optimal_message_selection3() {
         // this test uses 10 actors sending a block of messages to each other, with the the first
         // actors paying higher gas premium than the subsequent actors.


### PR DESCRIPTION
**Summary of changes**
This is to fix the issue #1369, a test case issue.
This test fails randomly because in optimal message selection, there is a shuffling at [L373](https://github.com/ChainSafe/forest/blob/main/blockchain/message_pool/src/msgpool/selection.rs#L373). Further at line [L412](https://github.com/ChainSafe/forest/blob/1aec44b1ba6d13e62449411683588f11564cbd16/blockchain/message_pool/src/msgpool/selection.rs#L412), there is a trim message chain operation. When performing `trim_msgs_at` and deriving the prev, when idx == 0, prev should equal to None, but instead returned from the function. By chance that the caller passes idx == 0 to the function, then the chain is not trimed and should have `valid` being false but instead true.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1369 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->