### PR TITLE
Include network in forest version string.

### DIFF
--- a/forest/build.rs
+++ b/forest/build.rs
@@ -9,12 +9,21 @@ const RELEASE_TRACK: &str = "unstable";
 #[cfg(feature = "release")]
 const RELEASE_TRACK: &str = "alpha";
 
+#[cfg(feature = "devnet")]
+const NETWORK: &str = "devnet";
+
+#[cfg(feature = "interopnet")]
+const NETWORK: &str = "interopnet";
+
+#[cfg(all(not(feature = "devnet"), not(feature = "interopnet")))]
+const NETWORK: &str = "mainnet";
+
 fn main() {
     // expose environment variable FOREST_VERSON at build time
     println!("cargo:rustc-env=FOREST_VERSION={}", version());
 }
 
-// returns version string at build time, e.g., `v0.1.0/unstable/7af2f5bf`
+// returns version string at build time, e.g., `v0.1.0/unstable/mainnet/7af2f5bf`
 fn version() -> String {
     let git_cmd = Command::new("git")
         .args(&["rev-parse", "--short", "HEAD"])
@@ -22,9 +31,10 @@ fn version() -> String {
         .expect("Git references should be available on a build system");
     let git_hash = String::from_utf8(git_cmd.stdout).unwrap_or_default();
     format!(
-        "v{}/{}/{}",
+        "v{}/{}/{}/{}",
         env!("CARGO_PKG_VERSION"),
         RELEASE_TRACK,
-        git_hash
+        NETWORK,
+        git_hash,
     )
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Include network (eg. `mainnet` or `devnet`) in the version string shown with `forest --version`.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->
Target network is selected at compile time but the forest executable couldn't show which network had been selected.


<!-- Thank you 🔥 -->