### PR TITLE
Improve snapshot parsing performance by ~2.5x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ name = "forest_db"
 version = "0.1.0"
 dependencies = [
  "forest_encoding",
+ "num_cpus",
  "parking_lot",
  "rocksdb",
  "sled",

--- a/ipld/car/src/lib.rs
+++ b/ipld/car/src/lib.rs
@@ -105,10 +105,11 @@ where
     let mut car_reader = CarReader::new(reader).await?;
 
     // Batch write key value pairs from car file
-    let mut buf: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(100);
+    const BATCH_SIZE: usize = 10240;
+    let mut buf: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
     while let Some(block) = car_reader.next_block().await? {
         buf.push((block.cid.to_bytes(), block.data));
-        if buf.len() > 1000 {
+        if buf.len() >= BATCH_SIZE {
             s.bulk_write(&buf)
                 .map_err(|e| Error::Other(e.to_string()))?;
             buf.clear();

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -13,3 +13,4 @@ sled = { version = "0.34", optional = true }
 parking_lot = "0.11"
 encoding = { package = "forest_encoding", version = "0.2" }
 thiserror = "1.0"
+num_cpus = "1.13"

--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -29,7 +29,7 @@ impl RocksDb {
         let mut db_opts = Options::default();
         db_opts.create_if_missing(true);
         db_opts.increase_parallelism(num_cpus::get() as i32);
-        db_opts.set_write_buffer_size(256*1024*1024); // 256MB
+        db_opts.set_write_buffer_size(256*1024*1024); // increase from 64MB to 256MB
         Ok(Self {
             db: DB::open(&db_opts, path)?,
         })

--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -5,6 +5,7 @@ use super::errors::Error;
 use super::Store;
 pub use rocksdb::{Options, WriteBatch, DB};
 use std::path::Path;
+use num_cpus;
 
 /// RocksDB instance this satisfies the [Store] interface.
 #[derive(Debug)]
@@ -27,6 +28,8 @@ impl RocksDb {
     {
         let mut db_opts = Options::default();
         db_opts.create_if_missing(true);
+        db_opts.increase_parallelism(num_cpus::get() as i32);
+        db_opts.set_write_buffer_size(256*1024*1024); // 256MB
         Ok(Self {
             db: DB::open(&db_opts, path)?,
         })

--- a/utils/net_utils/src/download.rs
+++ b/utils/net_utils/src/download.rs
@@ -13,6 +13,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use thiserror::Error;
 use url::Url;
+use std::time::Duration;
 
 #[derive(Debug, Error)]
 enum DownloadError {
@@ -71,6 +72,7 @@ impl TryFrom<Url> for FetchProgress<Body, Stdout> {
 
         let mut pb = ProgressBar::new(total_size);
         pb.set_units(Units::Bytes);
+        pb.set_max_refresh_rate(Some(Duration::from_millis(500)));
 
         Ok(FetchProgress {
             progress_bar: pb,
@@ -87,6 +89,7 @@ impl TryFrom<File> for FetchProgress<BufReader<File>, Stdout> {
 
         let mut pb = ProgressBar::new(total_size);
         pb.set_units(Units::Bytes);
+        pb.set_max_refresh_rate(Some(Duration::from_millis(500)));
 
         Ok(FetchProgress {
             progress_bar: pb,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Set RocksDB parallelism to `num_cpus`.
- Increase batch sizes to 10k.
- Increase write buffer size to 256MB.
- Reduce progress bar update frequency to 2hz.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1406 


**Other information and links**
<!-- Add any other context about the pull request here. -->
There is still a lot of improvements to be made. This PR just collects the low hanging fruit.

On my machine, this lowers snapshot parsing from 36 minutes to 13 minutes.

<!-- Thank you 🔥 -->