### PR TITLE
vm/actor: remove unused fields in paych actor tests

### DIFF
--- a/vm/actor/tests/paych_actor_test.rs
+++ b/vm/actor/tests/paych_actor_test.rs
@@ -173,10 +173,6 @@ mod create_lane_tests {
         desc: String,
         #[builder(default = "ACCOUNT_ACTOR_CODE_ID.clone()")]
         target_code: Cid,
-        #[builder(default)]
-        balance: u64,
-        #[builder(default)]
-        recieved: u64,
         #[builder(default = "1")]
         epoch: ChainEpoch,
         #[builder(default = "1")]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- removes `balance` and `recieved` from the test struct in paych actor tests that used to cause warnings on the CI.
