### PR TITLE
forest: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,7 +2072,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actor_interface",
  "async-log",

--- a/forest/Cargo.toml
+++ b/forest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forest"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 description = "Filecoin implementation in Rust. This command will start the daemon process."
 edition = "2018"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- forest 0.2.0 -> 0.2.1
- should have done this on main right after the release
