### PR TITLE
Fail CI on failed fmt or other linting file changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install RustFmt
         run: rustup component add rustfmt
       - name: Run Linters
-        run: make lint-check
+        run: make lint
 
   audit:
     name: Audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install RustFmt
         run: rustup component add rustfmt
       - name: Run Linters
-        run: make lint
+        run: make lint-check
 
   audit:
     name: Audit

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean:
 	@echo "Done cleaning."
 
 lint: license clean
-	cargo fmt --all
+	cargo fmt --all --check
 	cargo clippy -- -D warnings
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,9 @@ clean:
 	@cargo clean -p networks
 	@echo "Done cleaning."
 
-# Lints the project. Should be run before submitting a PR.
 lint: license clean
 	cargo fmt --all
 	cargo clippy -- -D warnings
-
-# Lints the project and fails if this resulted in any changes in tracked files. Used for CI.
-lint-check: lint
-	git diff --no-ext-diff --quiet --exit-code
 
 build:
 	cargo build --bin forest

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,14 @@ clean:
 	@cargo clean -p networks
 	@echo "Done cleaning."
 
+# Lints the project. Should be run before submitting a PR.
 lint: license clean
 	cargo fmt --all
 	cargo clippy -- -D warnings
+
+# Lints the project and fails if this resulted in any changes in tracked files. Used for CI.
+lint-check: lint
+	git diff --no-ext-diff --quiet --exit-code
 
 build:
 	cargo build --bin forest

--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -3,9 +3,9 @@
 
 use super::errors::Error;
 use super::Store;
+use num_cpus;
 pub use rocksdb::{Options, WriteBatch, DB};
 use std::path::Path;
-use num_cpus;
 
 /// RocksDB instance this satisfies the [Store] interface.
 #[derive(Debug)]
@@ -29,7 +29,7 @@ impl RocksDb {
         let mut db_opts = Options::default();
         db_opts.create_if_missing(true);
         db_opts.increase_parallelism(num_cpus::get() as i32);
-        db_opts.set_write_buffer_size(256*1024*1024); // increase from 64MB to 256MB
+        db_opts.set_write_buffer_size(256 * 1024 * 1024); // increase from 64MB to 256MB
         Ok(Self {
             db: DB::open(&db_opts, path)?,
         })

--- a/tests/conformance_tests/tests/conformance_runner.rs
+++ b/tests/conformance_tests/tests/conformance_runner.rs
@@ -74,7 +74,7 @@ fn is_valid_file(entry: &DirEntry) -> bool {
     // only run v6 vectors
     let v6_filepath = Regex::new(r"specs_actors_v6").unwrap();
     let is_extra = Regex::new(r"extra-vectors").unwrap();
-    if !v6_filepath.is_match(file_name) && ! is_extra.is_match(file_name) {
+    if !v6_filepath.is_match(file_name) && !is_extra.is_match(file_name) {
         println!("SKIPPING: {} ", file_name);
         return false;
     }

--- a/types/src/version.rs
+++ b/types/src/version.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use encoding::repr::Serialize_repr;
-use std::convert::TryFrom;
-use std::fmt::{self, Display, Formatter};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
+use std::convert::TryFrom;
+use std::fmt::{self, Display, Formatter};
 
 /// Specifies the network version
 #[derive(Debug, PartialEq, Clone, Copy, PartialOrd, Serialize_repr, FromPrimitive)]

--- a/utils/net_utils/src/download.rs
+++ b/utils/net_utils/src/download.rs
@@ -11,9 +11,9 @@ use std::convert::TryFrom;
 use std::io::{self, Stdout, Write};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 use thiserror::Error;
 use url::Url;
-use std::time::Duration;
 
 #[derive(Debug, Error)]
 enum DownloadError {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Changes the CI lint step to check for changes resulted from e.g. `cargo fmt`. Before they were silently discarded.
