### PR TITLE
ci: temporarily ignore RUSTSEC-2022-0009

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,7 +119,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0130
+          args: --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0130 --ignore RUSTSEC-2022-0009
 
   build:
     name: Build


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- ignore https://rustsec.org/advisories/RUSTSEC-2022-0009

**Reference issue to close (if applicable)**
- until #1420 is ready
- tracking in #1247
