### PR TITLE
Limit RocksDB to 200 open files.

### DIFF
--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -30,6 +30,7 @@ impl RocksDb {
         db_opts.create_if_missing(true);
         db_opts.increase_parallelism(num_cpus::get() as i32);
         db_opts.set_write_buffer_size(256 * 1024 * 1024); // increase from 64MB to 256MB
+        db_opts.set_max_open_files(200);
         Ok(Self {
             db: DB::open(&db_opts, path)?,
         })


### PR DESCRIPTION
Many systems are limited to 1k open files by default.

**Summary of changes**
Changes introduced in this pull request:
- Cap RocksDB to 200 open files. This is not optimal and more tuning is required.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->