### PR TITLE
parametrize current rocksdb settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,7 +3097,9 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "rocksdb",
+ "serde",
  "sled",
+ "tempfile",
  "thiserror",
 ]
 

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub sync: SyncConfig,
     pub encrypt_keystore: bool,
     pub metrics_port: u16,
+    pub rocks_db: db::rocks::RocksDbConfig,
 }
 
 impl Default for Config {
@@ -43,6 +44,7 @@ impl Default for Config {
             sync: SyncConfig::default(),
             encrypt_keystore: true,
             metrics_port: 6116,
+            rocks_db: db::rocks::RocksDbConfig::default(),
         }
     }
 }

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -70,9 +70,7 @@ pub(super) async fn start(config: Config) {
 
             let passphrase = read_password().expect("Error reading passphrase");
 
-            let mut data_dir = PathBuf::from(&config.data_dir);
-            data_dir.push(ENCRYPTED_KEYSTORE_NAME);
-
+            let data_dir = PathBuf::from(&config.data_dir).join(ENCRYPTED_KEYSTORE_NAME);
             if !data_dir.exists() {
                 print!("Confirm passphrase: ");
                 std::io::stdout().flush().unwrap();
@@ -119,7 +117,7 @@ pub(super) async fn start(config: Config) {
         .expect("Opening SledDB must succeed");
 
     #[cfg(feature = "rocksdb")]
-    let db = db::rocks::RocksDb::open(format!("{}/{}", config.data_dir.clone(), "db"))
+    let db = db::rocks::RocksDb::open(PathBuf::from(&config.data_dir).join("db"), config.rocks_db)
         .expect("Opening RocksDB must succeed");
 
     let db = Arc::new(db);
@@ -237,7 +235,11 @@ pub(super) async fn start(config: Config) {
         (format!("127.0.0.1:{}", config.metrics_port))
             .parse()
             .unwrap(),
-        format!("{}/{}", config.data_dir.clone(), "db"),
+        PathBuf::from(&config.data_dir)
+            .join("db")
+            .into_os_string()
+            .into_string()
+            .expect("Failed converting the path to db"),
     ));
 
     // Block until ctrl-c is hit

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -14,3 +14,7 @@ parking_lot = "0.11"
 encoding = { package = "forest_encoding", version = "0.2" }
 thiserror = "1.0"
 num_cpus = "1.13"
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3.3"

--- a/node/db/src/rocks.rs
+++ b/node/db/src/rocks.rs
@@ -5,7 +5,28 @@ use super::errors::Error;
 use super::Store;
 use num_cpus;
 pub use rocksdb::{Options, WriteBatch, DB};
+use serde::Deserialize;
 use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct RocksDbConfig {
+    create_if_missing: bool,
+    parallelism: i32,
+    write_buffer_size: usize,
+    max_open_files: i32,
+}
+
+impl Default for RocksDbConfig {
+    fn default() -> Self {
+        Self {
+            create_if_missing: true,
+            parallelism: num_cpus::get() as i32,
+            write_buffer_size: 256 * 1024 * 1024,
+            max_open_files: 200,
+        }
+    }
+}
 
 /// RocksDB instance this satisfies the [Store] interface.
 #[derive(Debug)]
@@ -17,20 +38,20 @@ pub struct RocksDb {
 ///
 /// Usage:
 /// ```no_run
-/// use forest_db::rocks::RocksDb;
+/// use forest_db::rocks::{RocksDb, RocksDbConfig};
 ///
-/// let mut db = RocksDb::open("test_db").unwrap();
+/// let mut db = RocksDb::open("test_db", RocksDbConfig::default()).unwrap();
 /// ```
 impl RocksDb {
-    pub fn open<P>(path: P) -> Result<Self, Error>
+    pub fn open<P>(path: P, config: RocksDbConfig) -> Result<Self, Error>
     where
         P: AsRef<Path>,
     {
         let mut db_opts = Options::default();
-        db_opts.create_if_missing(true);
-        db_opts.increase_parallelism(num_cpus::get() as i32);
-        db_opts.set_write_buffer_size(256 * 1024 * 1024); // increase from 64MB to 256MB
-        db_opts.set_max_open_files(200);
+        db_opts.create_if_missing(config.create_if_missing);
+        db_opts.increase_parallelism(config.parallelism);
+        db_opts.set_write_buffer_size(config.write_buffer_size);
+        db_opts.set_max_open_files(config.max_open_files);
         Ok(Self {
             db: DB::open(&db_opts, path)?,
         })
@@ -38,6 +59,13 @@ impl RocksDb {
 }
 
 impl Store for RocksDb {
+    fn read<K>(&self, key: K) -> Result<Option<Vec<u8>>, Error>
+    where
+        K: AsRef<[u8]>,
+    {
+        self.db.get(key).map_err(Error::from)
+    }
+
     fn write<K, V>(&self, key: K, value: V) -> Result<(), Error>
     where
         K: AsRef<[u8]>,
@@ -53,6 +81,16 @@ impl Store for RocksDb {
         Ok(self.db.delete(key)?)
     }
 
+    fn exists<K>(&self, key: K) -> Result<bool, Error>
+    where
+        K: AsRef<[u8]>,
+    {
+        self.db
+            .get_pinned(key)
+            .map(|v| v.is_some())
+            .map_err(Error::from)
+    }
+
     fn bulk_write<K, V>(&self, values: &[(K, V)]) -> Result<(), Error>
     where
         K: AsRef<[u8]>,
@@ -63,22 +101,5 @@ impl Store for RocksDb {
             batch.put(k, v);
         }
         Ok(self.db.write(batch)?)
-    }
-
-    fn read<K>(&self, key: K) -> Result<Option<Vec<u8>>, Error>
-    where
-        K: AsRef<[u8]>,
-    {
-        self.db.get(key).map_err(Error::from)
-    }
-
-    fn exists<K>(&self, key: K) -> Result<bool, Error>
-    where
-        K: AsRef<[u8]>,
-    {
-        self.db
-            .get_pinned(key)
-            .map(|v| v.is_some())
-            .map_err(Error::from)
     }
 }

--- a/node/db/tests/rocks_test.rs
+++ b/node/db/tests/rocks_test.rs
@@ -6,61 +6,52 @@
 mod db_utils;
 mod subtests;
 
-use db_utils::DBPath;
-use forest_db::rocks::RocksDb;
+use crate::db_utils::TempRocksDB;
 
 #[test]
 fn rocks_db_write() {
-    let path = DBPath::new("write_rocks_test");
-    let db = RocksDb::open(path.as_ref()).unwrap();
-    subtests::write(&db);
+    let db = TempRocksDB::new();
+    subtests::write(&*db);
 }
 
 #[test]
 fn rocks_db_read() {
-    let path = DBPath::new("read_rocks_test");
-    let db = RocksDb::open(path.as_ref()).unwrap();
-    subtests::read(&db);
+    let db = TempRocksDB::new();
+    subtests::read(&*db);
 }
 
 #[test]
 fn rocks_db_exists() {
-    let path = DBPath::new("exists_rocks_test");
-    let db = RocksDb::open(path.as_ref()).unwrap();
-    subtests::exists(&db);
+    let db = TempRocksDB::new();
+    subtests::exists(&*db);
 }
 
 #[test]
 fn rocks_db_does_not_exist() {
-    let path = DBPath::new("does_not_exists_rocks_test");
-    let db = RocksDb::open(path.as_ref()).unwrap();
-    subtests::does_not_exist(&db);
+    let db = TempRocksDB::new();
+    subtests::does_not_exist(&*db);
 }
 
 #[test]
 fn rocks_db_delete() {
-    let path = DBPath::new("delete_rocks_test");
-    let db = RocksDb::open(path.as_ref()).unwrap();
-    subtests::delete(&db);
+    let db = TempRocksDB::new();
+    subtests::delete(&*db);
 }
 
 #[test]
 fn rocks_db_bulk_write() {
-    let path = DBPath::new("bulk_write_rocks_test");
-    let db = RocksDb::open(path.as_ref()).unwrap();
-    subtests::bulk_write(&db);
+    let db = TempRocksDB::new();
+    subtests::bulk_write(&*db);
 }
 
 #[test]
 fn rocks_db_bulk_read() {
-    let path = DBPath::new("bulk_read_rocks_test");
-    let db = RocksDb::open(path.as_ref()).unwrap();
-    subtests::bulk_read(&db);
+    let db = TempRocksDB::new();
+    subtests::bulk_read(&*db);
 }
 
 #[test]
 fn rocks_db_bulk_delete() {
-    let path = DBPath::new("bulk_delete_rocks_test");
-    let db = RocksDb::open(path.as_ref()).unwrap();
-    subtests::bulk_delete(&db);
+    let db = TempRocksDB::new();
+    subtests::bulk_delete(&*db);
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Parametrized currently used `rocksdb` settings,
- refactored rocksdb tests a bit,
- some other cosmetic changes I couldn't resist,


**Other information and links**
Part of https://github.com/ChainSafe/forest/issues/1473, more settings and different defaults may come after some tinkering. Doesn't make sense to expose everything at once, there are quite a lot of different [knobs](https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#) available.