### PR TITLE
Use progress bars when downloading headers and scanning the blockchain.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "multihash 0.16.1",
  "networks",
  "num-traits",
+ "pbr",
  "serde",
  "state_tree",
  "test_utils",

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ChainSafe Systems <info@chainsafe.io>"]
 edition = "2021"
 
 [dependencies]
+pbr = "1.0.3"
 blocks = { package = "forest_blocks", path = "../blocks", features = ["json"] }
 db = { package = "forest_db", version = "0.1" }
 cid = { package = "forest_cid", version = "0.3" }

--- a/blockchain/chain/src/store/index.rs
+++ b/blockchain/chain/src/store/index.rs
@@ -84,7 +84,10 @@ where
                 return self.walk_back(lbe.tipset.clone(), to).await;
             }
             let to_be_done = lbe.tipset.epoch() - to;
-            pb.set((total_size - to_be_done) as u64);
+            // Don't show the progress bar if we're doing less than 10_000 units of work.
+            if total_size > 10_000 {
+                pb.set((total_size - to_be_done) as u64);
+            }
 
             cur = lbe.target.clone();
         }

--- a/blockchain/chain/src/store/index.rs
+++ b/blockchain/chain/src/store/index.rs
@@ -62,6 +62,10 @@ where
         if from.epoch() - to <= SKIP_LENGTH {
             return self.walk_back(from, to).await;
         }
+        let total_size = from.epoch() - to;
+        let mut pb = pbr::ProgressBar::new(total_size as u64);
+        pb.message("Scanning blockchain ");
+        pb.set_max_refresh_rate(Some(std::time::Duration::from_millis(500)));
 
         let rounded = self.round_down(from).await?;
 
@@ -79,6 +83,8 @@ where
             } else if to > lbe.target_height {
                 return self.walk_back(lbe.tipset.clone(), to).await;
             }
+            let to_be_done = lbe.tipset.epoch() - to;
+            pb.set((total_size - to_be_done) as u64);
 
             cur = lbe.target.clone();
         }

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -846,13 +846,15 @@ async fn sync_headers_in_reverse<DB: BlockStore + Sync + Send + 'static>(
 
     let total_size = proposed_head.epoch() - current_head.epoch();
     let mut pb = pbr::ProgressBar::new(total_size as u64);
+    pb.message("Downloading headers ");
     pb.set_max_refresh_rate(Some(std::time::Duration::from_millis(500)));
 
     'sync: loop {
         // Unwrapping is safe here because the tipset vector always
         // has at least one element
         let oldest_parent = parent_tipsets.last().unwrap();
-        pb.set((oldest_parent.epoch() - total_size).abs() as u64);
+        let work_to_be_done = oldest_parent.epoch() - current_head.epoch();
+        pb.set((work_to_be_done - total_size).abs() as u64);
         validate_tipset_against_cache(
             bad_block_cache.clone(),
             oldest_parent.parents(),

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -378,7 +378,7 @@ where
                 },
                 interval_event = interval.next() => if interval_event.is_some() {
                     // Print peer count on an interval.
-                    info!("Peers connected: {}", swarm_stream.get_mut().behaviour_mut().peers().len());
+                    debug!("Peers connected: {}", swarm_stream.get_mut().behaviour_mut().peers().len());
                 }
             };
         }

--- a/utils/net_utils/src/download.rs
+++ b/utils/net_utils/src/download.rs
@@ -72,6 +72,7 @@ impl TryFrom<Url> for FetchProgress<AsyncBody, Stdout> {
         let request = task::block_on(client.get_async(url.as_str()))?;
 
         let mut pb = ProgressBar::new(total_size);
+        pb.message("Downloading/Importing snapshot ");
         pb.set_units(Units::Bytes);
         pb.set_max_refresh_rate(Some(Duration::from_millis(500)));
 
@@ -89,6 +90,7 @@ impl TryFrom<File> for FetchProgress<BufReader<File>, Stdout> {
         let total_size = async_std::task::block_on(file.metadata())?.len();
 
         let mut pb = ProgressBar::new(total_size);
+        pb.message("Importing snapshot ");
         pb.set_units(Units::Bytes);
         pb.set_max_refresh_rate(Some(Duration::from_millis(500)));
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use progress bars for the three main time-sinks: Importing a snapshot, scanning the imported blockchain, downloading remaining headers from the network.
- Demote libp2p peer reports from INFO to DEBUG.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->