### PR TITLE
exposed more rocksdb options, increased max files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,6 +3094,7 @@ dependencies = [
 name = "forest_db"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "forest_encoding",
  "num_cpus",
  "parking_lot",

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
     pub sync: SyncConfig,
     pub encrypt_keystore: bool,
     pub metrics_port: u16,
-    pub rocks_db: db::rocks::RocksDbConfig,
+    pub rocks_db: db::rocks_config::RocksDbConfig,
 }
 
 impl Default for Config {
@@ -44,7 +44,7 @@ impl Default for Config {
             sync: SyncConfig::default(),
             encrypt_keystore: true,
             metrics_port: 6116,
-            rocks_db: db::rocks::RocksDbConfig::default(),
+            rocks_db: db::rocks_config::RocksDbConfig::default(),
         }
     }
 }

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -15,6 +15,7 @@ encoding = { package = "forest_encoding", version = "0.2" }
 thiserror = "1.0"
 num_cpus = "1.13"
 serde = { version = "1.0", features = ["derive"] }
+anyhow = "1"
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/node/db/src/lib.rs
+++ b/node/db/src/lib.rs
@@ -7,6 +7,9 @@ mod memory;
 #[cfg(feature = "rocksdb")]
 pub mod rocks;
 
+#[cfg(feature = "rocksdb")]
+pub mod rocks_config;
+
 #[cfg(feature = "sled")]
 pub mod sled;
 

--- a/node/db/src/rocks_config.rs
+++ b/node/db/src/rocks_config.rs
@@ -31,7 +31,7 @@ impl Default for RocksDbConfig {
             max_open_files: 1024,
             max_background_jobs: None,
             compaction_style: None,
-            compression_type: None,
+            compression_type: Some("lz4".into()),
             enable_statistics: false,
         }
     }

--- a/node/db/src/rocks_config.rs
+++ b/node/db/src/rocks_config.rs
@@ -1,0 +1,108 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+use anyhow::anyhow;
+use num_cpus;
+use rocksdb::{DBCompactionStyle, DBCompressionType};
+use serde::Deserialize;
+
+/// RocksDB configuration exposed in Forest.
+/// Only subset of possible options is implemented, add missing ones when needed.
+/// For description of different options please refer to the `rocksdb` crate documentation.
+/// <https://docs.rs/rocksdb/latest/rocksdb/>
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct RocksDbConfig {
+    pub create_if_missing: bool,
+    pub parallelism: i32,
+    pub write_buffer_size: usize,
+    pub max_open_files: i32,
+    pub max_background_jobs: Option<i32>,
+    pub compression_type: Option<String>,
+    pub compaction_style: Option<String>,
+    pub enable_statistics: bool,
+}
+
+impl Default for RocksDbConfig {
+    fn default() -> Self {
+        Self {
+            create_if_missing: true,
+            parallelism: num_cpus::get() as i32,
+            write_buffer_size: 256 * 1024 * 1024,
+            max_open_files: 1024,
+            max_background_jobs: None,
+            compaction_style: None,
+            compression_type: None,
+            enable_statistics: false,
+        }
+    }
+}
+
+/// Converts string to a compaction style RocksDB variant.
+pub(crate) fn compaction_style_from_str(s: &str) -> anyhow::Result<DBCompactionStyle> {
+    match s.to_lowercase().as_str() {
+        "level" => Ok(DBCompactionStyle::Level),
+        "universal" => Ok(DBCompactionStyle::Universal),
+        "fifo" => Ok(DBCompactionStyle::Fifo),
+        _ => Err(anyhow!("invalid compaction option")),
+    }
+}
+
+/// Converts string to a compression type RocksDB variant.
+pub(crate) fn compression_type_from_str(s: &str) -> anyhow::Result<DBCompressionType> {
+    match s.to_lowercase().as_str() {
+        "bz2" => Ok(DBCompressionType::Bz2),
+        "lz4" => Ok(DBCompressionType::Lz4),
+        "lz4hc" => Ok(DBCompressionType::Lz4hc),
+        "snappy" => Ok(DBCompressionType::Snappy),
+        "zlib" => Ok(DBCompressionType::Zlib),
+        "zstd" => Ok(DBCompressionType::Zstd),
+        "none" => Ok(DBCompressionType::None),
+        _ => Err(anyhow!("invalid compression option")),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rocksdb::DBCompactionStyle;
+
+    #[test]
+    fn compaction_style_from_str_test() {
+        let test_cases = vec![
+            ("Level", Ok(DBCompactionStyle::Level)),
+            ("UNIVERSAL", Ok(DBCompactionStyle::Universal)),
+            ("fifo", Ok(DBCompactionStyle::Fifo)),
+            ("cthulhu", Err(anyhow!("some error message"))),
+        ];
+        for (input, expected) in test_cases {
+            let actual = compaction_style_from_str(input);
+            if let Ok(compaction_style) = actual {
+                assert_eq!(expected.unwrap(), compaction_style);
+            } else {
+                assert!(expected.is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn compression_style_from_str_test() {
+        let test_cases = vec![
+            ("bz2", Ok(DBCompressionType::Bz2)),
+            ("lz4", Ok(DBCompressionType::Lz4)),
+            ("lz4HC", Ok(DBCompressionType::Lz4hc)),
+            ("SNAPPY", Ok(DBCompressionType::Snappy)),
+            ("zlib", Ok(DBCompressionType::Zlib)),
+            ("ZSTD", Ok(DBCompressionType::Zstd)),
+            ("none", Ok(DBCompressionType::None)),
+            ("cthulhu", Err(anyhow!("some error message"))),
+        ];
+        for (input, expected) in test_cases {
+            let actual = compression_type_from_str(input);
+            if let Ok(compression_type) = actual {
+                assert_eq!(expected.unwrap(), compression_type);
+            } else {
+                assert!(expected.is_err());
+            }
+        }
+    }
+}

--- a/node/db/tests/db_utils/mod.rs
+++ b/node/db/tests/db_utils/mod.rs
@@ -3,7 +3,8 @@
 
 #![cfg(feature = "rocksdb")]
 
-use forest_db::rocks::{RocksDb, RocksDbConfig};
+use forest_db::rocks::RocksDb;
+use forest_db::rocks_config::RocksDbConfig;
 use std::ops::Deref;
 
 /// Temporary, self-cleaning RocksDB
@@ -22,7 +23,7 @@ impl TempRocksDB {
         let path = dir.path().join("db");
 
         TempRocksDB {
-            db: RocksDb::open(&path, RocksDbConfig::default()).unwrap(),
+            db: RocksDb::open(&path, &RocksDbConfig::default()).unwrap(),
             _dir: dir,
         }
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Expose more options for RocksDB,
- Moved configuration to a separate file,
- Increased the default number of open files from 200 to 1000 (it made snapshot import 50% faster, from ~1800 to 900 seconds). I tinkered with other settings but didn't see any spectacular improvement. I left some options exposed if anyone wants to tinker on their own. 
- defaulted compression to `lz4` 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1473 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->