### PR TITLE
config dump with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +1984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2062,12 @@ dependencies = [
  "byteorder 1.4.3",
  "quick-error",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -2705,6 +2731,7 @@ name = "forest"
 version = "0.2.2"
 dependencies = [
  "actor_interface",
+ "assert_cmd",
  "async-log",
  "async-std",
  "auth",
@@ -2743,6 +2770,7 @@ dependencies = [
  "paramfetch",
  "pretty_env_logger",
  "prometheus 0.13.0",
+ "rand 0.8.5",
  "rayon",
  "rpassword",
  "rpc",
@@ -2753,8 +2781,10 @@ dependencies = [
  "serde_json",
  "state_manager",
  "structopt",
+ "tempfile",
  "ticker",
  "tokio",
+ "toml",
  "utils",
  "uuid",
 ]
@@ -6232,6 +6262,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "itertools 0.10.3",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8111,6 +8168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "test_utils"
 version = "0.1.0"
 dependencies = [
@@ -8673,6 +8736,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/blockchain/chain_sync/src/chain_muxer.rs
+++ b/blockchain/chain_sync/src/chain_muxer.rs
@@ -32,7 +32,7 @@ use async_std::task::{Context, Poll};
 use futures::stream::FuturesUnordered;
 use futures::{future::try_join_all, future::Future, try_join};
 use log::{debug, error, info, trace, warn};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use std::sync::Arc;
@@ -67,7 +67,7 @@ pub enum ChainMuxerError {
 }
 
 /// Struct that defines syncing configuration options
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct SyncConfig {
     /// Request window length for tipsets during chain exchange
     pub req_window: i64,

--- a/forest/Cargo.toml
+++ b/forest/Cargo.toml
@@ -59,11 +59,17 @@ prometheus = { version = "0.13", features = ["process"] }
 ticker = "0.1"
 byte-unit = "4.0"
 rug = "1.13"
+toml = "0.5"
 
 [dependencies.jsonrpc-v2]
 version = "0.10"
 features = ["easy-errors", "macros", "bytes-v05"]
 default-features = false
+
+[dev-dependencies]
+assert_cmd = "2"
+rand = "0.8"
+tempfile = "3"
 
 [features]
 default = ["rocksdb", "networks/mainnet"]

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -4,13 +4,12 @@
 use chain_sync::SyncConfig;
 use forest_libp2p::Libp2pConfig;
 use rpc_client::DEFAULT_PORT;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use utils::get_home_dir;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct Config {
-    pub network: Libp2pConfig,
     pub data_dir: String,
     pub genesis_file: Option<String>,
     pub enable_rpc: bool,
@@ -23,10 +22,11 @@ pub struct Config {
     /// Skips loading import CAR file and assumes it's already been loaded.
     /// Will use the cids in the header of the file to index the chain.
     pub skip_load: bool,
-    pub sync: SyncConfig,
     pub encrypt_keystore: bool,
     pub metrics_port: u16,
     pub rocks_db: db::rocks_config::RocksDbConfig,
+    pub network: Libp2pConfig,
+    pub sync: SyncConfig,
 }
 
 impl Default for Config {

--- a/forest/src/cli/config_cmd.rs
+++ b/forest/src/cli/config_cmd.rs
@@ -1,0 +1,47 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::cli::Config;
+use async_std::io::Write;
+use async_std::io::WriteExt;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub enum ConfigCommands {
+    #[structopt(about = "Dump current configuration to standard output")]
+    Dump,
+}
+
+impl ConfigCommands {
+    pub async fn run<W: Write + Unpin>(&self, config: &Config, sink: &mut W) {
+        match self {
+            Self::Dump => {
+                writeln!(
+                    sink,
+                    "{}",
+                    toml::to_string(config)
+                        .expect("Could not convert configuration to TOML format")
+                )
+                .await
+                .expect("Failed to write the configuration");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[async_std::test]
+    async fn given_default_configuration_should_print_valid_toml() {
+        let expected_config = Config::default();
+        let mut sink = futures::io::BufWriter::new(Vec::new());
+
+        ConfigCommands::Dump.run(&expected_config, &mut sink).await;
+
+        let actual_config: Config = toml::from_str(std::str::from_utf8(sink.buffer()).unwrap())
+            .expect("Invalid configuration!");
+        assert_eq!(actual_config, expected_config);
+    }
+}

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -4,6 +4,7 @@
 mod auth_cmd;
 mod chain_cmd;
 mod config;
+mod config_cmd;
 mod fetch_params_cmd;
 mod genesis_cmd;
 mod mpool_cmd;
@@ -38,6 +39,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use structopt::StructOpt;
 
+use crate::cli::config_cmd::ConfigCommands;
 use blocks::tipset_json::TipsetJson;
 use cid::Cid;
 use utils::{read_file_to_string, read_toml};
@@ -90,6 +92,9 @@ pub enum Subcommand {
 
     #[structopt(name = "state", about = "Interact with and query filecoin chain state")]
     State(StateCommands),
+
+    #[structopt(name = "config", about = "Manage node configuration")]
+    Config(ConfigCommands),
 }
 
 /// CLI options
@@ -172,7 +177,7 @@ impl CliOpts {
             cfg.enable_rpc = true;
             cfg.rpc_port = self.port.to_owned().unwrap_or(cfg.rpc_port);
 
-            if cfg.rpc_token.is_some() {
+            if self.token.is_some() {
                 cfg.rpc_token = self.token.to_owned();
             }
         } else {
@@ -220,7 +225,7 @@ impl CliOpts {
 }
 
 /// Blocks current thread until ctrl-c is received
-pub(super) async fn block_until_sigint() {
+pub async fn block_until_sigint() {
     let (ctrlc_send, ctrlc_oneshot) = futures::channel::oneshot::channel();
     let ctrlc_send_c = RefCell::new(Some(ctrlc_send));
 

--- a/forest/src/lib.rs
+++ b/forest/src/lib.rs
@@ -1,0 +1,3 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+pub mod cli;

--- a/forest/src/subcommand.rs
+++ b/forest/src/subcommand.rs
@@ -88,5 +88,8 @@ pub(super) async fn process(command: Subcommand, config: Config) {
         Subcommand::State(cmd) => {
             cmd.run().await;
         }
+        Subcommand::Config(cmd) => {
+            cmd.run(&config, &mut async_std::io::stdout()).await;
+        }
     }
 }

--- a/forest/tests/config_tests.rs
+++ b/forest/tests/config_tests.rs
@@ -1,0 +1,84 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+use assert_cmd::Command;
+use forest::cli::Config;
+use rand::Rng;
+use std::io::Write;
+
+#[test]
+fn test_config_subcommand_produces_valid_toml_configuration_dump() {
+    let cmd = Command::cargo_bin("forest")
+        .unwrap()
+        .arg("--rpc")
+        .arg("true")
+        .arg("--token")
+        .arg("Azazello")
+        .arg("config")
+        .arg("dump")
+        .assert()
+        .success();
+
+    let output = &cmd.get_output().stdout;
+    toml::from_str::<Config>(std::str::from_utf8(output).unwrap()).expect("Invalid configuration!");
+}
+
+#[test]
+fn test_overrides_are_reflected_in_configuration_dump() {
+    let mut rng = rand::thread_rng();
+    let randomized_metrics_port = rng.gen::<u16>();
+
+    let cmd = Command::cargo_bin("forest")
+        .unwrap()
+        .arg("--rpc")
+        .arg("true")
+        .arg("--token")
+        .arg("Azazello")
+        .arg("--metrics-port")
+        .arg(randomized_metrics_port.to_string())
+        .arg("config")
+        .arg("dump")
+        .assert()
+        .success();
+
+    let output = &cmd.get_output().stdout;
+    let config = toml::from_str::<Config>(std::str::from_utf8(output).unwrap())
+        .expect("Invalid configuration!");
+    assert_eq!(config.metrics_port, randomized_metrics_port);
+}
+
+#[test]
+fn test_reading_configuration_from_file() {
+    let mut rng = rand::thread_rng();
+
+    let expected_config = Config {
+        metrics_port: rng.gen(),
+        rpc_token: Some("Azazello".into()),
+        genesis_file: Some("cthulhu".into()),
+        encrypt_keystore: false,
+        ..Config::default()
+    };
+
+    let mut config_file = tempfile::Builder::new().tempfile().unwrap();
+    config_file
+        .write_all(toml::to_string(&expected_config).unwrap().as_bytes())
+        .expect("Failed writing configuration!");
+
+    let cmd = Command::cargo_bin("forest")
+        .unwrap()
+        .arg("--rpc")
+        .arg("true")
+        .arg("--token")
+        .arg("Azazello")
+        .arg("--config")
+        .arg(config_file.path())
+        .arg("config")
+        .arg("dump")
+        .assert()
+        .success();
+
+    let output = &cmd.get_output().stdout;
+    let actual_config = toml::from_str::<Config>(std::str::from_utf8(output).unwrap())
+        .expect("Invalid configuration!");
+
+    assert_eq!(expected_config, actual_config);
+}

--- a/node/db/src/rocks_config.rs
+++ b/node/db/src/rocks_config.rs
@@ -3,13 +3,13 @@
 use anyhow::anyhow;
 use num_cpus;
 use rocksdb::{DBCompactionStyle, DBCompressionType};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// RocksDB configuration exposed in Forest.
 /// Only subset of possible options is implemented, add missing ones when needed.
 /// For description of different options please refer to the `rocksdb` crate documentation.
 /// <https://docs.rs/rocksdb/latest/rocksdb/>
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct RocksDbConfig {
     pub create_if_missing: bool,

--- a/node/forest_libp2p/src/config.rs
+++ b/node/forest_libp2p/src/config.rs
@@ -3,10 +3,10 @@
 
 use libp2p::Multiaddr;
 use networks::DEFAULT_BOOTSTRAP;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Libp2p config for the Forest node.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct Libp2pConfig {
     /// Local address.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- added `config dump` subcommand which should dump the current configuration to stdout in a TOML format.
- added basic CLI tests
- fixed a minor bug with token used via CLI

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1478


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->