### PR TITLE
ci: enable rustc version trinity for builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rv: [1.58.1, stable]
+        rv: [1.58.1, stable, beta, nightly]
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1


### PR DESCRIPTION
`rv: [1.58.1, stable, beta, nightly]`