### PR TITLE
node: demote noisy warnings to debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,7 +3015,6 @@ dependencies = [
  "forest_crypto",
  "forest_db",
  "forest_encoding",
- "forest_ipld",
  "forest_runtime",
  "forest_vm",
  "fvm_shared",
@@ -3079,7 +3078,6 @@ dependencies = [
  "fvm_shared",
  "lazy_static",
  "leb128",
- "log",
  "num-derive",
  "num-traits",
  "once_cell",
@@ -3092,7 +3090,6 @@ name = "forest_bigint"
 version = "0.1.4"
 dependencies = [
  "cs_serde_bytes",
- "libipld-core",
  "num-bigint 0.4.3",
  "num-integer",
  "serde",
@@ -3165,9 +3162,7 @@ name = "forest_cid"
 version = "0.3.0"
 dependencies = [
  "cid",
- "cs_serde_bytes",
  "forest_json_utils",
- "fvm_shared",
  "generic-array 0.14.5",
  "integer-encoding 3.0.3",
  "multibase 0.9.1",
@@ -3217,7 +3212,6 @@ version = "0.2.2"
 dependencies = [
  "blake2b_simd 1.0.0",
  "cs_serde_bytes",
- "forest_cid",
  "fvm_shared",
  "serde",
  "serde_ipld_dagcbor",
@@ -3242,11 +3236,9 @@ dependencies = [
  "async-std",
  "async-trait",
  "forest_cid",
- "forest_db",
  "forest_encoding",
  "fvm_shared",
  "indexmap",
- "ipld_blockstore",
  "libipld-core",
  "multibase 0.9.1",
  "serde",
@@ -4344,8 +4336,6 @@ dependencies = [
  "forest_db",
  "forest_encoding",
  "forest_hash_utils",
- "forest_ipld",
- "hex",
  "ipld_blockstore",
  "libipld-core",
  "once_cell",
@@ -7446,16 +7436,12 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
  "bls-signatures",
- "fil_types",
- "forest_address",
  "forest_blocks",
  "forest_cid",
  "forest_crypto",
  "forest_encoding",
  "forest_message",
- "forest_vm",
  "hex",
- "num-traits",
  "serde",
  "serde_json",
 ]
@@ -8292,7 +8278,6 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "test_utils"
 version = "0.1.0"
 dependencies = [
- "async-std",
  "base64 0.13.0",
  "chain",
  "forest_address",
@@ -8303,7 +8288,6 @@ dependencies = [
  "forest_encoding",
  "forest_libp2p",
  "forest_message",
- "ipld_blockstore",
 ]
 
 [[package]]

--- a/blockchain/chain_sync/src/chain_muxer.rs
+++ b/blockchain/chain_sync/src/chain_muxer.rs
@@ -272,7 +272,7 @@ where
                 match network.hello_request(peer_id, request).await {
                     Ok(response) => response,
                     Err(e) => {
-                        error!("{}", e);
+                        debug!("Hello request failed: {}", e);
                         return;
                     }
                 };
@@ -381,7 +381,7 @@ where
                 {
                     Ok(tipset) => tipset,
                     Err(why) => {
-                        error!("Querying full tipset failed: {}", why);
+                        debug!("Querying full tipset failed: {}", why);
                         return Err(why);
                     }
                 };
@@ -497,7 +497,7 @@ where
                 let event = match p2p_messages.recv().await {
                     Ok(event) => event,
                     Err(why) => {
-                        error!("Receiving event from p2p event stream failed: {}", why);
+                        debug!("Receiving event from p2p event stream failed: {}", why);
                         return Err(ChainMuxerError::P2PEventStreamReceive(why.to_string()));
                     }
                 };
@@ -612,7 +612,7 @@ where
                 let event = match p2p_messages.recv().await {
                     Ok(event) => event,
                     Err(why) => {
-                        error!("Receiving event from p2p event stream failed: {}", why);
+                        debug!("Receiving event from p2p event stream failed: {}", why);
                         return Err(ChainMuxerError::P2PEventStreamReceive(why.to_string()));
                     }
                 };
@@ -702,7 +702,7 @@ where
                 // If a tipset has been provided, pass it to the tipset processor
                 if let Some(tipset) = tipset_opt {
                     if let Err(why) = tipset_sender.send(Arc::new(tipset.into_tipset())).await {
-                        error!("Sending tipset to TipsetProcessor failed: {}", why);
+                        debug!("Sending tipset to TipsetProcessor failed: {}", why);
                         return Err(ChainMuxerError::TipsetChannelSend(why.to_string()));
                     };
                 }
@@ -710,7 +710,7 @@ where
                     let event = match p2p_messages.recv().await {
                         Ok(event) => event,
                         Err(why) => {
-                            error!("Receiving event from p2p event stream failed: {}", why);
+                            debug!("Receiving event from p2p event stream failed: {}", why);
                             return Err(ChainMuxerError::P2PEventStreamReceive(why.to_string()));
                         }
                     };
@@ -748,7 +748,7 @@ where
                     }
 
                     if let Err(why) = tipset_sender.send(Arc::new(tipset.into_tipset())).await {
-                        error!("Sending tipset to TipsetProcessor failed: {}", why);
+                        debug!("Sending tipset to TipsetProcessor failed: {}", why);
                         return Err(ChainMuxerError::TipsetChannelSend(why.to_string()));
                     };
                 }

--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -196,7 +196,7 @@ where
                             }
                         },
                         Err(e) => {
-                            warn!("Failed chain_exchange request to peer {:?}: {}", p, e);
+                            debug!("Failed chain_exchange request to peer {:?}: {}", p, e);
                             continue;
                         }
                     }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -28,7 +28,7 @@ use byte_unit::Byte;
 use directories::ProjectDirs;
 use fil_types::FILECOIN_PRECISION;
 use jsonrpc_v2::Error as JsonRpcError;
-use log::{info, warn};
+use log::{info, warn, error};
 use num_bigint::BigInt;
 use rug::float::ParseFloatError;
 use rug::Float;
@@ -219,7 +219,7 @@ impl CliOpts {
 fn find_default_config() -> Option<Config> {
     if let Ok(config_file) = std::env::var("FOREST_CONFIG_PATH") {
         info!(
-            "FOREST_CONFIG_PATH is set! Using configuration at {}",
+            "FOREST_CONFIG_PATH detected, using configuration at {}",
             config_file
         );
         let path = PathBuf::from(config_file);
@@ -232,12 +232,12 @@ fn find_default_config() -> Option<Config> {
         let mut config_dir = dir.config_dir().to_path_buf();
         config_dir.push("config.toml");
         if config_dir.exists() {
-            info!("Found config file at {}", config_dir.display());
+            info!("Found a config file at {}", config_dir.display());
             return read_config_or_none(config_dir);
         }
     }
 
-    warn!("No configuration found! Using default");
+    warn!("No configurations found, using defaults.");
 
     None
 }
@@ -255,7 +255,7 @@ fn read_config_or_none(path: PathBuf) -> Option<Config> {
         Ok(cfg) => Some(cfg),
         Err(e) => {
             warn!(
-                "Error reading configuration, opting to default. Error was {} ",
+                "Error reading configuration file, opting to defaults. Error was {} ",
                 e
             );
             None
@@ -272,7 +272,7 @@ pub async fn block_until_sigint() {
     ctrlc::set_handler(move || {
         let prev = running.fetch_add(1, Ordering::SeqCst);
         if prev == 0 {
-            println!("Got interrupt, shutting down...");
+            warn!("Got interrupt, shutting down...");
             // Send sig int in channel to blocking task
             if let Some(ctrlc_send) = ctrlc_send_c.try_borrow_mut().unwrap().take() {
                 ctrlc_send.send(()).expect("Error sending ctrl-c message");
@@ -294,11 +294,11 @@ pub(super) fn handle_rpc_err(e: JsonRpcError) {
             message,
             data: _,
         } => {
-            println!("JSON RPC Error: Code: {} Message: {}", code, message);
+            error!("JSON RPC Error: Code: {} Message: {}", code, message);
             process::exit(code as i32);
         }
         JsonRpcError::Provided { code, message } => {
-            println!("JSON RPC Error: Code: {} Message: {}", code, message);
+            error!("JSON RPC Error: Code: {} Message: {}", code, message);
             process::exit(code as i32);
         }
     }
@@ -319,7 +319,7 @@ pub(super) fn to_size_string(bi: &BigInt) -> String {
 /// Print an error message and exit the program with an error code
 /// Used for handling high level errors such as invalid params
 pub(super) fn cli_error_and_die(msg: &str, code: i32) {
-    println!("Error: {}", msg);
+    error!("Error: {}", msg);
     std::process::exit(code);
 }
 

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -28,7 +28,7 @@ use byte_unit::Byte;
 use directories::ProjectDirs;
 use fil_types::FILECOIN_PRECISION;
 use jsonrpc_v2::Error as JsonRpcError;
-use log::{info, warn, error};
+use log::{error, info, warn};
 use num_bigint::BigInt;
 use rug::float::ParseFloatError;
 use rug::Float;

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -78,7 +78,7 @@ pub(super) async fn start(config: Config) {
                 std::io::stdout().flush().unwrap();
 
                 if passphrase != read_password().unwrap() {
-                    println!("Passphrases do not match. Please retry.");
+                    warn!("Passphrases do not match. Please retry.");
                     continue;
                 }
             }
@@ -91,7 +91,7 @@ pub(super) async fn start(config: Config) {
             match key_store_init_result {
                 Ok(ks) => break ks,
                 Err(_) => {
-                    log::error!("Incorrect passphrase entered. Please try again.")
+                    warn!("Incorrect passphrase entered. Please try again.")
                 }
             };
         }
@@ -121,7 +121,7 @@ pub(super) async fn start(config: Config) {
     // Print admin token
     let ki = ks.get(JWT_IDENTIFIER).unwrap();
     let token = create_token(ADMIN.to_owned(), ki.private_key()).unwrap();
-    println!("Admin token: {}", token);
+    info!("Admin token: {}", token);
 
     let keystore = Arc::new(RwLock::new(ks));
 
@@ -215,7 +215,7 @@ pub(super) async fn start(config: Config) {
         let keystore_rpc = Arc::clone(&keystore);
         let rpc_listen = format!("127.0.0.1:{}", &config.rpc_port);
         Some(task::spawn(async move {
-            info!("JSON RPC Endpoint at {}", &rpc_listen);
+            info!("JSON-RPC endpoint started at {}", &rpc_listen);
             start_rpc::<_, _, FullVerifier>(
                 Arc::new(RPCState {
                     state_manager: Arc::clone(&state_manager),
@@ -234,7 +234,7 @@ pub(super) async fn start(config: Config) {
             .await
         }))
     } else {
-        debug!("RPC disabled");
+        debug!("RPC disabled.");
         None
     };
 
@@ -254,7 +254,7 @@ pub(super) async fn start(config: Config) {
     }
     keystore_write.await;
 
-    info!("Forest finish shutdown");
+    info!("Forest finish shutdown.");
 }
 
 async fn sync_from_snapshot(config: &Config, state_manager: &Arc<StateManager<RocksDb>>) {

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -19,7 +19,7 @@ use wallet::{KeyStore, KeyStoreConfig};
 
 use async_std::{channel::bounded, sync::RwLock, task};
 use libp2p::identity::{ed25519, Keypair};
-use log::{debug, info, trace, warn};
+use log::{debug, error, info, trace, warn};
 use rpassword::read_password;
 
 use db::rocks::RocksDb;
@@ -78,7 +78,7 @@ pub(super) async fn start(config: Config) {
                 std::io::stdout().flush().unwrap();
 
                 if passphrase != read_password().unwrap() {
-                    warn!("Passphrases do not match. Please retry.");
+                    error!("Passphrases do not match. Please retry.");
                     continue;
                 }
             }
@@ -91,7 +91,7 @@ pub(super) async fn start(config: Config) {
             match key_store_init_result {
                 Ok(ks) => break ks,
                 Err(_) => {
-                    warn!("Incorrect passphrase entered. Please try again.")
+                    error!("Incorrect passphrase entered. Please try again.")
                 }
             };
         }

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -357,10 +357,10 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<ChainExchangeRequest, Cha
                     // Send the sucessful response through channel out.
                     if let Some(tx) = tx {
                         if tx.send(Ok(response)).is_err() {
-                            warn!("RPCResponse receive timed out")
+                            debug!("RPCResponse receive timed out")
                         }
                     } else {
-                        warn!("RPCResponse receive failed: channel not found");
+                        debug!("RPCResponse receive failed: channel not found");
                     };
                 }
             },

--- a/utils/paramfetch/src/lib.rs
+++ b/utils/paramfetch/src/lib.rs
@@ -11,7 +11,7 @@ use async_std::{
 use blake2b_simd::{Hash, State as Blake2b};
 use core::time::Duration;
 use fil_types::SectorSize;
-use log::{info, warn};
+use log::{debug, warn};
 use net_utils::FetchProgress;
 use pbr::{MultiBar, Units};
 use serde::{Deserialize, Serialize};
@@ -155,7 +155,7 @@ async fn fetch_params(
     multi_bar: Option<Arc<MultiBar<Stdout>>>,
 ) -> Result<(), Box<dyn StdError>> {
     let gw = std::env::var(GATEWAY_ENV).unwrap_or_else(|_| GATEWAY.to_owned());
-    info!("Fetching {:?} from {}", path, gw);
+    debug!("Fetching {:?} from {}", path, gw);
 
     let file = File::create(path).await?;
     let mut writer = BufWriter::new(file);
@@ -198,7 +198,7 @@ async fn fetch_params(
 
 async fn check_file(path: Arc<Path>, info: Arc<ParameterData>) -> Result<(), io::Error> {
     if std::env::var(TRUST_PARAMS_ENV) == Ok("1".to_owned()) {
-        warn!("Assuming parameter files are okay. DO NOT USE IN PRODUCTION");
+        warn!("Assuming parameter files are okay. Do not use in production!");
         return Ok(());
     }
 
@@ -215,7 +215,7 @@ async fn check_file(path: Arc<Path>, info: Arc<ParameterData>) -> Result<(), io:
     let str_sum = hash.to_hex();
     let str_sum = &str_sum[..32];
     if str_sum == info.digest {
-        info!("Parameter file {:?} is ok", path);
+        debug!("Parameter file {:?} is ok", path);
         Ok(())
     } else {
         Err(io::Error::new(


### PR DESCRIPTION
`info`, `warn`, and `error` should only be used if it is relevant for the user, not the developer.