### PR TITLE
Separate Chain DBs

### DIFF
--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -125,10 +125,11 @@ pub(super) async fn start(config: Config) {
 
     // Initialize database (RocksDb will be default if both features enabled)
     #[cfg(all(feature = "sled", not(feature = "rocksdb")))]
-    let db = db::sled::SledDb::open(format!(
-        "{}/{}/{}",
-        config.data_dir, &config.chain.name, "/sled"
-    ))
+    let db = db::sled::SledDb::open(
+        PathBuf::from(&config.data_dir)
+            .join(&config.chain.name)
+            .join("sled"),
+    )
     .expect("Opening SledDB must succeed");
 
     #[cfg(feature = "rocksdb")]

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -125,12 +125,20 @@ pub(super) async fn start(config: Config) {
 
     // Initialize database (RocksDb will be default if both features enabled)
     #[cfg(all(feature = "sled", not(feature = "rocksdb")))]
-    let db = db::sled::SledDb::open(format!("{}/{}", config.data_dir, "/sled"))
-        .expect("Opening SledDB must succeed");
+    let db = db::sled::SledDb::open(format!(
+        "{}/{}/{}",
+        config.data_dir, &config.chain.name, "/sled"
+    ))
+    .expect("Opening SledDB must succeed");
 
     #[cfg(feature = "rocksdb")]
-    let db = db::rocks::RocksDb::open(PathBuf::from(&config.data_dir).join("db"), &config.rocks_db)
-        .expect("Opening RocksDB must succeed");
+    let db = db::rocks::RocksDb::open(
+        PathBuf::from(&config.data_dir)
+            .join(&config.chain.name)
+            .join("db"),
+        &config.rocks_db,
+    )
+    .expect("Opening RocksDB must succeed");
 
     let db = Arc::new(db);
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Allows users switching between networks regularly to maintain separate blockstores.
- Also maintains separation between sled and rocksdb users such that at most (with 2 networks), there can be up to 4 different databases.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1418 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->