### PR TITLE
ci: add codecov target threshold tolerance of 1%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
 codecov:
   require_ci_to_pass: no
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,7 @@
 codecov:
   require_ci_to_pass: no
+
+coverage:
   status:
     project:
       default:


### PR DESCRIPTION
if a pull request only slightly decreases coverage, it will not go red.