### PR TITLE
log: don't override default filters (#1504)

### DIFF
--- a/forest/src/logger/mod.rs
+++ b/forest/src/logger/mod.rs
@@ -5,20 +5,22 @@ use log::LevelFilter;
 
 pub(crate) fn setup_logger() {
     let mut logger_builder = pretty_env_logger::formatted_timed_builder();
+
+    // Assign default log level settings
+    logger_builder.filter(Some("libp2p_gossipsub"), LevelFilter::Error);
+    logger_builder.filter(Some("filecoin_proofs"), LevelFilter::Warn);
+    logger_builder.filter(Some("storage_proofs_core"), LevelFilter::Warn);
+    logger_builder.filter(Some("surf::middleware"), LevelFilter::Warn);
+    logger_builder.filter(Some("tide"), LevelFilter::Warn);
+    logger_builder.filter(Some("libp2p_bitswap"), LevelFilter::Warn);
+    logger_builder.filter(Some("rpc"), LevelFilter::Info);
+    logger_builder.filter(None, LevelFilter::Info);
+
+    // Override log level based on filters if set
     if let Ok(s) = ::std::env::var("RUST_LOG") {
-        // Set log level based on filters if set
         logger_builder.parse_filters(&s);
-    } else {
-        // If no ENV variable specified, default to info
-        logger_builder.filter(Some("libp2p_gossipsub"), LevelFilter::Error);
-        logger_builder.filter(Some("filecoin_proofs"), LevelFilter::Warn);
-        logger_builder.filter(Some("storage_proofs_core"), LevelFilter::Warn);
-        logger_builder.filter(Some("surf::middleware"), LevelFilter::Warn);
-        logger_builder.filter(Some("tide"), LevelFilter::Warn);
-        logger_builder.filter(Some("libp2p_bitswap"), LevelFilter::Warn);
-        logger_builder.filter(Some("rpc"), LevelFilter::Info);
-        logger_builder.filter(None, LevelFilter::Info);
     }
+
     let logger = logger_builder.build();
 
     // Wrap Logger in async_log


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- don't override default filters when `RUST_LOG` environment variable is set



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1504 .

Not sure if there is a default test suite; please advise best way to test if possible.

<!-- Thank you 🔥 -->