### PR TITLE
implement NetDisconnect

### DIFF
--- a/forest/src/cli/net_cmd.rs
+++ b/forest/src/cli/net_cmd.rs
@@ -115,7 +115,7 @@ impl NetCommands {
             }
             Self::Disconnect { id } => match net_disconnect((id.to_owned(),)).await {
                 Ok(_) => {
-                    todo!();
+                    println!("disconnect {}: success", id);
                 }
                 Err(e) => handle_rpc_err(e),
             },

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -364,8 +364,8 @@ where
                                         warn!("Failed to connect to a peer");
                                     }
                                 }
-                                NetRPCMethods::NetDisconnect(response_channel, _peer_id) => {
-                                    warn!("NetDisconnect API not yet implmeneted"); // TODO: implement NetDisconnect - See #1181
+                                NetRPCMethods::NetDisconnect(response_channel, peer_id) => {
+                                    let _ = Swarm::disconnect_peer_id(swarm_stream.get_mut(), peer_id);
 
                                     if response_channel.send(()).is_err() {
                                         warn!("Failed to disconnect from a peer");


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Implemented missing NetDisconnect


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1181 


**Other information and links**
<!-- Add any other context about the pull request here. -->
Worth mentioning Swarm's `disconnect_peer_id()` API returns a `Result<(), ()>`,
and our NetDisconnect response channel only sends `()` regardless of the result,
might be worth updating it to `Result<(),()>` so that the receiver knows of the success, even a bool would suffice.


<!-- Thank you 🔥 -->