### PR TITLE
Make event logging less verbose in steady-state mode.

### DIFF
--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -1140,7 +1140,7 @@ async fn validate_tipset<
         validations.push(validation_fn);
     }
 
-    info!("Validating tipset: EPOCH = {}", epoch);
+    info!("Validating tipset: EPOCH = {epoch}");
     debug!("Tipset keys: {:?}", full_tipset_key.cids);
 
     while let Some(result) = validations.next().await {

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -1132,10 +1132,6 @@ async fn validate_tipset<
 
     let mut validations = FuturesUnordered::new();
     for b in full_tipset.into_blocks() {
-        // let ret =
-        //     validate_block::<_, _, V>(state_manager.clone(), beacon_scheduler.clone(), Arc::new(b))
-        //         .await;
-        // let validation_fn = task::spawn(async { ret });
         let validation_fn = task::spawn(validate_block::<_, _, V>(
             state_manager.clone(),
             beacon_scheduler.clone(),
@@ -1143,6 +1139,9 @@ async fn validate_tipset<
         ));
         validations.push(validation_fn);
     }
+
+    info!("Validating tipset: EPOCH = {}", epoch);
+    debug!("Tipset keys: {:?}", full_tipset_key.cids);
 
     while let Some(result) = validations.next().await {
         match result {
@@ -1171,10 +1170,6 @@ async fn validate_tipset<
             }
         }
     }
-    info!(
-        "Validating tipset: EPOCH = {}, KEY = {:?}",
-        epoch, full_tipset_key.cids,
-    );
     Ok(())
 }
 

--- a/forest/src/logger/mod.rs
+++ b/forest/src/logger/mod.rs
@@ -11,6 +11,10 @@ pub(crate) fn setup_logger() {
     logger_builder.filter(Some("filecoin_proofs"), LevelFilter::Warn);
     logger_builder.filter(Some("storage_proofs_core"), LevelFilter::Warn);
     logger_builder.filter(Some("surf::middleware"), LevelFilter::Warn);
+    logger_builder.filter(
+        Some("bellperson::groth16::aggregate::verify"),
+        LevelFilter::Warn,
+    );
     logger_builder.filter(Some("tide"), LevelFilter::Warn);
     logger_builder.filter(Some("libp2p_bitswap"), LevelFilter::Warn);
     logger_builder.filter(Some("rpc"), LevelFilter::Info);


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Only show tipset hashes when debug logging is enabled or when we fail to validate.
- Inhibit output from `bellperson`.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1456 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->