### PR TITLE
Fix Forest docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
+.github
 *target**
-.git
 /test_dir*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Build and publish Forest Docker image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-push-docker-image:
+    name: Build Docker image and push to repositories
+    runs-on: buildjet-16vcpu-ubuntu-2004
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build image and push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: |
+            ghcr.io/chainsafe/forest:latest
+          # build on feature branches, push only on main branch
+          push: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2004
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout code
         uses: actions/checkout@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,49 @@
 # This Dockerfile is for the main forest binary
-# Example usage:
+# 
+# Build and run locally:
+# ```
 # docker build -t forest:latest -f ./Dockerfile .
-# docker run forest
+# docker run --init -it forest
+# ```
+# 
+# Build and manually push to Github Container Registry (see https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+# ```
+# docker build -t ghcr.io/chainsafe/forest:latest .
+# docker push ghcr.io/chainsafe/forest:latest
+# ```
 
+##
+# Build stage
+## 
 FROM rust:1-buster AS build-env
+
+# Install dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential clang ocl-icd-opencl-dev
 
 WORKDIR /usr/src/forest
 COPY . .
 
-# Install dependencies
-RUN apt-get update
-RUN apt-get install --no-install-recommends -y build-essential clang ocl-icd-opencl-dev
+# Grab the correct toolchain
+RUN rustup toolchain install nightly && rustup target add wasm32-unknown-unknown
 
 # Install Forest
-RUN cargo install --path forest
+RUN make install
 
+# strip symbols to make executable smaller
+RUN strip /usr/local/cargo/bin/forest
+
+##
 # Prod image for forest binary
+##
 FROM debian:buster-slim
 
-# Install binary dependencies
-RUN apt-get update
-RUN apt-get install --no-install-recommends -y build-essential clang ocl-icd-opencl-dev
+# Link package to the repository
+LABEL org.opencontainers.image.source https://github.com/chainsafe/forest
 
-# Copy over binaries from the build-env
+# Install binary dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y ocl-icd-opencl-dev libssl1.1
+
+# Copy forest binary from the build-env
 COPY --from=build-env /usr/local/cargo/bin/forest /usr/local/bin/forest
 
-CMD ["forest"]
+ENTRYPOINT ["/usr/local/bin/forest"]

--- a/README.md
+++ b/README.md
@@ -28,13 +28,25 @@ Our crates:
 | `utils` | the forest toolbox (12 crates) |
 
 
+## Run with Docker
+
+No need to install Rust toolchain or other dependencies, you will need only Docker.
+```
+❯ docker run --init -it ghcr.io/chainsafe/forest:latest --help
+```
+
+Follow other instructions for proper `forest` usage. You may need to mount a volume to import a snapshot, e.g.
+```
+❯ docker run --init -it -v ~/Downloads:/downloads ghcr.io/chainsafe/forest:latest --import-snapshot /downloads/minimal_finality_stateroots_latest.car
+```
+
 ## Dependencies
 
 * Rust `rustc >= 1.58.1`
 * Rust WASM target `wasm32-unknown-unknown`
 
 ```shell
-rustup install stable
+rustup install nightly
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/forest/build.rs
+++ b/forest/build.rs
@@ -16,11 +16,13 @@ fn main() {
 
 // returns version string at build time, e.g., `v0.1.0/unstable/7af2f5bf`
 fn version() -> String {
-    let git_cmd = Command::new("git")
+    let git_hash = match Command::new("git")
         .args(&["rev-parse", "--short", "HEAD"])
         .output()
-        .expect("Git references should be available on a build system");
-    let git_hash = String::from_utf8(git_cmd.stdout).unwrap_or_default();
+    {
+        Ok(output) => String::from_utf8(output.stdout).unwrap_or_default(),
+        _ => "unknown".to_owned(),
+    };
     format!(
         "v{}/{}/{}",
         env!("CARGO_PKG_VERSION"),

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -56,7 +56,7 @@ use tiny_cid::Cid as Cid2;
 
 lazy_static! {
     static ref VERSION: &'static str = env!("CARGO_PKG_VERSION");
-    static ref CURRENT_COMMIT: &'static str = git_version!();
+    static ref CURRENT_COMMIT: &'static str = git_version!(fallback = "unknown");
 }
 
 /// Libp2p behaviour for the Forest node. This handles all sub protocols needed for a Filecoin node.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixed docker image for Forest + made it more usable,
- basic Docker CI and packaging (no release tags yet)
- build will no longer fail, even if run outside of the git context (e.g. release tarballs). 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Resolves https://github.com/ChainSafe/forest/issues/1384
Closes https://github.com/ChainSafe/forest/pull/1442


**Other information and links**
<!-- Add any other context about the pull request here. -->
Co-authoring @bodo-hugo-barwich as he had some good ideas and made the first `push` towards proper containerisation. Thank you @bodo-hugo-barwich!


<!-- Thank you 🔥 -->