### PR TITLE
Fix docker certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ FROM debian:buster-slim
 LABEL org.opencontainers.image.source https://github.com/chainsafe/forest
 
 # Install binary dependencies
-RUN apt-get update && apt-get install --no-install-recommends -y ocl-icd-opencl-dev libssl1.1
+RUN apt-get update && apt-get install --no-install-recommends -y ocl-icd-opencl-dev libssl1.1 ca-certificates
+RUN update-ca-certificates
 
 # Copy forest binary from the build-env
 COPY --from=build-env /usr/local/cargo/bin/forest /usr/local/bin/forest

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ rustup target add wasm32-unknown-unknown
 
 ```shell
 # Ubuntu
-sudo apt install build-essential clang ocl-icd-opencl-dev
+sudo apt install build-essential clang ocl-icd-opencl-dev libssl-dev
 
 # Archlinux
-sudo pacman -S base-devel clang ocl-icd
+sudo pacman -S base-devel clang ocl-icd openssl
 ```
 
 ## Installation


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixed CAs for Docker image, otherwise we got quite a bunch of:
```
 2022-06-28T11:21:39.311Z WARN  paramfetch                > Error in validating params BadServerCertificate(None): unknown error
 2022-06-28T11:21:39.312Z WARN  isahc::handler            > request completed with error: BadServerCertificate(None): unknown error
 2022-06-28T11:21:39.313Z WARN  paramfetch                > Error in validating params BadServerCertificate(None): unknown error
```

**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->