### PR TITLE
Propagate FVM error values.

### DIFF
--- a/vm/actor_interface/src/builtin/init/mod.rs
+++ b/vm/actor_interface/src/builtin/init/mod.rs
@@ -72,7 +72,7 @@ impl State {
         match self {
             State::V7(st) => {
                 let fvm_store = ipld_blockstore::FvmRefStore::new(store);
-                Ok(st.resolve_address(&fvm_store, addr).expect("FIXME"))
+                st.resolve_address(&fvm_store, addr)
             }
         }
     }

--- a/vm/actor_interface/src/builtin/market/mod.rs
+++ b/vm/actor_interface/src/builtin/market/mod.rs
@@ -101,7 +101,7 @@ impl State {
         match self {
             State::V7(st) => {
                 let fvm_store = ipld_blockstore::FvmRefStore::new(store);
-                Ok(fil_actor_market_v7::validate_deals_for_activation(
+                fil_actor_market_v7::validate_deals_for_activation(
                     st,
                     &fvm_store,
                     deal_ids,
@@ -110,7 +110,6 @@ impl State {
                     curr_epoch,
                 )
                 .map(|(deal_st, verified_st, _)| (deal_st, verified_st))
-                .expect("FIXME"))
             } // _ => unimplemented!(),
         }
     }

--- a/vm/actor_interface/src/builtin/miner/mod.rs
+++ b/vm/actor_interface/src/builtin/miner/mod.rs
@@ -85,13 +85,11 @@ impl State {
         match self {
             State::V7(st) => {
                 let fvm_store = ipld_blockstore::FvmRefStore::new(store);
-                st.load_deadlines(&fvm_store)?
-                    .for_each(&Default::default(), &fvm_store, |idx, dl| {
-                        f(idx as u64, Deadline::V7(dl)).expect("FIXME");
-                        Ok(())
-                    })
-                    .expect("FIXME");
-                Ok(())
+                st.load_deadlines(&fvm_store)?.for_each(
+                    &Default::default(),
+                    &fvm_store,
+                    |idx, dl| f(idx as u64, Deadline::V7(dl)),
+                )
             }
         }
     }
@@ -230,11 +228,8 @@ impl Deadline {
             Deadline::V7(dl) => {
                 let fvm_store = ipld_blockstore::FvmRefStore::new(store);
                 dl.for_each(&fvm_store, |idx, part| {
-                    f(idx as u64, Partition::V7(Cow::Borrowed(part))).expect("FIXME");
-                    Ok(())
+                    f(idx as u64, Partition::V7(Cow::Borrowed(part)))
                 })
-                .expect("FIXME");
-                Ok(())
             }
         }
     }

--- a/vm/actor_interface/src/builtin/power/mod.rs
+++ b/vm/actor_interface/src/builtin/power/mod.rs
@@ -108,9 +108,7 @@ impl State {
         match self {
             State::V7(st) => {
                 let fvm_store = ipld_blockstore::FvmRefStore::new(s);
-                Ok(st
-                    .miner_nominal_power_meets_consensus_minimum(&fvm_store, miner)
-                    .expect("FIXME"))
+                st.miner_nominal_power_meets_consensus_minimum(&fvm_store, miner)
             }
         }
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Propagate errors originating in the FVM.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->
Our error handling used to be incompatible with that of the FVM. That was fixed recently so now we can propagate the errors.


<!-- Thank you 🔥 -->