### PR TITLE
Fix clippy error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           target: wasm32-unknown-unknown
           override: true
       - name: Rust Cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
       - name: Add component llvm-tools-preview
-        run: rustup component add llvm-tools-preview --toolchain nightly-x86_64-unknown-linux-gnu
+        run: rustup component add llvm-tools-preview
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
       - name: Run cargo-llvm-cov

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,9 +95,12 @@ jobs:
           toolchain: nightly-2022-05-09
           target: wasm32-unknown-unknown
           override: true
-          components: clippy rustfmt
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
+      - name: Install Clippy
+        run: rustup component add clippy
+      - name: Install RustFmt
+        run: rustup component add rustfmt
       - name: Run Linters
         run: make lint
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,15 +92,12 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-05-09
           target: wasm32-unknown-unknown
           override: true
+          components: clippy rustfmt
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
-      - name: Install Clippy
-        run: rustup component add clippy
-      - name: Install RustFmt
-        run: rustup component add rustfmt
       - name: Run Linters
         run: make lint
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           target: wasm32-unknown-unknown
           override: true
       - name: Rust Cache
@@ -64,7 +63,6 @@ jobs:
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           target: wasm32-unknown-unknown
           override: true
       - name: Add component llvm-tools-preview
@@ -92,7 +90,6 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-05-09
           target: wasm32-unknown-unknown
           override: true
       - name: Rust Cache
@@ -113,7 +110,6 @@ jobs:
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           override: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
@@ -148,7 +144,7 @@ jobs:
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rv }}
+          #toolchain: ${{ matrix.rv }}
           target: wasm32-unknown-unknown
           override: true
       - name: Rust Cache

--- a/types/networks/src/calibnet/mod.rs
+++ b/types/networks/src/calibnet/mod.rs
@@ -89,6 +89,6 @@ pub const HEIGHT_INFOS: [HeightInfo; 17] = [
 lazy_static! {
     pub(super) static ref DRAND_SCHEDULE: [DrandPoint<'static>; 1] = [DrandPoint {
         height: 0,
-        config: &*DRAND_MAINNET,
+        config: &DRAND_MAINNET,
     },];
 }

--- a/types/networks/src/mainnet/mod.rs
+++ b/types/networks/src/mainnet/mod.rs
@@ -107,11 +107,11 @@ lazy_static! {
     pub(super) static ref DRAND_SCHEDULE: [DrandPoint<'static>; 2] = [
         DrandPoint {
             height: 0,
-            config: &*DRAND_INCENTINET,
+            config: &DRAND_INCENTINET,
         },
         DrandPoint {
             height: SMOKE_HEIGHT,
-            config: &*DRAND_MAINNET,
+            config: &DRAND_MAINNET,
         },
     ];
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixed an issue reported recently by clippy:
```
error: deref which would be done by auto-deref
  --> types/networks/src/calibnet/mod.rs:92:18
   |
92 |         config: &*DRAND_MAINNET,
   |                  ^^^^^^^^^^^^^^ help: try this: `DRAND_MAINNET`
   |
   = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

```
Note that clippy's exact suggestion leads to non-compiling code as reported here https://github.com/rust-lang/rust-clippy/issues/9101

- Those new suggestions sometimes are also false positives so they would need to be suppressed. I believe we should not bother with bleeding edge clippy warnings so I bolted the nightly version for linters to a fixed version which works.

<!-- Thank you 🔥 -->