### PR TITLE
Disable codecov annotations by default.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+github_checks:
+  annotations: false
+
 codecov:
   require_ci_to_pass: no
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- CodeCov annotations can be turned off when doing code reviews but I still find them annoying. This PR turns them off by default.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->