### PR TITLE
chore:docs:install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ sudo pacman -S base-devel clang ocl-icd openssl
 git clone --recursive https://github.com/chainsafe/forest
 cd forest
 
+# Run the correct rust toolchain
+rustup toolchain install nightly && rustup target add wasm32-unknown-unknown
+
 # Install binary to $HOME/.cargo/bin and run node
 make install
 forest


### PR DESCRIPTION
**Summary of changes**
Building forest from source with `make install` as specified in the readme didn't quite work for me.  I had to setup my rust toolchain in a specific way to get this to work.  At first I was thinking of putting this toolchain stuff in the makefile but that is probably doing more than user's want to delegate to the makefile so I just added a note to the readme.