### PR TITLE
Remove wasmtime dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,6 @@ dependencies = [
  "state_migration",
  "state_tree",
  "statediff",
- "wasmtime",
 ]
 
 [[package]]

--- a/vm/interpreter/Cargo.toml
+++ b/vm/interpreter/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 async-std = "1.9"
-wasmtime = { version = "0.37", default-features = false }
 anyhow = "1.0"
 fvm = { version = "1.0", features = [] }
 fvm_shared = { version = "0.8.0", default-features = false }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- The wasm engine is now a hidden implementation detail of the FVM and we no longer need to directly depend on `wasmtime`.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->