### PR TITLE
custom bind for metrics server

### DIFF
--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -7,7 +7,9 @@ use forest_libp2p::Libp2pConfig;
 use networks::ChainConfig;
 use rpc_client::DEFAULT_PORT;
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, PartialEq)]
@@ -27,7 +29,8 @@ pub struct Config {
     /// Will use the cids in the header of the file to index the chain.
     pub skip_load: bool,
     pub encrypt_keystore: bool,
-    pub metrics_port: u16,
+    /// Metrics bind, e.g. 0.0.0.0:6116
+    pub metrics_address: SocketAddr,
     pub rocks_db: db::rocks_config::RocksDbConfig,
     pub network: Libp2pConfig,
     pub sync: SyncConfig,
@@ -50,7 +53,7 @@ impl Default for Config {
             skip_load: false,
             sync: SyncConfig::default(),
             encrypt_keystore: true,
-            metrics_port: 6116,
+            metrics_address: FromStr::from_str("0.0.0.0:6116").unwrap(),
             rocks_db: db::rocks_config::RocksDbConfig::default(),
             chain: Arc::default(),
         }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -36,6 +36,7 @@ use rug::Float;
 use serde::Serialize;
 use std::cell::RefCell;
 use std::io::{self, Write};
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -117,8 +118,11 @@ pub struct CliOpts {
         help = "Client JWT token to use for JSON-RPC authentication"
     )]
     pub token: Option<String>,
-    #[structopt(long, help = "Port used for metrics collection server")]
-    pub metrics_port: Option<u16>,
+    #[structopt(
+        long,
+        help = "Address used for metrics collection server. By defaults binds on all interfaces on port 6116."
+    )]
+    pub metrics_address: Option<SocketAddr>,
     #[structopt(short, long, help = "Allow Kademlia (default = true)")]
     pub kademlia: Option<bool>,
     #[structopt(long, help = "Allow MDNS (default = false)")]
@@ -191,8 +195,8 @@ impl CliOpts {
         } else {
             cfg.enable_rpc = false;
         }
-        if let Some(metrics_port) = self.metrics_port {
-            cfg.metrics_port = metrics_port;
+        if let Some(metrics_address) = self.metrics_address {
+            cfg.metrics_address = metrics_address;
         }
         if self.import_snapshot.is_some() && self.import_chain.is_some() {
             panic!("Can't set import_snapshot and import_chain at the same time!");

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -99,9 +99,7 @@ pub(super) async fn start(config: Config) {
 
     // Start Prometheus server port
     let prometheus_server_task = task::spawn(metrics::init_prometheus(
-        (format!("127.0.0.1:{}", config.metrics_port))
-            .parse()
-            .unwrap(),
+        config.metrics_address,
         db_path(&config)
             .into_os_string()
             .into_string()


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- allow custom bind for metrics server, by default bind on all interfaces



**Other information and links**
<!-- Add any other context about the pull request here. -->
Perhaps RPC server should also get this treatment, there may be some security implications though so this PR only touches safe metrics server.


<!-- Thank you 🔥 -->