### PR TITLE
default metrics server to local loopback

### DIFF
--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -29,7 +29,7 @@ pub struct Config {
     /// Will use the cids in the header of the file to index the chain.
     pub skip_load: bool,
     pub encrypt_keystore: bool,
-    /// Metrics bind, e.g. 0.0.0.0:6116
+    /// Metrics bind, e.g. 127.0.0.1:6116
     pub metrics_address: SocketAddr,
     pub rocks_db: db::rocks_config::RocksDbConfig,
     pub network: Libp2pConfig,
@@ -53,7 +53,7 @@ impl Default for Config {
             skip_load: false,
             sync: SyncConfig::default(),
             encrypt_keystore: true,
-            metrics_address: FromStr::from_str("0.0.0.0:6116").unwrap(),
+            metrics_address: FromStr::from_str("127.0.0.1:6116").unwrap(),
             rocks_db: db::rocks_config::RocksDbConfig::default(),
             chain: Arc::default(),
         }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -120,7 +120,7 @@ pub struct CliOpts {
     pub token: Option<String>,
     #[structopt(
         long,
-        help = "Address used for metrics collection server. By defaults binds on all interfaces on port 6116."
+        help = "Address used for metrics collection server. By defaults binds on localhost on port 6116."
     )]
     pub metrics_address: Option<SocketAddr>,
     #[structopt(short, long, help = "Allow Kademlia (default = true)")]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Putting metrics server default back to local loopback as per @ec2 suggestion


**Other information and links**
<!-- Add any other context about the pull request here. -->
Assume people running Forest like to live on the dangerous side of life and have no firewall configured, better not introduce yet another vector of attack to their poor machines.


<!-- Thank you 🔥 -->