### PR TITLE
Fix network name as it is used in the p2p protocol.

### DIFF
--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -232,9 +232,16 @@ where
             .await
     }
 
-    /// Returns the network name from the init actor state.
+    // This function used to do this: Returns the network name from the init actor state.
+    /// Returns the internal, protocol-level network name.
     pub fn get_network_name(&self, _st: &Cid) -> Result<String, Error> {
-        Ok("cannot get name".into())
+        if self.chain_config.name == "calibnet" {
+            return Ok("calibrationnet".to_owned());
+        }
+        if self.chain_config.name == "mainnet" {
+            return Ok("testnetnet".to_owned());
+        }
+        Err(Error::Other("Cannot guess network name".to_owned()))
         // let init_act = self
         //     .get_actor(actor::init::ADDRESS, *st)?
         //     .ok_or_else(|| Error::State("Init actor address could not be resolved".to_string()))?;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Temporarily guess the protocol-required network name (either calibrationnet or testnetnet).
- A permanent solution should be able to get the network name from the genesis block.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->