### PR TITLE
Fail early servers if can't bind

### DIFF
--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::cli::{block_until_sigint, Config};
+use async_std::net::TcpListener;
 use auth::{create_token, generate_priv_key, ADMIN, JWT_IDENTIFIER};
 use beacon::DrandBeacon;
 use chain::ChainStore;
@@ -229,9 +230,13 @@ pub(super) async fn start(config: Config) {
     });
     let rpc_task = if config.enable_rpc {
         let keystore_rpc = Arc::clone(&keystore);
-        let rpc_listen = format!("127.0.0.1:{}", &config.rpc_port);
+        let rpc_address = format!("127.0.0.1:{}", config.rpc_port);
+        let rpc_listen = TcpListener::bind(&rpc_address)
+            .await
+            .unwrap_or_else(|_| panic!("could not bind to {rpc_address}"));
+
         Some(task::spawn(async move {
-            info!("JSON-RPC endpoint started at {}", &rpc_listen);
+            info!("JSON-RPC endpoint started at {}", rpc_address);
             start_rpc::<_, _, FullVerifier, FullConsensus>(
                 Arc::new(RPCState {
                     state_manager: Arc::clone(&state_manager),
@@ -245,7 +250,7 @@ pub(super) async fn start(config: Config) {
                     chain_store,
                     new_mined_block_tx: tipset_sink,
                 }),
-                &rpc_listen,
+                rpc_listen,
             )
             .await
         }))

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -100,8 +100,12 @@ pub(super) async fn start(config: Config) {
     }
 
     // Start Prometheus server port
+    let prometheus_listener = TcpListener::bind(config.metrics_address)
+        .await
+        .unwrap_or_else(|_| panic!("could not bind to {}", config.metrics_address));
+    info!("Prometheus server started at {}", config.metrics_address);
     let prometheus_server_task = task::spawn(metrics::init_prometheus(
-        config.metrics_address,
+        prometheus_listener,
         db_path(&config)
             .into_os_string()
             .into_string()

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -15,6 +15,7 @@ mod state_api;
 mod sync_api;
 mod wallet_api;
 
+use async_std::net::TcpListener;
 use async_std::sync::Arc;
 use chain::Scale;
 use jsonrpc_v2::{Data, Error as JSONRPCError, Server};
@@ -37,7 +38,7 @@ use rpc_api::{
 
 pub async fn start_rpc<DB, B, V, S>(
     state: Arc<RPCState<DB, B>>,
-    rpc_endpoint: &str,
+    rpc_endpoint: TcpListener,
 ) -> Result<(), JSONRPCError>
 where
     DB: BlockStore + Send + Sync + 'static,
@@ -177,7 +178,6 @@ where
         .post(rpc_http_handler::<DB, B>);
 
     info!("Ready for RPC connections");
-
     app.listen(rpc_endpoint).await?;
 
     info!("Stopped accepting RPC connections");

--- a/utils/metrics/src/lib.rs
+++ b/utils/metrics/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod db;
 
-use log::info;
+use async_std::net::TcpListener;
 use prometheus::{Encoder, TextEncoder};
 use thiserror::Error;
 
@@ -25,11 +25,9 @@ pub enum Error {
 }
 
 pub async fn init_prometheus(
-    prometheus_addr: SocketAddr,
+    prometheus_listener: TcpListener,
     db_directory: String,
 ) -> Result<(), Error> {
-    info!("Prometheus server started at {}", prometheus_addr);
-
     let registry = prometheus::default_registry();
 
     // Add the DBCollector to the registry
@@ -43,7 +41,7 @@ pub async fn init_prometheus(
     server.at("/metrics").get(collect_metrics);
 
     // Wait for server to exit
-    server.listen(prometheus_addr).await.map_err(Error::Io)
+    server.listen(prometheus_listener).await.map_err(Error::Io)
 }
 
 async fn collect_metrics(_req: tide::Request<()>) -> tide::Result {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fail Forest fast if RPC or Metrics server can't bind.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1684


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->