### PR TITLE
Don't let codecov comment on PRs.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+comment: false
 github_checks:
   annotations: false
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Prevent codecov from commenting on PRs. The code coverage reports are still available from the 'checks' tab.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->