### PR TITLE
Allow RPC bind address to be reconfigured

### DIFF
--- a/forest/src/cli/auth_cmd.rs
+++ b/forest/src/cli/auth_cmd.rs
@@ -57,7 +57,7 @@ impl AuthCommands {
                     Ok(token) => {
                         let mut addr = Multiaddr::empty();
                         addr.push(Protocol::Ip4(DEFAULT_HOST.parse().unwrap()));
-                        addr.push(Protocol::Tcp(cfg.rpc_port));
+                        addr.push(Protocol::Tcp(cfg.rpc_address.port()));
                         addr.push(Protocol::Http);
                         println!(
                             "FULLNODE_API_INFO=\"{}:{}\"",

--- a/forest/src/cli/auth_cmd.rs
+++ b/forest/src/cli/auth_cmd.rs
@@ -4,7 +4,7 @@
 use super::{handle_rpc_err, print_rpc_res_bytes, Config};
 use forest_libp2p::{Multiaddr, Protocol};
 use jsonrpc_v2::Error as JsonRpcError;
-use rpc_client::{auth_new, DEFAULT_HOST};
+use rpc_client::auth_new;
 use structopt::StructOpt;
 
 use auth::*;
@@ -56,7 +56,7 @@ impl AuthCommands {
                 match auth_new((perms,)).await {
                     Ok(token) => {
                         let mut addr = Multiaddr::empty();
-                        addr.push(Protocol::Ip4(DEFAULT_HOST.parse().unwrap()));
+                        addr.push(cfg.rpc_address.ip().into());
                         addr.push(Protocol::Tcp(cfg.rpc_address.port()));
                         addr.push(Protocol::Http);
                         println!(

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -7,9 +7,8 @@ use forest_libp2p::Libp2pConfig;
 use networks::ChainConfig;
 use rpc_client::DEFAULT_PORT;
 use serde::{Deserialize, Serialize};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, PartialEq)]
@@ -18,7 +17,6 @@ pub struct Config {
     pub data_dir: PathBuf,
     pub genesis_file: Option<String>,
     pub enable_rpc: bool,
-    pub rpc_port: u16,
     pub rpc_token: Option<String>,
     /// If this is true, then we do not validate the imported snapshot.
     /// Otherwise, we validate and compute the states.
@@ -31,13 +29,16 @@ pub struct Config {
     pub encrypt_keystore: bool,
     /// Metrics bind, e.g. 127.0.0.1:6116
     pub metrics_address: SocketAddr,
-    /// RPC bind, e.g. 127.0.0.1
-    pub rpc_ip: IpAddr,
+    /// RPC bind, e.g. 127.0.0.1:1234
+    pub rpc_address: SocketAddr,
     pub rocks_db: forest_db::rocks_config::RocksDbConfig,
     pub network: Libp2pConfig,
     pub sync: SyncConfig,
     pub chain: Arc<ChainConfig>,
 }
+
+// 127.0.0.1
+const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
 impl Default for Config {
     fn default() -> Self {
@@ -47,7 +48,6 @@ impl Default for Config {
             data_dir: dir.data_dir().to_path_buf(),
             genesis_file: None,
             enable_rpc: true,
-            rpc_port: DEFAULT_PORT,
             rpc_token: None,
             snapshot_path: None,
             snapshot: false,
@@ -55,8 +55,8 @@ impl Default for Config {
             skip_load: false,
             sync: SyncConfig::default(),
             encrypt_keystore: true,
-            metrics_address: FromStr::from_str("127.0.0.1:6116").unwrap(),
-            rpc_ip: FromStr::from_str("127.0.0.1").unwrap(),
+            metrics_address: SocketAddr::new(LOCALHOST, 6116),
+            rpc_address: SocketAddr::new(LOCALHOST, DEFAULT_PORT),
             rocks_db: forest_db::rocks_config::RocksDbConfig::default(),
             chain: Arc::default(),
         }

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -37,9 +37,6 @@ pub struct Config {
     pub chain: Arc<ChainConfig>,
 }
 
-// 127.0.0.1
-const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-
 impl Default for Config {
     fn default() -> Self {
         let dir = ProjectDirs::from("com", "ChainSafe", "Forest").expect("failed to find project directories, please set FOREST_CONFIG_PATH environment variable manually.");
@@ -55,8 +52,8 @@ impl Default for Config {
             skip_load: false,
             sync: SyncConfig::default(),
             encrypt_keystore: true,
-            metrics_address: SocketAddr::new(LOCALHOST, 6116),
-            rpc_address: SocketAddr::new(LOCALHOST, DEFAULT_PORT),
+            metrics_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6116),
+            rpc_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), DEFAULT_PORT),
             rocks_db: forest_db::rocks_config::RocksDbConfig::default(),
             chain: Arc::default(),
         }

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -7,7 +7,7 @@ use forest_libp2p::Libp2pConfig;
 use networks::ChainConfig;
 use rpc_client::DEFAULT_PORT;
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -31,6 +31,8 @@ pub struct Config {
     pub encrypt_keystore: bool,
     /// Metrics bind, e.g. 127.0.0.1:6116
     pub metrics_address: SocketAddr,
+    /// RPC bind, e.g. 127.0.0.1
+    pub rpc_ip: IpAddr,
     pub rocks_db: forest_db::rocks_config::RocksDbConfig,
     pub network: Libp2pConfig,
     pub sync: SyncConfig,
@@ -54,6 +56,7 @@ impl Default for Config {
             sync: SyncConfig::default(),
             encrypt_keystore: true,
             metrics_address: FromStr::from_str("127.0.0.1:6116").unwrap(),
+            rpc_ip: FromStr::from_str("127.0.0.1").unwrap(),
             rocks_db: forest_db::rocks_config::RocksDbConfig::default(),
             chain: Arc::default(),
         }

--- a/forest/src/cli/mod.rs
+++ b/forest/src/cli/mod.rs
@@ -110,8 +110,6 @@ pub struct CliOpts {
     pub genesis: Option<String>,
     #[structopt(short, long, help = "Allow rpc to be active or not (default = true)")]
     pub rpc: Option<bool>,
-    #[structopt(short, long, help = "Port used for JSON-RPC communication")]
-    pub port: Option<u16>,
     #[structopt(
         short,
         long,
@@ -123,6 +121,11 @@ pub struct CliOpts {
         help = "Address used for metrics collection server. By defaults binds on localhost on port 6116."
     )]
     pub metrics_address: Option<SocketAddr>,
+    #[structopt(
+        long,
+        help = "Address used for RPC. By defaults binds on localhost on port 1234."
+    )]
+    pub rpc_address: Option<SocketAddr>,
     #[structopt(short, long, help = "Allow Kademlia (default = true)")]
     pub kademlia: Option<bool>,
     #[structopt(long, help = "Allow MDNS (default = false)")]
@@ -187,7 +190,9 @@ impl CliOpts {
         }
         if self.rpc.unwrap_or(cfg.enable_rpc) {
             cfg.enable_rpc = true;
-            cfg.rpc_port = self.port.to_owned().unwrap_or(cfg.rpc_port);
+            if let Some(rpc_address) = self.rpc_address {
+                cfg.rpc_address = rpc_address;
+            }
 
             if self.token.is_some() {
                 cfg.rpc_token = self.token.to_owned();

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -18,6 +18,7 @@ use message_pool::{MessagePool, MpoolConfig, MpoolRpcProvider};
 use rpc::start_rpc;
 use rpc_api::data_types::RPCState;
 use state_manager::StateManager;
+use std::net::SocketAddr;
 use utils::write_to_file;
 
 use async_std::{channel::bounded, sync::RwLock, task};
@@ -300,7 +301,7 @@ pub(super) async fn start(config: Config) {
     });
     let rpc_task = if config.enable_rpc {
         let keystore_rpc = Arc::clone(&keystore);
-        let rpc_address = format!("127.0.0.1:{}", config.rpc_port);
+        let rpc_address = SocketAddr::new(config.rpc_ip, config.rpc_port);
         let rpc_listen = TcpListener::bind(&rpc_address)
             .await
             .unwrap_or_else(|_| cli_error_and_die("could not bind to {rpc_address}", 1));

--- a/forest/src/daemon.rs
+++ b/forest/src/daemon.rs
@@ -18,7 +18,6 @@ use message_pool::{MessagePool, MpoolConfig, MpoolRpcProvider};
 use rpc::start_rpc;
 use rpc_api::data_types::RPCState;
 use state_manager::StateManager;
-use std::net::SocketAddr;
 use utils::write_to_file;
 
 use async_std::{channel::bounded, sync::RwLock, task};
@@ -301,13 +300,12 @@ pub(super) async fn start(config: Config) {
     });
     let rpc_task = if config.enable_rpc {
         let keystore_rpc = Arc::clone(&keystore);
-        let rpc_address = SocketAddr::new(config.rpc_ip, config.rpc_port);
-        let rpc_listen = TcpListener::bind(&rpc_address)
+        let rpc_listen = TcpListener::bind(&config.rpc_address)
             .await
             .unwrap_or_else(|_| cli_error_and_die("could not bind to {rpc_address}", 1));
 
         Some(task::spawn(async move {
-            info!("JSON-RPC endpoint started at {}", rpc_address);
+            info!("JSON-RPC endpoint started at {}", config.rpc_address);
             start_rpc::<_, _, FullVerifier, FullConsensus>(
                 Arc::new(RPCState {
                     state_manager: Arc::clone(&state_manager),


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Allow the RPC address to be changed to `0.0.0.0`.
- It can be useful when accessing forest from a different container/machine.
- Security is still handled via access tokens.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->