### PR TITLE
add clean Fedora dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ sudo apt install build-essential clang ocl-icd-opencl-dev libssl-dev
 
 # Archlinux
 sudo pacman -S base-devel clang ocl-icd openssl
+
+# Fedora (36)
+sudo dnf install -y clang-devel ocl-icd-devel
 ```
 
 ## Installation


### PR DESCRIPTION
**Summary of changes**
While re-installing my system, I thought it'd be a good thing to document needed dependencies for Fedora 36. These are Forest-specific, I didn't include those in e.g. "Development Tools" group. 