### PR TITLE
check config params are always under section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "erased-serde"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,6 +2734,8 @@ dependencies = [
  "paramfetch",
  "pretty_env_logger",
  "prometheus 0.13.1",
+ "quickcheck",
+ "quickcheck_macros",
  "rand 0.8.5",
  "rayon",
  "rpassword",
@@ -5964,7 +5976,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
 ]
 
@@ -6221,6 +6233,28 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger 0.8.4",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
 
 [[package]]
 name = "quicksink"

--- a/forest/Cargo.toml
+++ b/forest/Cargo.toml
@@ -73,11 +73,11 @@ features         = ["easy-errors", "macros", "bytes-v05"]
 version          = "0.10"
 
 [dev-dependencies]
-assert_cmd = "2"
-rand       = "0.8"
-tempfile   = "3"
-quickcheck = "1"
+assert_cmd        = "2"
+quickcheck        = "1"
 quickcheck_macros = "1"
+rand              = "0.8"
+tempfile          = "3"
 
 [features]
 default       = ["fil_cns"]

--- a/forest/Cargo.toml
+++ b/forest/Cargo.toml
@@ -76,6 +76,8 @@ version          = "0.10"
 assert_cmd = "2"
 rand       = "0.8"
 tempfile   = "3"
+quickcheck = "1"
+quickcheck_macros = "1"
 
 [features]
 default       = ["fil_cns"]

--- a/forest/src/cli/client.rs
+++ b/forest/src/cli/client.rs
@@ -10,7 +10,7 @@ use std::{
     str::FromStr,
 };
 
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct Client {
     pub data_dir: PathBuf,

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use super::client::Client;
 
-#[derive(Serialize, Deserialize, PartialEq, Default)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(default)]
 pub struct Config {
     pub client: Client,
@@ -17,4 +17,95 @@ pub struct Config {
     pub network: Libp2pConfig,
     pub sync: SyncConfig,
     pub chain: Arc<ChainConfig>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use forest_db::rocks_config::RocksDbConfig;
+    use quickcheck::Arbitrary;
+    use quickcheck_macros::quickcheck;
+    use std::{
+        net::{Ipv4Addr, SocketAddr},
+        path::PathBuf,
+    };
+
+    /// Partial config, as some parts of the proper one don't implement required traits (i.e.
+    /// Debug)
+    #[derive(Clone, Debug)]
+    struct ConfigPartial {
+        client: Client,
+        rocks_db: forest_db::rocks_config::RocksDbConfig,
+        network: forest_libp2p::Libp2pConfig,
+        sync: chain_sync::SyncConfig,
+    }
+
+    impl From<ConfigPartial> for Config {
+        fn from(val: ConfigPartial) -> Self {
+            Config {
+                client: val.client,
+                rocks_db: val.rocks_db,
+                network: val.network,
+                sync: val.sync,
+                chain: Arc::new(ChainConfig::default()),
+            }
+        }
+    }
+
+    impl Arbitrary for ConfigPartial {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            ConfigPartial {
+                client: Client {
+                    data_dir: PathBuf::arbitrary(g),
+                    genesis_file: Option::arbitrary(g),
+                    enable_rpc: bool::arbitrary(g),
+                    rpc_port: u16::arbitrary(g),
+                    rpc_token: Option::arbitrary(g),
+                    snapshot: bool::arbitrary(g),
+                    snapshot_height: Option::arbitrary(g),
+                    snapshot_path: Option::arbitrary(g),
+                    skip_load: bool::arbitrary(g),
+                    encrypt_keystore: bool::arbitrary(g),
+                    metrics_address: SocketAddr::arbitrary(g),
+                    rpc_address: SocketAddr::arbitrary(g),
+                },
+                rocks_db: RocksDbConfig {
+                    create_if_missing: bool::arbitrary(g),
+                    parallelism: i32::arbitrary(g),
+                    write_buffer_size: usize::arbitrary(g),
+                    max_open_files: i32::arbitrary(g),
+                    max_background_jobs: Option::arbitrary(g),
+                    compression_type: Option::arbitrary(g),
+                    compaction_style: Option::arbitrary(g),
+                    enable_statistics: bool::arbitrary(g),
+                },
+                network: Libp2pConfig {
+                    listening_multiaddr: Ipv4Addr::arbitrary(g).into(),
+                    bootstrap_peers: vec![Ipv4Addr::arbitrary(g).into(); u8::arbitrary(g) as usize],
+                    mdns: bool::arbitrary(g),
+                    kademlia: bool::arbitrary(g),
+                    target_peer_count: u32::arbitrary(g),
+                },
+                sync: SyncConfig {
+                    req_window: i64::arbitrary(g),
+                    tipset_sample_size: usize::arbitrary(g),
+                },
+            }
+        }
+    }
+
+    #[quickcheck]
+    fn test_config_all_params_under_section(config: ConfigPartial) {
+        let config = Config::from(config);
+        let serialized_config =
+            toml::to_string(&config).expect("could not serialize the configuration");
+        assert_eq!(
+            serialized_config
+                .trim_start()
+                .chars()
+                .next()
+                .expect("configuration empty"),
+            '['
+        )
+    }
 }

--- a/forest/src/cli/config.rs
+++ b/forest/src/cli/config.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use super::client::Client;
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Default)]
 #[serde(default)]
 pub struct Config {
     pub client: Client,

--- a/node/db/src/rocks_config.rs
+++ b/node/db/src/rocks_config.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Only subset of possible options is implemented, add missing ones when needed.
 /// For description of different options please refer to the `rocksdb` crate documentation.
 /// <https://docs.rs/rocksdb/latest/rocksdb/>
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct RocksDbConfig {
     pub create_if_missing: bool,

--- a/node/forest_libp2p/src/config.rs
+++ b/node/forest_libp2p/src/config.rs
@@ -5,7 +5,7 @@ use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 
 /// Libp2p config for the Forest node.
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct Libp2pConfig {
     /// Local address.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Introduce `quickcheck` test,
- implemented a test asserting that the Forest config file always starts with a section


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1752


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->