### PR TITLE
Fix cargo dependency missing feature for unit tests

### DIFF
--- a/key_management/Cargo.toml
+++ b/key_management/Cargo.toml
@@ -23,4 +23,4 @@ serde_json = "1.0"
 log = "0.4"
 sodiumoxide = "0.2"
 utils = { path = "../node/utils" }
-fvm_shared = { version = "0.8", default-features = false }
+fvm_shared = { version = "0.8",  default-features = false, features = ["crypto"] }

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3"
 futures-util = "0.3"
 asynchronous-codec = "0.6"
 log = "0.4"
-async-std = "1.9"
+async-std = { version = "1.9", features = ["unstable"] }
 serde = { version = "1.0", features = ["derive"] }
 forest_blocks = { path = "../../blockchain/blocks" }
 forest_message = "0.7"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 

```
❯ cargo test --package key_management chain
error[E0599]: no method named `verify` found for struct `fvm_shared::crypto::signature::Signature` in the current scope
   --> key_management/src/wallet.rs:419:13
    |
419 |         sig.verify(&msg, &addr).unwrap();
    |             ^^^^^^ method not found in `fvm_shared::crypto::signature::Signature`

error[E0432]: unresolved import `async_std::stream::Interval`
 --> node/forest_libp2p/src/discovery.rs:4:31
  |
4 | use async_std::stream::{self, Interval};
  |  
```

**Other information and links**
<!-- Add any other context about the pull request here. -->

<!-- Thank you 🔥 -->