### PR TITLE
increase health check sync period

### DIFF
--- a/scripts/sync_check/docker-compose.yml
+++ b/scripts/sync_check/docker-compose.yml
@@ -83,8 +83,8 @@ services:
     entrypoint: ["/bin/bash","-c"]
     command:
       - |
-        bash ${FOREST_TARGET_SCRIPTS}/sync_check.sh forest-calibnet
-        bash ${FOREST_TARGET_SCRIPTS}/sync_check.sh forest-mainnet
+        bash ${FOREST_TARGET_SCRIPTS}/sync_check.sh forest-calibnet &
+        bash ${FOREST_TARGET_SCRIPTS}/sync_check.sh forest-mainnet &
         sleep infinity
     depends_on:
       - forest_mainnet

--- a/scripts/sync_check/health_check.sh
+++ b/scripts/sync_check/health_check.sh
@@ -18,7 +18,7 @@ if [ $# -eq 0 ]; then
 fi
 
 # Governs how long the health check will run to assert Forest condition
-HEALTH_CHECK_DURATION_SECONDS=${HEALTH_CHECK_DURATION_SECONDS:-"120"}
+HEALTH_CHECK_DURATION_SECONDS=${HEALTH_CHECK_DURATION_SECONDS:-"360"}
 # Forest metrics endpoint path
 FOREST_METRICS_ENDPOINT=${FOREST_METRICS_ENDPOINT:-"http://$1:6116/metrics"}
 # Initial sync timeout (in seconds) after which the health check will fail


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- The check sync period seems a bit short while the test node is in-sync as there is some fighting between tipsets. This fails the sync check from time to time. Increasing the period should help.
- made both checks run in parallel. Given this, the total check time, PR-wise should stay roughly the same.


<!-- Thank you 🔥 -->