### PR TITLE
improve chain export ergonomics

### DIFF
--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -473,7 +473,9 @@ where
                 if skip_old_msgs {
                     anyhow::anyhow!("Cid {cid} not found in blockstore")
                 } else {
-                    anyhow::anyhow!("Cid {cid} not found in blockstore. Exporting a full snapshot is only possible when the node is initialised with a full one. Consider exporting a lightweight snapshot, e.g. skip the old messages.")
+                    anyhow::anyhow!("Cid {cid} not found in blockstore. \
+                                    Exporting a full snapshot is only possible when the node is initialised with a full one. \
+                                    Consider exporting a lightweight snapshot, e.g. skip the old messages.")
                 }
             })?;
 

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -469,10 +469,13 @@ where
 
         // Walks over tipset and historical data, sending all blocks visited into the car writer.
         Self::walk_snapshot(tipset, recent_roots, skip_old_msgs, |cid| {
-            let block = self
-                .blockstore()
-                .get_bytes(&cid)?
-                .ok_or_else(|| anyhow::anyhow!("Cid {} not found in blockstore", cid))?;
+            let block = self.blockstore().get_bytes(&cid)?.ok_or_else(|| {
+                if skip_old_msgs {
+                    anyhow::anyhow!("Cid {cid} not found in blockstore")
+                } else {
+                    anyhow::anyhow!("Cid {cid} not found in blockstore. Exporting a full snapshot is only possible when the node is initialised with a full one. Consider exporting a lightweight snapshot, e.g. skip the old messages.")
+                }
+            })?;
 
             // * If cb can return a generic type, deserializing would remove need to clone.
             // Ignore error intentionally, if receiver dropped, error will be handled below

--- a/forest/src/cli/chain_cmd.rs
+++ b/forest/src/cli/chain_cmd.rs
@@ -23,17 +23,17 @@ pub enum ChainCommands {
     /// Export a snapshot of the chain to <output_path>
     #[structopt(about = "Export chain snapshot to file")]
     Export {
-        /// Tipset to start the export from, default is @HEAD
-        #[structopt(short)]
+        /// Tipset to start the export from, default is the chain head
+        #[structopt(short, long)]
         tipset: Option<i64>,
-        /// Specify the number of recent state roots to include in the export
-        #[structopt(short)]
+        /// Specify the number of recent state roots to include in the export, default is the chain finality value
+        #[structopt(short, long)]
         recent_stateroots: Option<i64>,
-        /// Skip old messages
-        #[structopt(short)]
-        skip_old_messages: bool,
+        /// Include old messages
+        #[structopt(short, long)]
+        include_old_messages: bool,
         /// Snapshot output path. Default to `forest_snapshot_{year}-{month}-{day}_height_{height}.car`
-        #[structopt(short)]
+        #[structopt(short, long)]
         output_path: Option<String>,
     },
 
@@ -72,7 +72,7 @@ impl ChainCommands {
             Self::Export {
                 tipset,
                 recent_stateroots,
-                skip_old_messages,
+                include_old_messages,
                 output_path,
             } => {
                 let chain_head = match chain_head().await {
@@ -99,7 +99,7 @@ impl ChainCommands {
                 let params = (
                     epoch,
                     *recent_stateroots,
-                    *skip_old_messages,
+                    *include_old_messages,
                     output_path,
                     TipsetKeysJson(chain_head.key().clone()),
                 );


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- changed the error message when most likely the user is trying to export a full snapshot from a lightweight-snapshot-initialised node.
```
 2022-08-08T14:07:01.085Z ERROR forest::cli    > JSON RPC Error: Code: 0 Message: Cid bafy2bzaceblp3pblsasknqb65bbvhpuyiryqjamnzrrc5joqj4ulxbezsigvk not found in blockstore. Exporting a full snapshot is only possible when the node is initialised with a full one. Consider exporting a lightweight snapshot, e.g. skip the old messages.
```
- on export failure, delete the incomplete snapshot file.
- changed API a bit to improve ergonomics, after these changes `forest chain export` should work by default by exporting a lightweight snapshot.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1782
Closes https://github.com/ChainSafe/forest/issues/1705


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->