### PR TITLE
chain export: revert default value for recent stateroots

### DIFF
--- a/forest/src/cli/chain_cmd.rs
+++ b/forest/src/cli/chain_cmd.rs
@@ -26,9 +26,9 @@ pub enum ChainCommands {
         /// Tipset to start the export from, default is the chain head
         #[structopt(short, long)]
         tipset: Option<i64>,
-        /// Specify the number of recent state roots to include in the export, default is the chain finality value
-        #[structopt(short, long)]
-        recent_stateroots: Option<i64>,
+        /// Specify the number of recent state roots to include in the export.
+        #[structopt(short, long, default_value = "2000")]
+        recent_stateroots: i64,
         /// Include old messages
         #[structopt(short, long)]
         include_old_messages: bool,

--- a/node/rpc-api/src/lib.rs
+++ b/node/rpc-api/src/lib.rs
@@ -180,7 +180,7 @@ pub mod chain_api {
     pub type ChainGetMessageResult = MessageJson;
 
     pub const CHAIN_EXPORT: &str = "Filecoin.ChainExport";
-    pub type ChainExportParams = (ChainEpoch, Option<i64>, bool, String, TipsetKeysJson);
+    pub type ChainExportParams = (ChainEpoch, i64, bool, String, TipsetKeysJson);
     pub type ChainExportResult = PathBuf;
 
     pub const CHAIN_READ_OBJ: &str = "Filecoin.ChainReadObj";

--- a/node/rpc/src/chain_api.rs
+++ b/node/rpc/src/chain_api.rs
@@ -63,7 +63,6 @@ where
     let skip_old_msgs = !include_olds_msgs;
 
     let chain_finality = data.state_manager.chain_config().policy.chain_finality;
-    let recent_roots = recent_roots.unwrap_or(chain_finality);
     if recent_roots < chain_finality {
         Err(&format!(
             "recent-stateroots must be greater than {}",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- move back to the default value 2000 for recent stateroots, seems the minimal one enforced before (chain finality) is too small and was causing issues when such snapshot is imported.



**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->