### PR TITLE
Improve HAMT diff algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,6 +3385,7 @@ dependencies = [
  "fvm",
  "fvm_ipld_bitfield",
  "fvm_ipld_encoding",
+ "fvm_ipld_hamt",
  "fvm_shared",
  "libipld-core",
  "serde",

--- a/utils/statediff/Cargo.toml
+++ b/utils/statediff/Cargo.toml
@@ -20,6 +20,7 @@ forest_vm              = "0.3"
 fvm                    = "1.0"
 fvm_ipld_bitfield      = "0.5.0"
 fvm_ipld_encoding      = "0.2"
+fvm_ipld_hamt          = "0.5.1"
 fvm_shared             = "0.8"
 libipld-core           = "0.13.1"
 serde                  = { version = "1.0", features = ["derive"] }

--- a/utils/statediff/src/lib.rs
+++ b/utils/statediff/src/lib.rs
@@ -342,3 +342,22 @@ where
 
     Ok(())
 }
+
+#[derive(Serialize, Deserialize)]
+pub enum ChangeType {
+    Add,
+    Remove,
+    Modify,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Change {
+    pub change_type: ChangeType,
+    pub key: String,
+    pub before: Vec<u8>,
+    pub after: Vec<u8>,
+}
+
+pub fn diff<BS>(bs: &BS, prev: &Cid, current: &Cid) -> Vec<Change> {
+    todo!()
+}

--- a/utils/statediff/src/lib.rs
+++ b/utils/statediff/src/lib.rs
@@ -14,6 +14,11 @@ use forest_ipld::json::{IpldJson, IpldJsonRef};
 use forest_ipld_blockstore::BlockStore;
 use forest_json::cid::CidJson;
 use fvm::state_tree::{ActorState, StateTree};
+use fvm_ipld_encoding::de::DeserializeOwned;
+use fvm_ipld_hamt;
+use fvm_ipld_hamt::Hamt;
+use fvm_ipld_hamt::Hash;
+use fvm_ipld_hamt::HashAlgorithm;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::BigInt;
 use libipld_core::ipld::Ipld;
@@ -378,10 +383,27 @@ pub struct KeyValue {
     pub value: Vec<u8>,
 }
 
-pub fn diff<BS>(bs: &BS, prev: &Cid, current: &Cid) -> Vec<Change> {
-    todo!()
+pub fn diff<BS, V, K, H>(
+    store: &BS,
+    previous: &Cid,
+    current: &Cid,
+) -> Result<Vec<Change>, anyhow::Error>
+where
+    BS: BlockStore,
+    V: DeserializeOwned + Serialize,
+    K: Hash + Eq + PartialOrd + Serialize + DeserializeOwned,
+    H: HashAlgorithm,
+{
+    let prev_hamt: Hamt<_, V, K, H> = Hamt::load_with_bit_width(previous, store, 8)?;
+    let current_hamt: Hamt<_, V, K, H> = Hamt::load_with_bit_width(current, store, 8)?;
+
+    diff_node(prev_hamt, current_hamt, 0)
 }
 
-pub fn load_node<BS>(store: BS, cid: &Cid) -> Result<Node<BS>, anyhow::Error> {
+fn diff_node<BS>(
+    previous: Node<BS>,
+    current: Node<BS>,
+    depth: i32,
+) -> Result<Vec<Change>, anyhow::Error> {
     todo!()
 }

--- a/utils/statediff/src/lib.rs
+++ b/utils/statediff/src/lib.rs
@@ -15,6 +15,7 @@ use forest_ipld_blockstore::BlockStore;
 use forest_json::cid::CidJson;
 use fvm::state_tree::{ActorState, StateTree};
 use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
 use libipld_core::ipld::Ipld;
 use resolve::resolve_cids_recursive;
 use serde::{Deserialize, Serialize};
@@ -358,6 +359,29 @@ pub struct Change {
     pub after: Vec<u8>,
 }
 
+pub struct Node<BS> {
+    pub bitfield: BigInt,
+    pub pointers: Vec<Pointer>,
+    pub bitwidth: i32,
+    // type HashFunction = fn(Vec<u8>) -> Vec<u8>
+    // pub hash_function: ??
+    pub store: BS,
+}
+
+pub struct Pointer {
+    pub key_values: Vec<KeyValue>,
+    pub link: Cid,
+}
+
+pub struct KeyValue {
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
+}
+
 pub fn diff<BS>(bs: &BS, prev: &Cid, current: &Cid) -> Vec<Change> {
+    todo!()
+}
+
+pub fn load_node<BS>(store: BS, cid: &Cid) -> Result<Node<BS>, anyhow::Error> {
     todo!()
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Improve the efficiency of the HAMT diff algorithm used for state diffs
- The new algorithm will be side by side the old algorithm for benchmarking purposes


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1638 


**Other information and links**
<!-- Add any other context about the pull request here. -->
CIDs used for benchmarking
pre-cid   :: bafy2bzaceaflpz4sdmyrvxbqs3zrwnbefdkql4yekzsfsffqqzuadrmjpa7o4
post-cid :: bafy2bzacedgoxsjnpdrks4ltoh4so4omu6ysqxmn6rriaijc4ripp2irshago


<!-- Thank you 🔥 -->