### PR TITLE
Add CI step to check for dead links in documentation book

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,17 +41,18 @@ jobs:
       - name: Install MDBook
         run: |
           cargo install mdbook
-      - name: Serve documentation
-        run: |
-          sudo `which mdbook` serve --port 80 --hostname localhost ./documentation/ &
-          sleep 1s
-      - name: Link Checker
+      - name: Install Lychee
         uses: lycheeverse/lychee-action@v1.5.1
         with:
           # Check all markdown and html files in repo (default)
-          args: --verbose --no-progress "http://localhost/"
+          args: --version
           # Fail action on broken links
           fail: true
+      - name: Check for dead links
+        run: |
+          sudo `which mdbook` serve --port 80 --hostname localhost ./documentation/ &
+          sleep 1s
+          lychee "http://localhost/"
       - name: Execute MDBook
         run: |
           mdbook build ./documentation/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
           fail: true
       - name: Check for dead links
         run: |
-          sudo `which mdbook` serve --port 80 --hostname localhost ./documentation/ &
+          sudo `which mdbook` serve --port 80 ./documentation/ &
           sleep 1s
           lychee "http://localhost/"
       - name: Execute MDBook

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,13 +43,13 @@ jobs:
           cargo install mdbook
       - name: Serve documentation
         run: |
-          mdbook serve --port 3000 --hostname localhost ./documentation/ &
+          sudo mdbook serve --port 80 --hostname localhost ./documentation/ &
           sleep 1s
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.5.1
         with:
           # Check all markdown and html files in repo (default)
-          args: --verbose --no-progress "http://localhost:3000/"
+          args: --verbose --no-progress "http://localhost/"
           # Fail action on broken links
           fail: true
       - name: Execute MDBook

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,6 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - name: Apt Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y linkchecker
       - name: Checkout Sources
         uses: actions/checkout@v2
       - name: Install Toolchain
@@ -45,12 +41,17 @@ jobs:
       - name: Install MDBook
         run: |
           cargo install mdbook
-      - name: Check for dead links
+      - name: Serve documentation
         run: |
-          set -e
-          mdbook serve --port 3000 --hostname localhost ./documentation/ &
+          mdbook serve --port 80 --hostname localhost ./documentation/ &
           sleep 1s
-          linkchecker "http://localhost:3000/"
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.5.1
+        with:
+          # Check all markdown and html files in repo (default)
+          args: --verbose --no-progress "http://localhost/"
+          # Fail action on broken links
+          fail: true
       - name: Execute MDBook
         run: |
           mdbook build ./documentation/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,8 +47,7 @@ jobs:
         uses: actions-rs/toolchain@v1
       - name: Install MDBook
         run: |
-          cargo install mdbook
-          cargo install mdbook-linkcheck
+          cargo install mdbook mdbook-linkcheck
       - name: Execute MDBook
         run: |
           mdbook build ./documentation/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install MDBook
         run: |
           cargo install mdbook
+          cargo install mdbook-linkcheck
       - name: Execute MDBook
         run: |
           mdbook build ./documentation/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,13 @@ jobs:
         with:
           command: doc
           args: --no-deps --workspace
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.5.1
+        with:
+          # Check all markdown and html files in repo (default)
+          args: --verbose --no-progress './target/doc/*/index.html'
+          # Fail action on broken links
+          fail: true
   publish-docs:
     name: Publish
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
           cargo install mdbook
       - name: Serve documentation
         run: |
-          sudo mdbook serve --port 80 --hostname localhost ./documentation/ &
+          sudo `which mdbook` serve --port 80 --hostname localhost ./documentation/ &
           sleep 1s
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.5.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,18 +41,6 @@ jobs:
       - name: Install MDBook
         run: |
           cargo install mdbook
-      - name: Install Lychee
-        uses: lycheeverse/lychee-action@v1.5.1
-        with:
-          # Check all markdown and html files in repo (default)
-          args: --version
-          # Fail action on broken links
-          fail: true
-      - name: Check for dead links
-        run: |
-          sudo `which mdbook` serve --port 80 ./documentation/ &
-          sleep 1s
-          lychee "http://localhost/"
       - name: Execute MDBook
         run: |
           mdbook build ./documentation/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,10 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Apt Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y linkchecker
       - name: Checkout Sources
         uses: actions/checkout@v2
       - name: Install Toolchain
@@ -41,6 +45,12 @@ jobs:
       - name: Install MDBook
         run: |
           cargo install mdbook
+      - name: Check for dead links
+        run: |
+          set -e
+          mdbook serve --port 3000 --hostname localhost ./documentation/ &
+          sleep 1s
+          linkchecker "http://localhost:3000/"
       - name: Execute MDBook
         run: |
           mdbook build ./documentation/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,13 +43,13 @@ jobs:
           cargo install mdbook
       - name: Serve documentation
         run: |
-          mdbook serve --port 80 --hostname localhost ./documentation/ &
+          mdbook serve --port 3000 --hostname localhost ./documentation/ &
           sleep 1s
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.5.1
         with:
           # Check all markdown and html files in repo (default)
-          args: --verbose --no-progress "http://localhost/"
+          args: --verbose --no-progress "http://localhost:3000/"
           # Fail action on broken links
           fail: true
       - name: Execute MDBook

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "cs_serde_bytes"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebca5e1e931005a5d90cc90831a22619c94fdeb645435c22eae52956dee29675"
+checksum = "5fc673ddabf48214550526b068dc28065a75f05e21e452880095247c635b1d91"
 dependencies = [
  "serde",
 ]

--- a/documentation/book.toml
+++ b/documentation/book.toml
@@ -3,3 +3,10 @@ authors      = []
 language     = "en"
 multilingual = false
 src          = "src"
+
+[build]
+create-missing = false
+
+[output.html]
+
+[output.linkcheck]

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -9,7 +9,7 @@ repository  = "https://github.com/ChainSafe/forest"
 
 [dependencies]
 blake2b_simd       = "1.0"
-cs_serde_bytes     = "0.12"
+cs_serde_bytes     = "0.12.2"
 fvm_ipld_encoding  = "0.2.1"
 fvm_shared         = { version = "0.8.0", default-features = false }
 serde              = { version = "1.0", features = ["derive"] }

--- a/utils/json/Cargo.toml
+++ b/utils/json/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 cid = { version = "0.8", default-features = false, features = ["std"] }
-cs_serde_bytes = "0.12"
+cs_serde_bytes = "0.12.2"
 data-encoding = "2.1"
 data-encoding-macro = "0.1"
 forest_encoding = "0.2"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Set `create-missing = false` such that missing pages are reported as errors.
- Install `mdbook-linkchecker` and run it against the mdbook documentation.
- Run [lychee](https://github.com/lycheeverse/lychee) on the output of `cargo doc`.
- Bump `cs-serde-bytes` dependency to fix a broken link.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1864


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->