### PR TITLE
Support multiple mining tasks started by the Proposer

### DIFF
--- a/blockchain/consensus/fil_cns/src/composition.rs
+++ b/blockchain/consensus/fil_cns/src/composition.rs
@@ -10,7 +10,7 @@ use forest_key_management::KeyStore;
 use forest_state_manager::StateManager;
 use std::sync::Arc;
 
-type MiningTask = JoinHandle<anyhow::Result<()>>;
+type MiningTask = JoinHandle<()>;
 
 pub type FullConsensus = FilecoinConsensus<DrandBeacon, FullVerifier>;
 
@@ -25,12 +25,12 @@ pub async fn consensus<DB, MP>(
     _keystore: &Arc<RwLock<KeyStore>>,
     _mpool: &Arc<MP>,
     _submitter: SyncGossipSubmitter,
-) -> (FullConsensus, Option<MiningTask>)
+) -> anyhow::Result<(FullConsensus, Vec<MiningTask>)>
 where
     DB: BlockStore + Send + Sync + 'static,
     MP: MessagePoolApi + Send + Sync + 'static,
 {
     let consensus = FilecoinConsensus::new(state_manager.beacon_schedule());
 
-    (consensus, None)
+    Ok((consensus, vec![]))
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- `Proposer::run` was replaced by `Proposer::spawn` which returns a `Vec<JoinHandle<()>>` to allow it to run multiple background tasks.

**Reference issue to close (if applicable)**
This is part of https://github.com/aakoshh/forest/pull/4 , cherry picked so we can open a separate PR upstream, changing existing integration patterns.
