### PR TITLE
Fix access level for CHAIN_GET_NAME.

### DIFF
--- a/node/rpc-api/src/lib.rs
+++ b/node/rpc-api/src/lib.rs
@@ -42,6 +42,7 @@ pub static ACCESS_MAP: Lazy<HashMap<&str, Access>> = Lazy::new(|| {
     access.insert(chain_api::CHAIN_GET_TIPSET, Access::Read);
     access.insert(chain_api::CHAIN_GET_RANDOMNESS_FROM_TICKETS, Access::Read);
     access.insert(chain_api::CHAIN_GET_RANDOMNESS_FROM_BEACON, Access::Read);
+    access.insert(chain_api::CHAIN_GET_NAME, Access::Read);
 
     // Message Pool API
     access.insert(mpool_api::MPOOL_ESTIMATE_GAS_PRICE, Access::Read);


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Set the access level for `CHAIN_GET_NAME` to `Read`.

This fixes the `forest chain export` command. In the future, (a) it would be nice to check that the access map matches the routes, and (b) the RPC should be automatically tested before PRs can be merged.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->