### PR TITLE
suggest GH Discussions instead of Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ _Work in progress_.
 
 ## Contributing
 - Check out our contribution guidelines: [CONTRIBUTING.md](documentation/developer_documentation/CONTRIBUTING.md)
-- Have questions? Say _hi_ on [Discord](https://discord.gg/Q6A3YA2)!
+- Have questions? Feel free to post them in [Forest Q&A](https://github.com/ChainSafe/forest/discussions/categories/forest-q-a)!
 
 ## ChainSafe Security Policy
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Our crates:
 | `types` | the forest types (2 crates) |
 | `utils` | the forest toolbox (12 crates) |
 
+## Questions
+Have questions? Feel free to post them in [Forest Q&A](https://github.com/ChainSafe/forest/discussions/categories/forest-q-a)!
 
 ## Run with Docker
 
@@ -185,7 +187,6 @@ _Work in progress_.
 
 ## Contributing
 - Check out our contribution guidelines: [CONTRIBUTING.md](documentation/developer_documentation/CONTRIBUTING.md)
-- Have questions? Feel free to post them in [Forest Q&A](https://github.com/ChainSafe/forest/discussions/categories/forest-q-a)!
 
 ## ChainSafe Security Policy
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Suggest to use GH Discussions and not Discord where we are not really active. Perhaps we should get rid of the Discord badge as well?

<!-- Thank you 🔥 -->