### PR TITLE
include snapshot path in logs

### DIFF
--- a/utils/genesis/src/lib.rs
+++ b/utils/genesis/src/lib.rs
@@ -130,7 +130,7 @@ where
 {
     let is_remote_file: bool = path.starts_with("http://") || path.starts_with("https://");
 
-    info!("Importing chain from snapshot");
+    info!("Importing chain from snapshot at: {path}");
     // start import
     let cids = if is_remote_file {
         let url = Url::parse(path).expect("URL is invalid");


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Include snapshot path in logs when importing. I find it useful when, e.g. piping stdout to a file, given that the command invoked is not there.


<!-- Thank you 🔥 -->