### PR TITLE
Remove unused call to git-version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,8 +3162,6 @@ dependencies = [
  "fvm_ipld_car",
  "fvm_ipld_encoding",
  "fvm_shared",
- "git-version",
- "lazy_static",
  "libp2p 0.46.1",
  "libp2p-bitswap",
  "log",

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -25,8 +25,6 @@ futures-util = "0.3"
 fvm_ipld_car = "0.4.1"
 fvm_ipld_encoding = "0.2"
 fvm_shared = { version = "0.8.0", default-features = false, features = ["testing"] }
-git-version = "0.3"
-lazy_static = "1.4"
 libp2p = { version = "0.46", default-features = false, features = [
   "gossipsub",
   "kad",

--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -18,8 +18,6 @@ use cid::Cid;
 use forest_encoding::blake2b_256;
 use futures::channel::oneshot::{self, Sender as OneShotSender};
 use futures::{prelude::*, stream::FuturesUnordered};
-use git_version::git_version;
-use lazy_static::lazy_static;
 use libp2p::ping::{Ping, PingEvent};
 use libp2p::request_response::{
     ProtocolSupport, RequestId, RequestResponse, RequestResponseConfig, RequestResponseEvent,
@@ -53,11 +51,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, convert::TryInto};
 use std::{task::Context, task::Poll};
 use tiny_cid::Cid as Cid2;
-
-lazy_static! {
-    static ref VERSION: &'static str = env!("CARGO_PKG_VERSION");
-    static ref CURRENT_COMMIT: &'static str = git_version!(fallback = "unknown");
-}
 
 /// Libp2p behavior for the Forest node. This handles all sub protocols needed for a Filecoin node.
 #[derive(NetworkBehaviour)]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Git-version can cause Forest to be recompiled even when it's not necessary.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->