### PR TITLE
add const-option macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
+name = "const_format"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "939dc9e2eb9077e0679d2ce32de1ded8531779360b003b4a972a7a39ec263495"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef196d5d972878a48da7decb7686eded338b4858fbabeed513d63a7c98b2b82d"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "unicode-xid 0.2.3",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +2691,7 @@ dependencies = [
  "forest_ipld",
  "forest_ipld_blockstore",
  "forest_legacy_ipld_amt",
+ "forest_macros",
  "forest_message",
  "forest_networks",
  "forest_test_utils",
@@ -2715,6 +2736,7 @@ dependencies = [
  "forest_json_utils",
  "forest_legacy_ipld_amt",
  "forest_libp2p",
+ "forest_macros",
  "forest_message",
  "forest_message_pool",
  "forest_networks",
@@ -3076,6 +3098,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "forest_macros"
+version = "0.1.0"
+dependencies = [
+ "const_format",
+]
+
+[[package]]
 name = "forest_message"
 version = "0.7.2"
 dependencies = [
@@ -3114,6 +3143,7 @@ dependencies = [
  "forest_ipld_blockstore",
  "forest_key_management",
  "forest_libp2p",
+ "forest_macros",
  "forest_message",
  "forest_networks",
  "forest_state_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   "utils/net_utils",
   "utils/statediff",
   "utils/test_utils",
+  "utils/macros",
   "utils/metrics",
   "utils/paramfetch",
   "utils/json",
@@ -69,6 +70,7 @@ forest_encoding        = { path = "./encoding" }
 forest_hash_utils      = { path = "./utils/hash_utils" }
 forest_json_utils      = { path = "./utils/json_utils" }
 forest_test_utils      = { path = "./utils/test_utils" }
+forest_macros          = { path = "./utils/macros" }
 forest_statediff       = { path = "./utils/statediff" }
 forest_genesis         = { path = "./utils/genesis" }
 forest_auth            = { path = "./utils/auth" }

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -23,6 +23,7 @@ forest_interpreter     = "0.1.0"
 forest_ipld            = "0.1.1"
 forest_ipld_blockstore = "0.1"
 forest_legacy_ipld_amt = "0.2.0"
+forest_macros          = "0.1"
 forest_message         = { version = "0.7", features = ["blst"] }
 forest_networks        = "0.1.0"
 futures                = "0.3.24"

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -48,7 +48,8 @@ const BLOCK_VAL_PREFIX: &[u8] = b"block_val/";
 // A cap on the size of the future_sink
 const SINK_CAP: usize = 200;
 
-const DEFAULT_TIPSET_CACHE_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(8192);
+const DEFAULT_TIPSET_CACHE_SIZE: NonZeroUsize =
+    forest_macros::const_option!(NonZeroUsize::new(8192));
 
 /// `Enum` for `pubsub` channel that defines message type variant and data contained in message type.
 #[derive(Clone, Debug)]
@@ -94,9 +95,7 @@ where
     pub fn new(db: DB) -> Self {
         let (publisher, _) = broadcast::channel(SINK_CAP);
         // unfallible unwrap due to `DEFAULT_TIPSET_CACHE_SIZE` being a non-None const
-        let ts_cache = Arc::new(RwLock::new(LruCache::new(
-            DEFAULT_TIPSET_CACHE_SIZE.unwrap(),
-        )));
+        let ts_cache = Arc::new(RwLock::new(LruCache::new(DEFAULT_TIPSET_CACHE_SIZE)));
         let cs = Self {
             publisher,
             subscriptions: Default::default(),

--- a/blockchain/chain/src/store/index.rs
+++ b/blockchain/chain/src/store/index.rs
@@ -10,7 +10,8 @@ use fvm_shared::clock::ChainEpoch;
 use lru::LruCache;
 use std::{num::NonZeroUsize, sync::Arc};
 
-const DEFAULT_CHAIN_INDEX_CACHE_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(32 << 10);
+const DEFAULT_CHAIN_INDEX_CACHE_SIZE: NonZeroUsize =
+    forest_macros::const_option!(NonZeroUsize::new(32 << 10));
 
 /// Configuration which sets the length of tipsets to skip in between each cached entry.
 const SKIP_LENGTH: ChainEpoch = 20;
@@ -43,8 +44,7 @@ where
 {
     pub(crate) fn new(ts_cache: Arc<TipsetCache>, db: BS) -> Self {
         Self {
-            // unfallible unwrap due to `DEFAULT_CHAIN_INDEX_CACHE_SIZE` being a non-None const
-            skip_cache: RwLock::new(LruCache::new(DEFAULT_CHAIN_INDEX_CACHE_SIZE.unwrap())),
+            skip_cache: RwLock::new(LruCache::new(DEFAULT_CHAIN_INDEX_CACHE_SIZE)),
             ts_cache,
             db,
         }

--- a/blockchain/chain_sync/Cargo.toml
+++ b/blockchain/chain_sync/Cargo.toml
@@ -22,6 +22,7 @@ forest_ipld_blockstore = "0.1"
 forest_json_utils      = "0.1"
 forest_legacy_ipld_amt = "0.2.0"
 forest_libp2p          = "0.1.0"
+forest_macros          = "0.1"
 forest_message         = { version = "0.7", features = ["proofs", "blst"] }
 forest_message_pool    = "0.1.0"
 forest_networks        = "0.1.0"

--- a/blockchain/chain_sync/src/bad_block_cache.rs
+++ b/blockchain/chain_sync/src/bad_block_cache.rs
@@ -15,7 +15,7 @@ pub struct BadBlockCache {
 
 impl Default for BadBlockCache {
     fn default() -> Self {
-        Self::new(NonZeroUsize::new(1 << 15).unwrap())
+        Self::new(forest_macros::const_option!(NonZeroUsize::new(1 << 15)))
     }
 }
 

--- a/blockchain/message_pool/Cargo.toml
+++ b/blockchain/message_pool/Cargo.toml
@@ -19,6 +19,7 @@ forest_fil_types       = "0.2"
 forest_interpreter     = "0.1.0"
 forest_ipld_blockstore = "0.1"
 forest_libp2p          = "0.1.0"
+forest_macros          = "0.1"
 forest_message         = { version = "0.7", features = ["proofs", "blst"] }
 forest_networks        = "0.1.0"
 forest_state_manager   = "0.1.0"

--- a/blockchain/message_pool/src/msgpool/msg_pool.rs
+++ b/blockchain/message_pool/src/msgpool/msg_pool.rs
@@ -25,6 +25,7 @@ use forest_blocks::{BlockHeader, Tipset, TipsetKeys};
 use forest_chain::{HeadChange, MINIMUM_BASE_FEE};
 use forest_db::Store;
 use forest_libp2p::{NetworkMessage, Topic, PUBSUB_MSG_STR};
+use forest_macros::const_option;
 use forest_message::message::valid_for_block_inclusion;
 use forest_message::{ChainMessage, Message, SignedMessage};
 use forest_networks::{ChainConfig, NEWEST_NETWORK_VERSION};
@@ -42,8 +43,8 @@ use std::time::Duration;
 use tokio::sync::broadcast::error::RecvError;
 
 // LruCache sizes have been taken from the lotus implementation
-const BLS_SIG_CACHE_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(40000);
-const SIG_VAL_CACHE_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(32000);
+const BLS_SIG_CACHE_SIZE: NonZeroUsize = const_option!(NonZeroUsize::new(40000));
+const SIG_VAL_CACHE_SIZE: NonZeroUsize = const_option!(NonZeroUsize::new(32000));
 
 /// Simple structure that contains a hash-map of messages where k: a message from address, v: a message
 /// which corresponds to that address.
@@ -188,10 +189,8 @@ where
         let tipset = Arc::new(RwLock::new(api.get_heaviest_tipset().await.ok_or_else(
             || Error::Other("Failed to retrieve heaviest tipset from provider".to_owned()),
         )?));
-        // unfallible unwrap due to `BLS_SIG_CACHE_SIZE` being a non-None const
-        let bls_sig_cache = Arc::new(RwLock::new(LruCache::new(BLS_SIG_CACHE_SIZE.unwrap())));
-        // unfallible unwrap due to `SIG_VAL_CACHE_SIZE` being a non-None const
-        let sig_val_cache = Arc::new(RwLock::new(LruCache::new(SIG_VAL_CACHE_SIZE.unwrap())));
+        let bls_sig_cache = Arc::new(RwLock::new(LruCache::new(BLS_SIG_CACHE_SIZE)));
+        let sig_val_cache = Arc::new(RwLock::new(LruCache::new(SIG_VAL_CACHE_SIZE)));
         let api_mutex = Arc::new(RwLock::new(api));
         let local_msgs = Arc::new(RwLock::new(HashSet::new()));
         let republished = Arc::new(RwLock::new(HashSet::new()));

--- a/utils/macros/Cargo.toml
+++ b/utils/macros/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name    = "forest_macros"
+version = "0.1.0"
+authors = ["ChainSafe Systems <info@chainsafe.io>"]
+edition = "2021"
+
+[dependencies]
+const_format = "0.2.26"

--- a/utils/macros/src/lib.rs
+++ b/utils/macros/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
 pub extern crate const_format;
 
 /// Creates a constant value from an expression that returns an Option that we *know* is not None.

--- a/utils/macros/src/lib.rs
+++ b/utils/macros/src/lib.rs
@@ -1,6 +1,6 @@
 pub extern crate const_format;
 
-/// Creates a const value from an expression that returns an Option that we *know* is not None.
+/// Creates a constant value from an expression that returns an Option that we *know* is not None.
 /// Basically a workaround till https://github.com/rust-lang/rust/issues/67441 is stabilized.
 ///
 /// # Example

--- a/utils/macros/src/lib.rs
+++ b/utils/macros/src/lib.rs
@@ -3,7 +3,7 @@
 pub extern crate const_format;
 
 /// Creates a constant value from an expression that returns an Option that we *know* is not None.
-/// Basically a workaround till https://github.com/rust-lang/rust/issues/67441 is stabilized.
+/// Basically a workaround till <https://github.com/rust-lang/rust/issues/67441> is stabilized.
 ///
 /// # Example
 /// ```

--- a/utils/macros/src/lib.rs
+++ b/utils/macros/src/lib.rs
@@ -1,0 +1,31 @@
+pub extern crate const_format;
+
+/// Creates a const value from an expression that returns an Option that we *know* is not None.
+/// Basically a workaround till https://github.com/rust-lang/rust/issues/67441 is stabilized.
+///
+/// # Example
+/// ```
+/// use forest_macros::const_option;
+/// const MY_CONST: i32 = const_option!(Some(42));
+/// ```
+///
+/// # This will at fail compile-time.
+/// ```compile_fail
+/// use forest_macros::const_option;
+/// const MY_CONST: i32 = const_option!(None);
+/// ```
+#[macro_export]
+macro_rules! const_option {
+    ($value:expr) => {
+        match $value {
+            Some(v) => v,
+            None => {
+                const error_msg: &str = $crate::const_format::concatcp!(
+                    "Failed on unwrapping expression ",
+                    stringify!($value)
+                );
+                panic!("{}", error_msg);
+            }
+        }
+    };
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Inspired by @lemmih comment [here](https://github.com/ChainSafe/forest/pull/1926#discussion_r972146474), added a custom macro that will allow us to create constants out of infallible options and applied it to the relevant PR. If a bad value is provided, it will fail at compile time with a pretty message.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1930


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->