### PR TITLE
Avoid 0s durations when using `tokio::time::interval`

### DIFF
--- a/node/forest_libp2p/src/discovery.rs
+++ b/node/forest_libp2p/src/discovery.rs
@@ -147,7 +147,7 @@ impl<'a> DiscoveryConfig<'a> {
         DiscoveryBehaviour {
             user_defined,
             kademlia: kademlia_opt.into(),
-            next_kad_random_query: tokio::time::interval(Duration::new(0, 0)),
+            next_kad_random_query: tokio::time::interval(Duration::from_secs(1)),
             duration_to_next_kad: Duration::from_secs(1),
             pending_events: VecDeque::new(),
             num_connections: 0,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- `async_std::stream::interval` allows 0s durations but `tokio::time::interval` does not. Oh well.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->