### PR TITLE
publish review stats 9AM Monday only

### DIFF
--- a/.github/workflows/pr_stats.yml
+++ b/.github/workflows/pr_stats.yml
@@ -2,7 +2,7 @@ name: Pull Request Stats
 
 on:
   schedule:
-    - cron:  '0 * * * 1'
+    - cron:  '0 9 * * 1'
 
 jobs:
   stats:


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Cuts short the interval from https://github.com/ChainSafe/forest/pull/1935.

Merge it ***only*** after confirming that the CR notification is satisfactory on Slack.

<!-- Thank you 🔥 -->