### PR TITLE
snapshot exporter error handling

### DIFF
--- a/scripts/daily_snapshot/daily_snapshot.rb
+++ b/scripts/daily_snapshot/daily_snapshot.rb
@@ -46,14 +46,15 @@ loop do
     # Sync and export snapshot
     snapshot_uploaded = system("bash upload_snapshot.sh #{CHAIN_NAME} #{latest} > #{LOG_EXPORT} 2>&1")
 
-    client = SlackClient.new CHANNEL, SLACK_TOKEN
-
     if snapshot_uploaded
       client.post_message "✅ Snapshot uploaded for #{CHAIN_NAME}. 🌲🌳🌲🌳🌲"
     else
       client.post_message "⛔ Snapshot failed for #{CHAIN_NAME}. 🔥🌲🔥 "
     end
+
+    # attach the log file and print the contents to STDOUT
     client.attach_files(LOG_EXPORT)
+    puts "Snapshot export log:\n#{File.read(LOG_EXPORT)}"
 
     # Prune snapshots
     pruned = prune_snapshots(SNAPSHOTS_DIR)


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- increase sync timeout from 30m to 90m, just in case of some failures, so we won't need manual intervention when there's a snapshot gap for whatever reason,
- handle errors in snapshot exporter so they are reported, and the script exits immediately,
- print the logs to container stdout so that they are easily inspectable with `docker logs`
- other minor fixes



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1961


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->