### PR TITLE
auto-updater for ready-to-merge PRs

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,3 +1,4 @@
+# This workflow should auto-update PRs that have automatic-merge enabled, i.e. reviewed and ready to merge.
 name: autoupdate
 on:
   push:

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,0 +1,14 @@
+name: autoupdate
+on:
+  push:
+    branches:
+      - main
+jobs:
+  autoupdate:
+    name: autoupdate
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PR_FILTER: "auto_merge"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- I got annoyed a bit by this manual clicking and merging races. This workflow should auto-update PRs that have automatic-merge enabled, i.e. reviewed and ready to merge.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. -->


<!-- Thank you 🔥 -->