### PR TITLE
Fix rubocop action

### DIFF
--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -21,7 +21,12 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - name: RuboCop Linter Action
-      uses: andrewmcodes/rubocop-linter-action@v3.3.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+      - name: Run rubocop
+        run: |
+          gem install rubocop --no-document
+          rubocop scripts/


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- gets rid of archived `rubocop` action in favour of a manual one. For our use case it should be enough.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->