### PR TITLE
fix: improve error message when importing bad snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,7 +2702,7 @@ dependencies = [
  "lazy_static",
  "lockfree",
  "log",
- "lru 0.8.0",
+ "lru 0.8.1",
  "multihash",
  "num-traits",
  "pbr",
@@ -2751,7 +2751,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
- "lru 0.8.0",
+ "lru 0.8.1",
  "nonempty",
  "num-bigint 0.4.3",
  "num-traits",
@@ -3158,7 +3158,7 @@ dependencies = [
  "fvm_shared",
  "libsecp256k1",
  "log",
- "lru 0.8.0",
+ "lru 0.8.1",
  "num-rational",
  "num-traits",
  "rand 0.8.5",
@@ -4566,9 +4566,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libipld"
@@ -5377,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936d98d2ddd79c18641c6709e7bb09981449694e402d1a0f0f657ea8d61f4a51"
+checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
  "hashbrown 0.12.3",
 ]
@@ -6189,9 +6189,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
+checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -7729,9 +7729,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smartstring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ libp2p                = "0.46"
 libp2p-bitswap        = { git = "https://github.com/ChainSafe/libp2p-bitswap", rev = "5c79b37feceb3ba76d5a488b1713cfaaf861baa3" }
 libsecp256k1          = "0.7"
 log                   = "0.4"
+lru                   = "0.8"
 multibase             = "0.9"
 multihash             = "0.16"
 num-bigint            = "0.4"

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -34,7 +34,7 @@ fvm_shared                       = { workspace = true, default-features = false 
 lazy_static.workspace            = true
 lockfree                         = "0.5.1"
 log.workspace                    = true
-lru                              = "0.8.0"
+lru.workspace                    = true
 num-traits.workspace             = true
 pbr.workspace                    = true
 serde                            = { workspace = true, features = ["derive"] }

--- a/blockchain/chain_sync/Cargo.toml
+++ b/blockchain/chain_sync/Cargo.toml
@@ -35,7 +35,7 @@ fvm_ipld_encoding.workspace      = true
 fvm_shared                       = { workspace = true, default-features = false }
 lazy_static.workspace            = true
 log.workspace                    = true
-lru                              = "0.8.0"
+lru.workspace                    = true
 nonempty                         = "0.8.0"
 num-bigint.workspace             = true
 num-traits.workspace             = true

--- a/blockchain/message_pool/Cargo.toml
+++ b/blockchain/message_pool/Cargo.toml
@@ -30,16 +30,15 @@ fvm_ipld_encoding.workspace      = true
 fvm_shared                       = { workspace = true, default-features = false }
 libsecp256k1.workspace           = true
 log.workspace                    = true
-# cannot update lru as `LruCache::new` changed its arguments
-lru                    = "0.8.0"
-num-rational.workspace = true
-num-traits.workspace   = true
-rand.workspace         = true
-serde                  = { workspace = true, features = ["derive"] }
-slotmap                = "1.0"
-statrs                 = "0.16"
-thiserror.workspace    = true
-tokio                  = { workspace = true, features = ["sync"] }
+lru.workspace                    = true
+num-rational.workspace           = true
+num-traits.workspace             = true
+rand.workspace                   = true
+serde                            = { workspace = true, features = ["derive"] }
+slotmap                          = "1.0"
+statrs                           = "0.16"
+thiserror.workspace              = true
+tokio                            = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 forest_key_management.workspace = true

--- a/utils/genesis/src/lib.rs
+++ b/utils/genesis/src/lib.rs
@@ -134,15 +134,13 @@ where
     info!("Importing chain from snapshot at: {path}");
     // start import
     let cids = if is_remote_file {
-        let url = Url::parse(path).expect("URL is invalid");
         info!("Downloading file...");
+        let url = Url::parse(path)?;
         let reader = FetchProgress::fetch_from_url(url).await?;
         load_and_retrieve_header(sm.blockstore(), reader, skip_load).await?
     } else {
-        let file = File::open(&path)
-            .await
-            .expect("Snapshot file path not found!");
         info!("Reading file...");
+        let file = File::open(&path).await?;
         let reader = FetchProgress::fetch_from_file(file).await?;
         load_and_retrieve_header(sm.blockstore(), reader, skip_load).await?
     };


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- improve error message when importing bad snapshot
- add unit tests to cover bad snapshot file path, bad snapshot  file, bad snapshot url cases
- (off topic) move `lru` dep to workspace manifest, remove stale comments

After fix:
```
 ...
 2022-10-03T07:10:47.153Z ERROR forest::daemon                 > Failed miserably while importing chain from snapshot Cargo.toml: Failed to parse CAR file: Serialization error for Cbor protocol: Mismatch { expect_major: 5, byte: 112 }
 2022-10-03T07:10:47.153Z ERROR forest::cli                    > Error: Database version 1 is too old (minimum 16 expected). Download a snapshot from a trusted source and import with --import-snapshot=[file|url]
```

```
 ...
 2022-10-03T07:14:28.541Z ERROR forest::daemon                 > Failed miserably while importing chain from snapshot dummy.car: could not open `dummy.car`
 2022-10-03T07:14:28.541Z INFO  forest_rpc                     > Ready for RPC connections
 2022-10-03T07:14:28.541Z ERROR forest::cli                    > Error: Database version 1 is too old (minimum 16 expected). Download a snapshot from a trusted source and import with --import-snapshot=[file|url]
```




**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1974


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->