### PR TITLE
Adjust `cancel previous runs` CI to run for PRs only

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           access_token: ${{ github.token }}
       - name: Checkout code
@@ -48,6 +49,7 @@ jobs:
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           access_token: ${{ github.token }}
       - name: Checkout code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           access_token: ${{ github.token }}
       - name: Install Dependencies
@@ -46,6 +47,7 @@ jobs:
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           access_token: ${{ github.token }}
       - name: Install Dependencies
@@ -138,6 +140,7 @@ jobs:
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           access_token: ${{ github.token }}
       - name: Install Dependencies


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- `Cancel Previous Runs` CI runs for PRs only



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1988


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->