### PR TITLE
Ignore merge conflicts in auto-updater

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -13,3 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.ACTIONS_PAT }}'
           PR_FILTER: "auto_merge"
+          MERGE_CONFLICT_ACTION: "ignore"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- the auto-updater seems to mark the entire CI red if it catches a merge conflict. Given that other workflows will catch it anyway, it's most likely safe to ignore it in this particular one.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->

**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->