### PR TITLE
use checksums for calibnet fetches

### DIFF
--- a/forest/src/cli/snapshot_fetch.rs
+++ b/forest/src/cli/snapshot_fetch.rs
@@ -61,7 +61,7 @@ async fn snapshot_fetch_calibnet(
         .ok_or_else(|| anyhow::anyhow!("Couldn't list bucket"))?
         .contents
         .iter()
-        .filter(|obj| obj.size > 0)
+        .filter(|obj| obj.size > 0 && obj.key.rsplit_once('.').unwrap_or_default().1 == "car")
         .max_by_key(|obj| DateTime::parse_from_rfc3339(&obj.last_modified).unwrap_or_default())
         .ok_or_else(|| anyhow::anyhow!("Couldn't retrieve bucket contents"))?
         .to_owned();
@@ -80,13 +80,27 @@ async fn snapshot_fetch_calibnet(
     let calibnet_path = &snapshot_fetch_config.calibnet.path;
     let url = snapshot_spaces_url.join(calibnet_path)?.join(filename)?;
 
-    let snapshot_response = client.get(url).send().await?;
+    let snapshot_response = client.get(url.clone()).send().await?;
     let total_size = last_modified.size;
-    let snapshot_digest =
+    let snapshot_checksum =
         download_snapshot_to_file(&snapshot_path, snapshot_response, total_size).await?;
+
+    info!("Validating checksum...");
+    let checksum_url = replace_extension_url(url, "sha256sum")?;
+    let checksum_expected_file = client.get(checksum_url).send().await?;
+    if !checksum_expected_file.status().is_success() {
+        bail!("Unable to get the checksum file. Snapshot downloaded but not verified.");
+    }
+
+    let checksum_expected = checksum_from_file(
+        &checksum_expected_file.bytes().await?,
+        Sha256::output_size(),
+    )?;
+
+    validate_checksum(&checksum_expected, &snapshot_checksum)?;
     info!(
-        "Snapshot checksum is {}. Validation is not yet available.",
-        snapshot_digest.encode_hex::<String>()
+        "Snapshot checksum correct. {}",
+        snapshot_checksum.encode_hex::<String>()
     );
     Ok(snapshot_path)
 }
@@ -127,11 +141,17 @@ async fn snapshot_fetch_mainnet(
 
     info!("Validating checksum...");
     let checksum_url = replace_extension_url(snapshot_url, "sha256sum")?;
-    let checksum_expected_file = client.get(checksum_url).send().await?.bytes().await?;
+    let checksum_expected_file = client.get(checksum_url).send().await?;
+    if !checksum_expected_file.status().is_success() {
+        bail!("Unable to get the checksum file. Snapshot downloaded but not verified.");
+    }
 
     // checksum file is hex-encoded with trailing `- ` at the end. Take only what's needed, i.e.
     // encoded digest, for SHA256 it's 32 bytes * 2.
-    let checksum_expected = checksum_from_file(&checksum_expected_file, Sha256::output_size())?;
+    let checksum_expected = checksum_from_file(
+        &checksum_expected_file.bytes().await?,
+        Sha256::output_size(),
+    )?;
 
     validate_checksum(&checksum_expected, &snapshot_checksum)?;
     info!(

--- a/scripts/daily_snapshot/snapshots_prune.rb
+++ b/scripts/daily_snapshot/snapshots_prune.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'date'
+require 'pathname'
 
 # Class representing a snapshot bucket with a defined number of entries.
 class SnapshotBucket
@@ -56,5 +57,12 @@ def prune_snapshots(snapshots_directory)
      .sort_by { |f| File.mtime(f) }
      .reverse
      .reject  { |f| buckets.any? { |bucket| bucket.add? f } }
-     .each    { |f| File.delete f }
+     .each    { |f| remove_snapshot f }
+end
+
+# Removes the snapshot and optionally the related checksum file if it exists.
+def remove_snapshot(snapshot)
+  checksum = Pathname.new(snapshot.path).sub_ext('.sha256sum')
+  File.delete checksum if checksum.file?
+  File.delete snapshot
 end


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- add checksum verification for our hosted calibnet snapshots
- prune the checksums along with the snapshots for exporter,

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1899


**Other information and links**
<!-- Add any other context about the pull request here. -->
https://github.com/ChainSafe/forest/pull/1979 should be merged first.


<!-- Thank you 🔥 -->