### PR TITLE
chore: add rustdoc links to readme.md

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,8 @@ jobs:
           args: --verbose --no-progress 'README.md'
           # Fail action on broken links
           fail: true
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Install MDBook
         run: cargo install mdbook mdbook-linkcheck
       - name: Execute MDBook

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/ChainSafe/forest?style=for-the-badge)](https://github.com/ChainSafe/forest/releases/latest)
 [![dependency status](https://deps.rs/repo/github/ChainSafe/forest/status.svg?style=for-the-badge)](https://deps.rs/repo/github/ChainSafe/forest)
 [![forest book](https://img.shields.io/badge/doc-book-green?style=for-the-badge)](https://chainsafe.github.io/forest/)
+[![rustdoc@main](https://img.shields.io/badge/doc-rustdoc@main-green?style=for-the-badge)](https://chainsafe.github.io/forest/rustdoc/)
 [![License Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge)](https://opensource.org/licenses/Apache-2.0)
 [![License MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Twitter](https://img.shields.io/twitter/follow/ChainSafeth.svg?style=for-the-badge&label=Twitter&color=1DA1F2)](https://twitter.com/ChainSafeth)
@@ -208,6 +209,7 @@ The command will block until the detached Forest process has started its RPC ser
 
 ### Documentation
 - [forest book (_Work in progress_)](https://chainsafe.github.io/forest/)
+- [rust doc](https://chainsafe.github.io/forest/rustdoc/)
 
 ## Contributing
 - Check out our contribution guidelines: [CONTRIBUTING.md](documentation/developer_documentation/CONTRIBUTING.md)


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Now the rustdoc  has been published, it should pass the CI check
- Add the rust-cache step back which was accidentally removed by my bad merge



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1996


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->