### PR TITLE
fix: cancel workflow event not trigger

### DIFF
--- a/.github/workflows/cancel-stale.yml
+++ b/.github/workflows/cancel-stale.yml
@@ -14,8 +14,11 @@ jobs:
   cancel:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.1
+      # TODO: switch back to styfle/cancel-workflow-action once the change get merged and released
+      - uses: hanabi1224/cancel-workflow-action@120898519f2940069cc6a070c4f9c3d6cc2e7ff8
         with:
           workflow_id: ${{ github.event.workflow.id }}
           # https://github.com/styfle/cancel-workflow-action#advanced-all-but-latest
           all_but_latest: true
+          ignore_branches_on_push: |
+            main

--- a/.github/workflows/cancel-stale.yml
+++ b/.github/workflows/cancel-stale.yml
@@ -10,8 +10,6 @@ on:
       - "Scripts"
     types:
       - requested
-    branches:
-      - "!main"
 jobs:
   cancel:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Summary of changes**

This is follow-up of https://github.com/ChainSafe/forest/pull/2012

Changes introduced in this pull request:
- filtering out `main` will cause the events never get triggered
- I looked at their code, it does not support filtering out branches ATM, so it will still cancel workflows triggered by commits to `main`, I can send out a PR to support the filtering, or we need to revert the previous change. (Note that PRs from forks will not be canceled then) @lemmih plz me know ur preference



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->