### PR TITLE
add shorter timeout to buildjet-based jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ jobs:
   codecov:
     name: Cover
     runs-on: buildjet-16vcpu-ubuntu-2004
+    timeout-minutes: 30
     steps:
       - name: Install Dependencies
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-push-docker-image:
     name: Build Docker image and push to repositories
     runs-on: buildjet-16vcpu-ubuntu-2004
-
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: Test
     runs-on: buildjet-16vcpu-ubuntu-2004
+    timeout-minutes: 30
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -119,6 +120,7 @@ jobs:
   calibnet-check:
     name: Calibnet sync check
     runs-on: buildjet-16vcpu-ubuntu-2004
+    timeout-minutes: 30
     steps:
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Introduce shorter [timeout](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) for buildjet-based jobs. This is to ensure we don't [burn money](https://buildjet.com/for-github-actions/pricing) when we submit a PR with a potential deadlock, infinite loop or any other kind of condition where the workflow gets stuck.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->