### PR TITLE
slower buildjet machines for workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   codecov:
     name: Cover
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 30
     steps:
       - name: Install Dependencies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push-docker-image:
     name: Build Docker image and push to repositories
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 30
     steps:
       - name: Checkout code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 30
     env:
       RUSTFLAGS: "-D warnings"
@@ -114,7 +114,7 @@ jobs:
 
   calibnet-check:
     name: Calibnet sync check
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 30
     steps:
       - name: Install Dependencies


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use cheaper buildjet machines for workflows
- entire Rust workflow stays at roughly at 21 minutes:
https://github.com/ChainSafe/forest/actions/runs/3245363626
https://github.com/ChainSafe/forest/actions/runs/3248401717

- Docker build is 50% slower but 2x cheaper, so we still gain 50%. Given that it still takes less than the Rust workflow, we should be fine.
- code coverage workflow will most likely take longer, but it happens only on merge to `main` so we don't care about the time (unless it's so slow that it times out or takes >2x longer, I'll revert the change for this if it's the case)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->