### PR TITLE
Fix missing task cancellations

### DIFF
--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -355,6 +355,10 @@ pub(super) async fn start(config: Config, detached: bool) {
 
     // Halt
     if config.client.halt_after_import {
+        // Cancel all async services
+        for handle in services {
+            handle.cancel().await;
+        }
         info!("Forest finish shutdown");
         return;
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix missing task cancellations when using flag `--halt-after-import`

It would result in unwanted logs at the end, ie:

```
Importing snapshot 4.84 GB / 4.84 GB [===============================================================================================================================================================================================] 100.00 % 117.13 MB/s
2022-10-13T17:20:06.408Z INFO  forest_genesis > Loaded .car file in 42s
Scanning blockchain 1368536 / 1376736 [============================================================================================================================================================================================>-] 99.40 % 2897.53/s 3s
2022-10-13T17:27:59.000Z INFO  forest_genesis > Accepting [Cid(bafy2bzacedhnc6zszqlrumtaleuuiw2n2ipiqftntlynmo3eyvwublnddqgfm)] as new head.
2022-10-13T17:27:59.001Z INFO  forest::daemon                   > Imported snapshot in: 514s
2022-10-13T17:27:59.001Z INFO  forest::daemon                   > Forest finish shutdown
2022-10-13T17:27:59.003Z ERROR forest_chain_sync::chain_muxer   > Evaluating the network head failed, retrying. Error = P2PEventStreamReceive("receiving from an empty and closed channel")
2022-10-13T17:27:59.003Z INFO  forest_chain_sync::chain_muxer   > Evaluating network head...
2022-10-13T17:27:59.003Z ERROR forest_chain_sync::chain_muxer   > Evaluating the network head failed, retrying. Error = P2PEventStreamReceive("receiving from an empty and closed channel")
2022-10-13T17:27:59.003Z INFO  forest_chain_sync::chain_muxer   > Evaluating network head...
2022-10-13T17:27:59.003Z ERROR forest_chain_sync::chain_muxer   > Evaluating the network head failed, retrying. Error = P2PEventStreamReceive("receiving from an empty and closed channel")
2022-10-13T17:27:59.003Z INFO  forest_chain_sync::chain_muxer   > Evaluating network head...
2022-10-13T17:27:59.003Z ERROR forest_chain_sync::chain_muxer   > Evaluating the network head failed, retrying. Error = P2PEventStreamReceive("receiving from an empty and closed channel")
2022-10-13T17:27:59.003Z INFO  forest_chain_sync::chain_muxer   > Evaluating network head...
```


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
n/a


**Other information and links**
<!-- Add any other context about the pull request here. -->
n/a


<!-- Thank you 🔥 -->