### PR TITLE
use shorter cache timeout

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,7 @@ jobs:
           submodules: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: 5
       - name: Run cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: 5
+        continue-on-error: true
       - name: Run cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
           fail: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: 5
       - name: Install MDBook
         run: cargo install mdbook mdbook-linkcheck
       - name: Execute MDBook

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: 5
+        continue-on-error: true
       - name: Install MDBook
         run: cargo install mdbook mdbook-linkcheck
       - name: Execute MDBook

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: 5
+        continue-on-error: true
       - name: Cargo Build
         run: cargo build --release --bin forest --bin forest-cli
       - name: Compress Binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: 5
       - name: Cargo Build
         run: cargo build --release --bin forest --bin forest-cli
       - name: Compress Binary

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        timeout-minutes: $CACHE_TIMEOUT_MINUTES
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
       - name: Cargo Check
         run: cargo check
       - name: Make Test-All
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        timeout-minutes: $CACHE_TIMEOUT_MINUTES
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
       - name: Install taplo (TOML linter)
         run: cargo install taplo-cli --locked
       - name: Run Linters
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        timeout-minutes: $CACHE_TIMEOUT_MINUTES
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
       - name: Install Audit
         run: cargo install cargo-audit
       - name: Run Audit
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        timeout-minutes: $CACHE_TIMEOUT_MINUTES
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
       - name: Install udeps
         run: cargo install cargo-udeps --locked
       - name: Run udeps
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        timeout-minutes: $CACHE_TIMEOUT_MINUTES
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
       - name: Install spellcheck
         run: cargo install cargo-spellcheck
       - name: Run Spellcheck
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        timeout-minutes: $CACHE_TIMEOUT_MINUTES
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
       - name: Cargo Build
         run: cargo build --profile dev
 
@@ -134,7 +134,7 @@ jobs:
           submodules: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        timeout-minutes: $CACHE_TIMEOUT_MINUTES
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
       - name: build and install binaries
         run: make install
       - name: download snapshot

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Cargo Check
         run: cargo check
       - name: Make Test-All
@@ -50,6 +51,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Install taplo (TOML linter)
         run: cargo install taplo-cli --locked
       - name: Run Linters
@@ -64,6 +66,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Install Audit
         run: cargo install cargo-audit
       - name: Run Audit
@@ -78,6 +81,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Install udeps
         run: cargo install cargo-udeps --locked
       - name: Run udeps
@@ -92,6 +96,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Install spellcheck
         run: cargo install cargo-spellcheck
       - name: Run Spellcheck
@@ -116,6 +121,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Cargo Build
         run: cargo build --profile dev
 
@@ -135,6 +141,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: build and install binaries
         run: make install
       - name: download snapshot

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ on:
 env:
   CI: 1
   CARGO_INCREMENTAL: 1
+  CACHE_TIMEOUT_MINUTES: 5
 
 jobs:
   test:
@@ -30,6 +31,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: $CACHE_TIMEOUT_MINUTES
       - name: Cargo Check
         run: cargo check
       - name: Make Test-All
@@ -47,6 +49,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: $CACHE_TIMEOUT_MINUTES
       - name: Install taplo (TOML linter)
         run: cargo install taplo-cli --locked
       - name: Run Linters
@@ -60,6 +63,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: $CACHE_TIMEOUT_MINUTES
       - name: Install Audit
         run: cargo install cargo-audit
       - name: Run Audit
@@ -73,6 +77,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: $CACHE_TIMEOUT_MINUTES
       - name: Install udeps
         run: cargo install cargo-udeps --locked
       - name: Run udeps
@@ -86,6 +91,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: $CACHE_TIMEOUT_MINUTES
       - name: Install spellcheck
         run: cargo install cargo-spellcheck
       - name: Run Spellcheck
@@ -109,6 +115,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: $CACHE_TIMEOUT_MINUTES
       - name: Cargo Build
         run: cargo build --profile dev
 
@@ -127,6 +134,7 @@ jobs:
           submodules: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        timeout-minutes: $CACHE_TIMEOUT_MINUTES
       - name: build and install binaries
         run: make install
       - name: download snapshot


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- as @lemmih suggested, if the cache action doesn't complete within 2-3 minutes then it's most likely stalled and we would timeout anyway.
- continue the job even if the cache failed for whatever reason. If it happens, we will just rebuild.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->