### PR TITLE
fix: avoid generating NaN values

### DIFF
--- a/ipld/src/json.rs
+++ b/ipld/src/json.rs
@@ -265,7 +265,8 @@ mod tests {
                 Ipld::Null,
                 Ipld::Bool(bool_item),
                 Ipld::Integer(int_item),
-                Ipld::Float(float_item),
+                // Filter out problematic NaN values.
+                Ipld::Float(if float_item.is_nan() { 0.0 } else { float_item }),
                 Ipld::String(string_item),
                 Ipld::Bytes(bytes_item),
                 Ipld::List(list_item),


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- NaN floating values are difficult to test with because NaN ≠ NaN. This PR changes the generator for Ipld structures to avoid NaN values.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->