### PR TITLE
chore: do not build libzstd-sys by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,6 @@ dependencies = [
  "forest_chain_sync",
  "forest_cli_shared",
  "forest_crypto",
- "forest_db",
  "forest_encoding",
  "forest_fil_types",
  "forest_interpreter",
@@ -3248,7 +3247,6 @@ dependencies = [
  "forest_actor_interface",
  "forest_blocks",
  "forest_crypto",
- "forest_db",
  "forest_encoding",
  "forest_fil_types",
  "forest_ipld_blockstore",
@@ -3807,9 +3805,9 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3822,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3832,15 +3830,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3850,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-lite"
@@ -3871,9 +3869,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -3893,15 +3891,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-timer"
@@ -3911,9 +3909,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -7721,9 +7719,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5543,7 +5543,6 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
- "pkg-config",
  "zstd-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5543,6 +5543,7 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "pkg-config",
  "zstd-sys",
 ]
 

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -23,7 +23,6 @@ forest_chain.workspace           = true
 forest_chain_sync.workspace      = true
 forest_cli_shared.workspace      = true
 forest_crypto.workspace          = true
-forest_db.workspace              = true
 forest_encoding.workspace        = true
 forest_fil_types.workspace       = true
 forest_interpreter.workspace     = true

--- a/ipld/legacy_amt/Cargo.toml
+++ b/ipld/legacy_amt/Cargo.toml
@@ -11,7 +11,6 @@ repository  = "https://github.com/ChainSafe/forest"
 ahash                            = { workspace = true, optional = true }
 anyhow.workspace                 = true
 cid                              = { workspace = true, default-features = false, features = ["std"] }
-forest_db.workspace              = true
 forest_encoding.workspace        = true
 forest_ipld_blockstore.workspace = true
 fvm_ipld_encoding.workspace      = true
@@ -19,6 +18,9 @@ itertools                        = "0.10"
 once_cell.workspace              = true
 serde                            = { workspace = true, features = ["derive"] }
 thiserror.workspace              = true
+
+[dev-dependencies]
+forest_db.workspace = true
 
 [features]
 go-interop = ["ahash"]

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -16,9 +16,6 @@ zlib   = ["rocksdb/zlib"]
 bzip2  = ["rocksdb/bzip2"]
 # not included by default to reduce build time
 zstd = ["rocksdb/zstd"]
-# might be helpful for tweaking performance
-io-uring = ["rocksdb/io-uring"]
-
 
 [dependencies]
 anyhow.workspace              = true

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -7,6 +7,19 @@ authors     = ["ChainSafe Systems <info@chainsafe.io>"]
 edition     = "2021"
 repository  = "https://github.com/ChainSafe/forest"
 
+[features]
+default = ["snappy", "lz4", "zlib", "bzip2"]
+
+snappy = ["rocksdb/snappy"]
+lz4    = ["rocksdb/lz4"]
+zlib   = ["rocksdb/zlib"]
+bzip2  = ["rocksdb/bzip2"]
+# not included by default to reduce build time
+zstd = ["rocksdb/zstd"]
+# might be helpful for tweaking performance
+io-uring = ["rocksdb/io-uring"]
+
+
 [dependencies]
 anyhow.workspace              = true
 cid                           = { workspace = true, default-features = false, features = ["std"] }
@@ -14,7 +27,7 @@ forest_encoding.workspace     = true
 fvm_ipld_blockstore.workspace = true
 num_cpus.workspace            = true
 parking_lot                   = "0.12"
-rocksdb                       = "0.19"
+rocksdb                       = { version = "0.19", default-features = false }
 serde                         = { workspace = true, features = ["derive"] }
 thiserror.workspace           = true
 

--- a/node/db/src/rocks_config.rs
+++ b/node/db/src/rocks_config.rs
@@ -59,6 +59,21 @@ pub(crate) fn compaction_style_from_str(s: &str) -> anyhow::Result<Option<DBComp
 
 /// Converts string to a compression type `RocksDB` variant.
 pub(crate) fn compression_type_from_str(s: &str) -> anyhow::Result<DBCompressionType> {
+    let valid_options = [
+        #[cfg(feature = "bzip2")]
+        "bz2",
+        #[cfg(feature = "lz4")]
+        "lz4",
+        #[cfg(feature = "lz4")]
+        "lz4hc",
+        #[cfg(feature = "snappy")]
+        "snappy",
+        #[cfg(feature = "zlib")]
+        "zlib",
+        #[cfg(feature = "zstd")]
+        "zstd",
+        "none",
+    ];
     match s.to_lowercase().as_str() {
         #[cfg(feature = "bzip2")]
         "bz2" => Ok(DBCompressionType::Bz2),
@@ -73,7 +88,10 @@ pub(crate) fn compression_type_from_str(s: &str) -> anyhow::Result<DBCompression
         #[cfg(feature = "zstd")]
         "zstd" => Ok(DBCompressionType::Zstd),
         "none" => Ok(DBCompressionType::None),
-        _ => Err(anyhow!("invalid compression option")),
+        opt => Err(anyhow!(
+            "invalid compression option: {opt}, valid options: {}",
+            valid_options.join(",")
+        )),
     }
 }
 

--- a/node/db/src/rocks_config.rs
+++ b/node/db/src/rocks_config.rs
@@ -60,11 +60,17 @@ pub(crate) fn compaction_style_from_str(s: &str) -> anyhow::Result<Option<DBComp
 /// Converts string to a compression type `RocksDB` variant.
 pub(crate) fn compression_type_from_str(s: &str) -> anyhow::Result<DBCompressionType> {
     match s.to_lowercase().as_str() {
+        #[cfg(feature = "bzip2")]
         "bz2" => Ok(DBCompressionType::Bz2),
+        #[cfg(feature = "lz4")]
         "lz4" => Ok(DBCompressionType::Lz4),
+        #[cfg(feature = "lz4")]
         "lz4hc" => Ok(DBCompressionType::Lz4hc),
+        #[cfg(feature = "snappy")]
         "snappy" => Ok(DBCompressionType::Snappy),
+        #[cfg(feature = "zlib")]
         "zlib" => Ok(DBCompressionType::Zlib),
+        #[cfg(feature = "zstd")]
         "zstd" => Ok(DBCompressionType::Zstd),
         "none" => Ok(DBCompressionType::None),
         _ => Err(anyhow!("invalid compression option")),
@@ -110,11 +116,17 @@ mod test {
     #[test]
     fn compression_style_from_str_test() {
         let test_cases = vec![
+            #[cfg(feature = "bzip2")]
             ("bz2", Ok(DBCompressionType::Bz2)),
+            #[cfg(feature = "lz4")]
             ("lz4", Ok(DBCompressionType::Lz4)),
+            #[cfg(feature = "lz4")]
             ("lz4HC", Ok(DBCompressionType::Lz4hc)),
+            #[cfg(feature = "snappy")]
             ("SNAPPY", Ok(DBCompressionType::Snappy)),
+            #[cfg(feature = "zlib")]
             ("zlib", Ok(DBCompressionType::Zlib)),
+            #[cfg(feature = "zstd")]
             ("ZSTD", Ok(DBCompressionType::Zstd)),
             ("none", Ok(DBCompressionType::None)),
             ("cthulhu", Err(anyhow!("some error message"))),
@@ -123,6 +135,11 @@ mod test {
             let actual = compression_type_from_str(input);
             if let Ok(compression_type) = actual {
                 assert_eq!(expected.unwrap(), compression_type);
+                let dir = tempfile::tempdir().unwrap();
+                let mut opt = rocksdb::Options::default();
+                opt.create_if_missing(true);
+                opt.set_compression_type(compression_type);
+                rocksdb::DB::open(&opt, dir.path()).unwrap();
             } else {
                 assert!(expected.is_err());
             }

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -14,7 +14,6 @@ cid = { workspace = true, default-features = false, features = ["std"] }
 fnv = "1.0"
 forest_blocks.workspace = true
 forest_chain.workspace = true
-forest_db.workspace = true
 forest_encoding.workspace = true
 forest_ipld_blockstore.workspace = true
 forest_message.workspace = true
@@ -51,7 +50,8 @@ tiny-cid        = "0.2"
 tokio           = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
-async-std      = { workspace = true, features = ["attributes", "unstable"] }
-forest_crypto  = { workspace = true, features = ["blst"] }
-forest_genesis = { workspace = true, features = ["testing"] }
-tokio-util     = { version = "0.7.0", features = ["compat"] }
+async-std           = { workspace = true, features = ["attributes", "unstable"] }
+forest_crypto       = { workspace = true, features = ["blst"] }
+forest_db.workspace = true
+forest_genesis      = { workspace = true, features = ["testing"] }
+tokio-util          = { version = "0.7.0", features = ["compat"] }

--- a/vm/interpreter/Cargo.toml
+++ b/vm/interpreter/Cargo.toml
@@ -14,7 +14,6 @@ fil_actors_runtime.workspace     = true
 forest_actor_interface.workspace = true
 forest_blocks.workspace          = true
 forest_crypto                    = { workspace = true, default-features = false, features = ["blst"] }
-forest_db.workspace              = true
 forest_encoding.workspace        = true
 forest_fil_types.workspace       = true
 forest_ipld_blockstore.workspace = true


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- make `rocksdb` compression types optional
- exclude `rocksdb/zstd` from default features to reduce build time cuz it's one of the slowest, see table in https://github.com/ChainSafe/forest/pull/2089
- improve tests



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes part of https://github.com/ChainSafe/forest/issues/2088


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->