### PR TITLE
clean force doesn't fail on non-existing target

### DIFF
--- a/forest/cli/tests/snapshot_tests.rs
+++ b/forest/cli/tests/snapshot_tests.rs
@@ -242,6 +242,28 @@ fn test_snapshot_subcommand_clean_empty() -> Result<()> {
 }
 
 #[test]
+fn test_snapshot_subcommand_clean_snapshot_dir_not_accessible() -> Result<()> {
+    let cmd = cli()?
+        .arg("--chain")
+        .arg("calibnet")
+        .arg("snapshot")
+        .arg("clean")
+        .arg("--force")
+        .arg("--snapshot-dir")
+        .arg("/turbo-cthulhu")
+        .assert()
+        .success();
+
+    let output = std::str::from_utf8(&cmd.get_output().stdout)?.to_owned();
+    ensure!(
+        output.contains("Target directory not accessible. Skipping."),
+        output
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_snapshot_subcommand_clean_one() -> Result<()> {
     let tmp_dir = TempDir::new().unwrap();
     let filenames = ["forest_snapshot_calibnet_2022-10-10_height_1376736.car"];


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- make `snapshot clean --force` less grumpy. In my view, with the `--force` flag it shouldn't complain panic on an unwrap if the `snapshots/mainnet` is not there (which may be the case if nothing was downloaded before).



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->