### PR TITLE
Clean up `forest_message`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,6 +3647,7 @@ dependencies = [
  "forest_encoding",
  "forest_fil_types",
  "forest_interpreter",
+ "forest_json",
  "forest_legacy_ipld_amt",
  "forest_message",
  "forest_networks",

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -18,7 +18,7 @@ use forest_interpreter::BlockMessages;
 use forest_ipld::recurse_links;
 use forest_legacy_ipld_amt::Amt;
 use forest_message::Message as MessageTrait;
-use forest_message::{ChainMessage, MessageReceipt, SignedMessage};
+use forest_message::{ChainMessage, SignedMessage};
 use forest_utils::db::BlockstoreExt;
 use forest_utils::io::Checksum;
 use fvm::state_tree::StateTree;
@@ -30,6 +30,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::{Signature, SignatureType};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
+use fvm_shared::receipt::Receipt;
 use log::{debug, info, trace, warn};
 use lru::LruCache;
 use serde::Serialize;
@@ -897,7 +898,7 @@ pub fn get_parent_reciept<DB>(
     db: &DB,
     block_header: &BlockHeader,
     i: usize,
-) -> Result<Option<MessageReceipt>, Error>
+) -> Result<Option<Receipt>, Error>
 where
     DB: Blockstore,
 {

--- a/blockchain/state_manager/Cargo.toml
+++ b/blockchain/state_manager/Cargo.toml
@@ -22,6 +22,7 @@ forest_db.workspace              = true
 forest_encoding.workspace        = true
 forest_fil_types.workspace       = true
 forest_interpreter.workspace     = true
+forest_json.workspace            = true
 forest_legacy_ipld_amt.workspace = true
 forest_message                   = { workspace = true, features = ["blst"] }
 forest_networks.workspace        = true

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -20,8 +20,9 @@ use forest_chain::{ChainStore, HeadChange};
 use forest_db::Store;
 use forest_fil_types::verifier::ProofVerifier;
 use forest_interpreter::{resolve_to_key_addr, BlockMessages, Heights, RewardCalc, VM};
+use forest_json::message_receipt;
 use forest_legacy_ipld_amt::Amt;
-use forest_message::{message_receipt, ChainMessage, Message as MessageTrait, MessageReceipt};
+use forest_message::{ChainMessage, Message as MessageTrait};
 use forest_networks::{ChainConfig, Height};
 use forest_utils::db::BlockstoreExt;
 use futures::{channel::oneshot, select, FutureExt};
@@ -37,6 +38,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
 use fvm_shared::randomness::Randomness;
+use fvm_shared::receipt::Receipt;
 use fvm_shared::sector::{SectorInfo, SectorSize, StoragePower};
 use fvm_shared::version::NetworkVersion;
 use log::{debug, info, trace, warn};
@@ -58,7 +60,7 @@ pub struct InvocResult {
     #[serde(with = "forest_message::message::json")]
     pub msg: Message,
     #[serde(with = "message_receipt::json::opt")]
-    pub msg_rct: Option<MessageReceipt>,
+    pub msg_rct: Option<Receipt>,
     pub error: Option<String>,
 }
 
@@ -922,7 +924,7 @@ where
         tipset: &Tipset,
         msg_cid: Cid,
         (message_from_address, message_sequence): (&Address, &u64),
-    ) -> Result<Option<MessageReceipt>, Error> {
+    ) -> Result<Option<Receipt>, Error> {
         if tipset.epoch() == 0 {
             return Ok(None);
         }
@@ -979,7 +981,7 @@ where
         &self,
         current: &Tipset,
         (message_from_address, message_cid, message_sequence): (&Address, &Cid, &u64),
-    ) -> Result<Option<(Arc<Tipset>, MessageReceipt)>, Result<Arc<Tipset>, Error>> {
+    ) -> Result<Option<(Arc<Tipset>, Receipt)>, Result<Arc<Tipset>, Error>> {
         if current.epoch() == 0 {
             return Ok(None);
         }
@@ -1025,7 +1027,7 @@ where
         &self,
         current: &Tipset,
         params: (&Address, &Cid, &u64),
-    ) -> Result<Option<(Arc<Tipset>, MessageReceipt)>, Error> {
+    ) -> Result<Option<(Arc<Tipset>, Receipt)>, Error> {
         let mut ts: Arc<Tipset> = match self.check_search(current, params).await {
             Ok(res) => return Ok(res),
             Err(e) => e?,
@@ -1040,7 +1042,7 @@ where
         }
     }
     /// Returns a message receipt from a given tipset and message CID.
-    pub async fn get_receipt(&self, tipset: &Tipset, msg: Cid) -> Result<MessageReceipt, Error> {
+    pub async fn get_receipt(&self, tipset: &Tipset, msg: Cid) -> Result<Receipt, Error> {
         let m = forest_chain::get_chain_message(self.blockstore(), &msg)
             .map_err(|e| Error::Other(e.to_string()))?;
         let message_var = (m.from(), &m.sequence());
@@ -1071,7 +1073,7 @@ where
         self: &Arc<Self>,
         msg_cid: Cid,
         confidence: i64,
-    ) -> Result<(Option<Arc<Tipset>>, Option<MessageReceipt>), Error>
+    ) -> Result<(Option<Arc<Tipset>>, Option<Receipt>), Error>
     where
         DB: Blockstore + Store + Clone + Send + Sync + 'static,
     {
@@ -1090,7 +1092,7 @@ where
         }
 
         let mut candidate_tipset: Option<Arc<Tipset>> = None;
-        let mut candidate_receipt: Option<MessageReceipt> = None;
+        let mut candidate_receipt: Option<Receipt> = None;
 
         let sm_cloned = Arc::clone(self);
         let cid = message
@@ -1119,61 +1121,59 @@ where
         let sm_cloned = Arc::clone(self);
 
         // Wait for message to be included in head change.
-        let mut subscriber_poll = task::spawn::<
-            _,
-            Result<(Option<Arc<Tipset>>, Option<MessageReceipt>), Error>,
-        >(async move {
-            loop {
-                match subscriber.recv().await {
-                    Ok(subscriber) => match subscriber {
-                        HeadChange::Revert(_tipset) => {
-                            if candidate_tipset.is_some() {
-                                candidate_tipset = None;
-                                candidate_receipt = None;
-                            }
-                        }
-                        HeadChange::Apply(tipset) => {
-                            if candidate_tipset
-                                .as_ref()
-                                .map(|s| tipset.epoch() >= s.epoch() + confidence)
-                                .unwrap_or_default()
-                            {
-                                return Ok((candidate_tipset, candidate_receipt));
-                            }
-                            let poll_receiver = receiver.try_recv();
-                            if let Ok(Some(_)) = poll_receiver {
-                                block_revert
-                                    .write()
-                                    .await
-                                    .insert(tipset.key().to_owned(), true);
-                            }
-
-                            let message_var = (message.from(), &message.sequence());
-                            let maybe_receipt = sm_cloned
-                                .tipset_executed_message(&tipset, msg_cid, message_var)
-                                .await?;
-                            if let Some(receipt) = maybe_receipt {
-                                if confidence == 0 {
-                                    return Ok((Some(tipset), Some(receipt)));
+        let mut subscriber_poll =
+            task::spawn::<_, Result<(Option<Arc<Tipset>>, Option<Receipt>), Error>>(async move {
+                loop {
+                    match subscriber.recv().await {
+                        Ok(subscriber) => match subscriber {
+                            HeadChange::Revert(_tipset) => {
+                                if candidate_tipset.is_some() {
+                                    candidate_tipset = None;
+                                    candidate_receipt = None;
                                 }
-                                candidate_tipset = Some(tipset);
-                                candidate_receipt = Some(receipt)
                             }
+                            HeadChange::Apply(tipset) => {
+                                if candidate_tipset
+                                    .as_ref()
+                                    .map(|s| tipset.epoch() >= s.epoch() + confidence)
+                                    .unwrap_or_default()
+                                {
+                                    return Ok((candidate_tipset, candidate_receipt));
+                                }
+                                let poll_receiver = receiver.try_recv();
+                                if let Ok(Some(_)) = poll_receiver {
+                                    block_revert
+                                        .write()
+                                        .await
+                                        .insert(tipset.key().to_owned(), true);
+                                }
+
+                                let message_var = (message.from(), &message.sequence());
+                                let maybe_receipt = sm_cloned
+                                    .tipset_executed_message(&tipset, msg_cid, message_var)
+                                    .await?;
+                                if let Some(receipt) = maybe_receipt {
+                                    if confidence == 0 {
+                                        return Ok((Some(tipset), Some(receipt)));
+                                    }
+                                    candidate_tipset = Some(tipset);
+                                    candidate_receipt = Some(receipt)
+                                }
+                            }
+                            _ => (),
+                        },
+                        Err(RecvError::Lagged(i)) => {
+                            warn!(
+                                "wait for message head change subscriber lagged, skipped {} events",
+                                i
+                            );
                         }
-                        _ => (),
-                    },
-                    Err(RecvError::Lagged(i)) => {
-                        warn!(
-                            "wait for message head change subscriber lagged, skipped {} events",
-                            i
-                        );
+                        Err(RecvError::Closed) => break,
                     }
-                    Err(RecvError::Closed) => break,
                 }
-            }
-            Ok((None, None))
-        })
-        .fuse();
+                Ok((None, None))
+            })
+            .fuse();
 
         // Search backwards for message.
         let mut search_back_poll = task::spawn::<_, Result<_, Error>>(async move {

--- a/node/rpc-api/src/data_types.rs
+++ b/node/rpc-api/src/data_types.rs
@@ -14,15 +14,13 @@ use forest_chain_sync::{BadBlockCache, SyncState};
 use forest_ipld::json::IpldJson;
 use forest_json::address::json::AddressJson;
 use forest_json::cid::CidJson;
+use forest_json::message_receipt::json::ReceiptJson;
 use forest_json::sector::json::{PoStProofJson, SectorInfoJson};
 use forest_json::token_amount::json;
 use forest_key_management::KeyStore;
 pub use forest_libp2p::{Multiaddr, Protocol};
 use forest_libp2p::{Multihash, NetworkMessage};
-use forest_message::{
-    message_receipt::json::MessageReceiptJson, signed_message,
-    signed_message::json::SignedMessageJson, SignedMessage,
-};
+use forest_message::{signed_message, signed_message::json::SignedMessageJson, SignedMessage};
 use forest_message_pool::{MessagePool, MpoolRpcProvider};
 use forest_state_manager::{MiningBaseInfo, StateManager};
 use fvm::state_tree::ActorState;
@@ -164,7 +162,7 @@ pub struct MarketDeal {
 #[derive(Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct MessageLookup {
-    pub receipt: MessageReceiptJson,
+    pub receipt: ReceiptJson,
     #[serde(rename = "TipSet")]
     pub tipset: TipsetKeysJson,
     pub height: i64,

--- a/node/rpc-api/src/lib.rs
+++ b/node/rpc-api/src/lib.rs
@@ -373,7 +373,8 @@ pub mod state_api {
     use forest_fil_types::deadlines::DeadlineInfo;
     use forest_json::address::json::AddressJson;
     use forest_json::cid::CidJson;
-    use forest_message::{message::json::MessageJson, message_receipt::json::MessageReceiptJson};
+    use forest_json::message_receipt::json::ReceiptJson;
+    use forest_message::message::json::MessageJson;
     use forest_state_manager::{InvocResult, MarketBalance};
     use fvm_ipld_bitfield::json::BitFieldJson;
     use fvm_shared::clock::ChainEpoch;
@@ -462,7 +463,7 @@ pub mod state_api {
 
     pub const STATE_GET_RECEIPT: &str = "Filecoin.StateGetReceipt";
     pub type StateGetReceiptParams = (CidJson, TipsetKeysJson);
-    pub type StateGetReceiptResult = MessageReceiptJson;
+    pub type StateGetReceiptResult = ReceiptJson;
 
     pub const STATE_WAIT_MSG: &str = "Filecoin.StateWaitMsg";
     pub type StateWaitMsgParams = (CidJson, i64);

--- a/utils/json/src/lib.rs
+++ b/utils/json/src/lib.rs
@@ -4,5 +4,6 @@ pub mod actor_state;
 pub mod address;
 pub mod bigint;
 pub mod cid;
+pub mod message_receipt;
 pub mod sector;
 pub mod token_amount;

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -5,7 +5,7 @@ use crate::fvm::ForestExterns;
 use cid::Cid;
 use forest_actor_interface::{cron, reward, system, AwardBlockRewardParams};
 use forest_db::Store;
-use forest_message::{ChainMessage, MessageReceipt};
+use forest_message::ChainMessage;
 use forest_networks::{ChainConfig, Height};
 use fvm::call_manager::DefaultCallManager;
 use fvm::executor::{ApplyRet, DefaultExecutor};
@@ -21,6 +21,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::message::Message;
+use fvm_shared::receipt::Receipt;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::{DefaultNetworkParams, NetworkParams, BLOCK_GAS_LIMIT, METHOD_SEND};
 use std::collections::HashSet;
@@ -208,7 +209,7 @@ where
         mut callback: Option<
             impl FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), anyhow::Error>,
         >,
-    ) -> Result<Vec<MessageReceipt>, anyhow::Error> {
+    ) -> Result<Vec<Receipt>, anyhow::Error> {
         let mut receipts = Vec::new();
         let mut processed = HashSet::<Cid>::default();
 

--- a/vm/message/src/lib.rs
+++ b/vm/message/src/lib.rs
@@ -3,13 +3,11 @@
 
 pub mod chain_message;
 pub mod message;
-pub mod message_receipt;
 pub mod signed_message;
 
 pub use chain_message::ChainMessage;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::econ::TokenAmount;
-pub use message_receipt::MessageReceipt;
 pub use signed_message::SignedMessage;
 
 use fvm_shared::address::Address;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Move json modules to `forest_json`
- Remove `MessageReciept` for `fvm_shared::Reciept`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #2119 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->