### PR TITLE
feat: enable avx2,fma cpu features for CI and docker image

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ env:
   CI: 1
   CARGO_INCREMENTAL: 1
   CACHE_TIMEOUT_MINUTES: 5
+  RUSTFLAGS: -Ctarget-feature=+avx2,+fma
 
 jobs:
   test:
@@ -21,7 +22,7 @@ jobs:
     runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 30
     env:
-      RUSTFLAGS: "-D warnings"
+      RUSTFLAGS: "-Ctarget-feature=+avx2,+fma -D warnings"
     steps:
       - name: Install Dependencies
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,11 +352,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
+ "futures-lite",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY . .
 # Grab the correct toolchain
 RUN rustup toolchain install nightly
 
+ENV RUSTFLAGS="-Ctarget-feature=+avx2,+fma"
+
 # Install Forest
 RUN make install
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ cd forest
 
 # Install binary to $HOME/.cargo/bin and run node
 make install
+
+# Simd is supported by many crypto / hashing crates
+# Install with avx2 cpu features
+RUSTFLAGS="-Ctarget-feature=+avx2,+fma" make install
+
+# Or install with local cpu features
+RUSTFLAGS="-Ctarget-cpu=native" make install
+
 forest
 ```
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- enable `avx2`,`fma` cpu features for CI and docker image

Per `rustc --print=cfg`
The default cpu features that `rustc` enables are `sse` and `sse2`

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2124


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->