### PR TITLE
Remove duplicate dependencies' versions from Cargo files (part 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ fvm_ipld_hamt         = "0.5"
 fvm_shared            = "2.0"
 git-version           = "0.3"
 hex                   = "0.4"
+jsonrpc-v2            = { version = "0.11", default-features = false, features = ["easy-errors", "macros", "bytes-v05"] }
 lazy_static           = "1.4"
 libipld               = "0.14"
 libipld-core          = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ async-std             = "1.12"
 async-trait           = "0.1"
 base64                = "0.13"
 blake2b_simd          = "1.0"
+bls-signatures        = { version = "0.12", default-features = false, features = ["blst"] }
 byteorder             = "1.4.3"
 chrono                = "0.4"
 cid                   = "0.8"

--- a/blockchain/beacon/Cargo.toml
+++ b/blockchain/beacon/Cargo.toml
@@ -13,7 +13,7 @@ anyhow.workspace          = true
 async-std.workspace       = true
 async-trait.workspace     = true
 base64.workspace          = true
-bls-signatures            = { version = "0.12", default-features = false, features = ["blst"] }
+bls-signatures.workspace  = true
 byteorder.workspace       = true
 forest_encoding.workspace = true
 forest_utils.workspace    = true

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -9,7 +9,7 @@ anyhow.workspace                 = true
 async-std                        = { workspace = true, features = ["tokio1"] }
 async-stream                     = "0.3.3"
 blake2b_simd.workspace           = true
-bls-signatures                   = { version = "0.12", default-features = false, features = ["blst"] }
+bls-signatures.workspace         = true
 byteorder.workspace              = true
 cid                              = { workspace = true, default-features = false, features = ["std"] }
 digest.workspace                 = true

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,7 +13,7 @@ features = ["json"]
 [dependencies]
 anyhow.workspace            = true
 base64.workspace            = true
-bls-signatures              = { version = "0.12", default-features = false }
+bls-signatures.workspace    = true
 forest_encoding.workspace   = true
 fvm_ipld_encoding.workspace = true
 fvm_shared                  = { workspace = true, default-features = false }

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -45,6 +45,7 @@ fvm_shared                       = { workspace = true, default-features = false 
 git-version.workspace            = true
 hex.workspace                    = true
 http                             = "0.2.8"
+jsonrpc-v2.workspace             = true
 lazy_static.workspace            = true
 libp2p                           = { workspace = true, default-features = false, features = ["identify"] }
 log.workspace                    = true
@@ -72,11 +73,6 @@ time.workspace                   = true
 tokio                            = { workspace = true, features = ["sync"] }
 toml.workspace                   = true
 uuid                             = { version = "1.1", features = ["v4"] }
-
-[dependencies.jsonrpc-v2]
-default-features = false
-features         = ["easy-errors", "macros", "bytes-v05"]
-version          = "0.11"
 
 [dev-dependencies]
 assert_cmd.workspace        = true

--- a/forest/daemon/Cargo.toml
+++ b/forest/daemon/Cargo.toml
@@ -56,6 +56,7 @@ fvm_ipld_encoding.workspace      = true
 fvm_shared                       = { workspace = true, default-features = false }
 git-version.workspace            = true
 hex.workspace                    = true
+jsonrpc-v2.workspace             = true
 lazy_static.workspace            = true
 libp2p                           = { workspace = true, default-features = false, features = ["identify"] }
 log.workspace                    = true
@@ -79,12 +80,6 @@ tempfile.workspace               = true
 time.workspace                   = true
 tokio                            = { workspace = true, features = ["sync"] }
 toml.workspace                   = true
-
-
-[dependencies.jsonrpc-v2]
-default-features = false
-features         = ["easy-errors", "macros", "bytes-v05"]
-version          = "0.11"
 
 [dev-dependencies]
 assert_cmd.workspace        = true

--- a/forest/shared/Cargo.toml
+++ b/forest/shared/Cargo.toml
@@ -41,6 +41,7 @@ fvm_ipld_encoding.workspace      = true
 fvm_shared                       = { workspace = true, default-features = false }
 git-version.workspace            = true
 hex.workspace                    = true
+jsonrpc-v2.workspace             = true
 lazy_static.workspace            = true
 libp2p                           = { workspace = true, default-features = false, features = ["identify"] }
 log.workspace                    = true
@@ -61,12 +62,6 @@ tempfile.workspace               = true
 time.workspace                   = true
 tokio                            = { workspace = true, features = ["sync"] }
 toml.workspace                   = true
-
-
-[dependencies.jsonrpc-v2]
-default-features = false
-features         = ["easy-errors", "macros", "bytes-v05"]
-version          = "0.11"
 
 [dev-dependencies]
 assert_cmd.workspace        = true

--- a/key_management/Cargo.toml
+++ b/key_management/Cargo.toml
@@ -11,7 +11,7 @@ features = ["json"]
 anyhow.workspace             = true
 argon2                       = "0.4"
 base64.workspace             = true
-bls-signatures               = { version = "0.12", default-features = false, features = ["blst"] }
+bls-signatures.workspace     = true
 forest_crypto                = { workspace = true, features = ["blst"] }
 forest_encoding.workspace    = true
 forest_utils.workspace       = true

--- a/node/rpc-api/Cargo.toml
+++ b/node/rpc-api/Cargo.toml
@@ -31,16 +31,12 @@ fvm.workspace                 = true
 fvm_ipld_bitfield             = { workspace = true, features = ["json"] }
 fvm_ipld_blockstore.workspace = true
 fvm_shared                    = { workspace = true, default-features = false }
+jsonrpc-v2.workspace          = true
 libp2p                        = { workspace = true, default-features = false }
 once_cell.workspace           = true
 serde                         = { workspace = true, default-features = false, features = ["derive"] }
 serde_json.workspace          = true
 tokio                         = { workspace = true, features = ["sync"] }
-
-[dependencies.jsonrpc-v2]
-default-features = false
-features         = ["easy-errors", "macros", "bytes-v05"]
-version          = "0.11"
 
 [build-dependencies]
 anyhow.workspace     = true

--- a/node/rpc-client/Cargo.toml
+++ b/node/rpc-client/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.2.0"
 [dependencies]
 # Public
 async-std            = { workspace = true, features = ["attributes"] }
+jsonrpc-v2.workspace = true
 log.workspace        = true
 once_cell.workspace  = true
 serde.workspace      = true
@@ -21,8 +22,3 @@ forest_key_management.workspace = true
 forest_libp2p.workspace         = true
 forest_message.workspace        = true
 forest_rpc-api.workspace        = true
-
-[dependencies.jsonrpc-v2]
-default-features = false
-features         = ["easy-errors", "macros", "bytes-v05"]
-version          = "0.11"

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow.workspace                 = true
 async-std                        = { workspace = true, features = ["attributes"] }
 base64.workspace                 = true
-bls-signatures                   = { version = "0.12", default-features = false, features = ["blst"] }
+bls-signatures.workspace         = true
 cid                              = { workspace = true, default-features = false, features = ["std"] }
 crossbeam                        = "0.8"
 fil_actor_miner_v8.workspace     = true

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -43,6 +43,7 @@ fvm_ipld_blockstore.workspace    = true
 fvm_ipld_encoding.workspace      = true
 fvm_shared                       = { workspace = true, default-features = false }
 hex.workspace                    = true
+jsonrpc-v2.workspace             = true
 libipld-core.workspace           = true
 log.workspace                    = true
 multibase.workspace              = true
@@ -57,11 +58,6 @@ tide-websockets                  = "0.4"
 tide.workspace                   = true
 tokio                            = { workspace = true, features = ["sync"] }
 tokio-util                       = { workspace = true, features = ["compat"] }
-
-[dependencies.jsonrpc-v2]
-default-features = false
-features         = ["easy-errors", "macros", "bytes-v05"]
-version          = "0.11"
 
 [dev-dependencies]
 forest_db.workspace         = true

--- a/tests/serialization_tests/Cargo.toml
+++ b/tests/serialization_tests/Cargo.toml
@@ -8,9 +8,8 @@ edition = "2021"
 submodule_tests = []
 
 [dev-dependencies]
-base64.workspace = true
-# cannot update due to `blst` version conflict
-bls-signatures              = { version = "0.12", default-features = false, features = ["blst"] }
+base64.workspace            = true
+bls-signatures.workspace    = true
 cid                         = { workspace = true, default-features = false, features = ["std"] }
 forest_blocks.workspace     = true
 forest_crypto               = { workspace = true, features = ["blst"] }

--- a/utils/auth/Cargo.toml
+++ b/utils/auth/Cargo.toml
@@ -6,17 +6,13 @@ edition = "2021"
 
 [dependencies]
 # Public
-fvm_shared          = { workspace = true, default-features = false }
-jsonwebtoken        = "8.1"
-once_cell.workspace = true
-rand.workspace      = true
-serde               = { workspace = true, default-features = false, features = ["derive"] }
-thiserror.workspace = true
+fvm_shared           = { workspace = true, default-features = false }
+jsonrpc-v2.workspace = true
+jsonwebtoken         = "8.1"
+once_cell.workspace  = true
+rand.workspace       = true
+serde                = { workspace = true, default-features = false, features = ["derive"] }
+thiserror.workspace  = true
 # Internal
 forest_crypto                   = { workspace = true, features = ["blst"] }
 forest_key_management.workspace = true
-
-[dependencies.jsonrpc-v2]
-default-features = false
-features         = ["easy-errors", "macros", "bytes-v05"]
-version          = "0.11"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Move duplicate dependencies to root Cargo file and use `workspace = true` to inherit version for `bls-signatures` and `jsonrpc-v2`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes associated tasks in #2051 


**Other information and links**
<!-- Add any other context about the pull request here. -->
N/A


<!-- Thank you 🔥 -->