### PR TITLE
move surf declaration to workspace parent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ serde_json            = "1.0"
 sha2                  = "0.10.5"
 smallvec              = "1.9"
 structopt             = "0.3"
+surf                  = { version = "2.3", default-features = false, features = ["h1-client-rustls"] }
 tempfile              = "3.3"
 thiserror             = "1.0"
 tide                  = "0.16"

--- a/blockchain/beacon/Cargo.toml
+++ b/blockchain/beacon/Cargo.toml
@@ -21,7 +21,7 @@ fvm_shared                = { workspace = true, default-features = false }
 hex.workspace             = true
 serde                     = { workspace = true, features = ["derive"] }
 sha2                      = { workspace = true, default-features = false }
-surf                      = { version = "2.3", default-features = false, features = ["h1-client-rustls"] }
+surf.workspace            = true
 tokio                     = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]

--- a/node/rpc-client/Cargo.toml
+++ b/node/rpc-client/Cargo.toml
@@ -12,7 +12,7 @@ log.workspace        = true
 once_cell.workspace  = true
 serde.workspace      = true
 serde_json.workspace = true
-surf                 = { version = "2.3", default-features = false, features = ["h1-client-rustls"] }
+surf.workspace       = true
 tokio                = { workspace = true, features = ["sync"] }
 
 # Internal

--- a/utils/paramfetch/Cargo.toml
+++ b/utils/paramfetch/Cargo.toml
@@ -13,7 +13,7 @@ log.workspace              = true
 pin-project-lite.workspace = true
 serde                      = { workspace = true, features = ["derive"] }
 serde_json.workspace       = true
-surf                       = { version = "2.3", default-features = false, features = ["h1-client-rustls"] }
+surf.workspace             = true
 tokio-util                 = { workspace = true, features = ["compat"] }
 tokio.workspace            = true
 url.workspace              = true


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- moved `surf` dependency declaration to workspace `Cargo.toml`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->
Last one to make https://github.com/ChainSafe/forest/pull/2050 clear, thanks @jdjaustin !


<!-- Thank you 🔥 -->