### PR TITLE
Reduce boot time by skipping genesis block scan for a given snapshot

### DIFF
--- a/API_IMPLEMENTATION.md
+++ b/API_IMPLEMENTATION.md
@@ -2,9 +2,9 @@
 
 ## Stats
 
-- Forest method count: 70
+- Forest method count: 71
 - Lotus method count: 173
-- API coverage: 40.46%
+- API coverage: 41.04%
 
 ## Forest-only Methods
 
@@ -14,6 +14,7 @@ These methods exist in Forest only and cannot be compared:
 - `Filecoin.AuthVerify`
 - `Filecoin.ChainExport`
 - `Filecoin.ChainGetName`
+- `Filecoin.ChainGetTipSetHash`
 - `Filecoin.ChainGetTipsetByHeight`
 - `Filecoin.ChainHeadSubscription`
 - `Filecoin.ChainNotify`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,6 +2730,7 @@ dependencies = [
  "lru",
  "multihash",
  "num-traits",
+ "once_cell",
  "prometheus",
  "serde",
  "thiserror",

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -41,6 +41,7 @@ serde                            = { workspace = true, features = ["derive"] }
 thiserror.workspace              = true
 tokio                            = { workspace = true, features = ["sync"] }
 tokio-util                       = { workspace = true, features = ["compat"] }
+once_cell.workspace              = true
 
 [dev-dependencies]
 multihash = { workspace = true, default-features = false, features = ["std", "blake2b", "derive"] }

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -36,12 +36,12 @@ lazy_static.workspace            = true
 log.workspace                    = true
 lru.workspace                    = true
 num-traits.workspace             = true
+once_cell.workspace              = true
 prometheus                       = { workspace = true }
 serde                            = { workspace = true, features = ["derive"] }
 thiserror.workspace              = true
 tokio                            = { workspace = true, features = ["sync"] }
 tokio-util                       = { workspace = true, features = ["compat"] }
-once_cell.workspace              = true
 
 [dev-dependencies]
 multihash = { workspace = true, default-features = false, features = ["std", "blake2b", "derive"] }

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::Scale;
-
 use super::metrics;
+use super::index::checkpoint_tipsets;
 use super::{index::ChainIndex, tipset_tracker::TipsetTracker, Error};
 use async_stream::stream;
 use bls_signatures::Serialize as SerializeBls;
@@ -204,6 +204,11 @@ where
             return Ok(self.heaviest_tipset().await.unwrap());
         }
         tipset_from_keys(&self.ts_cache, self.blockstore(), tsk).await
+    }
+
+    /// Returns Tipset key hash from key-value store from provided CIDs
+    pub async fn tipset_hash_from_keys(&self, tsk: &TipsetKeys) -> String {
+        checkpoint_tipsets::tipset_hash(tsk)
     }
 
     /// Determines if provided tipset is heavier than existing known heaviest tipset

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -1,10 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::Scale;
-use super::metrics;
 use super::index::checkpoint_tipsets;
+use super::metrics;
 use super::{index::ChainIndex, tipset_tracker::TipsetTracker, Error};
+use crate::Scale;
 use async_stream::stream;
 use bls_signatures::Serialize as SerializeBls;
 use cid::{multihash::Code::Blake2b256, Cid};

--- a/blockchain/chain/src/store/index.rs
+++ b/blockchain/chain/src/store/index.rs
@@ -25,18 +25,17 @@ pub(super) mod checkpoint_tipsets {
     use std::collections::HashMap;
     use std::str::FromStr;
 
-    const CALIBNET_GENESIS_CID: &str = "bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4";
-    const MAINNET_GENESIS_CID: &str = "bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2";
+    const CALIBNET_GENESIS_CID: &str =
+        "bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4";
+    const MAINNET_GENESIS_CID: &str =
+        "bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2";
 
     macro_rules! add_calibnet {
         ($map: ident, $key_hash:expr) => {
             $map.insert(
                 $key_hash,
                 // calibnet genesis tipset keys
-                TipsetKeys::new(vec![Cid::from_str(
-                    CALIBNET_GENESIS_CID,
-                )
-                .unwrap()]),
+                TipsetKeys::new(vec![Cid::from_str(CALIBNET_GENESIS_CID).unwrap()]),
             );
         };
     }
@@ -46,10 +45,7 @@ pub(super) mod checkpoint_tipsets {
             $map.insert(
                 $key_hash,
                 // mainnet genesis tipset keys
-                TipsetKeys::new(vec![Cid::from_str(
-                    MAINNET_GENESIS_CID,
-                )
-                .unwrap()]),
+                TipsetKeys::new(vec![Cid::from_str(MAINNET_GENESIS_CID).unwrap()]),
             );
         };
     }
@@ -161,7 +157,7 @@ impl<BS: Blockstore> ChainIndex<BS> {
                 if to == 0 {
                     let tipset =
                         tipset_from_keys(&self.ts_cache, &self.db, &genesis_tipset_keys).await?;
-                        info!("using checkpoint tipset at height: {}", lbe.tipset.epoch());
+                    info!("using checkpoint tipset at height: {}", lbe.tipset.epoch());
                     return Ok(tipset);
                 }
             }

--- a/forest/cli/src/cli/chain_cmd.rs
+++ b/forest/cli/src/cli/chain_cmd.rs
@@ -1,14 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-
-use forest_blocks::TipsetKeys;
-use structopt::StructOpt;
 use super::*;
 use cid::Cid;
+use forest_blocks::TipsetKeys;
 use forest_json::cid::CidJson;
 use forest_rpc_client::chain_ops::*;
 use std::str::FromStr;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub enum ChainCommands {

--- a/forest/cli/src/cli/chain_cmd.rs
+++ b/forest/cli/src/cli/chain_cmd.rs
@@ -1,12 +1,14 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use structopt::StructOpt;
 
+use forest_blocks::TipsetKeys;
+use structopt::StructOpt;
 use super::*;
 use cid::Cid;
 use forest_json::cid::CidJson;
 use forest_rpc_client::chain_ops::*;
+use std::str::FromStr;
 
 #[derive(Debug, StructOpt)]
 pub enum ChainCommands {
@@ -22,6 +24,9 @@ pub enum ChainCommands {
 
     /// Prints out the canonical head of the chain
     Head,
+
+    /// Prints a BLAKE2b hash of the tipset give a tipset keys. useful for setting checkpoints to speed up boot times from a snapshot
+    TipsetHash { cids: Vec<String> },
 
     /// Reads and prints out a message referenced by the specified CID from the
     /// chain block store
@@ -54,6 +59,22 @@ impl ChainCommands {
             }
             Self::Head => {
                 print_rpc_res_cids(chain_head(&config.client.rpc_token).await);
+            }
+            Self::TipsetHash { cids } => {
+                use forest_blocks::tipset_keys_json::TipsetKeysJson;
+
+                let tipset_keys = TipsetKeys::new(
+                    cids.iter()
+                        .map(|s| Cid::from_str(s).expect("invalid cid"))
+                        .collect(),
+                );
+
+                let tsk_json = TipsetKeysJson(tipset_keys);
+                print_rpc_res(
+                    chain_get_tipset_hash((tsk_json,), &config.client.rpc_token)
+                        .await
+                        .map(|s| format!("blake2b hash: {s}")),
+                );
             }
             Self::Message { cid } => {
                 let cid: Cid = cid.parse().unwrap();

--- a/node/rpc-api/src/lib.rs
+++ b/node/rpc-api/src/lib.rs
@@ -40,6 +40,7 @@ pub static ACCESS_MAP: Lazy<HashMap<&str, Access>> = Lazy::new(|| {
     access.insert(chain_api::CHAIN_TIPSET_WEIGHT, Access::Read);
     access.insert(chain_api::CHAIN_GET_BLOCK, Access::Read);
     access.insert(chain_api::CHAIN_GET_TIPSET, Access::Read);
+    access.insert(chain_api::CHAIN_GET_TIPSET_HASH, Access::Read);
     access.insert(chain_api::CHAIN_GET_RANDOMNESS_FROM_TICKETS, Access::Read);
     access.insert(chain_api::CHAIN_GET_RANDOMNESS_FROM_BEACON, Access::Read);
     access.insert(chain_api::CHAIN_GET_NAME, Access::Read);
@@ -237,6 +238,10 @@ pub mod chain_api {
     pub const CHAIN_GET_TIPSET: &str = "Filecoin.ChainGetTipSet";
     pub type ChainGetTipSetParams = (TipsetKeysJson,);
     pub type ChainGetTipSetResult = TipsetJson;
+
+    pub const CHAIN_GET_TIPSET_HASH: &str = "Filecoin.ChainGetTipSetHash";
+    pub type ChainGetTipSetHashParams = (TipsetKeysJson,);
+    pub type ChainGetTipSetHashResult = String;
 
     pub const CHAIN_GET_RANDOMNESS_FROM_TICKETS: &str = "Filecoin.ChainGetRandomnessFromTickets";
     pub type ChainGetRandomnessFromTicketsParams =

--- a/node/rpc-client/src/chain_ops.rs
+++ b/node/rpc-client/src/chain_ops.rs
@@ -50,6 +50,13 @@ pub async fn chain_get_tipset(
     call(CHAIN_GET_TIPSET, keys, auth_token).await
 }
 
+pub async fn chain_get_tipset_hash(
+    keys: ChainGetTipSetHashParams,
+    auth_token: &Option<String>,
+) -> Result<ChainGetTipSetHashResult, Error> {
+    call(CHAIN_GET_TIPSET_HASH, keys, auth_token).await
+}
+
 pub async fn chain_get_name(auth_token: &Option<String>) -> Result<ChainGetNameResult, Error> {
     call(CHAIN_GET_NAME, (), auth_token).await
 }

--- a/node/rpc/src/chain_api.rs
+++ b/node/rpc/src/chain_api.rs
@@ -338,6 +338,23 @@ where
     Ok(TipsetJson(ts))
 }
 
+pub(crate) async fn chain_get_tipset_hash<DB, B>(
+    data: Data<RPCState<DB, B>>,
+    Params(params): Params<ChainGetTipSetHashParams>,
+) -> Result<ChainGetTipSetHashResult, JsonRpcError>
+where
+    DB: Blockstore + Store + Clone + Send + Sync + 'static,
+    B: Beacon,
+{
+    let (TipsetKeysJson(tsk),) = params;
+    let ts = data
+        .state_manager
+        .chain_store()
+        .tipset_hash_from_keys(&tsk)
+        .await;
+    Ok(ts)
+}
+
 pub(crate) async fn chain_get_randomness_from_tickets<DB, B>(
     data: Data<RPCState<DB, B>>,
     Params(params): Params<ChainGetRandomnessFromTicketsParams>,

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -74,6 +74,7 @@ where
             .with_method(CHAIN_GET_GENESIS, chain_get_genesis::<DB, B>)
             .with_method(CHAIN_TIPSET_WEIGHT, chain_tipset_weight::<DB, B>)
             .with_method(CHAIN_GET_TIPSET, chain_get_tipset::<DB, B>)
+            .with_method(CHAIN_GET_TIPSET_HASH, chain_get_tipset_hash::<DB, B>)
             .with_method(CHAIN_HEAD, chain_head::<DB, B>)
             // XXX: CHAIN_HEAD_SUBSCRIPTION disabled since it is unsed
             // .with_method(CHAIN_HEAD_SUBSCRIPTION, chain_head_subscription::<DB, B>)


### PR DESCRIPTION
**Summary of changes**

This PR helps reduce boot time for the daemon by storing hashes of validated tipsets from a snapshot file.

Changes introduced in this pull request:
- [X] Add a validated tipset hash registry to keep track of tipset hashes.
- [X] Skips scanning blockchain if a known hash is found.
- [X] Docs
- [x] Add RPC command to retrieve/validate tipset hash for a given snapshot.

[Before] Mainnet snapshot import time: 59min
[After] Mainnet snapshot import time: 27min

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #2129 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->