### PR TITLE
chore: upgrade rust toolchain to 1.67.0-nightly

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,7 +23,7 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Ctarget-feature=+avx2,+fma", "-Zshare-
 # brew install michaeleisel/zld/zld
 # "-Clink-arg=-fuse-ld=zld"
 # For details checkout https://jondot.medium.com/8-steps-for-troubleshooting-your-rust-build-times-2ffc965fd13e
-rustflags = ["-Ctarget-feature=+avx2,+fma", "-Zshare-generics=y"]
+rustflags = ["-Zshare-generics=y"]
 
 [net]
 git-fetch-with-cli = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+checksum = "464b3811b747f8f7ebc8849c9c728c39f6ac98a055edad93baf9eb330e3f8f9d"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.8",
@@ -995,10 +995,11 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byte-unit"
-version = "4.0.14"
+version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ebf10dda65f19ff0f42ea15572a359ed60d7fc74fdc984d90310937be0014b"
+checksum = "581ad4b3d627b0c09a0ccb2912148f839acaca0b93cf54cbe42b6c674e86079c"
 dependencies = [
+ "serde",
  "utf8-width",
 ]
 
@@ -2767,7 +2768,7 @@ dependencies = [
 name = "forest_beacon"
 version = "0.2.0"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "anyhow",
  "async-std",
  "async-trait",
@@ -3152,7 +3153,7 @@ dependencies = [
 name = "forest_interpreter"
 version = "0.2.0"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "anyhow",
  "async-std",
  "byteorder",
@@ -3263,7 +3264,7 @@ dependencies = [
 name = "forest_legacy_ipld_amt"
 version = "0.2.0"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "anyhow",
  "cid",
  "forest_db",
@@ -4368,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.21"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a2df176f359a22aee9c8657e674f7aa54e9ba48b512a798e5ca36a1f51065c"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes 1.2.1",
  "futures-channel",
@@ -4540,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e481ccbe3dea62107216d0d1138bb8ad8e5e5c43009a098bd1990272c497b0"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
 name = "ipconfig"
@@ -6979,16 +6980,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.12"
+version = "0.35.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985947f9b6423159c4726323f373be0a21bdb514c5af06a849cb3d2dce2d01e8"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/blockchain/message_pool/src/msgpool/mod.rs
+++ b/blockchain/message_pool/src/msgpool/mod.rs
@@ -897,7 +897,7 @@ pub mod tests {
         for i in 0..10 {
             let msg = create_smsg(&a2, &a1, wallet.borrow_mut(), i, gas_limit, 1 + i);
             smsg_vec.push(msg.clone());
-            mset.insert(i as u64, msg);
+            mset.insert(i, msg);
         }
         let mut chains = Chains::new();
         create_message_chains(

--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -1342,7 +1342,7 @@ mod test_selection {
 
         let mut nonces = vec![0; n_actors as usize];
         for m in &msgs {
-            let who = who_is(m.message.from) as usize;
+            let who = who_is(m.message.from);
             if who < 3 {
                 panic!("got message from {}th actor", who);
             }

--- a/blockchain/state_manager/src/chain_rand.rs
+++ b/blockchain/state_manager/src/chain_rand.rs
@@ -256,10 +256,10 @@ pub fn draw_randomness(
     entropy: &[u8],
 ) -> anyhow::Result<[u8; 32]> {
     let mut state = Params::new().hash_length(32).to_state();
-    state.write_i64::<BigEndian>(pers as i64)?;
+    state.write_i64::<BigEndian>(pers)?;
     let vrf_digest = blake2b_256(rbase);
     state.write_all(&vrf_digest)?;
-    state.write_i64::<BigEndian>(round as i64)?;
+    state.write_i64::<BigEndian>(round)?;
     state.write_all(entropy)?;
     let mut ret = [0u8; 32];
     ret.clone_from_slice(state.finalize().as_bytes());

--- a/blockchain/state_manager/src/utils.rs
+++ b/blockchain/state_manager/src/utils.rs
@@ -68,7 +68,7 @@ where
             proving_sectors
         };
 
-        let num_prov_sect = proving_sectors.len() as u64;
+        let num_prov_sect = proving_sectors.len();
 
         if num_prov_sect == 0 {
             return Ok(Vec::new());

--- a/forest/cli/src/cli/net_cmd.rs
+++ b/forest/cli/src/cli/net_cmd.rs
@@ -78,7 +78,7 @@ impl NetCommands {
                 let addr: Multiaddr = address
                     .parse()
                     .map_err(|e| {
-                        cli_error_and_die(&format!("Error parsing multiaddr. Error was: {}", e), 1);
+                        cli_error_and_die(format!("Error parsing multiaddr. Error was: {}", e), 1);
                     })
                     .expect("Parse provided multiaddr from string");
 

--- a/forest/cli/src/cli/net_cmd.rs
+++ b/forest/cli/src/cli/net_cmd.rs
@@ -78,7 +78,7 @@ impl NetCommands {
                 let addr: Multiaddr = address
                     .parse()
                     .map_err(|e| {
-                        cli_error_and_die(format!("Error parsing multiaddr. Error was: {}", e), 1);
+                        cli_error_and_die(format!("Error parsing multiaddr. Error was: {e}"), 1);
                     })
                     .expect("Parse provided multiaddr from string");
 

--- a/forest/cli/src/cli/snapshot_cmd.rs
+++ b/forest/cli/src/cli/snapshot_cmd.rs
@@ -142,7 +142,7 @@ impl SnapshotCommands {
                 let output_path = match strfmt(&output_path.display().to_string(), &vars) {
                     Ok(path) => path.into(),
                     Err(e) => {
-                        cli_error_and_die(format!("Unparsable string error: {}", e), 1);
+                        cli_error_and_die(format!("Unparsable string error: {e}"), 1);
                     }
                 };
 

--- a/forest/cli/src/cli/snapshot_cmd.rs
+++ b/forest/cli/src/cli/snapshot_cmd.rs
@@ -129,7 +129,7 @@ impl SnapshotCommands {
 
                 let month_string = format!("{:02}", now.month() as u8);
                 let year = now.year();
-                let day_string = format!("{:02}", now.day() as u8);
+                let day_string = format!("{:02}", now.day());
                 let chain_name = chain_get_name().await.map_err(handle_rpc_err).unwrap();
 
                 let vars = HashMap::from([

--- a/forest/cli/src/cli/state_cmd.rs
+++ b/forest/cli/src/cli/state_cmd.rs
@@ -71,7 +71,7 @@ impl StateCommands {
                 let tipset_keys_json = TipsetKeysJson(tipset.0.key().to_owned());
 
                 let address = Address::from_str(&miner_address).unwrap_or_else(|_| {
-                    cli_error_and_die(format!("Cannot read address {}", miner_address), 1)
+                    cli_error_and_die(format!("Cannot read address {miner_address}"), 1)
                 });
 
                 match state_get_actor((AddressJson(address), tipset_keys_json.clone()))
@@ -89,7 +89,7 @@ impl StateCommands {
                         }
                     }
                     None => cli_error_and_die(
-                        format!("cannot find miner at address {}", miner_address),
+                        format!("cannot find miner at address {miner_address}"),
                         1,
                     ),
                 };
@@ -125,7 +125,7 @@ impl StateCommands {
             Self::GetActor { address } => {
                 let address = Address::from_str(&address.clone()).unwrap_or_else(|_| {
                     cli_error_and_die(
-                        format!("Failed to create address from argument {}", address),
+                        format!("Failed to create address from argument {address}"),
                         1,
                     )
                 });
@@ -168,7 +168,7 @@ impl StateCommands {
             }
             Self::Lookup { reverse, address } => {
                 let address = Address::from_str(address).unwrap_or_else(|_| {
-                    cli_error_and_die(format!("Invalid address: {}", address), 1)
+                    cli_error_and_die(format!("Invalid address: {address}"), 1)
                 });
 
                 let tipset = chain_head().await.map_err(handle_rpc_err).unwrap();

--- a/forest/cli/src/cli/state_cmd.rs
+++ b/forest/cli/src/cli/state_cmd.rs
@@ -89,7 +89,7 @@ impl StateCommands {
                         }
                     }
                     None => cli_error_and_die(
-                        &format!("cannot find miner at address {}", miner_address),
+                        format!("cannot find miner at address {}", miner_address),
                         1,
                     ),
                 };
@@ -215,7 +215,7 @@ impl StateCommands {
                 let miner_state: MinerState = chain_read_obj((CidJson(actor_state.state),))
                     .await
                     .map_err(handle_rpc_err)
-                    .map(|obj| hex::decode(&obj).expect("hex decode fiasco"))
+                    .map(|obj| hex::decode(obj).expect("hex decode fiasco"))
                     .map(RawBytes::from)
                     .map(|obj| {
                         RawBytes::deserialize(&obj).expect("Couldn't deserialize to MinerState")
@@ -226,7 +226,7 @@ impl StateCommands {
                     chain_read_obj((CidJson(miner_state.vesting_funds),))
                         .await
                         .map_err(handle_rpc_err)
-                        .map(|obj| hex::decode(&obj).expect("hex decode fiasco"))
+                        .map(|obj| hex::decode(obj).expect("hex decode fiasco"))
                         .map(RawBytes::from)
                         .map(|obj| {
                             RawBytes::deserialize(&obj)

--- a/forest/cli/src/cli/wallet_cmd.rs
+++ b/forest/cli/src/cli/wallet_cmd.rs
@@ -130,7 +130,7 @@ impl WalletCommands {
                 let key = match path {
                     Some(path) => match read_file_to_string(&PathBuf::from(path)) {
                         Ok(key) => key,
-                        _ => cli_error_and_die(format!("{} is not a valid path", path), 1),
+                        _ => cli_error_and_die(format!("{path} is not a valid path"), 1),
                     },
                     _ => {
                         println!("Enter the private key: ");
@@ -154,7 +154,7 @@ impl WalletCommands {
                     serde_json::from_str(key_str);
 
                 if key_result.is_err() {
-                    cli_error_and_die(format!("{} is not a valid key to import", key), 1);
+                    cli_error_and_die(format!("{key} is not a valid key to import"), 1);
                 }
 
                 let key = key_result.unwrap();
@@ -226,7 +226,7 @@ impl WalletCommands {
                 let address_result = Address::from_str(address);
 
                 if address_result.is_err() {
-                    cli_error_and_die(format!("{} is not a valid address", address), 1);
+                    cli_error_and_die(format!("{address} is not a valid address"), 1);
                 }
 
                 let address = address_result.unwrap();

--- a/forest/cli/src/cli/wallet_cmd.rs
+++ b/forest/cli/src/cli/wallet_cmd.rs
@@ -130,7 +130,7 @@ impl WalletCommands {
                 let key = match path {
                     Some(path) => match read_file_to_string(&PathBuf::from(path)) {
                         Ok(key) => key,
-                        _ => cli_error_and_die(&format!("{} is not a valid path", path), 1),
+                        _ => cli_error_and_die(format!("{} is not a valid path", path), 1),
                     },
                     _ => {
                         println!("Enter the private key: ");
@@ -154,7 +154,7 @@ impl WalletCommands {
                     serde_json::from_str(key_str);
 
                 if key_result.is_err() {
-                    cli_error_and_die(&format!("{} is not a valid key to import", key), 1);
+                    cli_error_and_die(format!("{} is not a valid key to import", key), 1);
                 }
 
                 let key = key_result.unwrap();
@@ -226,7 +226,7 @@ impl WalletCommands {
                 let address_result = Address::from_str(address);
 
                 if address_result.is_err() {
-                    cli_error_and_die(&format!("{} is not a valid address", address), 1);
+                    cli_error_and_die(format!("{} is not a valid address", address), 1);
                 }
 
                 let address = address_result.unwrap();

--- a/node/db/tests/db_utils/mod.rs
+++ b/node/db/tests/db_utils/mod.rs
@@ -21,7 +21,7 @@ impl TempRocksDB {
         let path = dir.path().join("db");
 
         TempRocksDB {
-            db: RocksDb::open(&path, &RocksDbConfig::default()).unwrap(),
+            db: RocksDb::open(path, &RocksDbConfig::default()).unwrap(),
             _dir: dir,
         }
     }

--- a/node/rpc/src/wallet_api.rs
+++ b/node/rpc/src/wallet_api.rs
@@ -272,7 +272,7 @@ where
 {
     let (addr_str, msg_str, SignatureJson(sig)) = params;
     let address = Address::from_str(&addr_str)?;
-    let msg = hex::decode(&msg_str)?;
+    let msg = hex::decode(msg_str)?;
 
     let ret = sig.verify(&msg, &address).is_ok();
     Ok(ret)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "nightly-2022-09-28"
+channel    = "nightly-2022-11-02"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets    = []

--- a/utils/forest_utils/src/io/mod.rs
+++ b/utils/forest_utils/src/io/mod.rs
@@ -18,7 +18,7 @@ pub fn set_user_perm(file: &File) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let mut perm = file.metadata()?.permissions();
-    perm.set_mode((libc::S_IWUSR | libc::S_IRUSR) as u32);
+    perm.set_mode(libc::S_IWUSR | libc::S_IRUSR);
     file.set_permissions(perm)?;
 
     info!("Permissions set to 0600 on {:?}", file);

--- a/utils/forest_utils/src/io/mod.rs
+++ b/utils/forest_utils/src/io/mod.rs
@@ -18,7 +18,8 @@ pub fn set_user_perm(file: &File) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let mut perm = file.metadata()?.permissions();
-    perm.set_mode(libc::S_IWUSR | libc::S_IRUSR);
+    #[allow(clippy::useless_conversion)] // Otherwise it does not build on macos
+    perm.set_mode((libc::S_IWUSR | libc::S_IRUSR).into());
     file.set_permissions(perm)?;
 
     info!("Permissions set to 0600 on {:?}", file);

--- a/utils/json/src/message.rs
+++ b/utils/json/src/message.rs
@@ -91,7 +91,7 @@ pub mod json {
             gas_premium: m.gas_premium,
             method_num: m.method_num,
             params: RawBytes::new(
-                base64::decode(&m.params.unwrap_or_default()).map_err(de::Error::custom)?,
+                base64::decode(m.params.unwrap_or_default()).map_err(de::Error::custom)?,
             ),
         })
     }

--- a/utils/json/src/message_receipt.rs
+++ b/utils/json/src/message_receipt.rs
@@ -63,7 +63,7 @@ pub mod json {
         } = Deserialize::deserialize(deserializer)?;
         Ok(Receipt {
             exit_code: ExitCode::new(exit_code as u32),
-            return_data: RawBytes::new(base64::decode(&return_data).map_err(de::Error::custom)?),
+            return_data: RawBytes::new(base64::decode(return_data).map_err(de::Error::custom)?),
             gas_used,
         })
     }

--- a/vm/actor_interface/src/builtin/miner/mod.rs
+++ b/vm/actor_interface/src/builtin/miner/mod.rs
@@ -99,7 +99,7 @@ impl State {
             State::V8(st) => {
                 st.load_deadlines(&store)?
                     .for_each(&Default::default(), &store, |idx, dl| {
-                        f(idx as u64, Deadline::V8(dl))
+                        f(idx, Deadline::V8(dl))
                     })
             }
         }
@@ -227,7 +227,7 @@ impl Deadline {
     ) -> anyhow::Result<()> {
         match self {
             Deadline::V8(dl) => dl.for_each(&store, |idx, part| {
-                f(idx as u64, Partition::V8(Cow::Borrowed(part)))
+                f(idx, Partition::V8(Cow::Borrowed(part)))
             }),
         }
     }

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -349,7 +349,7 @@ impl RewardCalc for FixedRewardCalc {
         let msg = Message {
             from: reward::ADDRESS,
             to: miner,
-            method_num: METHOD_SEND as u64,
+            method_num: METHOD_SEND,
             params: Default::default(),
             // Epoch as sequence is intentional
             sequence: epoch as u64,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Upgrade rust toolchain from `1.66.0-nightly` to `1.67.0-nightly`
- Fix `cargo clippy` errors

[1.65.0 changelog](https://releases.rs/docs/released/1.65.0/)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->