### PR TITLE
Link Forest IaC repo via README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ make test-vectors
 make test-all
 ```
 
+Chain synchronization checks are run after every merge to `main`. This code is maintained in a separate repository - [Forest IaC](https://github.com/ChainSafe/forest-iac).
+
 ### Linters
 The project uses exhaustively a set of linters to keep the codebase clean and secure in an automated fashion. While the CI will has them installed, if you want to run them yourself before submitting a PR (recommended), you should install a few of them.
 ```bash


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- added mention of Forest IaC in the README. During LabWeek22 in Lisbon one guy working on Sealing as a Service was particularly interested in this functionality but couldn't know of our implementation because it's not linked anywhere.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->