### PR TITLE
fix: snapshot fetch --aria2 bad checksum on mainnet

### DIFF
--- a/forest/shared/src/cli/snapshot_fetch.rs
+++ b/forest/shared/src/cli/snapshot_fetch.rs
@@ -243,7 +243,9 @@ where
     if !checksum_response.status().is_success() {
         bail!("Unable to get the checksum file. Url: {checksum_url}");
     }
-    let checksum_bytes = hyper::body::to_bytes(checksum_response.into_body()).await?[..64].to_vec();
+    let checksum_bytes = hyper::body::to_bytes(checksum_response.into_body()).await?
+        [..Sha256::output_size() * 2]
+        .to_vec();
     let checksum_expected = String::from_utf8(checksum_bytes)?;
     info!("Expected sha256 checksum: {checksum_expected}");
     download_with_aria2(

--- a/forest/shared/src/cli/snapshot_fetch.rs
+++ b/forest/shared/src/cli/snapshot_fetch.rs
@@ -243,10 +243,8 @@ where
     if !checksum_response.status().is_success() {
         bail!("Unable to get the checksum file. Url: {checksum_url}");
     }
-    let checksum_bytes = hyper::body::to_bytes(checksum_response.into_body())
-        .await?
-        .to_vec();
-    let checksum_expected = String::from_utf8(checksum_bytes)?.trim().to_owned();
+    let checksum_bytes = hyper::body::to_bytes(checksum_response.into_body()).await?[..64].to_vec();
+    let checksum_expected = String::from_utf8(checksum_bytes)?.to_owned();
     info!("Expected sha256 checksum: {checksum_expected}");
     download_with_aria2(
         url.as_str(),


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Checksum files on mainnet have a different format e.g. 
`6ab6b7ef0163b502a0d921ee67cadf1b6e8890a6dfc89cae2ccebc77d286dad3  -` in
https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_2336881_2022-11-14_08-00-30
- Manually verified `cargo run -p forest-cli --release --  --chain mainnet snapshot fetch --aria2` starts downloading


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->