### PR TITLE
feat: forest-cli db clean

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,6 +128,7 @@ jobs:
       - name: import snapshot and run Forest
         run: |
           forest --chain calibnet --target-peer-count 50 --encrypt-keystore false --halt-after-import --import-snapshot /tmp/snapshots/*.car
+          forest-cli --chain calibnet db stats
           forest --chain calibnet --target-peer-count 50 --encrypt-keystore false --detach
       - name: wait for sync and check health
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "forest_rpc-client",
  "forest_state_manager",
  "forest_utils",
+ "fs_extra",
  "futures",
  "fvm",
  "fvm_ipld_car",
@@ -2785,6 +2786,7 @@ dependencies = [
  "git-version",
  "hex",
  "http",
+ "human-repr",
  "jsonrpc-v2",
  "lazy_static",
  "libp2p",
@@ -4651,6 +4653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "human-repr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fb489e3108b684bba475a4cb9804260365870e2f60058265e3d0a3b309bdb1"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4931,9 +4939,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kv-log-macro"
@@ -8900,9 +8911,9 @@ checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom 0.2.8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ fil_actors_runtime    = { package = "fil_actors_runtime_common", version = "=9.0
 fil_actors_runtime_v9 = { package = "fil_actors_runtime", version = "9.0.0", git = "https://github.com/filecoin-project/builtin-actors", branch = "release/v9" }
 filecoin-proofs-api   = "12.0"
 flume                 = "0.10"
+fs_extra              = "1.2"
 futures               = "0.3"
 futures-util          = "0.3"
 fvm                   = "2.1"
@@ -96,6 +97,7 @@ fvm_shared            = "2.0"
 git-version           = "0.3"
 hex                   = "0.4"
 http                  = "0.2.8"
+human-repr            = "1.0"
 hyper                 = "0.14"
 hyper-rustls          = "0.23"
 jsonrpc-v2            = { version = "0.11", default-features = false, features = ["easy-errors", "macros", "bytes-v05"] }

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -35,6 +35,7 @@ forest_rpc-api.workspace         = true
 forest_rpc-client.workspace      = true
 forest_state_manager.workspace   = true
 forest_utils.workspace           = true
+fs_extra.workspace               = true
 futures.workspace                = true
 fvm.workspace                    = true
 fvm_ipld_car.workspace           = true
@@ -43,6 +44,7 @@ fvm_shared                       = { workspace = true, default-features = false 
 git-version.workspace            = true
 hex.workspace                    = true
 http.workspace                   = true
+human-repr.workspace             = true
 jsonrpc-v2.workspace             = true
 lazy_static.workspace            = true
 libp2p                           = { workspace = true, default-features = false, features = ["identify"] }

--- a/forest/cli/src/cli/db_cmd.rs
+++ b/forest/cli/src/cli/db_cmd.rs
@@ -1,0 +1,58 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use forest_cli_shared::cli::{db_path, Config};
+use log::error;
+use structopt::StructOpt;
+
+use crate::cli::prompt_confirm;
+
+#[derive(Debug, StructOpt)]
+pub enum DBCommands {
+    /// Show DB stats
+    Stats,
+    /// DB Clean up
+    Clean {
+        /// Answer yes to all forest-cli yes/no questions without prompting
+        #[structopt(long)]
+        force: bool,
+    },
+}
+
+impl DBCommands {
+    pub async fn run(&self, config: &Config) {
+        match self {
+            Self::Stats => {
+                use human_repr::HumanCount;
+
+                let dir = db_path(config);
+                println!("Database path: {}", dir.display());
+                let size = fs_extra::dir::get_size(dir).unwrap_or_default();
+                println!("Database size: {}", size.human_count_bytes());
+            }
+            Self::Clean { force } => {
+                let dir = db_path(config);
+                if !dir.is_dir() {
+                    println!(
+                        "Aborted. Database path {} is not a valid directory",
+                        dir.display()
+                    );
+                    return;
+                }
+                println!("Deleting {}", dir.display());
+                if !force && !prompt_confirm() {
+                    println!("Aborted.");
+                    return;
+                }
+                match fs_extra::dir::remove(&dir) {
+                    Ok(_) => {
+                        println!("Deleted {}", dir.display());
+                    }
+                    Err(err) => {
+                        error!("{err}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/forest/cli/src/cli/mod.rs
+++ b/forest/cli/src/cli/mod.rs
@@ -9,6 +9,7 @@
 mod auth_cmd;
 mod chain_cmd;
 mod config_cmd;
+mod db_cmd;
 mod fetch_params_cmd;
 mod genesis_cmd;
 mod mpool_cmd;
@@ -21,6 +22,7 @@ mod wallet_cmd;
 
 pub(super) use self::auth_cmd::AuthCommands;
 pub(super) use self::chain_cmd::ChainCommands;
+pub(super) use self::db_cmd::DBCommands;
 pub(super) use self::fetch_params_cmd::FetchCommands;
 pub(super) use self::genesis_cmd::GenesisCommands;
 pub(super) use self::mpool_cmd::MpoolCommands;
@@ -100,6 +102,9 @@ pub enum Subcommand {
 
     /// Send funds between accounts
     Send(SendCommand),
+
+    /// Database management
+    DB(DBCommands),
 }
 
 /// Pretty-print a JSON-RPC error and exit
@@ -198,6 +203,14 @@ pub(super) fn print_stdout(out: String) {
         .write("\n".as_bytes())
         .map_err(|e| handle_rpc_err(e.into()))
         .unwrap();
+}
+
+fn prompt_confirm() -> bool {
+    println!("Do you want to continue? [y/n]");
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line).unwrap();
+    let line = line.trim().to_lowercase();
+    line == "y" || line == "yes"
 }
 
 #[cfg(test)]

--- a/forest/cli/src/cli/snapshot_cmd.rs
+++ b/forest/cli/src/cli/snapshot_cmd.rs
@@ -382,14 +382,6 @@ fn delete_snapshot(snapshot_path: &PathBuf) {
     }
 }
 
-fn prompt_confirm() -> bool {
-    println!("Do you want to continue? [y/n]");
-    let mut line = String::new();
-    std::io::stdin().read_line(&mut line).unwrap();
-    let line = line.trim().to_lowercase();
-    line == "y" || line == "yes"
-}
-
 fn is_car_or_tmp(path: &Path) -> bool {
     let ext = path.extension().unwrap_or_default();
     ext == "car" || ext == "tmp" || ext == "aria2"

--- a/forest/cli/src/subcommand.rs
+++ b/forest/cli/src/subcommand.rs
@@ -41,5 +41,6 @@ pub(super) async fn process(command: Subcommand, config: Config) {
             cmd.run(config).await.unwrap();
         }
         Subcommand::Snapshot(cmd) => cmd.run(config).await,
+        Subcommand::DB(cmd) => cmd.run(&config).await,
     }
 }

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -9,8 +9,8 @@ use forest_chain::ChainStore;
 use forest_chain_sync::consensus::SyncGossipSubmitter;
 use forest_chain_sync::ChainMuxer;
 use forest_cli_shared::cli::{
-    cli_error_and_die, default_snapshot_dir, is_aria2_installed, snapshot_fetch, Client, Config,
-    FOREST_VERSION_STRING,
+    cli_error_and_die, db_path, default_snapshot_dir, is_aria2_installed, snapshot_fetch, Client,
+    Config, FOREST_VERSION_STRING,
 };
 use forest_db::rocks::RocksDb;
 use forest_fil_types::verifier::FullVerifier;
@@ -478,14 +478,6 @@ async fn sync_from_snapshot(config: &Config, state_manager: &Arc<StateManager<Ro
             }
         }
     }
-}
-
-fn db_path(config: &Config) -> PathBuf {
-    chain_path(config).join("db")
-}
-
-fn chain_path(config: &Config) -> PathBuf {
-    PathBuf::from(&config.client.data_dir).join(&config.chain.name)
 }
 
 fn get_actual_chain_name(internal_network_name: &str) -> &str {

--- a/forest/shared/src/cli/mod.rs
+++ b/forest/shared/src/cli/mod.rs
@@ -282,6 +282,16 @@ pub fn default_snapshot_dir(config: &Config) -> PathBuf {
         .join(config.chain.name.clone())
 }
 
+/// Gets database directory
+pub fn db_path(config: &Config) -> PathBuf {
+    chain_path(config).join("db")
+}
+
+/// Gets chain data directory
+pub fn chain_path(config: &Config) -> PathBuf {
+    PathBuf::from(&config.client.data_dir).join(&config.chain.name)
+}
+
 /// Print an error message and exit the program with an error code
 /// Used for handling high level errors such as invalid parameters
 pub fn cli_error_and_die(msg: impl AsRef<str>, code: i32) -> ! {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- impl `forest-cli --chain [chain] db stats`
- impl `forest-cli --chain [chain] db clean`

Sample output of `stats`:
```console
➜  forest git:(cli-db-cmd) cargo run -p forest-cli -- --chain mainnet db stats
    Finished dev [unoptimized] target(s) in 0.37s
     Running `target/debug/forest-cli --chain mainnet db stats`
Database path: /home/me/.local/share/forest/mainnet/db
Database size: 98.33GB
```


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/1954


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->