### PR TITLE
feat: support parity_db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,7 @@ dependencies = [
  "forest_utils",
  "futures",
  "fvm",
+ "fvm_ipld_blockstore",
  "fvm_ipld_car",
  "fvm_ipld_encoding 0.2.2",
  "fvm_shared",
@@ -3156,6 +3157,7 @@ dependencies = [
  "libipld",
  "libp2p-bitswap",
  "num_cpus",
+ "parity-db",
  "parking_lot 0.12.1",
  "prometheus",
  "rocksdb",
@@ -5545,6 +5547,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9e2dd86df36ce760a60f6ff6ad526f7ba1f14ba0356f8254fb6905e6494df1"
+dependencies = [
+ "libc",
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6148,6 +6170,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "parity-db"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a7511a0bec4a336b5929999d02b560d2439c993cccf98c26481484e811adc43"
+dependencies = [
+ "blake2",
+ "crc32fast",
+ "fs2",
+ "hex",
+ "libc",
+ "log",
+ "lz4",
+ "memmap2",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "snap",
 ]
 
 [[package]]
@@ -7732,6 +7773,12 @@ checksum = "e714dff2b33f2321fdcd475b71cec79781a692d846f37f415fb395a1d2bcd48e"
 dependencies = [
  "static_assertions",
 ]
+
+[[package]]
+name = "snap"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "snow"

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ lint: license clean
 	taplo fmt --check
 	taplo lint
 	cargo clippy --all-targets -- -D warnings
-	cargo clippy --all-targets --features forest_deleg_cns -- -D warnings
+	cargo clippy --all-targets --no-default-features --features forest_deleg_cns,paritydb -- -D warnings
 
 # Formats Rust and TOML files
 fmt:
@@ -91,9 +91,11 @@ test-vectors: pull-serialization-tests run-vectors
 
 # Test all without the submodule test vectors with release configuration
 test:
-	cargo nextest run --all --exclude serialization_tests --exclude forest_message --exclude forest_crypto
+	cargo nextest run --all --exclude serialization_tests --exclude forest_message --exclude forest_crypto --exclude forest_db
 	cargo nextest run -p forest_crypto --features blst --no-default-features
 	cargo nextest run -p forest_message --features blst --no-default-features
+	cargo nextest run -p forest_db --no-default-features --features paritydb
+	cargo nextest run -p forest_db --no-default-features --features rocksdb
 
 test-slow:
 	cargo nextest run -p forest_message_pool --features slow_tests
@@ -129,6 +131,6 @@ mdbook-build:
 	mdbook build ./documentation
 
 rustdoc:
-	cargo doc --workspace --all-features --no-deps
+	cargo doc --workspace --no-deps
 
 .PHONY: clean clean-all lint build release test test-all test-release license test-vectors run-vectors pull-serialization-tests install-cli install-daemon install install-deps install-lint-tools docs run-serialization-vectors rustdoc

--- a/blockchain/chain_sync/Cargo.toml
+++ b/blockchain/chain_sync/Cargo.toml
@@ -55,3 +55,7 @@ fvm_ipld_car.workspace      = true
 hex.workspace               = true
 quickcheck_macros.workspace = true
 serde_json.workspace        = true
+
+[features]
+rocksdb  = ["forest_statediff/rocksdb"]
+paritydb = ["forest_statediff/paritydb"]

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -76,4 +76,7 @@ quickcheck.workspace = true
 rand.workspace       = true
 
 [features]
+default    = ["rocksdb"]
+rocksdb    = ["forest_cli_shared/rocksdb", "forest_chain_sync/rocksdb"]
+paritydb   = ["forest_cli_shared/paritydb", "forest_chain_sync/paritydb"]
 slow_tests = []

--- a/forest/daemon/Cargo.toml
+++ b/forest/daemon/Cargo.toml
@@ -52,6 +52,7 @@ forest_state_manager.workspace   = true
 forest_utils.workspace           = true
 futures.workspace                = true
 fvm.workspace                    = true
+fvm_ipld_blockstore.workspace    = true
 fvm_ipld_car.workspace           = true
 fvm_ipld_encoding.workspace      = true
 fvm_shared                       = { workspace = true, default-features = false }
@@ -86,7 +87,9 @@ quickcheck.workspace = true
 rand.workspace       = true
 
 [features]
-default          = ["forest_fil_cns"]
+default          = ["forest_fil_cns", "rocksdb"]
+rocksdb          = ["forest_db/rocksdb", "forest_cli_shared/rocksdb", "forest_chain_sync/rocksdb"]
+paritydb         = ["forest_db/paritydb", "forest_cli_shared/paritydb", "forest_chain_sync/paritydb"]
 insecure_post    = ["forest_fil_cns/insecure_post"]
 forest_fil_cns   = ["dep:forest_fil_cns"]
 forest_deleg_cns = ["dep:forest_deleg_cns"]

--- a/forest/daemon/src/main.rs
+++ b/forest/daemon/src/main.rs
@@ -16,7 +16,6 @@ use lazy_static::lazy_static;
 use log::{info, warn};
 use raw_sync::events::{Event, EventInit};
 use raw_sync::Timeout;
-use rlimit::{getrlimit, Resource};
 use shared_memory::ShmemConf;
 use structopt::StructOpt;
 use tempfile::{Builder, TempPath};
@@ -94,7 +93,9 @@ fn build_daemon<'a>(config: &DaemonConfig) -> anyhow::Result<Daemon<'a>> {
     Ok(daemon)
 }
 
+#[cfg(feature = "rocksdb")]
 fn check_for_low_fd(config: &Config) -> Result<(), anyhow::Error> {
+    use rlimit::{getrlimit, Resource};
     // Conservative estimate of how many FD we will need to run a Forest node
     const MAINNET_CHAIN_SIZE: u64 = 1000_u64.pow(4); // 1TB
     const ANOTHER_CHAIN_SIZE: u64 = 100 * 1000_u64.pow(3); // 100GB
@@ -123,6 +124,10 @@ fn check_for_low_fd(config: &Config) -> Result<(), anyhow::Error> {
         anyhow::bail!("Open-file limit is too low. Suggesting `ulimit -n {rounded_estimate}`");
     }
 
+    Ok(())
+}
+#[cfg(feature = "paritydb")]
+fn check_for_low_fd(_config: &Config) -> Result<(), anyhow::Error> {
     Ok(())
 }
 

--- a/forest/shared/Cargo.toml
+++ b/forest/shared/Cargo.toml
@@ -77,3 +77,7 @@ quickcheck_macros.workspace = true
 rand.workspace              = true
 tokio.workspace             = true
 tower-http                  = { workspace = true, features = ["fs"] }
+
+[features]
+rocksdb  = []
+paritydb = []

--- a/forest/shared/src/cli/config.rs
+++ b/forest/shared/src/cli/config.rs
@@ -124,6 +124,7 @@ impl Default for DaemonConfig {
 #[serde(default)]
 pub struct Config {
     pub client: Client,
+    #[cfg(feature = "rocksdb")]
     pub rocks_db: forest_db::rocks_config::RocksDbConfig,
     pub network: Libp2pConfig,
     pub sync: SyncConfig,
@@ -137,7 +138,6 @@ pub struct Config {
 mod test {
     use super::*;
     use chrono::Duration;
-    use forest_db::rocks_config::RocksDbConfig;
     use forest_utils::io::ProgressBarVisibility;
     use quickcheck::Arbitrary;
     use quickcheck_macros::quickcheck;
@@ -151,6 +151,7 @@ mod test {
     #[derive(Clone, Debug)]
     struct ConfigPartial {
         client: Client,
+        #[cfg(feature = "rocksdb")]
         rocks_db: forest_db::rocks_config::RocksDbConfig,
         network: forest_libp2p::Libp2pConfig,
         sync: forest_chain_sync::SyncConfig,
@@ -160,6 +161,7 @@ mod test {
         fn from(val: ConfigPartial) -> Self {
             Config {
                 client: val.client,
+                #[cfg(feature = "rocksdb")]
                 rocks_db: val.rocks_db,
                 network: val.network,
                 sync: val.sync,
@@ -192,7 +194,8 @@ mod test {
                     token_exp: Duration::milliseconds(i64::arbitrary(g)),
                     show_progress_bars: ProgressBarVisibility::arbitrary(g),
                 },
-                rocks_db: RocksDbConfig {
+                #[cfg(feature = "rocksdb")]
+                rocks_db: forest_db::rocks_config::RocksDbConfig {
                     create_if_missing: bool::arbitrary(g),
                     parallelism: i32::arbitrary(g),
                     write_buffer_size: usize::arbitrary(g),

--- a/forest/shared/src/cli/mod.rs
+++ b/forest/shared/src/cli/mod.rs
@@ -282,9 +282,16 @@ pub fn default_snapshot_dir(config: &Config) -> PathBuf {
         .join(config.chain.name.clone())
 }
 
+#[cfg(feature = "rocksdb")]
 /// Gets database directory
 pub fn db_path(config: &Config) -> PathBuf {
-    chain_path(config).join("db")
+    chain_path(config).join("rocksdb")
+}
+
+#[cfg(feature = "paritydb")]
+/// Gets database directory
+pub fn db_path(config: &Config) -> PathBuf {
+    chain_path(config).join("paritydb")
 }
 
 /// Gets chain data directory

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -11,10 +11,10 @@ repository  = "https://github.com/ChainSafe/forest"
 default = []
 
 rocksdb = ["dep:rocksdb", "snappy", "lz4", "zlib", "bzip2"]
-snappy  = ["rocksdb/snappy"]
-lz4     = ["rocksdb/lz4"]
-zlib    = ["rocksdb/zlib"]
-bzip2   = ["rocksdb/bzip2"]
+snappy  = ["rocksdb?/snappy"]
+lz4     = ["rocksdb?/lz4"]
+zlib    = ["rocksdb?/zlib"]
+bzip2   = ["rocksdb?/bzip2"]
 # not included by default to reduce build time
 # uncomment when it needs to be used by other crates
 # zstd = ["rocksdb/zstd"]

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -8,15 +8,18 @@ edition     = "2021"
 repository  = "https://github.com/ChainSafe/forest"
 
 [features]
-default = ["snappy", "lz4", "zlib", "bzip2"]
+default = []
 
-snappy = ["rocksdb/snappy"]
-lz4    = ["rocksdb/lz4"]
-zlib   = ["rocksdb/zlib"]
-bzip2  = ["rocksdb/bzip2"]
+rocksdb = ["dep:rocksdb", "snappy", "lz4", "zlib", "bzip2"]
+snappy  = ["rocksdb/snappy"]
+lz4     = ["rocksdb/lz4"]
+zlib    = ["rocksdb/zlib"]
+bzip2   = ["rocksdb/bzip2"]
 # not included by default to reduce build time
 # uncomment when it needs to be used by other crates
 # zstd = ["rocksdb/zstd"]
+
+paritydb = ["dep:parity-db"]
 
 [dependencies]
 anyhow.workspace              = true
@@ -27,9 +30,10 @@ lazy_static.workspace         = true
 libipld.workspace             = true
 libp2p-bitswap.workspace      = true
 num_cpus.workspace            = true
+parity-db                     = { version = "0.4", default-features = false, optional = true }
 parking_lot                   = "0.12"
 prometheus                    = { workspace = true }
-rocksdb                       = { version = "0.19", default-features = false }
+rocksdb                       = { version = "0.19", default-features = false, optional = true }
 serde                         = { workspace = true, features = ["derive"] }
 thiserror.workspace           = true
 

--- a/node/db/src/errors.rs
+++ b/node/db/src/errors.rs
@@ -11,8 +11,12 @@ pub enum Error {
     InvalidBulkLen,
     #[error("Cannot use unopened database")]
     Unopened,
+    #[cfg(feature = "rocksdb")]
     #[error(transparent)]
     Database(#[from] rocksdb::Error),
+    #[cfg(feature = "paritydb")]
+    #[error(transparent)]
+    Database(#[from] parity_db::Error),
     #[error(transparent)]
     Encoding(#[from] CborError),
     #[error("{0}")]
@@ -26,7 +30,9 @@ impl PartialEq for Error {
         match (self, other) {
             (&InvalidBulkLen, &InvalidBulkLen) => true,
             (&Unopened, &Unopened) => true,
+            #[cfg(feature = "rocksdb")]
             (&Database(_), &Database(_)) => true,
+            #[cfg(feature = "rocksdb")]
             (&Encoding(_), &Encoding(_)) => true,
             (&Other(ref a), &Other(ref b)) => a == b,
             _ => false,

--- a/node/db/src/lib.rs
+++ b/node/db/src/lib.rs
@@ -6,8 +6,13 @@ mod memory;
 mod metrics;
 mod utils;
 
+#[cfg(feature = "rocksdb")]
 pub mod rocks;
+#[cfg(feature = "rocksdb")]
 pub mod rocks_config;
+
+#[cfg(feature = "paritydb")]
+pub mod parity_db;
 
 pub use errors::Error;
 pub use memory::MemoryDB;

--- a/node/db/src/parity_db.rs
+++ b/node/db/src/parity_db.rs
@@ -76,6 +76,19 @@ impl Store for ParityDb {
         self.db.commit(tx).map_err(Error::from)
     }
 
+    fn bulk_write<K, V>(&self, values: &[(K, V)]) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        let tx = values
+            .iter()
+            .map(|(k, v)| (0, k.as_ref(), Some(v.as_ref().to_owned())))
+            .collect::<Vec<_>>();
+
+        self.db.commit(tx).map_err(Error::from)
+    }
+
     fn delete<K>(&self, key: K) -> Result<(), Error>
     where
         K: AsRef<[u8]>,

--- a/node/db/src/parity_db.rs
+++ b/node/db/src/parity_db.rs
@@ -1,0 +1,141 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::errors::Error;
+use crate::utils::bitswap_missing_blocks;
+use crate::Store;
+use cid::Cid;
+use fvm_ipld_blockstore::Blockstore;
+use libp2p_bitswap::BitswapStore;
+use parity_db::Db;
+use parity_db::Options;
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct ParityDb {
+    pub db: Arc<parity_db::Db>,
+}
+
+pub struct ParityDbConfig {
+    pub path: PathBuf,
+    pub columns: u8,
+}
+
+impl ParityDbConfig {
+    pub fn from_path(path: &Path) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            columns: 1,
+        }
+    }
+}
+
+impl ParityDb {
+    fn to_options(config: &ParityDbConfig) -> Options {
+        Options {
+            path: config.path.to_owned(),
+            sync_wal: true,
+            sync_data: true,
+            stats: true,
+            salt: None,
+            columns: (0..config.columns)
+                .map(|_| parity_db::ColumnOptions {
+                    compression: parity_db::CompressionType::Lz4,
+                    ..Default::default()
+                })
+                .collect(),
+            compression_threshold: HashMap::new(),
+        }
+    }
+
+    pub fn open(config: &ParityDbConfig) -> anyhow::Result<Self> {
+        let opts = Self::to_options(config);
+        Ok(Self {
+            db: Arc::new(Db::open_or_create(&opts)?),
+        })
+    }
+}
+
+impl Store for ParityDb {
+    fn read<K>(&self, key: K) -> Result<Option<Vec<u8>>, Error>
+    where
+        K: AsRef<[u8]>,
+    {
+        self.db.get(0, key.as_ref()).map_err(Error::from)
+    }
+
+    fn write<K, V>(&self, key: K, value: V) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        let tx = [(0, key.as_ref(), Some(value.as_ref().to_owned()))];
+        self.db.commit(tx).map_err(Error::from)
+    }
+
+    fn delete<K>(&self, key: K) -> Result<(), Error>
+    where
+        K: AsRef<[u8]>,
+    {
+        let tx = [(0, key.as_ref(), None)];
+        self.db.commit(tx).map_err(Error::from)
+    }
+
+    fn exists<K>(&self, key: K) -> Result<bool, Error>
+    where
+        K: AsRef<[u8]>,
+    {
+        self.db
+            .get_size(0, key.as_ref())
+            .map(|size| size.is_some())
+            .map_err(Error::from)
+    }
+}
+
+impl Blockstore for ParityDb {
+    fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        self.read(k.to_bytes()).map_err(|e| e.into())
+    }
+
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
+        self.write(k.to_bytes(), block).map_err(|e| e.into())
+    }
+
+    fn put_many_keyed<D, I>(&self, blocks: I) -> anyhow::Result<()>
+    where
+        Self: Sized,
+        D: AsRef<[u8]>,
+        I: IntoIterator<Item = (Cid, D)>,
+    {
+        let values = blocks
+            .into_iter()
+            .map(|(k, v)| (k.to_bytes(), v))
+            .collect::<Vec<_>>();
+        self.bulk_write(&values).map_err(|e| e.into())
+    }
+}
+
+impl BitswapStore for ParityDb {
+    /// `fvm_ipld_encoding::DAG_CBOR(0x71)` is covered by [`libipld::DefaultParams`]
+    /// under feature `dag-cbor`
+    type Params = libipld::DefaultParams;
+
+    fn contains(&mut self, cid: &Cid) -> anyhow::Result<bool> {
+        Ok(self.exists(cid.to_bytes())?)
+    }
+
+    fn get(&mut self, cid: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
+        Blockstore::get(self, cid)
+    }
+
+    fn insert(&mut self, block: &libipld::Block<Self::Params>) -> anyhow::Result<()> {
+        self.put_keyed(block.cid(), block.data())
+    }
+
+    fn missing_blocks(&mut self, cid: &Cid) -> anyhow::Result<Vec<Cid>> {
+        bitswap_missing_blocks::<_, Self::Params>(self, cid)
+    }
+}

--- a/node/db/tests/db_utils/mod.rs
+++ b/node/db/tests/db_utils/mod.rs
@@ -1,36 +1,8 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use forest_db::rocks::RocksDb;
-use forest_db::rocks_config::RocksDbConfig;
-use std::ops::Deref;
+#[cfg(feature = "paritydb")]
+pub(crate) mod parity;
 
-/// Temporary, self-cleaning RocksDB
-pub struct TempRocksDB {
-    db: RocksDb,
-    _dir: tempfile::TempDir, // kept for cleaning up during Drop
-}
-
-impl TempRocksDB {
-    /// Creates a new DB in a temporary path that gets wiped out when the variable
-    /// gets out of scope.
-    pub fn new() -> TempRocksDB {
-        let dir = tempfile::Builder::new()
-            .tempdir()
-            .expect("Failed to create temporary path for db.");
-        let path = dir.path().join("db");
-
-        TempRocksDB {
-            db: RocksDb::open(path, &RocksDbConfig::default()).unwrap(),
-            _dir: dir,
-        }
-    }
-}
-
-impl Deref for TempRocksDB {
-    type Target = RocksDb;
-
-    fn deref(&self) -> &Self::Target {
-        &self.db
-    }
-}
+#[cfg(feature = "rocksdb")]
+pub(crate) mod rocks;

--- a/node/db/tests/db_utils/parity.rs
+++ b/node/db/tests/db_utils/parity.rs
@@ -1,0 +1,38 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::ops::Deref;
+
+use forest_db::parity_db::{ParityDb, ParityDbConfig};
+
+/// Temporary, self-cleaning ParityDB
+pub struct TempParityDB {
+    db: ParityDb,
+    _dir: tempfile::TempDir, // kept for cleaning up during Drop
+}
+
+impl TempParityDB {
+    /// Creates a new DB in a temporary path that gets wiped out when the variable
+    /// gets out of scope.
+    pub fn new() -> TempParityDB {
+        let dir = tempfile::Builder::new()
+            .tempdir()
+            .expect("Failed to create temporary path for db.");
+        let path = dir.path().join("paritydb");
+
+        let config = ParityDbConfig::from_path(&path);
+
+        TempParityDB {
+            db: ParityDb::open(&config).unwrap(),
+            _dir: dir,
+        }
+    }
+}
+
+impl Deref for TempParityDB {
+    type Target = ParityDb;
+
+    fn deref(&self) -> &Self::Target {
+        &self.db
+    }
+}

--- a/node/db/tests/db_utils/rocks.rs
+++ b/node/db/tests/db_utils/rocks.rs
@@ -1,0 +1,36 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use forest_db::rocks::RocksDb;
+use forest_db::rocks_config::RocksDbConfig;
+use std::ops::Deref;
+
+/// Temporary, self-cleaning RocksDB
+pub struct TempRocksDB {
+    db: RocksDb,
+    _dir: tempfile::TempDir, // kept for cleaning up during Drop
+}
+
+impl TempRocksDB {
+    /// Creates a new DB in a temporary path that gets wiped out when the variable
+    /// gets out of scope.
+    pub fn new() -> TempRocksDB {
+        let dir = tempfile::Builder::new()
+            .tempdir()
+            .expect("Failed to create temporary path for db.");
+        let path = dir.path().join("rocksdb");
+
+        TempRocksDB {
+            db: RocksDb::open(path, &RocksDbConfig::default()).unwrap(),
+            _dir: dir,
+        }
+    }
+}
+
+impl Deref for TempRocksDB {
+    type Target = RocksDb;
+
+    fn deref(&self) -> &Self::Target {
+        &self.db
+    }
+}

--- a/node/db/tests/parity_test.rs
+++ b/node/db/tests/parity_test.rs
@@ -1,62 +1,62 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "paritydb")]
 mod db_utils;
-
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "paritydb")]
 mod subtests;
 
-#[cfg(feature = "rocksdb")]
-mod rocksdb_tests {
+#[cfg(feature = "paritydb")]
+mod paritydb_tests {
+    use crate::db_utils::parity::TempParityDB;
+
     use super::*;
-    use crate::db_utils::rocks::TempRocksDB;
 
     #[test]
     fn db_write() {
-        let db = TempRocksDB::new();
+        let db = TempParityDB::new();
         subtests::write(&*db);
     }
 
     #[test]
     fn db_read() {
-        let db = TempRocksDB::new();
+        let db = TempParityDB::new();
         subtests::read(&*db);
     }
 
     #[test]
     fn db_exists() {
-        let db = TempRocksDB::new();
+        let db = TempParityDB::new();
         subtests::exists(&*db);
     }
 
     #[test]
     fn db_does_not_exist() {
-        let db = TempRocksDB::new();
+        let db = TempParityDB::new();
         subtests::does_not_exist(&*db);
     }
 
     #[test]
     fn db_delete() {
-        let db = TempRocksDB::new();
+        let db = TempParityDB::new();
         subtests::delete(&*db);
     }
 
     #[test]
     fn db_bulk_write() {
-        let db = TempRocksDB::new();
+        let db = TempParityDB::new();
         subtests::bulk_write(&*db);
     }
 
     #[test]
     fn db_bulk_read() {
-        let db = TempRocksDB::new();
+        let db = TempParityDB::new();
         subtests::bulk_read(&*db);
     }
 
     #[test]
     fn db_bulk_delete() {
-        let db = TempRocksDB::new();
+        let db = TempParityDB::new();
         subtests::bulk_delete(&*db);
     }
 }

--- a/utils/statediff/Cargo.toml
+++ b/utils/statediff/Cargo.toml
@@ -24,3 +24,7 @@ serde                         = { workspace = true, features = ["derive"] }
 serde_json.workspace          = true
 structopt.workspace           = true
 tokio                         = { workspace = true, features = ["rt-multi-thread"] }
+
+[features]
+paritydb = ["forest_db/paritydb"]
+rocksdb  = ["forest_db/rocksdb"]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- added optional support for [paritydb](https://github.com/paritytech/parity-db)
- build Forest with `paritydb` backend: `cargo build --release --no-default-features --features forest_fil_cns,paritydb`
- separate `rocksdb` a bit; probably a more abstract way can be devised
- configuration files with rocksdb config will not compatible with `paritydb`-backed Forest



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2002


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->