### PR TITLE
chore: speed up build by removing bzip and libz from critical path

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,9 +19,8 @@ env:
 jobs:
   test:
     name: Test
-    # runs-on: buildjet-8vcpu-ubuntu-2004
-    # timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2004
+    timeout-minutes: 30
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,8 @@ jobs:
   test:
     name: Test
     # runs-on: buildjet-8vcpu-ubuntu-2004
-    timeout-minutes: 30
+    # timeout-minutes: 30
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
@@ -107,7 +108,8 @@ jobs:
     name: Calibnet sync check
     #if: ${{ false }}
     # runs-on: buildjet-8vcpu-ubuntu-2004
-    timeout-minutes: 30
+    # timeout-minutes: 30
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    # runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 30
     steps:
       - name: Checkout Sources
@@ -106,7 +106,7 @@ jobs:
   calibnet-check:
     name: Calibnet sync check
     #if: ${{ false }}
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    # runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 30
     steps:
       - name: Checkout Sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
  "log",
  "memchr",
  "once_cell",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -503,7 +503,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -591,11 +591,11 @@ dependencies = [
  "memchr",
  "mime",
  "percent-encoding",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha-1 0.10.0",
+ "sha-1",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -630,7 +630,7 @@ dependencies = [
  "futures-core",
  "getrandom 0.2.8",
  "instant",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "rand 0.8.5",
  "tokio",
 ]
@@ -2669,17 +2669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
-dependencies = [
- "crc32fast",
- "libz-sys",
- "miniz_oxide",
-]
-
-[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,7 +3546,7 @@ dependencies = [
  "blake2b_simd",
  "fvm_shared",
  "log",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "surf",
@@ -3796,7 +3785,7 @@ dependencies = [
  "libc",
  "log",
  "pbr",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "quickcheck",
  "serde",
  "serde_derive",
@@ -3980,7 +3969,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "waker-fn",
 ]
 
@@ -3993,17 +3982,6 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
-]
-
-[[package]]
-name = "futures-rustls"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
-dependencies = [
- "futures-io",
- "rustls 0.20.7",
- "webpki 0.22.0",
 ]
 
 [[package]]
@@ -4037,7 +4015,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "pin-utils",
  "slab",
 ]
@@ -4537,7 +4515,7 @@ checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes 1.2.1",
  "http",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4578,7 +4556,7 @@ dependencies = [
  "cookie",
  "futures-lite",
  "infer",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -4629,7 +4607,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -4733,9 +4711,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -5070,7 +5048,6 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-swarm-derive",
  "libp2p-tcp",
- "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
  "parking_lot 0.12.1",
@@ -5376,25 +5353,6 @@ dependencies = [
  "libp2p-core",
  "log",
  "socket2",
-]
-
-[[package]]
-name = "libp2p-websocket"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3758ae6f89b2531a24b6d9f5776bda6a626b60a57600d7185d43dfa75ca5ecc4"
-dependencies = [
- "either",
- "futures",
- "futures-rustls",
- "libp2p-core",
- "log",
- "parking_lot 0.12.1",
- "quicksink",
- "rw-stream-sink",
- "soketto",
- "url",
- "webpki-roots 0.22.5",
 ]
 
 [[package]]
@@ -6313,12 +6271,6 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
-
-[[package]]
-name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
@@ -6690,17 +6642,6 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
-]
-
-[[package]]
-name = "quicksink"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77de3c815e5a160b1539c6592796801df2043ae35e123b46d73380cfa57af858"
-dependencies = [
- "futures-core",
- "futures-sink",
- "pin-project-lite 0.1.12",
 ]
 
 [[package]]
@@ -7199,7 +7140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7c4cd1e0a04c48f953473383a60143884515b7a8eb7ca7d9b1baa9c05dee75"
 dependencies = [
  "bytes 1.2.1",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "rxml_validation",
  "smartstring",
  "tokio",
@@ -7396,9 +7337,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
 dependencies = [
  "itoa",
  "ryu",
@@ -7504,19 +7445,6 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -7758,22 +7686,6 @@ checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "soketto"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
-dependencies = [
- "base64 0.13.1",
- "bytes 1.2.1",
- "flate2",
- "futures",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha-1 0.9.8",
 ]
 
 [[package]]
@@ -8058,7 +7970,7 @@ dependencies = [
  "log",
  "mime_guess",
  "once_cell",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "rustls 0.18.1",
  "serde",
  "serde_json",
@@ -8332,7 +8244,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -8367,7 +8279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -8393,7 +8305,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -8415,7 +8327,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -8439,7 +8351,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
@@ -8467,7 +8379,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -8554,7 +8466,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.10.0",
+ "sha-1",
  "thiserror",
  "url",
  "utf-8",

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -8,14 +8,14 @@ edition     = "2021"
 repository  = "https://github.com/ChainSafe/forest"
 
 [features]
-default = ["snappy", "lz4", "zlib", "bzip2"]
+default = ["lz4"]
 
-snappy = ["rocksdb/snappy"]
-lz4    = ["rocksdb/lz4"]
-zlib   = ["rocksdb/zlib"]
-bzip2  = ["rocksdb/bzip2"]
+lz4 = ["rocksdb/lz4"]
 # not included by default to reduce build time
 # uncomment when it needs to be used by other crates
+# snappy = ["rocksdb/snappy"]
+# zlib   = ["rocksdb/zlib"]
+# bzip2  = ["rocksdb/bzip2"]
 # zstd = ["rocksdb/zstd"]
 
 [dependencies]

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -38,7 +38,6 @@ libp2p = { workspace = true, default-features = false, features = [
   "dns-async-std",
   "mplex",
   "request-response",
-  "websocket",
 ] }
 libp2p-bitswap.workspace = true
 log.workspace = true

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -781,7 +781,6 @@ async fn emit_event(sender: &flume::Sender<NetworkEvent>, event: NetworkEvent) {
 pub async fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
     let tcp_transport =
         || libp2p::tcp::TokioTcpTransport::new(libp2p::tcp::GenTcpConfig::new().nodelay(true));
-    // let transport = libp2p::websocket::WsConfig::new(tcp_transport()).or_transport(tcp_transport());
     let transport = libp2p::dns::TokioDnsConfig::system(tcp_transport()).unwrap();
     let auth_config = {
         let dh_keys = noise::Keypair::<noise::X25519Spec>::new()

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -33,14 +33,13 @@ use libp2p::ping::{self};
 use libp2p::request_response::{
     RequestId, RequestResponseEvent, RequestResponseMessage, ResponseChannel,
 };
-use libp2p::swarm::SwarmEvent;
 use libp2p::{
     core,
     core::muxing::StreamMuxerBox,
     core::transport::Boxed,
     identity::{ed25519, Keypair},
     mplex, noise,
-    swarm::ConnectionLimits,
+    swarm::{ConnectionLimits, SwarmEvent},
     yamux, PeerId, Swarm, Transport,
 };
 use libp2p::{core::Multiaddr, swarm::SwarmBuilder};
@@ -754,8 +753,10 @@ async fn emit_event(sender: &flume::Sender<NetworkEvent>, event: NetworkEvent) {
 pub async fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
     let tcp_transport =
         || libp2p::tcp::TcpTransport::new(libp2p::tcp::GenTcpConfig::new().nodelay(true));
-    let transport = libp2p::websocket::WsConfig::new(tcp_transport()).or_transport(tcp_transport());
-    let transport = libp2p::dns::DnsConfig::system(transport).await.unwrap();
+    // let transport = libp2p::websocket::WsConfig::new(tcp_transport()).or_transport(tcp_transport());
+    let transport = libp2p::dns::DnsConfig::system(tcp_transport())
+        .await
+        .unwrap();
     let auth_config = {
         let dh_keys = noise::Keypair::<noise::X25519Spec>::new()
             .into_authentic(&local_key)


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Speed up build by removing `bzip` and `libz` from critical path
- Try CI without buildjet
- `libz` and `bzip` features of `rocksdb` are disabled
- `libp2p-websoket` is removed. Alternatively we can patch the `soketto` or `flate2` crate to get rid of `libz-sys` (`flate2` uses rust implement of the compression algorithm by default, for some reason `soketto` specifies the `libz` feature)
- `libz` and `bzip` remains in `Cargo.lock` maybe because `librocksdb-sys` has `libz-sys?/static` feature.

Given the number, I think we can use gh hosted runner for calibnet sync check job, given MacOS build is likely to be slower

Build time  on hosted runner

|job|[cache miss](https://github.com/ChainSafe/forest/actions/runs/3495118179/jobs/5851529367)|[cache hit](https://github.com/ChainSafe/forest/actions/runs/3495411368)|migrate?|
|--|--|--|--|
|test|42m10s|15m29s| no |
|calibnet sync check|25m37s|9m41s| yes? |

For reference, [test job on buildjet with cache](https://github.com/ChainSafe/forest/actions/runs/3493035550) takes `5m11s`. (This job does not have `bzip` and `libz` removed)

Build time report of `main` from CI build artifacts:

| Rank |Unit | Total | Codegen | Features|
| -- | -- | -- | -- | -- |
|1. | wasmtime-runtime v1.0.2 build script (run) | 63.5s |   | pooling-allocator|
|2. | libz-sys v1.1.8 build script (run) | 59.9s |   | static
|3. | psm v0.1.21 build script (run) | 59.4s |   |  
|4. | sha2-asm v0.6.2 build script (run) | 58.0s |   |  
|5. | blake3 v1.3.1 build script (run) | 54.2s |   |  
|6. | bzip2-sys v0.1.11+1.0.8 build script (run) | 36.4s |   | static
|7. | librocksdb-sys v0.8.0+7.4.4 build script (run) | 34.0s |   | bzip2, bzip2-sys, default, libz-sys, lz4, snappy, static, zlib
|8. | blst v0.3.9 build script (run) | 29.0s |   | default
|9. | ring v0.16.20 build script (run) | 23.6s |   | alloc, default, dev_urandom_fallback, once_cell, std
|10. | proc-macro2 v1.0.47 build script | 8.2s |   | default, proc-macro, span-locations

Clean build time report on my laptop (no `target` dir, no sccache), with `cargo check --timings` 
full report: [build-time.zip](https://github.com/ChainSafe/forest/files/10043154/build-time.zip)

TLDR:
|branch|total time|ratio|
|--|--|--|
|main|212.2s|100%|
|pr|184.8s|87.09%|

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes part of https://github.com/ChainSafe/forest/issues/2088


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->