### PR TITLE
chore: upgrade CI / dockerfile to use ubuntu 22.04

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   autoupdate:
     name: autoupdate
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:

--- a/.github/workflows/cancel-stale.yml
+++ b/.github/workflows/cancel-stale.yml
@@ -12,7 +12,7 @@ on:
       - requested
 jobs:
   cancel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # TODO: switch back to styfle/cancel-workflow-action once the change get merged and released
       - uses: hanabi1224/cancel-workflow-action@120898519f2940069cc6a070c4f9c3d6cc2e7ff8

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   codecov:
     name: Cover
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 30
     steps:
       - name: Checkout Sources
@@ -20,7 +20,7 @@ jobs:
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         with:
-          release-name: v0.3.0
+          release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-codecov-${{ hashFiles('rust-toolchain.toml') }}
           cache-update: ${{ github.event_name != 'pull_request' }}
       - name: Run cargo-llvm-cov

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push-docker-image:
     name: Build Docker image and push to repositories
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 30
     steps:
       - name: List cached docker images

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check-publish-docs:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         with:
-          release-name: v0.3.0
+          release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-docs-${{ hashFiles('rust-toolchain.toml') }}
           # true: always save cache
           # false: only save when cache is not found

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             file: forest-${{ github.ref_name }}-linux-amd64.zip
           - os: macos-latest
             file: forest-${{ github.ref_name }}-macos-amd64.zip

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 30
     steps:
       - name: Checkout Sources
@@ -27,7 +27,7 @@ jobs:
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         with:
-          release-name: v0.3.0
+          release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-test-${{ hashFiles('rust-toolchain.toml') }}
           cache-update: ${{ github.event_name != 'pull_request' }}
       - name: Apt Dependencies
@@ -41,7 +41,7 @@ jobs:
 
   lint-all:
     name: All lint checks (lint audit spellcheck udeps)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         with:
-          release-name: v0.3.0
+          release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-lints-${{ hashFiles('rust-toolchain.toml') }}
           cache-update: ${{ github.event_name != 'pull_request' }}
       - run: make lint-all
@@ -70,7 +70,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
         uses: hanabi1224/sccache-action@v1.2.0
         with:
           # hard code release-name for macos, it always get rate limited when calling github api
-          release-name: v0.3.0
+          release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-${{ hashFiles('rust-toolchain.toml') }}
           cache-update: ${{ github.event_name != 'pull_request' }}
       - name: Install Apt Dependencies
@@ -106,7 +106,7 @@ jobs:
   calibnet-check:
     name: Calibnet sync check
     #if: ${{ false }}
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 30
     steps:
       - name: Checkout Sources
@@ -118,7 +118,7 @@ jobs:
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         with:
-          release-name: v0.3.0
+          release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-calibnet-check-${{ hashFiles('rust-toolchain.toml') }}
           cache-update: ${{ github.event_name != 'pull_request' }}
       - name: build and install binaries
@@ -146,7 +146,7 @@ jobs:
 
   dependencies-duplicate-check:
     name: Check cargo files for duplicates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -19,7 +19,7 @@ jobs:
       env:
         SHELLCHECK_OPTS: --external-sources
   rubocop:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Use github action runner cached images to avoid being rate limited
 # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#cached-docker-images
 ## 
-FROM buildpack-deps:buster AS build-env
+FROM buildpack-deps:bullseye AS build-env
 
 # Install dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential clang ocl-icd-opencl-dev protobuf-compiler cmake ca-certificates curl
@@ -39,7 +39,7 @@ RUN make install
 # Use github action runner cached images to avoid being rate limited
 # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#cached-docker-images
 ##
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Link package to the repository
 LABEL org.opencontainers.image.source https://github.com/chainsafe/forest


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Upgrade CI linux os to `ubuntu-22.04`
- Upgrade Dockerfile to use `debain:bullseyes` and `ubuntu:22.04`
- Upgrade `sccache` to latest

Get us prepared for the roll out.

Ubuntu-latest workflows will use Ubuntu-22.04 https://github.com/actions/runner-images/issues/6399 
> This change will be rolled out over a period of several weeks beginning in October, 3. We plan to complete the migration by December, 1.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2239


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->