### PR TITLE
increase SST file size to 1G

### DIFF
--- a/node/db/src/rocks_config.rs
+++ b/node/db/src/rocks_config.rs
@@ -32,7 +32,7 @@ impl Default for RocksDbConfig {
         Self {
             create_if_missing: true,
             parallelism: num_cpus::get() as i32,
-            write_buffer_size: 256 * 1024 * 1024,
+            write_buffer_size: 2usize.pow(30), // 1 GiB
             max_open_files: -1,
             max_background_jobs: None,
             compaction_style: "none".into(),


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Increase the `buffer_write_size` to 1G, effectively increasing SST file size to 1G.
- see the linked issue for benchmark results between baseline and this branch.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2217


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->