### PR TITLE
feat: more block validation metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -346,7 +346,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -428,7 +428,7 @@ dependencies = [
  "axum-core",
  "base64",
  "bitflags",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-util",
  "http",
  "http-body",
@@ -459,7 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
 dependencies = [
  "async-trait",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-util",
  "http",
  "http-body",
@@ -624,7 +624,7 @@ checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
@@ -635,7 +635,7 @@ checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
@@ -646,20 +646,20 @@ checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+checksum = "895adc16c8b3273fbbc32685a7d55227705eda08c01e77704020f3491924b44b"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
  "cfg-if 1.0.0",
- "constant_time_eq",
+ "constant_time_eq 0.2.4",
 ]
 
 [[package]]
@@ -836,9 +836,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2-sys"
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -1139,6 +1139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,22 +1337,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1354,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2972,9 +2978,11 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.2",
  "fvm_shared",
+ "lazy_static",
  "log",
  "nonempty",
  "num-traits",
+ "prometheus",
  "thiserror",
  "tokio",
 ]
@@ -3168,7 +3176,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "asynchronous-codec",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "cid",
  "flume",
  "fnv",
@@ -3453,8 +3461,10 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.2",
  "fvm_shared",
+ "lazy_static",
  "log",
  "num-traits",
+ "prometheus",
  "serde",
  "thiserror",
  "tokio",
@@ -4224,7 +4234,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "fnv",
  "itoa",
 ]
@@ -4235,7 +4245,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "http",
  "pin-project-lite 0.2.9",
 ]
@@ -4279,7 +4289,7 @@ version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4681,7 +4691,7 @@ version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec878fda12ebec479186b3914ebc48ff180fa4c51847e11a1a68bf65249e02c1"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures",
  "futures-timer",
  "getrandom 0.2.8",
@@ -4784,7 +4794,7 @@ dependencies = [
  "asynchronous-codec",
  "base64",
  "byteorder",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "fnv",
  "futures",
  "hex_fmt",
@@ -4832,7 +4842,7 @@ checksum = "6721c200e2021f6c3fab8b6cf0272ead8912d871610ee194ebd628cecf428f22"
 dependencies = [
  "arrayvec 0.7.2",
  "asynchronous-codec",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "either",
  "fnv",
  "futures",
@@ -4894,7 +4904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692664acfd98652de739a8acbb0a0d670f1d67190a49be6b4395e22c37337d89"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures",
  "libp2p-core",
  "log",
@@ -4911,7 +4921,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048155686bd81fe6cb5efdef0c6290f25ad32a0a42e8f4f72625cf6a505a206f"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "curve25519-dalek 3.2.0",
  "futures",
  "lazy_static",
@@ -4950,7 +4960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8827af16a017b65311a410bb626205a9ad92ec0473967618425039fa5231adc1"
 dependencies = [
  "async-trait",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures",
  "instant",
  "libp2p-core",
@@ -5292,6 +5302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "merkletree"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5435,7 +5454,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bc41247ec209813e2fd414d6e16b9d94297dacf3cd613fa6ef09cd4d9755c10"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures",
  "log",
  "pin-project",
@@ -5549,7 +5568,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures",
  "log",
  "netlink-packet-core",
@@ -5565,7 +5584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
 dependencies = [
  "async-io",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures",
  "libc",
  "log",
@@ -5581,7 +5600,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -5605,7 +5624,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
  "pin-utils",
 ]
 
@@ -6234,7 +6253,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "prost-derive",
 ]
 
@@ -6244,7 +6263,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "heck 0.4.0",
  "itertools 0.10.5",
  "lazy_static",
@@ -6267,7 +6286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "prost",
  "thiserror",
  "unsigned-varint",
@@ -6292,7 +6311,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "prost",
 ]
 
@@ -6491,11 +6510,10 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
 dependencies = [
- "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -6503,9 +6521,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -6823,7 +6841,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7c4cd1e0a04c48f953473383a60143884515b7a8eb7ca7d9b1baa9c05dee75"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "pin-project-lite 0.2.9",
  "rxml_validation",
  "smartstring",
@@ -6996,9 +7014,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -7281,9 +7299,9 @@ dependencies = [
 
 [[package]]
 name = "snap"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snow"
@@ -7319,7 +7337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "flate2",
  "futures",
  "httparse",
@@ -7756,12 +7774,12 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "libc",
  "memchr",
  "mio",
@@ -7823,7 +7841,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -7863,7 +7881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
 dependencies = [
  "bitflags",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-core",
  "futures-util",
  "http",
@@ -7985,7 +8003,7 @@ checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64",
  "byteorder",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "http",
  "httparse",
  "log",
@@ -8095,7 +8113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.2.1",
+ "bytes 1.3.0",
  "futures-io",
  "futures-util",
 ]
@@ -8428,7 +8446,7 @@ dependencies = [
  "libc",
  "log",
  "mach",
- "memoffset",
+ "memoffset 0.6.5",
  "paste",
  "rand 0.8.5",
  "rustix",

--- a/blockchain/chain_sync/src/metrics.rs
+++ b/blockchain/chain_sync/src/metrics.rs
@@ -4,7 +4,7 @@
 use lazy_static::lazy_static;
 use prometheus::{
     core::{AtomicU64, GenericCounter, GenericCounterVec, GenericGauge, Opts},
-    Histogram, HistogramOpts,
+    Histogram, HistogramOpts, HistogramVec,
 };
 
 lazy_static! {
@@ -23,6 +23,41 @@ lazy_static! {
             "Registering the tipset_processing_time metric with the metrics registry must succeed",
         );
         tipset_processing_time
+    };
+    pub static ref BLOCK_VALIDATION_TIME: Box<Histogram> = {
+        let block_validation_time = Box::new(
+            Histogram::with_opts(HistogramOpts {
+                common_opts: Opts::new(
+                    "block_validation_time",
+                    "Duration of routine which validate blocks with no cache hit",
+                ),
+                buckets: vec![],
+            })
+            .expect("Defining the block_validation_time metric must succeed"),
+        );
+        prometheus::default_registry().register(block_validation_time.clone()).expect(
+            "Registering the block_validation_time metric with the metrics registry must succeed",
+        );
+        block_validation_time
+    };
+    pub static ref BLOCK_VALIDATION_TASKS_TIME: Box<HistogramVec> = {
+        let block_validation_tasks_time = Box::new(
+            HistogramVec::new(
+                HistogramOpts {
+                    common_opts: Opts::new(
+                        "block_validation_tasks_time",
+                        "Duration of subroutines inside block validation",
+                    ),
+                    buckets: vec![],
+                },
+                &["type"],
+            )
+            .expect("Defining the block_validation_time metric must succeed"),
+        );
+        prometheus::default_registry().register(block_validation_tasks_time.clone()).expect(
+            "Registering the block_validation_time metric with the metrics registry must succeed",
+        );
+        block_validation_tasks_time
     };
     pub static ref LIBP2P_MESSAGE_TOTAL: Box<GenericCounterVec<AtomicU64>> = {
         let libp2p_message_total = Box::new(
@@ -212,6 +247,11 @@ pub mod values {
     pub const CHAIN_EXCHANGE_RESPONSE_OUTBOUND: &str = "chain_exchange_response_out";
     pub const BITSWAP_BLOCK_REQUEST_OUTBOUND: &str = "bitswap_block_request_out";
     pub const BITSWAP_BLOCK_RESPONSE_INBOUND: &str = "bitswap_block_response_in";
+
+    // block validation tasks
+    pub const BASE_FEE_CHECK: &str = "base_fee_check";
+    pub const PARENT_WEIGHT_CAL: &str = "parent_weight_check";
+    pub const BLOCK_SIGNATURE_CHECK: &str = "block_signature_check";
 }
 
 #[cfg(test)]

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -1155,7 +1155,13 @@ async fn validate_tipset<DB: Blockstore + Store + Clone + Send + Sync + 'static,
 
     let mut validations = FuturesUnordered::new();
     let blocks = full_tipset.into_blocks();
-    let blocks_len = blocks.len();
+
+    info!(
+        "Validating tipset: EPOCH = {epoch}, N blocks = {}",
+        blocks.len()
+    );
+    debug!("Tipset keys: {:?}", full_tipset_key.cids);
+
     for b in blocks {
         let validation_fn = tokio::task::spawn(validate_block::<_, C>(
             consensus.clone(),
@@ -1164,9 +1170,6 @@ async fn validate_tipset<DB: Blockstore + Store + Clone + Send + Sync + 'static,
         ));
         validations.push(validation_fn);
     }
-
-    info!("Validating tipset: EPOCH = {epoch}, N blocks = {blocks_len}");
-    debug!("Tipset keys: {:?}", full_tipset_key.cids);
 
     while let Some(result) = validations.next().await {
         match result? {

--- a/blockchain/consensus/fil_cns/Cargo.toml
+++ b/blockchain/consensus/fil_cns/Cargo.toml
@@ -27,9 +27,11 @@ fvm.workspace                    = true
 fvm_ipld_blockstore.workspace    = true
 fvm_ipld_encoding.workspace      = true
 fvm_shared                       = { workspace = true, default-features = false }
+lazy_static.workspace            = true
 log.workspace                    = true
 nonempty.workspace               = true
 num-traits.workspace             = true
+prometheus.workspace             = true
 thiserror.workspace              = true
 tokio                            = { workspace = true, features = ["sync"] }
 

--- a/blockchain/consensus/fil_cns/src/lib.rs
+++ b/blockchain/consensus/fil_cns/src/lib.rs
@@ -19,6 +19,7 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::Error as ForestEncodingError;
 use nonempty::NonEmpty;
 
+mod metrics;
 mod validation;
 mod weight;
 

--- a/blockchain/consensus/fil_cns/src/metrics.rs
+++ b/blockchain/consensus/fil_cns/src/metrics.rs
@@ -1,0 +1,50 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use lazy_static::lazy_static;
+use prometheus::{core::Opts, Histogram, HistogramOpts, HistogramVec};
+
+lazy_static! {
+    pub static ref CONSENSUS_BLOCK_VALIDATION_TIME: Box<Histogram> = {
+        let cns_block_validation_time = Box::new(
+            Histogram::with_opts(HistogramOpts {
+                common_opts: Opts::new(
+                    "cns_block_validation_time",
+                    "Duration of routine which validate blocks in fil_cns",
+                ),
+                buckets: vec![],
+            })
+            .expect("Defining the cns_block_validation_time metric must succeed"),
+        );
+        prometheus::default_registry().register(cns_block_validation_time.clone()).expect(
+            "Registering the cns_block_validation_time metric with the metrics registry must succeed",
+        );
+        cns_block_validation_time
+    };
+    pub static ref CONSENSUS_BLOCK_VALIDATION_TASKS_TIME: Box<HistogramVec> = {
+        let cns_block_validation_tasks_time = Box::new(
+            HistogramVec::new(
+                HistogramOpts {
+                    common_opts: Opts::new(
+                        "cns_block_validation_tasks_time",
+                        "Duration of subroutines inside cns block validation",
+                    ),
+                    buckets: vec![],
+                },
+                &["type"],
+            )
+            .expect("Defining the cns_block_validation_tasks_time metric must succeed"),
+        );
+        prometheus::default_registry().register(cns_block_validation_tasks_time.clone()).expect(
+            "Registering the cns_block_validation_tasks_time metric with the metrics registry must succeed",
+        );
+        cns_block_validation_tasks_time
+    };
+}
+
+pub mod values {
+    pub const VALIDATE_MINER: &str = "validate_miner";
+    pub const VALIDATE_WINNER_ELECTION: &str = "validate_winner_election";
+    pub const VALIDATE_TICKET_ELECTION: &str = "validate_ticket_election";
+    pub const VERIFY_WINNING_POST_PROOF: &str = "verify_winning_post_proof";
+}

--- a/blockchain/consensus/fil_cns/src/validation.rs
+++ b/blockchain/consensus/fil_cns/src/validation.rs
@@ -22,7 +22,7 @@ use fvm_shared::TICKET_RANDOMNESS_LOOKBACK;
 use nonempty::NonEmpty;
 use std::sync::Arc;
 
-use crate::FilecoinConsensusError;
+use crate::{metrics, FilecoinConsensusError};
 
 fn to_errs<E: Into<FilecoinConsensusError>>(e: E) -> NonEmpty<FilecoinConsensusError> {
     NonEmpty::new(e.into())
@@ -44,6 +44,8 @@ pub(crate) async fn validate_block<
     beacon_schedule: Arc<BeaconSchedule<B>>,
     block: Arc<Block>,
 ) -> Result<(), NonEmpty<FilecoinConsensusError>> {
+    let _timer = metrics::CONSENSUS_BLOCK_VALIDATION_TIME.start_timer();
+
     let chain_store = state_manager.chain_store().clone();
     let header = block.header();
 
@@ -208,6 +210,10 @@ fn validate_miner<DB: Blockstore + Store + Clone + Send + Sync + 'static>(
     miner_addr: &Address,
     tipset_state: &Cid,
 ) -> Result<(), FilecoinConsensusError> {
+    let _timer = metrics::CONSENSUS_BLOCK_VALIDATION_TASKS_TIME
+        .with_label_values(&[metrics::values::VALIDATE_MINER])
+        .start_timer();
+
     let actor = state_manager
         .get_actor(&power::ADDRESS, *tipset_state)?
         .ok_or(FilecoinConsensusError::PowerActorUnavailable)?;
@@ -231,6 +237,10 @@ fn validate_winner_election<DB: Blockstore + Store + Clone + Sync + Send + 'stat
     work_addr: &Address,
     state_manager: &StateManager<DB>,
 ) -> Result<(), FilecoinConsensusError> {
+    let _timer = metrics::CONSENSUS_BLOCK_VALIDATION_TASKS_TIME
+        .with_label_values(&[metrics::values::VALIDATE_WINNER_ELECTION])
+        .start_timer();
+
     // Safe to unwrap because checked to `Some` in sanity check
     let election_proof = header.election_proof().as_ref().unwrap();
     if election_proof.win_count < 1 {
@@ -283,6 +293,10 @@ fn validate_ticket_election(
     work_addr: &Address,
     chain_config: &ChainConfig,
 ) -> Result<(), FilecoinConsensusError> {
+    let _timer = metrics::CONSENSUS_BLOCK_VALIDATION_TASKS_TIME
+        .with_label_values(&[metrics::values::VALIDATE_TICKET_ELECTION])
+        .start_timer();
+
     let mut miner_address_buf = header.miner_address().marshal_cbor()?;
     let smoke_height = chain_config.epoch(Height::Smoke);
 
@@ -334,6 +348,10 @@ fn verify_winning_post_proof<
     prev_beacon_entry: &BeaconEntry,
     lookback_state: &Cid,
 ) -> Result<(), FilecoinConsensusError> {
+    let _timer = metrics::CONSENSUS_BLOCK_VALIDATION_TASKS_TIME
+        .with_label_values(&[metrics::values::VERIFY_WINNING_POST_PROOF])
+        .start_timer();
+
     if cfg!(feature = "insecure_post") {
         let wpp = header.winning_post_proof();
         if wpp.is_empty() {

--- a/blockchain/state_manager/Cargo.toml
+++ b/blockchain/state_manager/Cargo.toml
@@ -33,8 +33,10 @@ fvm_ipld_bitfield.workspace      = true
 fvm_ipld_blockstore.workspace    = true
 fvm_ipld_encoding.workspace      = true
 fvm_shared                       = { workspace = true, default-features = false }
+lazy_static.workspace            = true
 log.workspace                    = true
 num-traits.workspace             = true
+prometheus.workspace             = true
 serde                            = { workspace = true, features = ["derive"] }
 thiserror.workspace              = true
 tokio                            = { workspace = true, features = ["sync"] }

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod chain_rand;
 mod errors;
+mod metrics;
 mod utils;
 mod vm_circ_supply;
 
@@ -341,6 +342,8 @@ where
         R: Rand + Clone + 'static,
         CB: FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), anyhow::Error>,
     {
+        let _timer = metrics::APPLY_BLOCKS_TIME.start_timer();
+
         let db = self.blockstore().clone();
 
         let turbo_height = self.chain_config.epoch(Height::Turbo);

--- a/blockchain/state_manager/src/metrics.rs
+++ b/blockchain/state_manager/src/metrics.rs
@@ -1,0 +1,25 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use lazy_static::lazy_static;
+use prometheus::{core::Opts, Histogram, HistogramOpts};
+
+lazy_static! {
+    pub static ref APPLY_BLOCKS_TIME: Box<Histogram> =
+        {
+            let apply_blocks_time = Box::new(
+                Histogram::with_opts(HistogramOpts {
+                    common_opts: Opts::new(
+                        "apply_blocks_time",
+                        "Duration of routine which applied blocks",
+                    ),
+                    buckets: vec![],
+                })
+                .expect("Defining the apply_blocks_time metric must succeed"),
+            );
+            prometheus::default_registry().register(apply_blocks_time.clone()).expect(
+            "Registering the apply_blocks_time metric with the metrics registry must succeed",
+        );
+            apply_blocks_time
+        };
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- More metrics on block validation with no cache hit
- More metrics on all functions that are spawned by `spawn_blocking`

Conclusions:
We should seek opportunities to better parallelize slow functions below and maybe move fast ones out of `spawn_blocking`.  `apply_blocks` is the dominant one which invokes `fvm`

Observations (mainnet, with 3300 blocks validated without hitting cache):
|fn|time(avg)|
|--|--|
|`apply_blocks`|8.3s|
|`base_fee_check`|0.0088s|
|`block_signature_check`|0.0033s|
|`parent_weight_check`|0.00048s|
|`block_validation`|8.58s|
|`cns_block_validation`| 0.7435s |
|`validate_miner`|0.00092s|
|`validate_ticket_election`| 0.00423s |
|`validate_winner_election`| 0.0113s |
|`verify_winning_post_proof`| 0.581s |

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes Part of https://github.com/ChainSafe/forest/issues/2048


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->