### PR TITLE
fix: get rid of RUSTSEC-2020-0071

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "thiserror",
- "time 0.3.17",
+ "time",
  "url",
 ]
 
@@ -947,12 +947,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -2490,7 +2487,6 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "async-log",
  "base64",
  "cid",
  "directories",
@@ -2549,7 +2545,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "ticker",
- "time 0.3.17",
+ "time",
  "tokio",
  "toml",
  "url",
@@ -2561,7 +2557,6 @@ name = "forest-daemon"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "async-log",
  "atty",
  "base64",
  "chrono",
@@ -2630,7 +2625,7 @@ dependencies = [
  "shared_memory",
  "structopt",
  "tempfile",
- "time 0.3.17",
+ "time",
  "tokio",
  "toml",
 ]
@@ -2834,7 +2829,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "thiserror",
- "time 0.3.17",
+ "time",
  "tokio",
 ]
 
@@ -2902,7 +2897,7 @@ dependencies = [
  "sha2 0.10.6",
  "structopt",
  "tempfile",
- "time 0.3.17",
+ "time",
  "tokio",
  "toml",
  "tower-http",
@@ -3045,7 +3040,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]
@@ -5946,12 +5941,10 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 [[package]]
 name = "pbr"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5751d87f7c00ae6403eb1fcbba229b9c76c9a30de8c1cf87182177b168cea2"
+source = "git+https://github.com/a8m/pb?rev=09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd#09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd"
 dependencies = [
  "crossbeam-channel",
  "libc",
- "time 0.1.44",
  "winapi",
 ]
 
@@ -6499,7 +6492,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "nix 0.25.0",
- "rand 0.7.3",
+ "rand 0.8.5",
  "winapi",
 ]
 
@@ -6747,7 +6740,7 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.6",
  "thiserror",
- "time 0.3.17",
+ "time",
  "url",
 ]
 
@@ -7081,7 +7074,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]
@@ -7243,7 +7236,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]
@@ -7690,17 +7683,6 @@ name = "ticker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6821a2afe2700471d4572a25bcbfc091d6d596902a279ed41af139f350b76e"
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
 
 [[package]]
 name = "time"
@@ -8193,12 +8175,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ resolver = "2"
 # temporary solution to funty@1.2.0 being yanked, we should propose bitvec upgrade to upstream filecoin crates
 # tracking issue: https://github.com/bitvecto-rs/funty/issues/7
 funty = { git = "https://github.com/bitvecto-rs/funty/", rev = "7ef0d890fbcd8b3def1635ac1a877fc298488446" }
+# get rid of RUSTSEC-2020-0071, the fix is in place but not published to crates.io
+pbr = { git = "https://github.com/a8m/pb", rev = "09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd" }
 
 [workspace.dependencies]
 ahash                 = "0.8"
@@ -60,7 +62,7 @@ blake2b_simd          = "1.0"
 bls-signatures        = { version = "0.12", default-features = false, features = ["blst"] }
 byteorder             = "1.4.3"
 bytes                 = "1.2"
-chrono                = "0.4"
+chrono                = { version = "0.4", default-features = false, features = [] }
 cid                   = { version = "0.8", default-features = false, features = ["std"] }
 cs_serde_bytes        = "0.12.2"
 digest                = "0.10.5"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ clean:
 lint-all: lint audit spellcheck udeps
 
 audit:
-	cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0040
+	cargo audit
 
 udeps:
 	cargo udeps --all-targets --features submodule_tests

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -7,7 +7,6 @@ edition     = "2021"
 
 [dependencies]
 anyhow.workspace                 = true
-async-log.workspace              = true
 base64.workspace                 = true
 cid.workspace                    = true
 directories.workspace            = true

--- a/forest/daemon/Cargo.toml
+++ b/forest/daemon/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace                 = true
-async-log.workspace              = true
 atty.workspace                   = true
 base64.workspace                 = true
 chrono.workspace                 = true


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- fix [RUSTSEC-2020-0071](https://github.com/rustsec/advisory-db/blob/main/crates/time/RUSTSEC-2020-0071.md) by removing `time@0.1` from `chrono` and `pbr`
- remove [RUSTSEC-2022-0040](https://rustsec.org/advisories/RUSTSEC-2022-0040.html) from `cargo audit` ignore list as it's no longer valid



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->