### PR TITLE
Add explicit shutdown of tokio rt

### DIFF
--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -11,7 +11,6 @@ use forest_cli_shared::cli::{
     cli_error_and_die, db_path, default_snapshot_dir, is_aria2_installed, snapshot_fetch, Client,
     Config, FOREST_VERSION_STRING,
 };
-use forest_db::rocks::RocksDb;
 use forest_db::Store;
 use forest_fil_types::verifier::FullVerifier;
 use forest_genesis::{get_network_name_from_genesis, import_chain, read_genesis_header};
@@ -59,7 +58,7 @@ fn unblock_parent_process() {
 }
 
 /// Starts daemon process
-pub(super) async fn start(config: Config, detached: bool) -> RocksDb {
+pub(super) async fn start(config: Config, detached: bool) -> Db {
     let mut ctrlc_oneshot = set_sigint_handler();
 
     info!(
@@ -493,6 +492,12 @@ fn open_db(config: &Config) -> forest_db::parity_db::ParityDb {
     };
     ParityDb::open(&config).expect("Opening ParityDb must succeed")
 }
+
+#[cfg(feature = "rocksdb")]
+type Db = forest_db::rocks::RocksDb;
+
+#[cfg(feature = "paritydb")]
+type Db = forest_db::parity_db::ParityDb;
 
 #[cfg(test)]
 mod test {

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -11,6 +11,7 @@ use forest_cli_shared::cli::{
     cli_error_and_die, db_path, default_snapshot_dir, is_aria2_installed, snapshot_fetch, Client,
     Config, FOREST_VERSION_STRING,
 };
+use forest_db::rocks::RocksDb;
 use forest_db::Store;
 use forest_fil_types::verifier::FullVerifier;
 use forest_genesis::{get_network_name_from_genesis, import_chain, read_genesis_header};
@@ -58,7 +59,7 @@ fn unblock_parent_process() {
 }
 
 /// Starts daemon process
-pub(super) async fn start(config: Config, detached: bool) {
+pub(super) async fn start(config: Config, detached: bool) -> RocksDb {
     let mut ctrlc_oneshot = set_sigint_handler();
 
     info!(
@@ -362,7 +363,7 @@ pub(super) async fn start(config: Config, detached: bool) {
         _ = ctrlc_oneshot => {
             // Cancel all async services
             services.shutdown().await;
-            return;
+            return db;
         },
     }
 
@@ -370,14 +371,10 @@ pub(super) async fn start(config: Config, detached: bool) {
     if config.client.halt_after_import {
         // Cancel all async services
         services.shutdown().await;
-        info!("Forest finish shutdown");
-        return;
+        return db;
     }
 
     services.spawn(p2p_service.run());
-
-    let db_weak_ref = Arc::downgrade(&db.db);
-    drop(db);
 
     // Block until ctrl-c is hit
     ctrlc_oneshot.await.unwrap();
@@ -391,13 +388,7 @@ pub(super) async fn start(config: Config, detached: bool) {
 
     keystore_write.await.expect("keystore write failed");
 
-    if db_weak_ref.strong_count() != 0 {
-        error!(
-            "Dangling reference to DB detected: {}. Tracking issue: https://github.com/ChainSafe/forest/issues/1891",
-            db_weak_ref.strong_count()
-        );
-    }
-    info!("Forest finish shutdown");
+    db
 }
 
 /// Optionally fetches the snapshot. Returns the configuration (modified accordingly if a snapshot was fetched).

--- a/forest/daemon/src/main.rs
+++ b/forest/daemon/src/main.rs
@@ -132,6 +132,12 @@ fn check_for_low_fd(_config: &Config) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[cfg(feature = "rocksdb")]
+type Db = forest_db::rocks::RocksDb;
+
+#[cfg(feature = "paritydb")]
+type Db = forest_db::parity_db::ParityDb;
+
 fn main() {
     // Capture Cli inputs
     let Cli { opts, cmd } = Cli::from_args();
@@ -191,7 +197,7 @@ fn main() {
                     }
 
                     let rt = Runtime::new().unwrap();
-                    let db = rt.block_on(daemon::start(cfg, opts.detach));
+                    let db: Db = rt.block_on(daemon::start(cfg, opts.detach));
 
                     info!("Shutting down tokio...");
                     rt.shutdown_timeout(Duration::from_secs(10));


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Add explicit shutdown of tokio runtime

Tasks running longer than 10s could still produce the dangling error but overall I've got much less errors.

We should probably have more insights on what those tasks are with the tokio console and add yield points.

I've check LOG file in rocksdb dir and it correctly shutdowns when there are no errors:
`2022/11/23-18:20:16.538822 4771888640 [db/db_impl/db_impl.cc:710] Shutdown complete`

Tested the `paritydb` backend as well.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #1848 #1891


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->