### PR TITLE
handle no directory for snapshots

### DIFF
--- a/forest/cli/src/cli/snapshot_cmd.rs
+++ b/forest/cli/src/cli/snapshot_cmd.rs
@@ -218,11 +218,12 @@ fn list(config: &Config, snapshot_dir: &Option<PathBuf>) -> anyhow::Result<()> {
         .unwrap_or_else(|| default_snapshot_dir(config));
     println!("Snapshot dir: {}", snapshot_dir.display());
     println!("\nLocal snapshots:");
-    fs::read_dir(snapshot_dir)?
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|p| is_car_or_tmp(p))
-        .for_each(|p| println!("{}", p.display()));
+    if let Ok(dir) = fs::read_dir(snapshot_dir) {
+        dir.flatten()
+            .map(|entry| entry.path())
+            .filter(|p| is_car_or_tmp(p))
+            .for_each(|p| println!("{}", p.display()));
+    };
 
     Ok(())
 }

--- a/forest/cli/tests/snapshot_tests.rs
+++ b/forest/cli/tests/snapshot_tests.rs
@@ -58,10 +58,10 @@ fn test_snapshot_subcommand_list_invalid_dir() -> Result<()> {
         .arg("--snapshot-dir")
         .arg("/this/is/dummy/path")
         .assert()
-        .failure();
+        .success();
 
-    let stderr = std::str::from_utf8(&cmd.get_output().stderr)?.to_owned();
-    ensure!(stderr.contains("No such file or directory"));
+    let output = std::str::from_utf8(&cmd.get_output().stdout)?.trim_end();
+    ensure!(output.ends_with("Local snapshots:"));
 
     Ok(())
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixed an issue where `forest-cli` panicked on:
```
❯ target/debug/forest-cli snapshot list
Snapshot dir: /home/rumcajs-work/.local/share/forest/snapshots/mainnet

Local snapshots:
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: No such file or directory (os error 2)', forest/cli/src/cli/snapshot_cmd.rs:190:45
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
this happens on a clean Forest data directory and the `snapshots/mainnet` is not yet created.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->