### PR TITLE
fix: flacky sccache-action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  CACHE_TIMEOUT_MINUTES: 5
+
 jobs:
   codecov:
     name: Cover
@@ -19,6 +22,8 @@ jobs:
         run: sudo make install-deps
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
         with:
           release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-codecov-${{ hashFiles('rust-toolchain.toml') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ on:
 env:
   # https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#--index-page-provide-a-top-level-landing-page-for-docs
   RUSTDOCFLAGS: "-Dwarnings -Zunstable-options --enable-index-page"
+  CACHE_TIMEOUT_MINUTES: 5
 
 jobs:
   check-publish-docs:
@@ -39,6 +40,8 @@ jobs:
         continue-on-error: true
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
         with:
           release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-docs-${{ hashFiles('rust-toolchain.toml') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
         with:
           release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-test-${{ hashFiles('rust-toolchain.toml') }}
@@ -56,6 +58,8 @@ jobs:
         continue-on-error: true
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
         with:
           release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-lints-${{ hashFiles('rust-toolchain.toml') }}
@@ -81,6 +85,8 @@ jobs:
           protoc --version
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
         with:
           # hard code release-name for macos, it always get rate limited when calling github api
           release-name: v0.3.1
@@ -115,6 +121,8 @@ jobs:
         run: sudo make install-deps
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
         with:
           release-name: v0.3.1
           cache-key: ${{ runner.os }}-sccache-calibnet-check-${{ hashFiles('rust-toolchain.toml') }}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- add back `timeout-minutes` and `continue-on-error` to `sccache-action`, it should be able to continue without cache. The timeout happens quite often on buildjet, the I/O speed of uploading/downloading the cache is much slower than that in github hosted runners



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->