### PR TITLE
Use `quickinstall` for installing cargo tools

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,9 @@ jobs:
             ~/.cargo/bin/
           key: ${{ runner.os }}-docs-cargo-bin-${{ hashFiles('rust-toolchain.toml') }}
       - name: Install MDBook
-        run: cargo install mdbook mdbook-linkcheck --locked
+        run: cargo install cargo-quickinstall && make install-doc-tools
         env:
           RUSTFLAGS: "-Cstrip=symbols"
-        continue-on-error: true
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,8 @@ jobs:
           key: ${{ runner.os }}-lints-cargo-bin-${{ hashFiles('rust-toolchain.toml') }}
       - name: Install Lint tools
         run: cargo install cargo-quickinstall && make install-lint-tools
+        env:
+          RUSTFLAGS: "-Cstrip=symbols"
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,8 +55,8 @@ jobs:
           path: |
             ~/.cargo/bin/
           key: ${{ runner.os }}-lints-cargo-bin-${{ hashFiles('rust-toolchain.toml') }}
-      - run: make install-lint-tools
-        continue-on-error: true
+      - name: Install Lint tools
+        run: cargo install cargo-quickinstall && make install-lint-tools
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ install-lint-tools:
 	-which cargo-spellcheck && cargo quickinstall cargo-spellcheck
 	-which cargo-udeps && cargo quickinstall cargo-udeps
 
+install-doc-tools:
+	-which mdbook && cargo quickinstall mdbook
+	-which mdbook-linkcheck && cargo quickinstall mdbook
+
 clean-all:
 	cargo clean
 

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ install-deps:
 	apt-get install --no-install-recommends -y build-essential clang protobuf-compiler ocl-icd-opencl-dev aria2 cmake
 
 install-lint-tools:
-	which taplo && cargo quickinstall taplo-cli || true
-	which cargo-audit && cargo quickinstall cargo-audit  || true
-	which cargo-spellcheck && cargo quickinstall cargo-spellcheck || true
-	which cargo-udeps && cargo quickinstall cargo-udeps || true
+	-which taplo && cargo quickinstall taplo-cli
+	-which cargo-audit && cargo quickinstall cargo-audit
+	-which cargo-spellcheck && cargo quickinstall cargo-spellcheck
+	-which cargo-udeps && cargo quickinstall cargo-udeps
 
 clean-all:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ install-deps:
 	apt-get install --no-install-recommends -y build-essential clang protobuf-compiler ocl-icd-opencl-dev aria2 cmake
 
 install-lint-tools:
-	-which taplo && cargo quickinstall taplo-cli
-	-which cargo-audit && cargo quickinstall cargo-audit
-	-which cargo-spellcheck && cargo quickinstall cargo-spellcheck
-	-which cargo-udeps && cargo quickinstall cargo-udeps
+	-which taplo || cargo quickinstall taplo-cli
+	-which cargo-audit || cargo quickinstall cargo-audit
+	-which cargo-spellcheck || cargo quickinstall cargo-spellcheck
+	-which cargo-udeps || cargo quickinstall cargo-udeps
 
 install-doc-tools:
-	-which mdbook && cargo quickinstall mdbook
-	-which mdbook-linkcheck && cargo quickinstall mdbook
+	-which mdbook || cargo quickinstall mdbook
+	-which mdbook-linkcheck || cargo quickinstall mdbook
 
 clean-all:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ install-deps:
 	apt-get install --no-install-recommends -y build-essential clang protobuf-compiler ocl-icd-opencl-dev aria2 cmake
 
 install-lint-tools:
-	RUSTFLAGS="-Cstrip=symbols" cargo install --locked taplo-cli cargo-audit cargo-spellcheck cargo-udeps
+	which taplo && cargo quickinstall taplo-cli || true
+	which cargo-audit && cargo quickinstall cargo-audit  || true
+	which cargo-spellcheck && cargo quickinstall cargo-spellcheck || true
+	which cargo-udeps && cargo quickinstall cargo-udeps || true
 
 clean-all:
 	cargo clean


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- this should fix the flaky lint step check plus introduce a faster cargo tool installation when we don't hit the cache. 

Example fiasco: https://github.com/ChainSafe/forest/actions/runs/3574718464/jobs/6012629867



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->