### PR TITLE
fix Grafana on MacOS

### DIFF
--- a/.maintain/monitoring/README.md
+++ b/.maintain/monitoring/README.md
@@ -4,7 +4,7 @@
 
 1. `forest` node running locally
 2. `docker` & `docker-compose` must be available in the `$PATH`
-3. Ports `3000` (for `grafana`) and `9090` (for `prometheus`) have to be free.
+3. Ports `3000` for `grafana` have to be free.
 
 ## Run
 

--- a/.maintain/monitoring/README.md
+++ b/.maintain/monitoring/README.md
@@ -4,7 +4,7 @@
 
 1. `forest` node running locally
 2. `docker` & `docker-compose` must be available in the `$PATH`
-3. Ports `3000` for `grafana` have to be free.
+3. Port `3000` for `grafana` has to be free.
 
 ## Run
 

--- a/.maintain/monitoring/docker-compose.yml
+++ b/.maintain/monitoring/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus/
     restart: unless-stopped
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   grafana:
     image: grafana/grafana

--- a/.maintain/monitoring/docker-compose.yml
+++ b/.maintain/monitoring/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus/
-    network_mode: host
     restart: unless-stopped
 
   grafana:
@@ -31,5 +30,6 @@ services:
     volumes:
       - ./grafana/provisioning/:/etc/grafana/provisioning
       - ./grafana/dashboards/:/etc/grafana/provisioning/dashboard-definitions
-    network_mode: host
     restart: unless-stopped
+    ports:
+      - "3000:3000"

--- a/.maintain/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/.maintain/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -18,7 +18,7 @@ datasources:
   # <int> org id. will default to orgId 1 if not specified
   orgId: 1
   # <string> url
-  url: http://localhost:9090
+  url: http://prometheus:9090
   # <string> database password, if used
   password:
   # <string> database user, if used

--- a/.maintain/monitoring/prometheus/prometheus.yml
+++ b/.maintain/monitoring/prometheus/prometheus.yml
@@ -4,4 +4,4 @@ global:
 scrape_configs:
   - job_name: 'forest'
     static_configs:
-      - targets: ['127.0.0.1:6116']
+      - targets: ['host.docker.internal:6116']

--- a/forest/shared/src/cli/client.rs
+++ b/forest/shared/src/cli/client.rs
@@ -60,7 +60,7 @@ impl Default for Client {
             snapshot_height: None,
             skip_load: false,
             encrypt_keystore: true,
-            metrics_address: FromStr::from_str("127.0.0.1:6116").unwrap(),
+            metrics_address: FromStr::from_str("0.0.0.0:6116").unwrap(),
             rpc_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), DEFAULT_PORT),
             download_snapshot: false,
             token_exp: Duration::seconds(5184000), // 60 Days = 5184000 Seconds


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- change Grafana compose to work on both Linux and MacOS,
- listen on all interfaces by default for metrics endpoint. Security shouldn't be a concern here; it's up to the operator to configure the firewall properly.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2288


**Other information and links**
<!-- Add any other context about the pull request here. -->
The issue stems from the fact that MacOS uses a thin VM for running docker. This doesn't work well with `host` network, and the ports should be exposed explicitly (which is not possible with `host` network). 

A way out of this is using `host.docker.internal`... which unfortunately exists only in Docker for MacOS (and probably in Docker for Windows). The way out of this is using a recently (2021) added `host-gateway`, see more https://github.com/docker/for-linux/issues/264#issuecomment-965465879. 

Tested on MacOS Ventura 13.01 and Linux Fedora Workstation 36.


<!-- Thank you 🔥 -->