### PR TITLE
remove 'needs triage' label

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_report.md
+++ b/.github/ISSUE_TEMPLATE/general_report.md
@@ -2,7 +2,6 @@
 name: General issue
 about: General purpose issue template
 title: ''
-labels: 'Status: Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new_issue.md
+++ b/.github/ISSUE_TEMPLATE/new_issue.md
@@ -2,7 +2,6 @@
 name: New issue
 about: New issue template
 title: ''
-labels: 'Status: Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/task_req.md
+++ b/.github/ISSUE_TEMPLATE/task_req.md
@@ -2,7 +2,6 @@
 name: Task requirement
 about: Required tasks to complete 
 title: ''
-labels: 'Status: Needs Triage'
 assignees: ''
 
 ---


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- remove the `needs triage` label from templates; it's more of a nuisance than anything else. We can filter unlabeled issues anyway.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->