### PR TITLE
fix: add retry to flacky apt install steps on CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,9 +18,11 @@ jobs:
         with:
           submodules: true
       - name: Apt Dependencies
-        run: |
-          # retrying this for a few times as it fails occasionally on CI runners
-          sudo make install-deps || sudo make install-deps || sudo make install-deps
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: sudo make install-deps
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           submodules: true
       - name: Apt Dependencies
-        run: sudo make install-deps
+        run: |
+          # retrying this for a few times as it fails occasionally on CI runners
+          sudo make install-deps || sudo make install-deps || sudo make install-deps
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v3
       - name: Apt Dependencies
-        run: sudo make install-deps
+        run: |
+          # retrying this for a few times as it fails occasionally on CI runners
+          sudo make install-deps || sudo make install-deps || sudo make install-deps
       - name: Link Checker (Repo)
         uses: lycheeverse/lychee-action@v1.5.4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,11 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v3
       - name: Apt Dependencies
-        run: |
-          # retrying this for a few times as it fails occasionally on CI runners
-          sudo make install-deps || sudo make install-deps || sudo make install-deps
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: sudo make install-deps
       - name: Link Checker (Repo)
         uses: lycheeverse/lychee-action@v1.5.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Apt Dependencies
         if: startsWith(matrix.os, 'Ubuntu')
-        run: sudo make install-deps
+        run: |
+          # retrying this for a few times as it fails occasionally on CI runners
+          sudo make install-deps || sudo make install-deps || sudo make install-deps
       - name: Homebrew Utils
         if: startsWith(matrix.os, 'macOS')
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Apt Dependencies
         if: startsWith(matrix.os, 'Ubuntu')
-        run: |
-          # retrying this for a few times as it fails occasionally on CI runners
-          sudo make install-deps || sudo make install-deps || sudo make install-deps
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: sudo make install-deps
       - name: Homebrew Utils
         if: startsWith(matrix.os, 'macOS')
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,9 @@ jobs:
           cache-key: ${{ runner.os }}-sccache-test-${{ hashFiles('rust-toolchain.toml') }}
           cache-update: ${{ github.event_name != 'pull_request' }}
       - name: Apt Dependencies
-        run: sudo make install-deps
+        run: |
+          # retrying this for a few times as it fails occasionally on CI runners
+          sudo make install-deps || sudo make install-deps || sudo make install-deps
       - name: install nextest
         uses: taiki-e/install-action@nextest
       - run: make test-all
@@ -50,7 +52,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Apt Dependencies
         run: |
-          sudo make install-deps
+          # retrying this for a few times as it fails occasionally on CI runners
+          sudo make install-deps || sudo make install-deps || sudo make install-deps
           sudo apt-get install -y libclang-dev # required dep for cargo-spellcheck
       - uses: actions/cache@v3
         with:
@@ -123,7 +126,9 @@ jobs:
         with:
           submodules: true
       - name: Apt Dependencies
-        run: sudo make install-deps
+        run: |
+          # retrying this for a few times as it fails occasionally on CI runners
+          sudo make install-deps || sudo make install-deps || sudo make install-deps
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,9 +34,11 @@ jobs:
           cache-key: ${{ runner.os }}-sccache-test-${{ hashFiles('rust-toolchain.toml') }}
           cache-update: ${{ github.event_name != 'pull_request' }}
       - name: Apt Dependencies
-        run: |
-          # retrying this for a few times as it fails occasionally on CI runners
-          sudo make install-deps || sudo make install-deps || sudo make install-deps
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: sudo make install-deps
       - name: install nextest
         uses: taiki-e/install-action@nextest
       - run: make test-all
@@ -51,10 +53,13 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v3
       - name: Apt Dependencies
-        run: |
-          # retrying this for a few times as it fails occasionally on CI runners
-          sudo make install-deps || sudo make install-deps || sudo make install-deps
-          sudo apt-get install -y libclang-dev # required dep for cargo-spellcheck
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: |
+            sudo make install-deps
+            sudo apt-get install -y libclang-dev # required dep for cargo-spellcheck
       - uses: actions/cache@v3
         with:
           path: |
@@ -126,9 +131,11 @@ jobs:
         with:
           submodules: true
       - name: Apt Dependencies
-        run: |
-          # retrying this for a few times as it fails occasionally on CI runners
-          sudo make install-deps || sudo make install-deps || sudo make install-deps
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: sudo make install-deps
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- add retry to flacky apt install steps on CI

Just got quite a few failures within like 1 hour: 
https://github.com/ChainSafe/forest/actions/runs/3594775435/jobs/6053456826
https://github.com/ChainSafe/forest/actions/runs/3594703435/jobs/6053298474


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->