### PR TITLE
Fix rpc net disconnect endpoint

### DIFF
--- a/node/rpc/src/net_api.rs
+++ b/node/rpc/src/net_api.rs
@@ -14,6 +14,8 @@ use forest_rpc_api::{
 };
 use fvm_ipld_blockstore::Blockstore;
 
+use std::str::FromStr;
+
 pub(crate) async fn net_addrs_listen<
     DB: Blockstore + Store + Clone + Send + Sync + 'static,
     B: Beacon,
@@ -91,7 +93,7 @@ pub(crate) async fn net_disconnect<
     Params(params): Params<NetDisconnectParams>,
 ) -> Result<NetDisconnectResult, JsonRpcError> {
     let (id,) = params;
-    let peer_id = PeerId::from_bytes(id.as_bytes())?;
+    let peer_id = PeerId::from_str(&id)?;
 
     let (tx, rx) = oneshot::channel();
     let req = NetworkMessage::JSONRPCRequest {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix `PeerId` construction that was using vector of bytes

We have now this output:
```
$ ./target/release/forest-cli --token <token> net disconnect 12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc
disconnect 12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc: success
```

And the peer is gone if I do just after a `forest-cli net peers`. 

I was not able to reproduce issue #2153 (maybe upgrade to libp2p 0.50 fixed this)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #2152 #2153



**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->