### PR TITLE
fix: timeout calibnet sync check CI job after 30min

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -161,6 +161,7 @@ jobs:
       - name: Validate checkpoint tipset hashes
         run: forest-cli chain validate-tipset-checkpoints
       - name: wait for sync and check health
+        timeout-minutes: 30
         run: |
           forest-cli sync wait
           forest-cli --chain calibnet db stats


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- timeout calibnet sync check CI job after 30min in case sth fiasco happens

The sync check get stuck for many jobs today
https://github.com/ChainSafe/forest/actions/runs/3602116313/jobs/6068686595
https://github.com/ChainSafe/forest/actions/runs/3599914822/jobs/6069802055
https://github.com/ChainSafe/forest/actions/runs/3600286567/jobs/6064781162
and many others

Manually cancelling them to save CI resources


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->