### PR TITLE
fix: CI codecov temporary fix by using filecoin snapshot

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate code coverage
         run: |
           cargo llvm-cov --workspace --no-report --features slow_tests
-          cargo llvm-cov --no-report run --bin=forest-cli -- --chain calibnet snapshot fetch -s .
+          cargo llvm-cov --no-report run --bin=forest-cli -- --chain calibnet snapshot fetch --provider filecoin -s .
           cargo llvm-cov --no-report run --bin=forest -- --chain calibnet --encrypt-keystore false --import-snapshot *.car --detach
           cargo llvm-cov --no-report run --bin=forest-cli -- sync wait
           cargo llvm-cov --no-report run --bin=forest-cli -- snapshot export


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
Looks like codecov CI get stuck: https://github.com/ChainSafe/forest/actions/runs/3648465953/jobs/6161920245
Using filecoin snapshot until snapshot validation is in place



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->