### PR TITLE
fix: use forest snapshot in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate code coverage
         run: |
           cargo llvm-cov --workspace --no-report --features slow_tests
-          cargo llvm-cov --no-report run --bin=forest-cli -- --chain calibnet snapshot fetch --provider filecoin -s .
+          cargo llvm-cov --no-report run --bin=forest-cli -- --chain calibnet snapshot fetch -s .
           cargo llvm-cov --no-report run --bin=forest -- --chain calibnet --encrypt-keystore false --import-snapshot *.car --detach
           cargo llvm-cov --no-report run --bin=forest-cli -- sync wait
           cargo llvm-cov --no-report run --bin=forest-cli -- snapshot export

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -148,7 +148,7 @@ jobs:
       - name: fetch params
         run: forest-cli fetch-params --keys
       - name: download snapshot
-        run: forest-cli --chain calibnet snapshot fetch --provider filecoin --aria2 -s $SNAPSHOT_DIRECTORY
+        run: forest-cli --chain calibnet snapshot fetch --aria2 -s $SNAPSHOT_DIRECTORY
       - name: import snapshot and run Forest
         run: |
           forest --chain calibnet --target-peer-count 50 --encrypt-keystore false --halt-after-import --import-snapshot $SNAPSHOT_DIRECTORY/*.car


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Move back to forest snapshot in CI jobs since bad snapshot issue has been fixed by https://github.com/ChainSafe/forest/pull/2351
- [ ] Pending new snapshot being uploaded



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->