### PR TITLE
feat: relative offets for validating the tipsets in a snapshot

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           cargo llvm-cov --workspace --no-report --features slow_tests
           cargo llvm-cov --no-report run --bin=forest-cli -- --chain calibnet snapshot fetch -s .
-          cargo llvm-cov --no-report run --bin=forest -- --chain calibnet --encrypt-keystore false --import-snapshot *.car --detach
+          cargo llvm-cov --no-report run --bin=forest -- --chain calibnet --encrypt-keystore false --import-snapshot *.car --height=-200 --detach
           cargo llvm-cov --no-report run --bin=forest-cli -- sync wait
           cargo llvm-cov --no-report run --bin=forest-cli -- snapshot export
           timeout 5 killall --wait --signal SIGINT forest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -151,7 +151,7 @@ jobs:
         run: forest-cli --chain calibnet snapshot fetch --aria2 -s $SNAPSHOT_DIRECTORY
       - name: import snapshot and run Forest
         run: |
-          forest --chain calibnet --target-peer-count 50 --encrypt-keystore false --halt-after-import --import-snapshot $SNAPSHOT_DIRECTORY/*.car
+          forest --chain calibnet --target-peer-count 50 --encrypt-keystore false --halt-after-import --height=-200 --import-snapshot $SNAPSHOT_DIRECTORY/*.car
           forest-cli --chain calibnet db stats
           forest --chain calibnet --target-peer-count 50 --encrypt-keystore false --detach
       - name: Validate checkpoint tipset hashes

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -1290,6 +1290,12 @@ where
         mut ts: Arc<Tipset>,
         height: i64,
     ) -> Result<(), anyhow::Error> {
+        if height > ts.epoch() {
+            anyhow::bail!(
+                "height {height} cannot be greater than tipset epoch {}",
+                ts.epoch()
+            );
+        }
         let mut ts_chain = Vec::<Arc<Tipset>>::new();
         while ts.epoch() != height {
             let next = self.cs.tipset_from_keys(ts.parents()).await?;

--- a/forest/shared/src/cli/mod.rs
+++ b/forest/shared/src/cli/mod.rs
@@ -54,7 +54,7 @@ pub struct CliOpts {
     /// Allow MDNS (default: false)
     #[structopt(long)]
     pub mdns: Option<bool>,
-    /// Validate snapshot at given EPOCH
+    /// Validate snapshot at given EPOCH, use a negative value -N to validate the last N EPOCH(s)
     #[structopt(long)]
     pub height: Option<i64>,
     /// Import a snapshot from a local CAR file or URL

--- a/utils/genesis/src/lib.rs
+++ b/utils/genesis/src/lib.rs
@@ -181,7 +181,7 @@ where
         let height = if height > 0 {
             height
         } else {
-            ts.epoch() + height
+            (ts.epoch() + height).max(0)
         };
         info!("Validating imported chain from height: {}", height);
         sm.validate_chain::<V>(ts.clone(), height).await?;

--- a/utils/genesis/src/lib.rs
+++ b/utils/genesis/src/lib.rs
@@ -178,6 +178,11 @@ where
     sm.blockstore().flush()?;
 
     if let Some(height) = validate_height {
+        let height = if height > 0 {
+            height
+        } else {
+            ts.epoch() + height
+        };
         info!("Validating imported chain from height: {}", height);
         sm.validate_chain::<V>(ts.clone(), height).await?;
     }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- relative offets for validating the tipsets in a snapshot
- update CI calibnet sync check
- update CI codecov

CI log looks good: https://github.com/ChainSafe/forest/actions/runs/3675346677/jobs/6214650918#step:8:32
```console
2022-12-12T11:41:27.365Z INFO  forest_genesis                   > Importing chain from snapshot at: /tmp/snapshots/forest_snapshot_calibnet_2022-12-12_height_115992.car
 2022-12-12T11:41:27.365Z INFO  forest_genesis                   > Reading file...
 2022-12-12T11:41:34.777Z INFO  forest_genesis                   > Loaded .car file in 7s
 2022-12-12T11:41:37.140Z INFO  forest_chain::store::index       > Resolving genesis using checkpoint tipset at height: 84000
 2022-12-12T11:41:42.379Z INFO  forest_genesis                   > Validating imported chain from height: 115792
```

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2354


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->