### PR TITLE
fix: issue 2362 and improve chain exchange failure message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,9 +894,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byte-unit"
-version = "4.0.17"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581ad4b3d627b0c09a0ccb2912148f839acaca0b93cf54cbe42b6c674e86079c"
+checksum = "3348673602e04848647fffaa8e9a861e7b5d5cae6570727b41bde0f722514484"
 dependencies = [
  "serde",
  "utf8-width",
@@ -1640,13 +1640,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-pre.1"
+version = "4.0.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4033478fbf70d6acf2655ac70da91ee65852d69daf7a67bf7a2f518fb47aafcf"
+checksum = "67bc65846be335cb20f4e52d49a437b773a2c1fdb42b19fc84e79e6f6771536f"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
+ "cfg-if 1.0.0",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
  "subtle",
  "zeroize",
 ]
@@ -2250,6 +2251,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
 
 [[package]]
 name = "fil_actor_account_v8"
@@ -5023,6 +5030,12 @@ dependencies = [
 
 [[package]]
 name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
@@ -5545,9 +5558,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -6143,7 +6156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
+ "libm 0.2.6",
 ]
 
 [[package]]
@@ -6269,6 +6282,16 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.6",
+]
+
+[[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libm 0.1.4",
 ]
 
 [[package]]
@@ -6494,6 +6517,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "polling"
@@ -7373,7 +7402,7 @@ dependencies = [
  "errno",
  "io-lifetimes 1.0.3",
  "libc",
- "linux-raw-sys 0.1.3",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.42.0",
 ]
 
@@ -7979,7 +8008,7 @@ dependencies = [
  "aes-gcm 0.9.4",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.0.0-pre.1",
+ "curve25519-dalek 4.0.0-pre.5",
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
@@ -8568,9 +8597,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]

--- a/blockchain/chain_sync/src/metrics.rs
+++ b/blockchain/chain_sync/src/metrics.rs
@@ -3,7 +3,10 @@
 
 use lazy_static::lazy_static;
 use prometheus::{
-    core::{AtomicU64, GenericCounter, GenericCounterVec, GenericGauge, Opts},
+    core::{
+        AtomicI64, AtomicU64, GenericCounter, GenericCounterVec, GenericGauge, GenericGaugeVec,
+        Opts,
+    },
     Histogram, HistogramOpts, HistogramVec,
 };
 
@@ -154,16 +157,26 @@ lazy_static! {
     };
     pub static ref LAST_VALIDATED_TIPSET_EPOCH: Box<GenericGauge<AtomicU64>> = {
         let last_validated_tipset_epoch = Box::new(
-            GenericGauge::<AtomicU64>::new(
-                "last_validated_tipset_epoch",
-                "Last validated tipset epoch",
-            )
-            .expect("Defining the last_validated_tipset_epoch metric must succeed"),
+            GenericGauge::new("last_validated_tipset_epoch", "Last validated tipset epoch")
+                .expect("Defining the last_validated_tipset_epoch metric must succeed"),
         );
         prometheus::default_registry()
             .register(last_validated_tipset_epoch.clone())
             .expect("Registering the last_validated_tipset_epoch metric with the metrics registry must succeed");
         last_validated_tipset_epoch
+    };
+    pub static ref PEER_TIPSET_EPOCH: Box<GenericGaugeVec<AtomicI64>> = {
+        let peer_tipset_epoch = Box::new(
+            GenericGaugeVec::new(
+                Opts::new("peer_tipset_epoch", "peer tipset epoch"),
+                &["PEER"],
+            )
+            .expect("Defining the peer_tipset_epoch metric must succeed"),
+        );
+        prometheus::default_registry()
+            .register(peer_tipset_epoch.clone())
+            .expect("Registering the last_validated_tipset_epoch metric with the metrics registry must succeed");
+        peer_tipset_epoch
     };
     pub static ref NETWORK_HEAD_EVALUATION_ERRORS: Box<GenericCounter<AtomicU64>> = {
         let network_head_evaluation_errors = Box::new(

--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -248,7 +248,7 @@ where
                         log::debug!("Succeed: handle_chain_exchange_request");
                         result.map_err(|e| e.to_string())?
                     },
-                    _ = wait_all(&mut tasks) => return Err(format!("ChainExchange request failed for all top peers. {} network failures, {} lookup failures", network_failures.load(Ordering::Relaxed), lookup_failures.load(Ordering::Relaxed))),
+                    _ = wait_all(&mut tasks) => return Err(format!("ChainExchange request failed for all top peers. {} network failures, {} lookup failures, request:\n{request:?}", network_failures.load(Ordering::Relaxed), lookup_failures.load(Ordering::Relaxed))),
                 }
             }
         };

--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -26,8 +26,8 @@ use tokio::{task::JoinSet, time::timeout};
 /// Timeout for response from an RPC request
 // TODO this value can be tweaked, this is just set pretty low to avoid peers timing out
 // requests from slowing the node down. If increase, should create a countermeasure for this.
-const BITSWAP_TIMEOUT: Duration = Duration::from_secs(30);
-const CHAIN_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
+const BITSWAP_TIMEOUT: Duration = Duration::from_secs(5);
+const CHAIN_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Maximum number of concurrent chain exchange request being sent to the network
 const MAX_CONCURRENT_CHAIN_EXCHANGE_REQUESTS: usize = 2;

--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -26,7 +26,8 @@ use tokio::{task::JoinSet, time::timeout};
 /// Timeout for response from an RPC request
 // TODO this value can be tweaked, this is just set pretty low to avoid peers timing out
 // requests from slowing the node down. If increase, should create a countermeasure for this.
-const RPC_TIMEOUT: u64 = 5;
+const BITSWAP_TIMEOUT: Duration = Duration::from_secs(30);
+const CHAIN_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Maximum number of concurrent chain exchange request being sent to the network
 const MAX_CONCURRENT_CHAIN_EXCHANGE_REQUESTS: usize = 2;
@@ -136,7 +137,7 @@ where
             })
             .await
             .map_err(|_| "failed to send bitswap request, network receiver dropped")?;
-        let res = timeout(Duration::from_secs(RPC_TIMEOUT), rx).await;
+        let res = timeout(BITSWAP_TIMEOUT, rx).await;
         match res {
             Ok(Ok(())) => {
                 match self.db.get_obj(&content) {
@@ -289,7 +290,7 @@ where
 
         // Add timeout to receiving response from p2p service to avoid stalling.
         // There is also a timeout inside the request-response calls, but this ensures this.
-        let res = timeout(Duration::from_secs(RPC_TIMEOUT), rx).await;
+        let res = timeout(CHAIN_EXCHANGE_TIMEOUT, rx).await;
         let res_duration = SystemTime::now()
             .duration_since(req_pre_time)
             .unwrap_or_default();

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -1076,7 +1076,7 @@ async fn sync_messages_check_state<
     invalid_block_strategy: InvalidBlockStrategy,
 ) -> Result<(), TipsetRangeSyncerError<C>> {
     // Sync the messages for one or many tipsets @ a time
-    const REQUEST_WINDOW: usize = 8;
+    const REQUEST_WINDOW: usize = 4;
 
     let task_chainstore = chainstore.clone();
 

--- a/node/forest_libp2p/src/rpc/decoder.rs
+++ b/node/forest_libp2p/src/rpc/decoder.rs
@@ -42,7 +42,8 @@ where
     type Output = io::Result<T>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let mut buf = [0u8; 1024];
+        // https://github.com/mxinden/asynchronous-codec/blob/master/src/framed_read.rs#L161
+        let mut buf = [0u8; 8 * 1024];
         loop {
             let n = std::task::ready!(Pin::new(&mut self.io).poll_read(cx, &mut buf))?;
             // Terminated

--- a/node/forest_libp2p/src/rpc/decoder.rs
+++ b/node/forest_libp2p/src/rpc/decoder.rs
@@ -3,6 +3,7 @@
 
 use bytes::BytesMut;
 use futures::prelude::*;
+use log::warn;
 use pin_project_lite::pin_project;
 use std::io;
 use std::marker::PhantomData;
@@ -54,13 +55,15 @@ where
             }
             self.bytes_read += n;
             if self.max_bytes_allowed > 0 && self.bytes_read > self.max_bytes_allowed {
-                return Poll::Ready(Err(io::Error::new(
+                let err = io::Error::new(
                     io::ErrorKind::Other,
                     format!(
                         "Buffer size exceeds the maximum allowed {}B",
                         self.max_bytes_allowed,
                     ),
-                )));
+                );
+                warn!("{err}");
+                return Poll::Ready(Err(err));
             }
             self.bytes.extend_from_slice(&buf[..n.min(buf.len())]);
             // This is what `FramedRead` does internally

--- a/node/forest_libp2p/src/rpc/mod.rs
+++ b/node/forest_libp2p/src/rpc/mod.rs
@@ -127,7 +127,7 @@ where
     IO: AsyncRead + Unpin,
     T: serde::de::DeserializeOwned,
 {
-    const MAX_BYTES_ALLOWED: usize = 2 * 1024 * 1024; // messages over 2MB are likely malicious
+    const MAX_BYTES_ALLOWED: usize = 20 * 1024 * 1024; // messages over 20MB are likely malicious
     const TIMEOUT: Duration = Duration::from_secs(30);
 
     // Currently the protocol does not send length encoded message,

--- a/node/forest_libp2p/src/rpc/mod.rs
+++ b/node/forest_libp2p/src/rpc/mod.rs
@@ -127,7 +127,9 @@ where
     IO: AsyncRead + Unpin,
     T: serde::de::DeserializeOwned,
 {
-    const MAX_BYTES_ALLOWED: usize = 20 * 1024 * 1024; // messages over 20MB are likely malicious
+    // FIXME: investigate the best value here, 2MB is not enough for mainnet epoch 2419928
+    // Issue: https://github.com/ChainSafe/forest/issues/2362
+    const MAX_BYTES_ALLOWED: usize = 200 * 1024 * 1024; // messages over 200MB are likely malicious
     const TIMEOUT: Duration = Duration::from_secs(30);
 
     // Currently the protocol does not send length encoded message,

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -560,7 +560,7 @@ async fn handle_hello_event<P: StoreParams>(
                 // Send the sucessful response through channel out.
                 if let Some(tx) = hello_request_table.remove(&request_id) {
                     if tx.send(Ok(response)).is_err() {
-                        warn!("RPCResponse receive timed out");
+                        warn!("Fail to send Hello response");
                     } else {
                         emit_event(
                             network_sender_out,
@@ -729,7 +729,7 @@ async fn handle_chain_exchange_event<DB, P: StoreParams>(
                     // Send the sucessful response through channel out.
                     if let Some(tx) = tx {
                         if tx.send(Ok(response)).is_err() {
-                            warn!("RPCResponse receive timed out")
+                            warn!("Fail to send ChainExchange response")
                         }
                     } else {
                         warn!("RPCResponse receive failed: channel not found");

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -74,6 +74,7 @@ pub enum NetworkEvent {
     },
     HelloRequestInbound {
         source: PeerId,
+        request: HelloRequest,
     },
     HelloResponseOutbound {
         source: PeerId,
@@ -504,7 +505,10 @@ async fn handle_hello_event<P: StoreParams>(
             } => {
                 emit_event(
                     network_sender_out,
-                    NetworkEvent::HelloRequestInbound { source: peer },
+                    NetworkEvent::HelloRequestInbound {
+                        source: peer,
+                        request: request.clone(),
+                    },
                 )
                 .await;
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Relax chain exchange message size limit to 200MB (which is the root cause of https://github.com/ChainSafe/forest/issues/2362)
- Improve chain exchange error messages
- Add peer tipset epoch to metrics
- Reduce chain exchange batch size for message lookup to reduce bundled message size.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes Related to https://github.com/ChainSafe/forest/issues/2244 and https://github.com/ChainSafe/forest/issues/2362


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->