### PR TITLE
Use builtin actors serde for Policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,7 +3540,6 @@ dependencies = [
  "anyhow",
  "fil_actors_runtime_v9",
  "forest_beacon",
- "forest_json",
  "fvm_shared",
  "serde",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,7 +3543,6 @@ dependencies = [
  "forest_json",
  "fvm_shared",
  "serde",
- "serde_json",
  "toml",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,7 @@ checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
 [[package]]
 name = "fil_actor_account_v8"
 version = "8.0.0"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "fil_actors_runtime_v8",
  "fvm_ipld_blockstore",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_account_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "fil_actors_runtime_v9",
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_cron_v8"
 version = "8.0.0"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "fil_actors_runtime_v8",
  "fvm_ipld_blockstore",
@@ -2289,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_cron_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "fil_actors_runtime_v9",
  "fvm_ipld_blockstore",
@@ -2304,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_init_v8"
 version = "8.0.0"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "cid",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_init_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "cid",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_market_v8"
 version = "8.0.0"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "cid",
@@ -2360,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_market_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "cid",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_miner_v8"
 version = "8.0.0"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_miner_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_multisig_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "cid",
@@ -2452,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_power_v8"
 version = "8.0.0"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "cid",
@@ -2472,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_power_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "cid",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_reward_v8"
 version = "8.0.0"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "fil_actors_runtime_v8",
  "fvm_ipld_blockstore",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_reward_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "fil_actors_runtime_v9",
  "fvm_ipld_blockstore",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_system_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "cid",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime_v8"
 version = "8.0.0"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "base64",
@@ -2574,7 +2574,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime_v9"
 version = "9.0.3"
-source = "git+https://github.com/ChainSafe/fil-actor-states#9aa6d6e3675ea43a33e6341008cde9f3275c4e64"
+source = "git+https://github.com/ChainSafe/fil-actor-states#942818b811f2400059707c77754ca02e8443b514"
 dependencies = [
  "anyhow",
  "base64",
@@ -2590,6 +2590,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "multihash",
+ "num",
  "num-derive",
  "num-traits",
  "paste",
@@ -6094,6 +6095,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6103,6 +6118,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "quickcheck",
+ "serde",
 ]
 
 [[package]]
@@ -6112,6 +6128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -6136,6 +6153,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6145,6 +6173,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/networks/Cargo.toml
+++ b/networks/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 anyhow.workspace = true
 fil_actors_runtime.workspace = true
 forest_beacon.workspace = true
-forest_json.workspace = true
 fvm_shared = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive"] }
 

--- a/networks/Cargo.toml
+++ b/networks/Cargo.toml
@@ -11,7 +11,6 @@ forest_beacon.workspace = true
 forest_json.workspace = true
 fvm_shared = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
 
 [dev-dependencies]
 toml = "0.5"

--- a/networks/src/lib.rs
+++ b/networks/src/lib.rs
@@ -4,11 +4,9 @@
 use fil_actors_runtime::runtime::Policy;
 use forest_beacon::{BeaconPoint, BeaconSchedule, DrandBeacon, DrandConfig};
 use fvm_shared::clock::{ChainEpoch, EPOCH_DURATION_SECONDS};
-use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, StoragePower};
 use fvm_shared::version::NetworkVersion;
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::sync::Arc;
 
 pub mod calibnet;
@@ -108,7 +106,6 @@ pub struct ChainConfig {
     pub block_delay_secs: u64,
     pub height_infos: Vec<HeightInfo>,
     #[serde(default = "default_policy")]
-    #[serde(with = "serde_policy")]
     pub policy: Policy,
 }
 
@@ -191,181 +188,6 @@ impl Default for ChainConfig {
 // XXX: Dummy default. Will be overwritten later. Wish we could get rid of this.
 fn default_policy() -> Policy {
     Policy::mainnet()
-}
-
-mod serde_policy {
-    use crate::*;
-    use forest_json::bigint::json as bigint_json;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    #[derive(Serialize, Deserialize)]
-    struct PolicySerDe {
-        max_aggregated_sectors: u64,
-        min_aggregated_sectors: u64,
-        max_aggregated_proof_size: usize,
-        max_replica_update_proof_size: usize,
-
-        pre_commit_sector_batch_max_size: usize,
-        prove_replica_updates_max_size: usize,
-
-        expired_pre_commit_clean_up_delay: i64,
-
-        wpost_proving_period: ChainEpoch,
-        wpost_challenge_window: ChainEpoch,
-        wpost_period_deadlines: u64,
-        wpost_max_chain_commit_age: ChainEpoch,
-        wpost_dispute_window: ChainEpoch,
-
-        sectors_max: usize,
-        max_partitions_per_deadline: u64,
-        max_control_addresses: usize,
-        max_peer_id_length: usize,
-        max_multiaddr_data: usize,
-        addressed_partitions_max: u64,
-        declarations_max: u64,
-        addressed_sectors_max: u64,
-        max_pre_commit_randomness_lookback: ChainEpoch,
-        pre_commit_challenge_delay: ChainEpoch,
-        wpost_challenge_lookback: ChainEpoch,
-        fault_declaration_cutoff: ChainEpoch,
-        fault_max_age: ChainEpoch,
-        worker_key_change_delay: ChainEpoch,
-        min_sector_expiration: i64,
-        max_sector_expiration_extension: i64,
-        deal_limit_denominator: u64,
-        consensus_fault_ineligibility_duration: ChainEpoch,
-        new_sectors_per_period_max: usize,
-        chain_finality: ChainEpoch,
-        valid_post_proof_type: HashSet<RegisteredPoStProof>,
-        valid_pre_commit_proof_type: HashSet<RegisteredSealProof>,
-        #[serde(with = "bigint_json")]
-        minimum_verified_allocation_size: StoragePower,
-        deal_updates_interval: i64,
-        prov_collateral_percent_supply_num: i64,
-        prov_collateral_percent_supply_denom: i64,
-        #[serde(with = "bigint_json")]
-        minimum_consensus_power: StoragePower,
-        end_of_life_claim_drop_period: ChainEpoch,
-        market_default_allocation_term_buffer: i64,
-        maximum_verified_allocation_expiration: i64,
-        maximum_verified_allocation_term: i64,
-        minimum_verified_allocation_term: i64,
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Policy, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let policy: PolicySerDe = Deserialize::deserialize(deserializer)?;
-        Ok(Policy {
-            max_aggregated_sectors: policy.max_aggregated_sectors,
-            min_aggregated_sectors: policy.min_aggregated_sectors,
-            max_aggregated_proof_size: policy.max_aggregated_proof_size,
-            max_replica_update_proof_size: policy.max_replica_update_proof_size,
-
-            pre_commit_sector_batch_max_size: policy.pre_commit_sector_batch_max_size,
-            prove_replica_updates_max_size: policy.prove_replica_updates_max_size,
-
-            expired_pre_commit_clean_up_delay: policy.expired_pre_commit_clean_up_delay,
-
-            wpost_proving_period: policy.wpost_proving_period,
-            wpost_challenge_window: policy.wpost_challenge_window,
-            wpost_period_deadlines: policy.wpost_period_deadlines,
-            wpost_max_chain_commit_age: policy.wpost_max_chain_commit_age,
-            wpost_dispute_window: policy.wpost_dispute_window,
-
-            sectors_max: policy.sectors_max,
-            max_partitions_per_deadline: policy.max_partitions_per_deadline,
-            max_control_addresses: policy.max_control_addresses,
-            max_peer_id_length: policy.max_peer_id_length,
-            max_multiaddr_data: policy.max_multiaddr_data,
-            addressed_partitions_max: policy.addressed_partitions_max,
-            declarations_max: policy.declarations_max,
-            addressed_sectors_max: policy.addressed_sectors_max,
-            max_pre_commit_randomness_lookback: policy.max_pre_commit_randomness_lookback,
-            pre_commit_challenge_delay: policy.pre_commit_challenge_delay,
-            wpost_challenge_lookback: policy.wpost_challenge_lookback,
-            fault_declaration_cutoff: policy.fault_declaration_cutoff,
-            fault_max_age: policy.fault_max_age,
-            worker_key_change_delay: policy.worker_key_change_delay,
-            min_sector_expiration: policy.min_sector_expiration,
-            max_sector_expiration_extension: policy.max_sector_expiration_extension,
-            deal_limit_denominator: policy.deal_limit_denominator,
-            consensus_fault_ineligibility_duration: policy.consensus_fault_ineligibility_duration,
-            new_sectors_per_period_max: policy.new_sectors_per_period_max,
-            chain_finality: policy.chain_finality,
-            valid_post_proof_type: policy.valid_post_proof_type.clone(),
-            valid_pre_commit_proof_type: policy.valid_pre_commit_proof_type.clone(),
-            minimum_verified_allocation_size: policy.minimum_verified_allocation_size.clone(),
-            deal_updates_interval: policy.deal_updates_interval,
-            prov_collateral_percent_supply_num: policy.prov_collateral_percent_supply_num,
-            prov_collateral_percent_supply_denom: policy.prov_collateral_percent_supply_denom,
-            minimum_consensus_power: policy.minimum_consensus_power,
-
-            end_of_life_claim_drop_period: policy.end_of_life_claim_drop_period,
-            market_default_allocation_term_buffer: policy.market_default_allocation_term_buffer,
-            maximum_verified_allocation_expiration: policy.maximum_verified_allocation_expiration,
-            maximum_verified_allocation_term: policy.maximum_verified_allocation_term,
-            minimum_verified_allocation_term: policy.minimum_verified_allocation_term,
-        })
-    }
-
-    pub fn serialize<S>(policy: &Policy, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        PolicySerDe {
-            max_aggregated_sectors: policy.max_aggregated_sectors,
-            min_aggregated_sectors: policy.min_aggregated_sectors,
-            max_aggregated_proof_size: policy.max_aggregated_proof_size,
-            max_replica_update_proof_size: policy.max_replica_update_proof_size,
-
-            pre_commit_sector_batch_max_size: policy.pre_commit_sector_batch_max_size,
-            prove_replica_updates_max_size: policy.prove_replica_updates_max_size,
-
-            expired_pre_commit_clean_up_delay: policy.expired_pre_commit_clean_up_delay,
-
-            wpost_proving_period: policy.wpost_proving_period,
-            wpost_challenge_window: policy.wpost_challenge_window,
-            wpost_period_deadlines: policy.wpost_period_deadlines,
-            wpost_max_chain_commit_age: policy.wpost_max_chain_commit_age,
-            wpost_dispute_window: policy.wpost_dispute_window,
-
-            sectors_max: policy.sectors_max,
-            max_partitions_per_deadline: policy.max_partitions_per_deadline,
-            max_control_addresses: policy.max_control_addresses,
-            max_peer_id_length: policy.max_peer_id_length,
-            max_multiaddr_data: policy.max_multiaddr_data,
-            addressed_partitions_max: policy.addressed_partitions_max,
-            declarations_max: policy.declarations_max,
-            addressed_sectors_max: policy.addressed_sectors_max,
-            max_pre_commit_randomness_lookback: policy.max_pre_commit_randomness_lookback,
-            pre_commit_challenge_delay: policy.pre_commit_challenge_delay,
-            wpost_challenge_lookback: policy.wpost_challenge_lookback,
-            fault_declaration_cutoff: policy.fault_declaration_cutoff,
-            fault_max_age: policy.fault_max_age,
-            worker_key_change_delay: policy.worker_key_change_delay,
-            min_sector_expiration: policy.min_sector_expiration,
-            max_sector_expiration_extension: policy.max_sector_expiration_extension,
-            deal_limit_denominator: policy.deal_limit_denominator,
-            consensus_fault_ineligibility_duration: policy.consensus_fault_ineligibility_duration,
-            new_sectors_per_period_max: policy.new_sectors_per_period_max,
-            chain_finality: policy.chain_finality,
-            valid_post_proof_type: policy.valid_post_proof_type.clone(),
-            valid_pre_commit_proof_type: policy.valid_pre_commit_proof_type.clone(),
-            minimum_verified_allocation_size: policy.minimum_verified_allocation_size.clone(),
-            deal_updates_interval: policy.deal_updates_interval,
-            prov_collateral_percent_supply_num: policy.prov_collateral_percent_supply_num,
-            prov_collateral_percent_supply_denom: policy.prov_collateral_percent_supply_denom,
-            minimum_consensus_power: policy.minimum_consensus_power.clone(),
-            end_of_life_claim_drop_period: policy.end_of_life_claim_drop_period,
-            market_default_allocation_term_buffer: policy.market_default_allocation_term_buffer,
-            maximum_verified_allocation_expiration: policy.maximum_verified_allocation_expiration,
-            maximum_verified_allocation_term: policy.maximum_verified_allocation_term,
-            minimum_verified_allocation_term: policy.minimum_verified_allocation_term,
-        }
-        .serialize(serializer)
-    }
 }
 
 pub fn default_network_version() -> NetworkVersion {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Policy from builtin-actors is now `Serialize/Deserialize`. No need to re-implement the fields.

:warning: it's a breaking change if you used `config dump` to generate your configuration - for BigInt fields, the serializer is slightly different.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->

**Other information and links**
<!-- Add any other context about the pull request here. -->
https://github.com/ChainSafe/fil-actor-states/issues/2


<!-- Thank you 🔥 -->