### PR TITLE
fix: exclude twitter from the link-checker

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Link Checker (Repo)
         uses: lycheeverse/lychee-action@v1.5.4
         with:
-          args: --verbose --timeout 60 --no-progress 'README.md'
+          args: --verbose --timeout 60 --exclude twitter.com --no-progress 'README.md'
           # Fail action on broken links
           fail: true
       - uses: hanabi1224/cache-cargo-bin-action@v1.0.0


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Twitter has started to timeout more often than not. Let's exclude it. Checking twitter links is not too important.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->