### PR TITLE
chore: move peer manager to libp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d47fbf90d5149a107494b15a7dc8d69b351be2db3bb9691740e88ec17fd880"
+checksum = "b0224938f92e7aef515fac2ff2d18bd1115c1394ddf4a092e0c87e8be9499ee5"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -571,7 +571,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.30.0",
+ "object 0.30.1",
  "rustc-demangle",
 ]
 
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a16495aeb28047bb1185fca837baf755e7d71ed3aeed7f8504654ffa927208"
+checksum = "cf460bbff5f571bfc762da5102729f59f338be7db17a21fade44c5c4f5005350"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3043,7 +3043,6 @@ dependencies = [
  "prometheus",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.8.5",
  "serde",
  "serde_json",
  "smallvec",
@@ -3447,6 +3446,7 @@ dependencies = [
  "fvm_ipld_car",
  "fvm_ipld_encoding 0.2.3",
  "fvm_shared",
+ "lazy_static",
  "libipld",
  "libp2p",
  "libp2p-bitswap",
@@ -3456,6 +3456,7 @@ dependencies = [
  "prometheus",
  "quickcheck",
  "quickcheck_macros",
+ "rand 0.8.5",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -6222,9 +6223,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
+checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
 dependencies = [
  "memchr",
 ]
@@ -6695,9 +6696,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8992a85d8e93a28bdf76137db888d3874e3b230dee5ed8bebac4c9f7617773"
+checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -8574,9 +8575,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "7125661431c26622a80ca5051a2f936c9a678318e0351007b0cc313143024e5c"
 dependencies = [
  "autocfg",
  "bytes 1.3.0",

--- a/blockchain/chain_sync/Cargo.toml
+++ b/blockchain/chain_sync/Cargo.toml
@@ -39,7 +39,6 @@ num-bigint.workspace = true
 num-traits.workspace = true
 prometheus = { workspace = true, features = ["process"] }
 quickcheck.workspace = true
-rand.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 smallvec.workspace = true
 thiserror.workspace = true

--- a/blockchain/chain_sync/src/lib.rs
+++ b/blockchain/chain_sync/src/lib.rs
@@ -8,7 +8,6 @@ mod chain_muxer;
 pub mod consensus;
 mod metrics;
 mod network_context;
-mod peer_manager;
 mod sync_state;
 mod tipset_syncer;
 mod validation;

--- a/blockchain/chain_sync/src/metrics.rs
+++ b/blockchain/chain_sync/src/metrics.rs
@@ -114,47 +114,6 @@ lazy_static! {
             .expect("Registering the head_epoch metric with the metrics registry must succeed");
         head_epoch
     };
-    pub static ref PEER_FAILURE_TOTAL: Box<GenericCounter<AtomicU64>> = {
-        let peer_failure_total = Box::new(
-            GenericCounter::<AtomicU64>::new(
-                "peer_failure_total",
-                "Total number of failed peer requests",
-            )
-            .expect("Defining the peer_failure_total metric must succeed"),
-        );
-        prometheus::default_registry()
-            .register(peer_failure_total.clone())
-            .expect(
-                "Registering the peer_failure_total metric with the metrics registry must succeed",
-            );
-        peer_failure_total
-    };
-    pub static ref FULL_PEERS: Box<GenericGauge<AtomicU64>> = {
-        let full_peers = Box::new(
-            GenericGauge::<AtomicU64>::new(
-                "full_peers",
-                "Number of healthy peers recognized by the node",
-            )
-            .expect("Defining the full_peers metric must succeed"),
-        );
-        prometheus::default_registry()
-            .register(full_peers.clone())
-            .expect("Registering the full_peers metric with the metrics registry must succeed");
-        full_peers
-    };
-    pub static ref BAD_PEERS: Box<GenericGauge<AtomicU64>> = {
-        let bad_peers = Box::new(
-            GenericGauge::<AtomicU64>::new(
-                "bad_peers",
-                "Number of bad peers recognized by the node",
-            )
-            .expect("Defining the bad_peers metric must succeed"),
-        );
-        prometheus::default_registry()
-            .register(bad_peers.clone())
-            .expect("Registering the bad_peers metric with the metrics registry must succeed");
-        bad_peers
-    };
     pub static ref LAST_VALIDATED_TIPSET_EPOCH: Box<GenericGauge<AtomicU64>> = {
         let last_validated_tipset_epoch = Box::new(
             GenericGauge::new("last_validated_tipset_epoch", "Last validated tipset epoch")
@@ -290,9 +249,6 @@ mod tests {
         test_counter!(INVALID_TIPSET_TOTAL);
         test_counter!(TIPSET_RANGE_SYNC_FAILURE_TOTAL);
         test_counter!(HEAD_EPOCH);
-        test_counter!(PEER_FAILURE_TOTAL);
-        test_counter!(FULL_PEERS);
-        test_counter!(BAD_PEERS);
         test_counter!(LAST_VALIDATED_TIPSET_EPOCH);
         test_counter!(NETWORK_HEAD_EVALUATION_ERRORS);
         test_counter!(BOOTSTRAP_ERRORS);

--- a/blockchain/chain_sync/src/network_context.rs
+++ b/blockchain/chain_sync/src/network_context.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use super::peer_manager::PeerManager;
 use cid::Cid;
 use forest_blocks::{FullTipset, Tipset, TipsetKeys};
 use forest_encoding::de::DeserializeOwned;
@@ -12,7 +11,7 @@ use forest_libp2p::{
     },
     hello::{HelloRequest, HelloResponse},
     rpc::RequestResponseError,
-    NetworkMessage, PeerId,
+    NetworkMessage, PeerId, PeerManager,
 };
 use forest_utils::db::BlockstoreExt;
 use futures::channel::oneshot::channel as oneshot_channel;

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -25,6 +25,7 @@ fvm_ipld_blockstore.workspace = true
 fvm_ipld_car.workspace = true
 fvm_ipld_encoding.workspace = true
 fvm_shared = { workspace = true, default-features = false, features = ["testing"] }
+lazy_static.workspace = true
 libipld.workspace = true
 libp2p = { workspace = true, default-features = false, features = [
   "gossipsub",
@@ -48,6 +49,7 @@ multihash = { workspace = true, default-features = false, features = ["std", "mu
 pin-project-lite.workspace = true
 prometheus.workspace = true
 quickcheck.workspace = true
+rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_ipld_dagcbor.workspace = true
 serde_json.workspace = true

--- a/node/forest_libp2p/src/lib.rs
+++ b/node/forest_libp2p/src/lib.rs
@@ -9,11 +9,14 @@ mod config;
 mod discovery;
 mod gossip_params;
 pub mod hello;
+mod metrics;
+mod peer_manager;
 pub mod rpc;
 mod service;
 
 pub(crate) use self::behaviour::*;
 pub use self::config::*;
+pub use self::peer_manager::*;
 pub use self::service::*;
 
 // Re-export some libp2p types

--- a/node/forest_libp2p/src/metrics.rs
+++ b/node/forest_libp2p/src/metrics.rs
@@ -1,0 +1,49 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use lazy_static::lazy_static;
+use prometheus::core::{AtomicU64, GenericCounter, GenericGauge};
+
+lazy_static! {
+    pub static ref PEER_FAILURE_TOTAL: Box<GenericCounter<AtomicU64>> = {
+        let peer_failure_total = Box::new(
+            GenericCounter::<AtomicU64>::new(
+                "peer_failure_total",
+                "Total number of failed peer requests",
+            )
+            .expect("Defining the peer_failure_total metric must succeed"),
+        );
+        prometheus::default_registry()
+            .register(peer_failure_total.clone())
+            .expect(
+                "Registering the peer_failure_total metric with the metrics registry must succeed",
+            );
+        peer_failure_total
+    };
+    pub static ref FULL_PEERS: Box<GenericGauge<AtomicU64>> = {
+        let full_peers = Box::new(
+            GenericGauge::<AtomicU64>::new(
+                "full_peers",
+                "Number of healthy peers recognized by the node",
+            )
+            .expect("Defining the full_peers metric must succeed"),
+        );
+        prometheus::default_registry()
+            .register(full_peers.clone())
+            .expect("Registering the full_peers metric with the metrics registry must succeed");
+        full_peers
+    };
+    pub static ref BAD_PEERS: Box<GenericGauge<AtomicU64>> = {
+        let bad_peers = Box::new(
+            GenericGauge::<AtomicU64>::new(
+                "bad_peers",
+                "Number of bad peers recognized by the node",
+            )
+            .expect("Defining the bad_peers metric must succeed"),
+        );
+        prometheus::default_registry()
+            .register(bad_peers.clone())
+            .expect("Registering the bad_peers metric with the metrics registry must succeed");
+        bad_peers
+    };
+}

--- a/node/forest_libp2p/src/peer_manager.rs
+++ b/node/forest_libp2p/src/peer_manager.rs
@@ -1,18 +1,16 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use crate::*;
+use forest_blocks::Tipset;
+use log::{debug, trace};
+use rand::seq::SliceRandom;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{cmp::Ordering, collections::HashSet};
-
-use forest_blocks::Tipset;
-use forest_libp2p::PeerId;
-use log::{debug, trace};
-use rand::seq::SliceRandom;
 use tokio::sync::RwLock;
 
-use crate::metrics;
 /// New peer multiplier slightly less than 1 to incentivize choosing new peers.
 const NEW_PEER_MUL: f64 = 0.9;
 
@@ -60,7 +58,7 @@ struct PeerSets {
 
 /// Thread safe peer manager which handles peer management for the `ChainExchange` protocol.
 #[derive(Default)]
-pub(crate) struct PeerManager {
+pub struct PeerManager {
     /// Full and bad peer sets.
     peers: RwLock<PeerSets>,
     /// Average response time from peers.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- move peer manager to libp2p

Unblocks https://github.com/ChainSafe/forest/issues/2391


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2392


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->