### PR TITLE
fix: `scanning blockchain` progress bar never hits 100% when using checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Notable updates:
 
 ### Removed
 
+### Fixed
+* [console ui] `Scanning Blockchain` progess bar never hits 100% during snapshot import. [2403](https://github.com/ChainSafe/forest/pull/2403)
+
 ## Forest v0.6.0 (2023-01-06)
 
 Notable updates:

--- a/blockchain/chain/src/store/index.rs
+++ b/blockchain/chain/src/store/index.rs
@@ -191,12 +191,13 @@ impl<BS: Blockstore> ChainIndex<BS> {
                 self.fill_cache(std::mem::take(&mut cur)).await?
             };
 
-            if let Some(genesis_tipset_keys) =
-                checkpoint_tipsets::genesis_from_checkpoint_tipset(lbe.tipset.key())
-            {
-                if to == 0 {
+            if to == 0 {
+                if let Some(genesis_tipset_keys) =
+                    checkpoint_tipsets::genesis_from_checkpoint_tipset(lbe.tipset.key())
+                {
                     let tipset =
                         tipset_from_keys(&self.ts_cache, &self.db, &genesis_tipset_keys).await?;
+                    pb.set(total_size as u64);
                     info!(
                         "Resolving genesis using checkpoint tipset at height: {}",
                         lbe.tipset.epoch()


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- Fix an issue that `Scanning blockchain` progress bar never hit 100% when checkpoints are used during snapshot import, looks confusing


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2404


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
