### PR TITLE
chore: get rid of async in lookback queries

### DIFF
--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -1269,7 +1269,6 @@ async fn validate_block<DB: Blockstore + Store + Clone + Sync + Send + 'static, 
     // Retrieve lookback tipset for validation
     let lookback_state = state_manager
         .get_lookback_tipset_for_round(base_tipset.clone(), block.header().epoch())
-        .await
         .map_err(|e| (*block_cid, e.into()))
         .map(|(_, s)| Arc::new(s))?;
 

--- a/blockchain/consensus/fil_cns/src/validation.rs
+++ b/blockchain/consensus/fil_cns/src/validation.rs
@@ -66,7 +66,6 @@ pub(crate) async fn validate_block<
     // Retrieve lookback tipset for validation
     let (lookback_tipset, lookback_state) = state_manager
         .get_lookback_tipset_for_round(base_tipset.clone(), block.header().epoch())
-        .await
         .map_err(to_errs)?;
 
     let lookback_state = Arc::new(lookback_state);

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -1233,16 +1233,12 @@ where
 fn chain_epoch_root<DB>(
     sm: Arc<StateManager<DB>>,
     tipset: Arc<Tipset>,
-) -> Box<dyn Fn(ChainEpoch) -> Cid>
+) -> Box<dyn Fn(ChainEpoch) -> anyhow::Result<Cid>>
 where
-    // Yes, both are needed, because the VM should only use the buffered store
     DB: Blockstore + Store + Clone + Send + Sync + 'static,
 {
     Box::new(move |round| {
-        let (_, st) =
-            (sm.get_lookback_tipset_for_round(tipset.clone(), round)).unwrap_or_else(|err| {
-                panic!("Internal Error. Failed to find root CID for epoch {round}: {err}")
-            });
-        st
+        let (_, st) = sm.get_lookback_tipset_for_round(tipset.clone(), round)?;
+        Ok(st)
     })
 }

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -43,7 +43,6 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use tokio::runtime::Handle;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::RwLock;
@@ -380,11 +379,7 @@ where
                 self.genesis_info
                     .get_circulating_supply(epoch, &db, &state_root)?,
                 self.reward_calc.clone(),
-                chain_epoch_root(
-                    Arc::clone(self),
-                    Arc::clone(tipset),
-                    tokio::runtime::Handle::current(),
-                ),
+                chain_epoch_root(Arc::clone(self), Arc::clone(tipset)),
                 &self.engine,
                 Arc::clone(self.chain_config()),
             )
@@ -473,11 +468,7 @@ where
             self.genesis_info
                 .get_circulating_supply(bheight, self.blockstore(), bstate)?,
             self.reward_calc.clone(),
-            chain_epoch_root(
-                Arc::clone(self),
-                Arc::clone(tipset),
-                tokio::runtime::Handle::current(),
-            ),
+            chain_epoch_root(Arc::clone(self), Arc::clone(tipset)),
             &self.engine,
             Arc::clone(self.chain_config()),
         )?;
@@ -549,7 +540,6 @@ where
         let store = self.blockstore().clone();
         // Since we're simulating a future message, pretend we're applying it in the "next" tipset
         let epoch = ts.epoch() + 1;
-        let async_handle = tokio::runtime::Handle::current();
         let mut vm = VM::new(
             st,
             store,
@@ -559,7 +549,7 @@ where
             self.genesis_info
                 .get_circulating_supply(epoch, self.blockstore(), &st)?,
             self.reward_calc.clone(),
-            chain_epoch_root(Arc::clone(self), Arc::clone(&ts), async_handle),
+            chain_epoch_root(Arc::clone(self), Arc::clone(&ts)),
             &self.engine,
             Arc::clone(self.chain_config()),
         )?;
@@ -624,7 +614,12 @@ where
     }
 
     /// Gets look-back tipset for block validations.
-    pub async fn get_lookback_tipset_for_round(
+    ///
+    /// The look-back tipset for a round is the tipset with epoch `round - chain_finality`.
+    /// Chain finality is usually 900. The given is a reference point in the
+    /// blockchain such that the look-back tipset can be found by tracing the
+    /// `parent` pointers.
+    pub fn get_lookback_tipset_for_round(
         self: &Arc<Self>,
         tipset: Arc<Tipset>,
         round: ChainEpoch,
@@ -639,11 +634,10 @@ where
 
         // More null blocks than lookback
         if lbr >= tipset.epoch() {
-            let (st, _) = self
-                .tipset_state(&tipset)
-                .await
-                .map_err(|e| Error::Other(format!("Could execute tipset_state {e:?}")))?;
-            return Ok((tipset, st));
+            // This is not allowed to happen after network V3.
+            return Err(Error::Other(
+                "Failed to find look-back tipset: Unexpected number of null blocks.".to_string(),
+            ));
         }
 
         let next_ts = self
@@ -1239,20 +1233,16 @@ where
 fn chain_epoch_root<DB>(
     sm: Arc<StateManager<DB>>,
     tipset: Arc<Tipset>,
-    async_handle: Handle,
 ) -> Box<dyn Fn(ChainEpoch) -> Cid>
 where
     // Yes, both are needed, because the VM should only use the buffered store
     DB: Blockstore + Store + Clone + Send + Sync + 'static,
 {
     Box::new(move |round| {
-        let (_, st) = tokio::task::block_in_place(|| {
-            async_handle
-                .block_on(sm.get_lookback_tipset_for_round(tipset.clone(), round))
-                .unwrap_or_else(|err| {
-                    panic!("Internal Error. Failed to find root CID for epoch {round}: {err}")
-                })
-        });
+        let (_, st) =
+            (sm.get_lookback_tipset_for_round(tipset.clone(), round)).unwrap_or_else(|err| {
+                panic!("Internal Error. Failed to find root CID for epoch {round}: {err}")
+            });
         st
     })
 }

--- a/vm/interpreter/src/fvm.rs
+++ b/vm/interpreter/src/fvm.rs
@@ -23,7 +23,7 @@ pub struct ForestExterns<DB> {
     rand: Box<dyn Rand>,
     epoch: ChainEpoch,
     root: Cid,
-    lookback: Box<dyn Fn(ChainEpoch) -> Cid>,
+    lookback: Box<dyn Fn(ChainEpoch) -> anyhow::Result<Cid>>,
     db: DB,
     chain_config: Arc<ChainConfig>,
 }
@@ -33,7 +33,7 @@ impl<DB: Blockstore> ForestExterns<DB> {
         rand: impl Rand + 'static,
         epoch: ChainEpoch,
         root: Cid,
-        lookback: Box<dyn Fn(ChainEpoch) -> Cid>,
+        lookback: Box<dyn Fn(ChainEpoch) -> anyhow::Result<Cid>>,
         db: DB,
         chain_config: Arc<ChainConfig>,
     ) -> Self {
@@ -60,7 +60,7 @@ impl<DB: Blockstore> ForestExterns<DB> {
             );
         }
 
-        let prev_root = (self.lookback)(height);
+        let prev_root = (self.lookback)(height)?;
         let lb_state = StateTree::new_from_root(&self.db, &prev_root)?;
 
         let actor = lb_state

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -77,7 +77,7 @@ where
         base_fee: TokenAmount,
         circ_supply: TokenAmount,
         reward_calc: Arc<dyn RewardCalc>,
-        lb_fn: Box<dyn Fn(ChainEpoch) -> Cid>,
+        lb_fn: Box<dyn Fn(ChainEpoch) -> anyhow::Result<Cid>>,
         multi_engine: &MultiEngine,
         chain_config: Arc<ChainConfig>,
     ) -> Result<Self, anyhow::Error> {


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- Lookback queries should never execute tipset messages. This also means that lookback queries aren't async.
- Propagate errors from lookback queries.

## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
