### PR TITLE
Fix Docker tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ github.ref == 'refs/heads/main' }}
- 
       - name: List docker images
         run: docker image ls
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ github.ref == 'refs/heads/main' }}
-      
+ 
       - name: List docker images
         run: docker image ls
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,43 +33,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compute labels
-        id: labels
-        run: |
-          # We would like to tag docker images with three labels:
-          #  - latest
-          #  - {git tag}, eg v0.5.0
-          #  - {date-sha}, eg 2022-12-15-6a935b9ee
-
-          # github context: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-
-          # If the workflow is triggered by a tag, use it as a label. Otherwise add a superfluous `latest` label.
-          if [ ${{ github.ref_type == 'tag' }} ]
-          then
-            REF=$(echo "${{ github.ref_name }}" | sed 's/\//_/g')
-          else
-            REF=latest
-          fi
-
-          # Date format is ISO 8601, eg 2022-01-26T19:14:43Z.
-          # Taking the first 10 characters yields: 2022-01-26
-          DATE=$(echo "${{ github.event.repository.updated_at }}" | head -c 10)
-
-          echo "ref=$REF" >> $GITHUB_OUTPUT
-          echo "date=$DATE" >> $GITHUB_OUTPUT
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      # This step yields the following labels
+      # - latest,
+      # - date+sha, e.g. 2023-01-19-da4692d,
+      # - tag (if pushed).
+      - name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/chainsafe/forest
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{date 'YYYY-MM-DD'}}-{{sha}}
+            type=ref,event=tag
 
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v3
         with:
-          context: .
-          tags: |
-            ghcr.io/chainsafe/forest:latest
-            ghcr.io/chainsafe/forest:${{ steps.labels.outputs.date }}-${{ steps.labels.outputs.sha_short }}
-            ghcr.io/chainsafe/forest:${{ steps.labels.outputs.ref }}
-          # build on feature branches, push only on main branch
+          tags: ${{ steps.meta.outputs.tags }}
           push: ${{ github.ref == 'refs/heads/main' }}
-
+      
       - name: List docker images
         run: docker image ls
 


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- refactored the tag generation with the use of [metadata-action](https://github.com/docker/metadata-action). It should fix the issue where we pushed a `main` tag, and there were no release tags to be found.

Sample tags:
```
ghcr.io/chainsafe/forest   2023-01-19-da4692d   ade78d8de9c6   1 second ago   220MB
ghcr.io/chainsafe/forest   latest               ade78d8de9c6   1 second ago   220MB
ghcr.io/chainsafe/forest   test-tag             ade78d8de9c6   1 second ago   220MB
```

## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
