### PR TITLE
chore: upgrade rust toolchain to 1.69.0-nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-12-15"
+channel = "nightly-2023-01-30"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = []

--- a/utils/forest_utils/src/io/progress_bar.rs
+++ b/utils/forest_utils/src/io/progress_bar.rs
@@ -10,16 +10,12 @@ pub use pbr::Units;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum ProgressBarVisibility {
     Always,
+    #[default]
     Auto,
     Never,
-}
-
-impl Default for ProgressBarVisibility {
-    fn default() -> Self {
-        ProgressBarVisibility::Auto
-    }
 }
 
 impl FromStr for ProgressBarVisibility {


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- upgrade rust toolchain to 1.69.0-nightly (e972bc808 2023-01-29)
- all code changes come from `cargo clippy --fix` and `cargo fmt`


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->
Rust 1.67.0 has been released on 26 January, 2023 https://releases.rs/docs/1.67.0/

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
