### PR TITLE
fix: no cargo-quickinstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,14 @@ install-deps:
 	apt-get install --no-install-recommends -y build-essential clang protobuf-compiler ocl-icd-opencl-dev aria2 cmake
 
 install-lint-tools:
-	cargo install cargo-quickinstall
-	cargo quickinstall taplo-cli
-	cargo quickinstall cargo-audit
-	cargo quickinstall cargo-spellcheck
-	cargo quickinstall cargo-udeps
+	cargo install --locked taplo-cli
+	cargo install --locked cargo-audit
+	cargo install --locked cargo-spellcheck
+	cargo install --locked cargo-udeps
 
 install-doc-tools:
-	cargo install cargo-quickinstall
-	cargo quickinstall mdbook
-	cargo quickinstall mdbook-linkcheck
+	cargo install --locked mdbook
+	cargo install --locked mdbook-linkcheck
 
 clean-all:
 	cargo clean


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- Switch back to `cargo install`

`cargo-quickinstall v0.2.8` does not work with the `cache-cargo-bin` action and give `mdbook`, `taplo` not found errors, detailed explanations in slack.

A quick local repro:
```
cargo install cargo-quickinstall
cargo quickinstall mdbook
rm ~/.cargo/bin/mdbook
cargo quickinstall mdbook
which mdbook
```


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
