### PR TITLE
Unify metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "forest_actor_interface"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "forest_auth"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "forest_key_management",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "forest_beacon"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "forest_blocks"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "base64 0.21.0",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "forest_chain"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "forest_chain_sync"
-version = "0.2.1"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "forest_cli_shared"
-version = "0.4.1"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "forest_db"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "forest_deleg_cns"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "forest_encoding"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "forest_fil_cns"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "forest_fil_types"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "filecoin-proofs-api",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "forest_genesis"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "forest_interpreter"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "forest_ipld"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "forest_json"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "arbitrary",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "forest_key_management"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "forest_legacy_ipld_amt"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "forest_libp2p"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "forest_libp2p_bitswap"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "forest_message"
-version = "0.8.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "forest_message_pool"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "forest_metrics"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "forest_networks"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "fil_actors_runtime_v9",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "forest_paramfetch"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "forest_rpc"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "forest_rpc-api"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "forest_rpc-client"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "forest_libp2p",
  "forest_rpc-api",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "forest_shim"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "fvm_shared 2.0.0",
  "fvm_shared 3.0.0-alpha.17",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "forest_state_manager"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "forest_state_migration"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "cid",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "forest_statediff"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "forest_test_utils"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.21.0",
  "cid",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "forest_utils"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7775,7 +7775,7 @@ dependencies = [
 
 [[package]]
 name = "serialization_tests"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.21.0",
  "bls-signatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
+[workspace.package]
+version = "0.6.0"
+authors = ["ChainSafe Systems <info@chainsafe.io>"]
+repository = "https://github.com/ChainSafe/forest"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
 [workspace]
 members = [
   "forest/cli",

--- a/blockchain/beacon/Cargo.toml
+++ b/blockchain/beacon/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_beacon"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [package.metadata.docs.rs]
 features = ["json"]

--- a/blockchain/blocks/Cargo.toml
+++ b/blockchain/blocks/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_blocks"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/blockchain/chain/Cargo.toml
+++ b/blockchain/chain/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_chain"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/blockchain/chain_sync/Cargo.toml
+++ b/blockchain/chain_sync/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_chain_sync"
-version = "0.2.1"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/blockchain/consensus/deleg_cns/Cargo.toml
+++ b/blockchain/consensus/deleg_cns/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_deleg_cns"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/blockchain/consensus/fil_cns/Cargo.toml
+++ b/blockchain/consensus/fil_cns/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_fil_cns"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/blockchain/message_pool/Cargo.toml
+++ b/blockchain/message_pool/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_message_pool"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/blockchain/state_manager/Cargo.toml
+++ b/blockchain/state_manager/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_state_manager"
-version = "0.1.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "forest_crypto"
 description = "Filecoin crypto utilities for use in Forest"
-license = "MIT OR Apache-2.0"
-version = "0.6.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
-repository = "https://github.com/ChainSafe/forest"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [package.metadata.docs.rs]
 features = ["json"]

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "forest_encoding"
 description = "Filecoin encoding and decoding utilities for use in Forest"
-license = "MIT OR Apache-2.0"
-version = "0.4.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
-repository = "https://github.com/ChainSafe/forest"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 blake2b_simd.workspace = true

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "forest-cli"
-version = "0.6.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
 description = "Filecoin implementation in Rust. This crate contains all the subcommands except the daemon."
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/forest/daemon/Cargo.toml
+++ b/forest/daemon/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "forest-daemon"
-version = "0.6.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
 description = "Filecoin implementation in Rust. This command will start the daemon process."
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "forest"

--- a/forest/shared/Cargo.toml
+++ b/forest/shared/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "forest_cli_shared"
-version = "0.4.1"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
 description = "Filecoin implementation in Rust. This crate contains shared utilities that power both cli and daemon."
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/ipld/Cargo.toml
+++ b/ipld/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "forest_ipld"
 description = "Interplanetary linked data types and implementation"
-version = "0.2.0"
-license = "MIT OR Apache-2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
-repository = "https://github.com/ChainSafe/forest"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/ipld/legacy_amt/Cargo.toml
+++ b/ipld/legacy_amt/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "forest_legacy_ipld_amt"
 description = "Sharded IPLD Array implementation."
-version = "0.2.0"
-license = "MIT OR Apache-2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
-repository = "https://github.com/ChainSafe/forest"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash = { workspace = true, optional = true }

--- a/key_management/Cargo.toml
+++ b/key_management/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_key_management"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [package.metadata.docs.rs]
 features = ["json"]

--- a/networks/Cargo.toml
+++ b/networks/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_networks"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "forest_db"
 description = "Database types used in Forest"
-version = "0.2.0"
-license = "MIT OR Apache-2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
-repository = "https://github.com/ChainSafe/forest"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [features]
 default = []

--- a/node/forest_libp2p/Cargo.toml
+++ b/node/forest_libp2p/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_libp2p"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/node/forest_libp2p/bitswap/Cargo.toml
+++ b/node/forest_libp2p/bitswap/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_libp2p_bitswap"
-version = "0.1.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/node/rpc-api/Cargo.toml
+++ b/node/rpc-api/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_rpc-api"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 # Internal

--- a/node/rpc-client/Cargo.toml
+++ b/node/rpc-client/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
 name = "forest_rpc-client"
-version = "0.2.0"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 # Public

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_rpc"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/tests/serialization_tests/Cargo.toml
+++ b/tests/serialization_tests/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "serialization_tests"
-version = "0.1.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [features]
 submodule_tests = []

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "forest_fil_types"
 description = "Filecoin types used in Forest."
-version = "0.4.0"
-license = "MIT OR Apache-2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
-repository = "https://github.com/ChainSafe/forest"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/utils/auth/Cargo.toml
+++ b/utils/auth/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_auth"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 # Public

--- a/utils/forest_shim/Cargo.toml
+++ b/utils/forest_shim/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "forest_shim"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 #fvm.workspace = true

--- a/utils/forest_utils/Cargo.toml
+++ b/utils/forest_utils/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "forest_utils"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/utils/genesis/Cargo.toml
+++ b/utils/genesis/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_genesis"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [features]
 testing = []

--- a/utils/json/Cargo.toml
+++ b/utils/json/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "forest_json"
-version = "0.2.0"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 base64.workspace = true

--- a/utils/metrics/Cargo.toml
+++ b/utils/metrics/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_metrics"
-version = "0.2.0"
-authors = ["jorge <jorgeaolivero@gmail.com>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/utils/paramfetch/Cargo.toml
+++ b/utils/paramfetch/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_paramfetch"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/utils/statediff/Cargo.toml
+++ b/utils/statediff/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_statediff"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/utils/test_utils/Cargo.toml
+++ b/utils/test_utils/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_test_utils"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 base64.workspace = true

--- a/vm/actor_interface/Cargo.toml
+++ b/vm/actor_interface/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_actor_interface"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 fil_actor_account_v8.workspace = true

--- a/vm/interpreter/Cargo.toml
+++ b/vm/interpreter/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_interpreter"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/vm/message/Cargo.toml
+++ b/vm/message/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "forest_message"
 description = "Filecoin message types"
-license = "MIT OR Apache-2.0"
-version = "0.8.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
-repository = "https://github.com/ChainSafe/forest"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/vm/state_migration/Cargo.toml
+++ b/vm/state_migration/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "forest_state_migration"
-version = "0.2.0"
-authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 ahash.workspace = true


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
I encountered a bug where the version shown in the help was wrongly stuck at `0.4.1` because of the `forest_shared` crate that didn't get bumped.

Changes introduced in this pull request:
- moved standard metadata to the workspace Cargo file, made all children crates inherit the meta from it. Consequently, every project crate will share a standard version, which should be fine. We can easily add exceptions in the future.


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
