### PR TITLE
fix no such device error when non interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Notable updates:
 * [config] `stats` and `compression` keys in `parity_db` section were renamed to `enable_statistics` and `compression_type` respectively. [#2444](https://github.com/ChainSafe/forest/pull/2444)
 * [config] `download-snapshot` flag was renamed to `auto-download-snapshot`. `download_snapshot` key in `client` section in configuration renamed to `auto_download_snapshot`. [#257](https://github.com/ChainSafe/forest/pull/2457)
 * [docker|security] the Forest image is no longer running on a root user but a dedicated one. [#2463](https://github.com/ChainSafe/forest/pull/2463)
+* [keystore] Allow specifying the encryption passphrase via environmental variable. [#2514](https://github.com/ChainSafe/forest/pull/2514)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ version = "0.6.0"
 dependencies = [
  "anes",
  "anyhow",
+ "assert_cmd",
  "atty",
  "ctrlc",
  "daemonize-me",

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ make install # install forest daemon and cli
 
 ### Config
 
+#### Keystore
+To encrypt the keystore while in headless mode, set the `FOREST_KEYSTORE_PHRASE` environmental variable. Otherwise, skip the encryption (not recommended in production environments) with `--encrypt-keystore false`.
+
+
+#### Network
 Run the node with custom config and bootnodes
 
 ```bash
@@ -127,6 +132,8 @@ bootstrap_peers = ["<multiaddress>"]
 ```
 
 Example of a [multiaddress](https://github.com/multiformats/multiaddr): `"/ip4/54.186.82.90/tcp/1347/p2p/12D3K1oWKNF7vNFEhnvB45E9mw2B5z6t419W3ziZPLdUDVnLLKGs"`
+
+#### Configuration sources
 
 Forest will look for config files in the following order and priority:
  * Paths passed to the command line via the `--config` flag.

--- a/forest/daemon/Cargo.toml
+++ b/forest/daemon/Cargo.toml
@@ -55,6 +55,7 @@ time.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
 
 [dev-dependencies]
+assert_cmd.workspace = true
 
 [features]
 default = ["forest_fil_cns", "rocksdb"]

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -89,7 +89,7 @@ pub(super) async fn start(config: Config, detached: bool) -> anyhow::Result<Db> 
     // from.
     info!("PeerId: {}", PeerId::from(net_keypair.public()));
 
-    let mut ks = if config.client.encrypt_keystore {
+    let mut ks = if config.client.encrypt_keystore && atty::is(atty::Stream::Stdin) {
         loop {
             print!("Enter the keystore passphrase: ");
             std::io::stdout().flush()?;

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -12,8 +12,8 @@ use forest_chain_sync::{consensus::SyncGossipSubmitter, ChainMuxer};
 use forest_cli_shared::{
     chain_path,
     cli::{
-        cli_error_and_die, default_snapshot_dir, is_aria2_installed, snapshot_fetch, Client,
-        Config, FOREST_VERSION_STRING,
+        default_snapshot_dir, is_aria2_installed, snapshot_fetch, Client, Config,
+        FOREST_VERSION_STRING,
     },
 };
 use forest_db::{
@@ -461,7 +461,7 @@ fn create_keystore(config: &Config) -> anyhow::Result<KeyStore> {
 
     // encrypted keystore, headless
     if config.client.encrypt_keystore && passphrase.is_err() && !is_interactive {
-        cli_error_and_die(format!("Passphrase for the keystore was not provided and the encryption was not explicitly disabled. Please set the {FOREST_KEYSTORE_PHRASE_ENV} environmental variable and re-run the command"), 1);
+        anyhow::bail!("Passphrase for the keystore was not provided and the encryption was not explicitly disabled. Please set the {FOREST_KEYSTORE_PHRASE_ENV} environmental variable and re-run the command");
     // encrypted keystore, either headless or interactive, passphrase provided
     } else if config.client.encrypt_keystore && passphrase.is_ok() {
         let passphrase = passphrase.unwrap();

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -12,8 +12,8 @@ use forest_chain_sync::{consensus::SyncGossipSubmitter, ChainMuxer};
 use forest_cli_shared::{
     chain_path,
     cli::{
-        default_snapshot_dir, is_aria2_installed, snapshot_fetch, Client, Config,
-        FOREST_VERSION_STRING,
+        cli_error_and_die, default_snapshot_dir, is_aria2_installed, snapshot_fetch, Client,
+        Config, FOREST_VERSION_STRING,
     },
 };
 use forest_db::{
@@ -21,7 +21,9 @@ use forest_db::{
     Store,
 };
 use forest_genesis::{get_network_name_from_genesis, import_chain, read_genesis_header};
-use forest_key_management::{KeyStore, KeyStoreConfig, ENCRYPTED_KEYSTORE_NAME};
+use forest_key_management::{
+    KeyStore, KeyStoreConfig, ENCRYPTED_KEYSTORE_NAME, FOREST_KEYSTORE_PHRASE_ENV,
+};
 use forest_libp2p::{
     ed25519, get_keypair, Keypair, Libp2pConfig, Libp2pService, PeerId, PeerManager,
 };
@@ -89,54 +91,19 @@ pub(super) async fn start(config: Config, detached: bool) -> anyhow::Result<Db> 
     // from.
     info!("PeerId: {}", PeerId::from(net_keypair.public()));
 
-    let mut ks = if config.client.encrypt_keystore && atty::is(atty::Stream::Stdin) {
-        loop {
-            print!("Enter the keystore passphrase: ");
-            std::io::stdout().flush()?;
+    let mut keystore = create_keystore(&config)?;
 
-            let passphrase = read_password()?;
-
-            let data_dir = PathBuf::from(&config.client.data_dir).join(ENCRYPTED_KEYSTORE_NAME);
-            if !data_dir.exists() {
-                print!("Confirm passphrase: ");
-                std::io::stdout().flush()?;
-
-                if passphrase != read_password()? {
-                    error!("Passphrases do not match. Please retry.");
-                    continue;
-                }
-            }
-
-            let key_store_init_result = KeyStore::new(KeyStoreConfig::Encrypted(
-                PathBuf::from(&config.client.data_dir),
-                passphrase,
-            ));
-
-            match key_store_init_result {
-                Ok(ks) => break ks,
-                Err(_) => {
-                    error!("Incorrect passphrase entered. Please try again.")
-                }
-            };
-        }
-    } else {
-        warn!("Warning: Keystore encryption disabled!");
-        KeyStore::new(KeyStoreConfig::Persistent(PathBuf::from(
-            &config.client.data_dir,
-        )))?
-    };
-
-    if ks.get(JWT_IDENTIFIER).is_err() {
-        ks.put(JWT_IDENTIFIER.to_owned(), generate_priv_key())?;
+    if keystore.get(JWT_IDENTIFIER).is_err() {
+        keystore.put(JWT_IDENTIFIER.to_owned(), generate_priv_key())?;
     }
 
     // Print admin token
-    let ki = ks.get(JWT_IDENTIFIER)?;
+    let ki = keystore.get(JWT_IDENTIFIER)?;
     let token_exp = config.client.token_exp;
     let token = create_token(ADMIN.to_owned(), ki.private_key(), token_exp)?;
     info!("Admin token: {}", token);
 
-    let keystore = Arc::new(RwLock::new(ks));
+    let keystore = Arc::new(RwLock::new(keystore));
 
     let db = open_db(&db_path(&chain_path(&config)), config.db_config())?;
 
@@ -485,6 +452,62 @@ fn get_actual_chain_name(internal_network_name: &str) -> &str {
         "testnetnet" => "mainnet",
         "calibrationnet" => "calibnet",
         _ => internal_network_name,
+    }
+}
+
+fn create_keystore(config: &Config) -> anyhow::Result<KeyStore> {
+    let passphrase = std::env::var(FOREST_KEYSTORE_PHRASE_ENV);
+    let is_interactive = atty::is(atty::Stream::Stdin);
+
+    // encrypted keystore, headless
+    if config.client.encrypt_keystore && passphrase.is_err() && !is_interactive {
+        cli_error_and_die(format!("Passphrase for the keystore was not provided and the encryption was not explicitly disabled. Please set the {FOREST_KEYSTORE_PHRASE_ENV} environmental variable and re-run the command"), 1);
+    // encrypted keystore, either headless or interactive, passphrase provided
+    } else if config.client.encrypt_keystore && passphrase.is_ok() {
+        let passphrase = passphrase.unwrap();
+
+        let keystore = KeyStore::new(KeyStoreConfig::Encrypted(
+            PathBuf::from(&config.client.data_dir),
+            passphrase,
+        ));
+
+        keystore.map_err(|_| anyhow::anyhow!("Incorrect passphrase. Please verify the {FOREST_KEYSTORE_PHRASE_ENV} environmental variable."))
+    // encrypted keystore, interactive, passphrase not provided
+    } else if config.client.encrypt_keystore && passphrase.is_err() && is_interactive {
+        loop {
+            print!("Enter the keystore passphrase: ");
+            std::io::stdout().flush()?;
+
+            let passphrase = read_password()?;
+
+            let data_dir = PathBuf::from(&config.client.data_dir).join(ENCRYPTED_KEYSTORE_NAME);
+            if !data_dir.exists() {
+                print!("Confirm passphrase: ");
+                std::io::stdout().flush()?;
+
+                if passphrase != read_password()? {
+                    error!("Passphrases do not match. Please retry.");
+                    continue;
+                }
+            }
+
+            let key_store_init_result = KeyStore::new(KeyStoreConfig::Encrypted(
+                config.client.data_dir.clone(),
+                passphrase,
+            ));
+
+            match key_store_init_result {
+                Ok(ks) => break Ok(ks),
+                Err(_) => {
+                    error!("Incorrect passphrase entered. Please try again.")
+                }
+            };
+        }
+    } else {
+        warn!("Warning: Keystore encryption disabled!");
+        Ok(KeyStore::new(KeyStoreConfig::Persistent(
+            config.client.data_dir.clone(),
+        ))?)
     }
 }
 

--- a/forest/daemon/tests/keystore_tests.rs
+++ b/forest/daemon/tests/keystore_tests.rs
@@ -1,0 +1,41 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+// https://github.com/ChainSafe/forest/issues/2499
+#[test]
+fn forest_headless_encrypt_keystore_no_passphrase_should_fail() -> Result<()> {
+    let (config_file, _data_dir) = create_tmp_config()?;
+    cli()?.arg("--config").arg(config_file).assert().failure();
+
+    Ok(())
+}
+
+fn cli() -> Result<Command> {
+    Ok(Command::cargo_bin("forest")?)
+}
+
+fn create_tmp_config() -> Result<(PathBuf, TempDir)> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let config = format!(
+        r#"
+[client]
+data_dir = "{}"
+
+[chain]
+name = "calibnet"
+"#,
+        temp_dir.path().display()
+    );
+
+    let config_file = temp_dir.path().join("config.toml");
+    std::fs::write(&config_file, config)?;
+
+    Ok((config_file, temp_dir))
+}

--- a/key_management/src/keystore.rs
+++ b/key_management/src/keystore.rs
@@ -28,6 +28,9 @@ use super::errors::Error;
 pub const KEYSTORE_NAME: &str = "keystore.json";
 pub const ENCRYPTED_KEYSTORE_NAME: &str = "keystore";
 
+/// Environmental variable which holds the keystore encryption phrase.
+pub const FOREST_KEYSTORE_PHRASE_ENV: &str = "FOREST_KEYSTORE_PHRASE";
+
 type SaltByteArray = [u8; RECOMMENDED_SALT_LEN];
 
 // TODO need to update keyinfo to not use SignatureType, use string instead to


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- added an environmental variable for specifying encryption passphrase for Keystore,
- fixed a case where running Forest in headless mode would cause a cryptic `no such device` error. Now it will enforce setting the passphrase via the environmental variable unless the encryption is explicitly disabled.


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2499


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
