### PR TITLE
fix cargo warnings from workspace default features not set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ derive_builder = "0.11"
 dialoguer = "0.10.2"
 digest = "0.10.5"
 directories = "4.0.1"
-filecoin-proofs-api = "12.0"
+filecoin-proofs-api = { version = "12.0", default-features = false }
 flume = "0.10"
 fs_extra = "1.2"
 futures = "0.3"
@@ -87,7 +87,7 @@ fvm_ipld_bitfield = "0.5"
 fvm_ipld_blockstore = "0.1"
 fvm_ipld_car = "0.6"
 fvm_ipld_encoding = "0.2"
-fvm_shared = "2.0"
+fvm_shared = { version = "2.0", default-features = false }
 gethostname = "0.4"
 git-version = "0.3"
 hex = "0.4"
@@ -107,7 +107,7 @@ libsecp256k1 = "0.7"
 log = "0.4"
 lru = "0.9"
 multibase = "0.9"
-multihash = "0.16"
+multihash = { version = "0.16", default-features = false }
 nonempty = "0.8.0"
 num = "0.4.0"
 num-bigint = "0.4"
@@ -125,12 +125,12 @@ rand = "0.8"
 rayon = "1.5"
 regex = "1.6"
 rpassword = "7.2"
-serde = "1.0"
+serde = { version = "1.0", default-features = false }
 serde_ipld_dagcbor = "0.2"
 serde_json = "1.0"
 serde_repr = "0.1.8"
 serde_with = { version = "2.0.1", features = ["chrono_0_4"] }
-sha2 = "0.10.5"
+sha2 = { version = "0.10.5", default-features = false }
 structopt = "0.3"
 tempfile = "3.3"
 thiserror = "1.0"
@@ -192,7 +192,7 @@ forest_key_management = { path = "./key_management" }
 forest_legacy_ipld_amt = { path = "./ipld/legacy_amt" }
 forest_libp2p = { path = "./node/forest_libp2p" }
 forest_libp2p_bitswap = { path = "./node/forest_libp2p/bitswap" }
-forest_message = { path = "./vm/message" }
+forest_message = { path = "./vm/message", default-features = false }
 forest_message_pool = { path = "./blockchain/message_pool" }
 forest_metrics = { path = "./utils/metrics" }
 forest_networks = { path = "./networks" }


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- fix the warnings generated for `cargo build` and others after the toolchain bump.

> When specifying a workspace dependency it is not obvious, and rather surprising that, not specifying default-features = false in the workspace dependency, means that any default-features = false is ignored in any member crate.

> This I assume is because the features of workspace dependencies are additive, and by not specifying default-features = false, the default features are automatically and always enabled.

https://github.com/rust-lang/cargo/issues/11329#issue-1434113367


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
