### PR TITLE
chore: [libp2p] refactor chain exchange into its own behaviour

### DIFF
--- a/node/forest_libp2p/src/chain_exchange/behaviour.rs
+++ b/node/forest_libp2p/src/chain_exchange/behaviour.rs
@@ -1,0 +1,132 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use ahash::HashMap;
+use libp2p::{
+    request_response::{
+        OutboundFailure, ProtocolSupport, RequestId, RequestResponse, ResponseChannel,
+    },
+    swarm::NetworkBehaviour,
+    PeerId,
+};
+use log::warn;
+
+use super::*;
+use crate::{rpc::RequestResponseError, service::metrics};
+
+type InnerBehaviour = RequestResponse<ChainExchangeCodec>;
+
+pub struct ChainExchangeBehaviour {
+    inner: InnerBehaviour,
+    response_channels:
+        HashMap<RequestId, flume::Sender<Result<ChainExchangeResponse, RequestResponseError>>>,
+}
+
+impl ChainExchangeBehaviour {
+    pub fn send_request(
+        &mut self,
+        peer: &PeerId,
+        request: ChainExchangeRequest,
+        response_channel: flume::Sender<Result<ChainExchangeResponse, RequestResponseError>>,
+    ) -> RequestId {
+        let request_id = self.inner.send_request(peer, request);
+        self.response_channels.insert(request_id, response_channel);
+        self.track_metrics();
+        request_id
+    }
+
+    pub fn complete_request(&mut self, request_id: RequestId) {
+        self.response_channels.remove(&request_id);
+    }
+
+    pub fn send_response(
+        &mut self,
+        channel: ResponseChannel<ChainExchangeResponse>,
+        response: ChainExchangeResponse,
+    ) -> Result<(), ChainExchangeResponse> {
+        self.inner.send_response(channel, response)
+    }
+
+    pub async fn handle_inbound_response(
+        &mut self,
+        request_id: &RequestId,
+        response: ChainExchangeResponse,
+    ) {
+        if let Some(channel) = self.response_channels.remove(request_id) {
+            self.track_metrics();
+            if let Err(err) = channel.send_async(Ok(response)).await {
+                warn!("{err}");
+            }
+        }
+    }
+
+    pub fn on_outbound_error(&mut self, request_id: &RequestId, error: OutboundFailure) {
+        if let Some(tx) = self.response_channels.remove(request_id) {
+            if let Err(err) = tx.send(Err(error.into())) {
+                warn!("{err}");
+            }
+            self.track_metrics();
+        }
+    }
+
+    fn track_metrics(&self) {
+        metrics::NETWORK_CONTAINER_CAPACITIES
+            .with_label_values(&[metrics::values::CHAIN_EXCHANGE_REQUEST_TABLE])
+            .set(self.response_channels.capacity() as u64);
+    }
+}
+
+impl Default for ChainExchangeBehaviour {
+    fn default() -> Self {
+        Self {
+            inner: RequestResponse::new(
+                ChainExchangeCodec::default(),
+                [(ChainExchangeProtocolName, ProtocolSupport::Full)],
+                Default::default(),
+            ),
+            response_channels: Default::default(),
+        }
+    }
+}
+
+impl NetworkBehaviour for ChainExchangeBehaviour {
+    type ConnectionHandler = <InnerBehaviour as NetworkBehaviour>::ConnectionHandler;
+
+    type OutEvent = <InnerBehaviour as NetworkBehaviour>::OutEvent;
+
+    fn new_handler(&mut self) -> Self::ConnectionHandler {
+        self.inner.new_handler()
+    }
+
+    fn addresses_of_peer(&mut self, peer: &PeerId) -> Vec<libp2p::Multiaddr> {
+        self.inner.addresses_of_peer(peer)
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: libp2p::swarm::derive_prelude::ConnectionId,
+        event: <<Self::ConnectionHandler as libp2p::swarm::IntoConnectionHandler>::Handler as
+            libp2p::swarm::ConnectionHandler>::OutEvent,
+    ) {
+        self.inner
+            .on_connection_handler_event(peer_id, connection_id, event)
+    }
+
+    fn on_swarm_event(
+        &mut self,
+        event: libp2p::swarm::derive_prelude::FromSwarm<Self::ConnectionHandler>,
+    ) {
+        self.inner.on_swarm_event(event)
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        params: &mut impl libp2p::swarm::PollParameters,
+    ) -> std::task::Poll<
+        libp2p::swarm::NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>,
+    > {
+        self.inner.poll(cx, params)
+    }
+}

--- a/node/forest_libp2p/src/chain_exchange/behaviour.rs
+++ b/node/forest_libp2p/src/chain_exchange/behaviour.rs
@@ -61,11 +61,11 @@ impl ChainExchangeBehaviour {
     }
 
     pub fn on_outbound_error(&mut self, request_id: &RequestId, error: OutboundFailure) {
+        self.track_metrics();
         if let Some(tx) = self.response_channels.remove(request_id) {
             if let Err(err) = tx.send(Err(error.into())) {
                 warn!("{err}");
             }
-            self.track_metrics();
         }
     }
 

--- a/node/forest_libp2p/src/chain_exchange/mod.rs
+++ b/node/forest_libp2p/src/chain_exchange/mod.rs
@@ -1,9 +1,10 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+mod behaviour;
 mod message;
 mod provider;
-
+pub use behaviour::*;
 use libp2p::core::ProtocolName;
 
 pub use self::{message::*, provider::*};

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use ahash::{HashMap, HashMapExt};
+use ahash::HashMap;
 use cid::Cid;
 use flume::Sender;
 use forest_blocks::GossipBlock;
@@ -31,8 +31,7 @@ use libp2p::{
     metrics::{Metrics, Recorder},
     multiaddr::Protocol,
     multihash::Multihash,
-    noise,
-    ping::{self},
+    noise, ping,
     request_response::{RequestId, RequestResponseEvent, RequestResponseMessage, ResponseChannel},
     swarm::{ConnectionLimits, SwarmBuilder, SwarmEvent},
     yamux::YamuxConfig,
@@ -46,6 +45,7 @@ use super::{
     ForestBehaviour, ForestBehaviourEvent, Libp2pConfig,
 };
 use crate::{
+    chain_exchange::ChainExchangeBehaviour,
     discovery::DiscoveryOut,
     hello::{HelloBehaviour, HelloRequest, HelloResponse},
     rpc::RequestResponseError,
@@ -76,7 +76,7 @@ pub(crate) mod metrics {
 
     pub mod values {
         pub const HELLO_REQUEST_TABLE: &str = "hello_request_table";
-        pub const CX_REQUEST_TABLE: &str = "cx_request_table";
+        pub const CHAIN_EXCHANGE_REQUEST_TABLE: &str = "cx_request_table";
     }
 
     pub mod labels {
@@ -94,9 +94,6 @@ const PUBSUB_TOPICS: [&str; 2] = [PUBSUB_BLOCK_STR, PUBSUB_MSG_STR];
 pub const BITSWAP_TIMEOUT: Duration = Duration::from_secs(10);
 
 const BAN_PEER_DURATION: Duration = Duration::from_secs(60 * 60); //1h
-
-type CxRequestTable =
-    HashMap<RequestId, OneShotSender<Result<ChainExchangeResponse, RequestResponseError>>>;
 
 /// Events emitted by this Service.
 #[allow(clippy::large_enum_variant)]
@@ -156,7 +153,7 @@ pub enum NetworkMessage {
     ChainExchangeRequest {
         peer_id: PeerId,
         request: ChainExchangeRequest,
-        response_channel: OneShotSender<Result<ChainExchangeResponse, RequestResponseError>>,
+        response_channel: flume::Sender<Result<ChainExchangeResponse, RequestResponseError>>,
     },
     HelloRequest {
         peer_id: PeerId,
@@ -270,7 +267,6 @@ where
         let pubsub_block_str = format!("{}/{}", PUBSUB_BLOCK_STR, self.network_name);
         let pubsub_msg_str = format!("{}/{}", PUBSUB_MSG_STR, self.network_name);
 
-        let mut cx_request_table = HashMap::new();
         let (cx_response_tx, cx_response_rx) = flume::unbounded();
 
         let mut cx_response_rx_stream = cx_response_rx.stream().fuse();
@@ -296,7 +292,6 @@ where
                             &self.cs,
                             &self.genesis_cid,
                             &self.network_sender_out,
-                            &mut cx_request_table,
                             cx_response_tx.clone(),
                             &pubsub_block_str,
                             &pubsub_msg_str,).await;
@@ -312,8 +307,7 @@ where
                             self.cs.clone(),
                             bitswap_request_manager.clone(),
                             message,
-                            &self.network_sender_out,
-                            &mut cx_request_table).await;
+                            &self.network_sender_out).await;
                     }
                     None => { break; }
                 },
@@ -376,7 +370,6 @@ async fn handle_network_message(
     bitswap_request_manager: Arc<BitswapRequestManager>,
     message: NetworkMessage,
     network_sender_out: &Sender<NetworkEvent>,
-    cx_request_table: &mut CxRequestTable,
 ) {
     match message {
         NetworkMessage::PubsubMessage { topic, message } => {
@@ -405,14 +398,11 @@ async fn handle_network_message(
             request,
             response_channel,
         } => {
-            let request_id = swarm
-                .behaviour_mut()
-                .chain_exchange
-                .send_request(&peer_id, request);
-            cx_request_table.insert(request_id, response_channel);
-            metrics::NETWORK_CONTAINER_CAPACITIES
-                .with_label_values(&[metrics::values::CX_REQUEST_TABLE])
-                .set(cx_request_table.capacity() as u64);
+            let request_id = swarm.behaviour_mut().chain_exchange.send_request(
+                &peer_id,
+                request,
+                response_channel,
+            );
             emit_event(
                 network_sender_out,
                 NetworkEvent::ChainExchangeRequestOutbound { request_id },
@@ -674,10 +664,10 @@ async fn handle_ping_event(ping_event: ping::Event, peer_manager: &Arc<PeerManag
 }
 
 async fn handle_chain_exchange_event<DB>(
+    chain_exchange: &mut ChainExchangeBehaviour,
     ce_event: RequestResponseEvent<ChainExchangeRequest, ChainExchangeResponse>,
     db: &Arc<ChainStore<DB>>,
     network_sender_out: &Sender<NetworkEvent>,
-    cx_request_table: &mut CxRequestTable,
     cx_response_tx: Sender<(
         RequestId,
         ResponseChannel<ChainExchangeResponse>,
@@ -720,42 +710,18 @@ async fn handle_chain_exchange_event<DB>(
                         NetworkEvent::ChainExchangeResponseInbound { request_id },
                     )
                     .await;
-                    let tx = cx_request_table.remove(&request_id);
-                    // Send the successful response through channel out.
-                    if let Some(tx) = tx {
-                        metrics::NETWORK_CONTAINER_CAPACITIES
-                            .with_label_values(&[metrics::values::CX_REQUEST_TABLE])
-                            .set(cx_request_table.capacity() as u64);
-                        if tx.send(Ok(response)).is_err() {
-                            debug!("Failed to send ChainExchange response")
-                        }
-                    } else {
-                        warn!("RPCResponse receive failed: channel not found");
-                    };
+                    chain_exchange
+                        .handle_inbound_response(&request_id, response)
+                        .await;
                 }
             }
         }
         RequestResponseEvent::OutboundFailure {
-            peer,
+            peer: _,
             request_id,
             error,
         } => {
-            warn!(
-                "ChainExchange outbound error (peer: {:?}) (id: {:?}): {:?}",
-                peer, request_id, error
-            );
-
-            let tx = cx_request_table.remove(&request_id);
-
-            // Send error through channel out.
-            if let Some(tx) = tx {
-                metrics::NETWORK_CONTAINER_CAPACITIES
-                    .with_label_values(&[metrics::values::CX_REQUEST_TABLE])
-                    .set(cx_request_table.capacity() as u64);
-                if tx.send(Err(error.into())).is_err() {
-                    warn!("RPCResponse receive failed")
-                }
-            }
+            chain_exchange.on_outbound_error(&request_id, error);
         }
         RequestResponseEvent::InboundFailure {
             peer,
@@ -786,7 +752,6 @@ async fn handle_forest_behaviour_event<DB>(
     db: &Arc<ChainStore<DB>>,
     genesis_cid: &Cid,
     network_sender_out: &Sender<NetworkEvent>,
-    cx_request_table: &mut CxRequestTable,
     cx_response_tx: Sender<(
         RequestId,
         ResponseChannel<ChainExchangeResponse>,
@@ -827,10 +792,10 @@ async fn handle_forest_behaviour_event<DB>(
         ForestBehaviourEvent::Identify(_) => {}
         ForestBehaviourEvent::ChainExchange(ce_event) => {
             handle_chain_exchange_event(
+                &mut swarm.behaviour_mut().chain_exchange,
                 ce_event,
                 db,
                 network_sender_out,
-                cx_request_table,
                 cx_response_tx,
             )
             .await


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:

[CI log](https://github.com/ChainSafe/forest/actions/runs/4161248415/jobs/7199006862#step:13:1264) looks good
```
# HELP libp2p_messsage_total Total number of libp2p messages by type
# TYPE libp2p_messsage_total counter
libp2p_messsage_total{libp2p_message_kind="chain_exchange_request_out"} 320
libp2p_messsage_total{libp2p_message_kind="chain_exchange_response_in"} 280
```


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2497


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
