### PR TITLE
chore: use shim::TokenAmount in message related code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,6 +3739,7 @@ dependencies = [
  "fvm_shared 2.0.0",
  "fvm_shared 3.0.0-alpha.20",
  "num-bigint",
+ "num-traits",
  "serde",
 ]
 

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -21,7 +21,7 @@ use forest_libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
 use forest_message::{ChainMessage, Message as MessageTrait, SignedMessage};
 use forest_metrics::metrics;
 use forest_networks::ChainConfig;
-use forest_shim::state_tree::StateTree;
+use forest_shim::{econ::TokenAmount, state_tree::StateTree};
 use forest_utils::{db::BlockstoreExt, io::Checksum};
 use futures::Future;
 use fvm_ipld_blockstore::Blockstore;
@@ -31,7 +31,6 @@ use fvm_shared::{
     address::Address,
     clock::ChainEpoch,
     crypto::signature::{Signature, SignatureType},
-    econ::TokenAmount,
     message::Message,
     receipt::Receipt,
 };
@@ -809,7 +808,7 @@ where
                     .map_err(|e| Error::Other(e.to_string()))?
                     .ok_or_else(|| Error::Other("Actor state not found".to_string()))?;
                 applied.insert(*from_address, actor_state.sequence);
-                balances.insert(*from_address, actor_state.balance);
+                balances.insert(*from_address, actor_state.balance.into());
             }
             if let Some(seq) = applied.get_mut(from_address) {
                 if *seq != message.sequence() {

--- a/blockchain/message_pool/src/msg_chain.rs
+++ b/blockchain/message_pool/src/msg_chain.rs
@@ -11,9 +11,10 @@ use ahash::HashMap;
 use forest_blocks::Tipset;
 use forest_message::{Message, SignedMessage};
 use forest_networks::ChainConfig;
+use forest_shim::econ::TokenAmount;
 use fvm::gas::{price_list_by_network_version, Gas};
 use fvm_ipld_encoding::Cbor;
-use fvm_shared::{address::Address, econ::TokenAmount};
+use fvm_shared::address::Address;
 use log::warn;
 use num_traits::Zero;
 use slotmap::{new_key_type, SlotMap};
@@ -365,8 +366,7 @@ where
     //   that exceed the balance
     let actor_state = api.get_actor_after(actor, ts)?;
     let mut cur_seq = actor_state.sequence;
-    let mut balance: TokenAmount =
-        forest_shim::econ::TokenAmount::from(&actor_state.balance).into();
+    let mut balance: TokenAmount = forest_shim::econ::TokenAmount::from(&actor_state.balance);
 
     let mut gas_limit = 0;
     let mut skip = 0;

--- a/blockchain/message_pool/src/msg_chain.rs
+++ b/blockchain/message_pool/src/msg_chain.rs
@@ -366,7 +366,7 @@ where
     //   that exceed the balance
     let actor_state = api.get_actor_after(actor, ts)?;
     let mut cur_seq = actor_state.sequence;
-    let mut balance: TokenAmount = forest_shim::econ::TokenAmount::from(&actor_state.balance);
+    let mut balance: TokenAmount = TokenAmount::from(&actor_state.balance);
 
     let mut gas_limit = 0;
     let mut skip = 0;

--- a/blockchain/message_pool/src/msgpool/mod.rs
+++ b/blockchain/message_pool/src/msgpool/mod.rs
@@ -173,7 +173,7 @@ where
             // check the baseFee lower bound -- only republish messages that can be included
             // in the chain within the next 20 blocks.
             for m in chain.msgs.iter() {
-                if m.gas_fee_cap() < &base_fee_lower_bound {
+                if m.gas_fee_cap() < base_fee_lower_bound {
                     let key = chains.get_key_at(i);
                     chains.invalidate(key);
                     continue 'l;
@@ -324,9 +324,8 @@ pub mod tests {
     use forest_message::SignedMessage;
     #[cfg(feature = "slow_tests")]
     use forest_networks::ChainConfig;
-    use fvm_shared::{
-        address::Address, crypto::signature::SignatureType, econ::TokenAmount, message::Message,
-    };
+    use forest_shim::econ::TokenAmount;
+    use fvm_shared::{address::Address, crypto::signature::SignatureType, message::Message};
     #[cfg(feature = "slow_tests")]
     use num_traits::Zero;
     use test_provider::*;
@@ -350,8 +349,8 @@ pub mod tests {
             from: *from,
             sequence,
             gas_limit,
-            gas_fee_cap: TokenAmount::from_atto(gas_price + 100),
-            gas_premium: TokenAmount::from_atto(gas_price),
+            gas_fee_cap: TokenAmount::from_atto(gas_price + 100).into(),
+            gas_premium: TokenAmount::from_atto(gas_price).into(),
             ..Message::default()
         };
         let msg_signing_bytes = umsg.cid().unwrap().to_bytes();

--- a/blockchain/message_pool/src/msgpool/msg_pool.rs
+++ b/blockchain/message_pool/src/msgpool/msg_pool.rs
@@ -17,6 +17,7 @@ use forest_db::Store;
 use forest_libp2p::{NetworkMessage, Topic, PUBSUB_MSG_STR};
 use forest_message::{message::valid_for_block_inclusion, ChainMessage, Message, SignedMessage};
 use forest_networks::{ChainConfig, NEWEST_NETWORK_VERSION};
+use forest_shim::econ::TokenAmount;
 use forest_utils::const_option;
 use futures::StreamExt;
 use fvm::gas::{price_list_by_network_version, Gas};
@@ -24,7 +25,6 @@ use fvm_ipld_encoding::Cbor;
 use fvm_shared::{
     address::Address,
     crypto::signature::{Signature, SignatureType},
-    econ::TokenAmount,
 };
 use log::warn;
 use lru::LruCache;
@@ -74,11 +74,11 @@ impl MsgSet {
         }
         if let Some(exms) = self.msgs.get(&m.sequence()) {
             if m.cid()? != exms.cid()? {
-                let premium = exms.message().gas_premium.clone();
+                let premium = TokenAmount::from(&exms.message().gas_premium);
                 let min_price = premium.clone()
                     + ((premium * RBF_NUM).div_floor(RBF_DENOM))
                     + TokenAmount::from_atto(1u8);
-                if m.message().gas_premium <= min_price {
+                if m.message().gas_premium <= min_price.into() {
                     return Err(Error::GasPriceTooLow);
                 }
             } else {
@@ -323,7 +323,7 @@ where
             return Err(Error::MessageTooBig);
         }
         valid_for_block_inclusion(msg.message(), Gas::new(0), NEWEST_NETWORK_VERSION)?;
-        if msg.value() > &fvm_shared::TOTAL_FILECOIN {
+        if msg.value() > TokenAmount::from(&*fvm_shared::TOTAL_FILECOIN) {
             return Err(Error::MessageValueTooHigh);
         }
         if msg.gas_fee_cap().atto() < &MINIMUM_BASE_FEE.into() {
@@ -429,7 +429,7 @@ where
     /// address and tipset, if this actor does not exist, return an error.
     fn get_state_balance(&self, addr: &Address, ts: &Tipset) -> Result<TokenAmount, Error> {
         let actor = self.api.get_actor_after(addr, ts)?;
-        Ok(forest_shim::econ::TokenAmount::from(&actor.balance).into())
+        Ok(TokenAmount::from(&actor.balance))
     }
 
     /// Remove a message given a sequence and address from the message pool.
@@ -635,11 +635,9 @@ fn verify_msg_before_add(
     valid_for_block_inclusion(m.message(), min_gas.total(), NEWEST_NETWORK_VERSION)?;
     if !cur_ts.blocks().is_empty() {
         let base_fee = cur_ts.blocks()[0].parent_base_fee();
-        let base_fee_lower_bound = get_base_fee_lower_bound(
-            &base_fee.clone().into(),
-            BASE_FEE_LOWER_BOUND_FACTOR_CONSERVATIVE,
-        );
-        if m.gas_fee_cap() < &base_fee_lower_bound {
+        let base_fee_lower_bound =
+            get_base_fee_lower_bound(&base_fee.clone(), BASE_FEE_LOWER_BOUND_FACTOR_CONSERVATIVE);
+        if m.gas_fee_cap() < base_fee_lower_bound {
             if local {
                 warn!("local message will not be immediately published because GasFeeCap doesn't meet the lower bound for inclusion in the next 20 blocks (GasFeeCap: {}, baseFeeLowerBound: {})",m.gas_fee_cap(), base_fee_lower_bound);
                 return Ok(false);

--- a/blockchain/message_pool/src/msgpool/msg_pool.rs
+++ b/blockchain/message_pool/src/msgpool/msg_pool.rs
@@ -636,7 +636,7 @@ fn verify_msg_before_add(
     if !cur_ts.blocks().is_empty() {
         let base_fee = cur_ts.blocks()[0].parent_base_fee();
         let base_fee_lower_bound =
-            get_base_fee_lower_bound(&base_fee.clone(), BASE_FEE_LOWER_BOUND_FACTOR_CONSERVATIVE);
+            get_base_fee_lower_bound(base_fee, BASE_FEE_LOWER_BOUND_FACTOR_CONSERVATIVE);
         if m.gas_fee_cap() < base_fee_lower_bound {
             if local {
                 warn!("local message will not be immediately published because GasFeeCap doesn't meet the lower bound for inclusion in the next 20 blocks (GasFeeCap: {}, baseFeeLowerBound: {})",m.gas_fee_cap(), base_fee_lower_bound);

--- a/blockchain/message_pool/src/msgpool/provider.rs
+++ b/blockchain/message_pool/src/msgpool/provider.rs
@@ -10,11 +10,14 @@ use forest_chain::HeadChange;
 use forest_db::Store;
 use forest_message::{ChainMessage, SignedMessage};
 use forest_networks::Height;
-use forest_shim::state_tree::{ActorState, StateTree};
+use forest_shim::{
+    econ::TokenAmount,
+    state_tree::{ActorState, StateTree},
+};
 use forest_state_manager::StateManager;
 use forest_utils::db::BlockstoreExt;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::{address::Address, econ::TokenAmount, message::Message};
+use fvm_shared::{address::Address, message::Message};
 use tokio::sync::broadcast::{Receiver as Subscriber, Sender as Publisher};
 
 use crate::errors::Error;

--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -11,7 +11,8 @@ use std::{borrow::BorrowMut, cmp::Ordering, sync::Arc};
 use ahash::{HashMap, HashMapExt};
 use forest_blocks::Tipset;
 use forest_message::{Message, SignedMessage};
-use fvm_shared::{address::Address, econ::TokenAmount};
+use forest_shim::econ::TokenAmount;
+use fvm_shared::address::Address;
 use parking_lot::RwLock;
 use rand::{prelude::SliceRandom, thread_rng};
 

--- a/blockchain/message_pool/src/msgpool/test_provider.rs
+++ b/blockchain/message_pool/src/msgpool/test_provider.rs
@@ -12,8 +12,8 @@ use forest_blocks::{BlockHeader, ElectionProof, Ticket, Tipset, TipsetKeys};
 use forest_chain::HeadChange;
 use forest_crypto::VRFProof;
 use forest_message::{ChainMessage, Message as MessageTrait, SignedMessage};
-use forest_shim::state_tree::ActorState;
-use fvm_shared::{address::Address, econ::TokenAmount, message::Message};
+use forest_shim::{econ::TokenAmount, state_tree::ActorState};
+use fvm_shared::{address::Address, message::Message};
 use num::BigInt;
 use parking_lot::Mutex;
 use tokio::sync::broadcast;
@@ -150,7 +150,7 @@ impl Provider for TestApi {
         let actor = <ActorState as forest_shim::Inner>::FVM::new(
             Cid::default(),
             Cid::default(),
-            forest_shim::econ::TokenAmount::from(balance).into(),
+            balance.into(),
             sequence,
             None,
         );

--- a/blockchain/message_pool/src/msgpool/utils.rs
+++ b/blockchain/message_pool/src/msgpool/utils.rs
@@ -4,8 +4,9 @@
 use cid::Cid;
 use forest_chain::MINIMUM_BASE_FEE;
 use forest_message::{Message as MessageTrait, SignedMessage};
+use forest_shim::econ::TokenAmount;
 use fvm_ipld_encoding::Cbor;
-use fvm_shared::{crypto::signature::Signature, econ::TokenAmount, message::Message};
+use fvm_shared::{crypto::signature::Signature, message::Message};
 use lru::LruCache;
 use num_rational::BigRational;
 use num_traits::ToPrimitive;
@@ -24,8 +25,8 @@ pub(crate) fn get_base_fee_lower_bound(base_fee: &TokenAmount, factor: i64) -> T
 /// Gets the gas reward for the given message.
 pub(crate) fn get_gas_reward(msg: &SignedMessage, base_fee: &TokenAmount) -> TokenAmount {
     let mut max_prem = msg.gas_fee_cap() - base_fee;
-    if &max_prem < msg.gas_premium() {
-        max_prem = msg.gas_premium().clone();
+    if max_prem < msg.gas_premium() {
+        max_prem = msg.gas_premium();
     }
     max_prem * msg.gas_limit()
 }

--- a/utils/forest_shim/Cargo.toml
+++ b/utils/forest_shim/Cargo.toml
@@ -12,6 +12,7 @@ fvm3 = { package = "fvm", version = "3.0.0-alpha.19" }
 fvm_shared.workspace = true
 fvm_shared3 = { package = "fvm_shared", version = "3.0.0-alpha.16" }
 num-bigint.workspace = true
+num-traits.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/utils/forest_shim/src/econ.rs
+++ b/utils/forest_shim/src/econ.rs
@@ -1,18 +1,28 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::ops::{Add, AddAssign, Deref, DerefMut, Mul};
+use std::ops::{Add, AddAssign, Deref, DerefMut, Mul, Sub, SubAssign};
 
 use fvm_shared::econ::TokenAmount as TokenAmount_v2;
 use fvm_shared3::econ::TokenAmount as TokenAmount_v3;
 use num_bigint::BigInt;
+use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
 // FIXME: Transparent Debug trait impl
 // FIXME: Consider 'type TokenAmount = TokenAmount_v3'
-#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug, Default)]
 #[serde(transparent)]
 pub struct TokenAmount(TokenAmount_v3);
+
+impl Zero for TokenAmount {
+    fn zero() -> Self {
+        TokenAmount(TokenAmount_v3::zero())
+    }
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
 
 impl Deref for TokenAmount {
     type Target = TokenAmount_v3;
@@ -43,6 +53,10 @@ impl TokenAmount {
 
     pub fn from_atto(atto: impl Into<BigInt>) -> Self {
         TokenAmount_v3::from_atto(atto).into()
+    }
+
+    pub fn from_whole(fil: impl Into<BigInt>) -> Self {
+        TokenAmount_v3::from_whole(fil).into()
     }
 
     #[inline]
@@ -119,6 +133,27 @@ impl Mul<i64> for &TokenAmount {
     }
 }
 
+impl Mul<i64> for TokenAmount {
+    type Output = TokenAmount;
+    fn mul(self, rhs: i64) -> Self::Output {
+        (&self.0).mul(rhs).into()
+    }
+}
+
+impl Mul<u64> for &TokenAmount {
+    type Output = TokenAmount;
+    fn mul(self, rhs: u64) -> Self::Output {
+        (&self.0).mul(rhs).into()
+    }
+}
+
+impl Mul<u64> for TokenAmount {
+    type Output = TokenAmount;
+    fn mul(self, rhs: u64) -> Self::Output {
+        (&self.0).mul(rhs).into()
+    }
+}
+
 impl Add<TokenAmount> for &TokenAmount {
     type Output = TokenAmount;
     fn add(self, rhs: TokenAmount) -> Self::Output {
@@ -126,8 +161,42 @@ impl Add<TokenAmount> for &TokenAmount {
     }
 }
 
+impl Add<&TokenAmount> for &TokenAmount {
+    type Output = TokenAmount;
+    fn add(self, rhs: &TokenAmount) -> Self::Output {
+        (&self.0).add(&rhs.0).into()
+    }
+}
+
+impl Add<TokenAmount> for TokenAmount {
+    type Output = TokenAmount;
+    fn add(self, rhs: TokenAmount) -> Self::Output {
+        (&self.0).add(rhs.0).into()
+    }
+}
+
+impl Add<&TokenAmount> for TokenAmount {
+    type Output = TokenAmount;
+    fn add(self, rhs: &TokenAmount) -> Self::Output {
+        (&self.0).add(&rhs.0).into()
+    }
+}
+
 impl AddAssign for TokenAmount {
     fn add_assign(&mut self, other: Self) {
         self.0.add_assign(other.0)
+    }
+}
+
+impl SubAssign for TokenAmount {
+    fn sub_assign(&mut self, other: Self) {
+        self.0.sub_assign(other.0)
+    }
+}
+
+impl Sub<&TokenAmount> for TokenAmount {
+    type Output = TokenAmount;
+    fn sub(self, rhs: &TokenAmount) -> Self::Output {
+        (&self.0).sub(&rhs.0).into()
     }
 }

--- a/vm/message/src/chain_message.rs
+++ b/vm/message/src/chain_message.rs
@@ -1,6 +1,8 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::borrow::Borrow;
+
 use cid::Cid;
 use forest_shim::econ::TokenAmount;
 use fvm_ipld_encoding::{Cbor, Error, RawBytes};
@@ -50,7 +52,7 @@ impl MessageTrait for ChainMessage {
     fn value(&self) -> TokenAmount {
         match self {
             Self::Signed(t) => t.value(),
-            Self::Unsigned(t) => TokenAmount::from(&t.value),
+            Self::Unsigned(t) => t.value.borrow().into(),
         }
     }
     fn method_num(&self) -> MethodNum {
@@ -86,19 +88,19 @@ impl MessageTrait for ChainMessage {
     fn required_funds(&self) -> TokenAmount {
         match self {
             Self::Signed(t) => t.required_funds(),
-            Self::Unsigned(t) => TokenAmount::from(&t.gas_fee_cap * t.gas_limit + &t.value),
+            Self::Unsigned(t) => (&t.gas_fee_cap * t.gas_limit + &t.value).into(),
         }
     }
     fn gas_fee_cap(&self) -> TokenAmount {
         match self {
             Self::Signed(t) => t.gas_fee_cap(),
-            Self::Unsigned(t) => TokenAmount::from(&t.gas_fee_cap),
+            Self::Unsigned(t) => (&t.gas_fee_cap).into(),
         }
     }
     fn gas_premium(&self) -> TokenAmount {
         match self {
             Self::Signed(t) => t.gas_premium(),
-            Self::Unsigned(t) => TokenAmount::from(&t.gas_premium),
+            Self::Unsigned(t) => (&t.gas_premium).into(),
         }
     }
 

--- a/vm/message/src/chain_message.rs
+++ b/vm/message/src/chain_message.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
+use forest_shim::econ::TokenAmount;
 use fvm_ipld_encoding::{Cbor, Error, RawBytes};
-use fvm_shared::{address::Address, econ::TokenAmount, message::Message, MethodNum};
+use fvm_shared::{address::Address, message::Message, MethodNum};
 use serde::{Deserialize, Serialize};
 
 use super::Message as MessageTrait;
@@ -46,10 +47,10 @@ impl MessageTrait for ChainMessage {
             Self::Unsigned(t) => t.sequence,
         }
     }
-    fn value(&self) -> &TokenAmount {
+    fn value(&self) -> TokenAmount {
         match self {
             Self::Signed(t) => t.value(),
-            Self::Unsigned(t) => &t.value,
+            Self::Unsigned(t) => TokenAmount::from(&t.value),
         }
     }
     fn method_num(&self) -> MethodNum {
@@ -85,33 +86,33 @@ impl MessageTrait for ChainMessage {
     fn required_funds(&self) -> TokenAmount {
         match self {
             Self::Signed(t) => t.required_funds(),
-            Self::Unsigned(t) => &t.gas_fee_cap * t.gas_limit + &t.value,
+            Self::Unsigned(t) => TokenAmount::from(&t.gas_fee_cap * t.gas_limit + &t.value),
         }
     }
-    fn gas_fee_cap(&self) -> &TokenAmount {
+    fn gas_fee_cap(&self) -> TokenAmount {
         match self {
             Self::Signed(t) => t.gas_fee_cap(),
-            Self::Unsigned(t) => &t.gas_fee_cap,
+            Self::Unsigned(t) => TokenAmount::from(&t.gas_fee_cap),
         }
     }
-    fn gas_premium(&self) -> &TokenAmount {
+    fn gas_premium(&self) -> TokenAmount {
         match self {
             Self::Signed(t) => t.gas_premium(),
-            Self::Unsigned(t) => &t.gas_premium,
+            Self::Unsigned(t) => TokenAmount::from(&t.gas_premium),
         }
     }
 
     fn set_gas_fee_cap(&mut self, cap: TokenAmount) {
         match self {
             Self::Signed(t) => t.set_gas_fee_cap(cap),
-            Self::Unsigned(t) => t.gas_fee_cap = cap,
+            Self::Unsigned(t) => t.gas_fee_cap = cap.into(),
         }
     }
 
     fn set_gas_premium(&mut self, prem: TokenAmount) {
         match self {
             Self::Signed(t) => t.set_gas_premium(prem),
-            Self::Unsigned(t) => t.gas_premium = prem,
+            Self::Unsigned(t) => t.gas_premium = prem.into(),
         }
     }
 }

--- a/vm/message/src/lib.rs
+++ b/vm/message/src/lib.rs
@@ -6,8 +6,9 @@ pub mod message;
 pub mod signed_message;
 
 pub use chain_message::ChainMessage;
+use forest_shim::econ::TokenAmount;
 use fvm_ipld_encoding::RawBytes;
-use fvm_shared::{address::Address, econ::TokenAmount, MethodNum};
+use fvm_shared::{address::Address, MethodNum};
 pub use signed_message::SignedMessage;
 
 /// Message interface to interact with Signed and unsigned messages in a generic
@@ -20,7 +21,7 @@ pub trait Message {
     /// Returns the message sequence or nonce.
     fn sequence(&self) -> u64;
     /// Returns the amount sent in message.
-    fn value(&self) -> &TokenAmount;
+    fn value(&self) -> TokenAmount;
     /// Returns the method number to be called.
     fn method_num(&self) -> MethodNum;
     /// Returns the encoded parameters for the method call.
@@ -34,9 +35,9 @@ pub trait Message {
     /// Returns the required funds for the message.
     fn required_funds(&self) -> TokenAmount;
     /// gets gas fee cap for the message.
-    fn gas_fee_cap(&self) -> &TokenAmount;
+    fn gas_fee_cap(&self) -> TokenAmount;
     /// gets gas premium for the message.
-    fn gas_premium(&self) -> &TokenAmount;
+    fn gas_premium(&self) -> TokenAmount;
     /// sets the gas fee cap.
     fn set_gas_fee_cap(&mut self, cap: TokenAmount);
     /// sets the gas premium.

--- a/vm/message/src/signed_message.rs
+++ b/vm/message/src/signed_message.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use forest_encoding::tuple::*;
+use forest_shim::econ::TokenAmount;
 use fvm_ipld_encoding::{to_vec, Cbor, Error as CborError, RawBytes};
 use fvm_shared::{
     address::Address,
     crypto::signature::{Signature, SignatureType},
-    econ::TokenAmount,
     message::Message,
     MethodNum,
 };
@@ -78,8 +78,8 @@ impl MessageTrait for SignedMessage {
     fn sequence(&self) -> u64 {
         self.message.sequence
     }
-    fn value(&self) -> &TokenAmount {
-        &self.message.value
+    fn value(&self) -> TokenAmount {
+        TokenAmount::from(&self.message.value)
     }
     fn method_num(&self) -> MethodNum {
         self.message.method_num
@@ -97,21 +97,21 @@ impl MessageTrait for SignedMessage {
         self.message.sequence = new_sequence;
     }
     fn required_funds(&self) -> TokenAmount {
-        &self.message.gas_fee_cap * self.message.gas_limit + &self.message.value
+        TokenAmount::from(&self.message.gas_fee_cap * self.message.gas_limit + &self.message.value)
     }
-    fn gas_fee_cap(&self) -> &TokenAmount {
-        &self.message.gas_fee_cap
+    fn gas_fee_cap(&self) -> TokenAmount {
+        TokenAmount::from(&self.message.gas_fee_cap)
     }
-    fn gas_premium(&self) -> &TokenAmount {
-        &self.message.gas_premium
+    fn gas_premium(&self) -> TokenAmount {
+        TokenAmount::from(&self.message.gas_premium)
     }
 
     fn set_gas_fee_cap(&mut self, cap: TokenAmount) {
-        self.message.gas_fee_cap = cap;
+        self.message.gas_fee_cap = cap.into();
     }
 
     fn set_gas_premium(&mut self, prem: TokenAmount) {
-        self.message.gas_premium = prem;
+        self.message.gas_premium = prem.into();
     }
 }
 


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- Switch the `MessageTrait` to using `shim::TokenAmount`


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
