### PR TITLE
change default loki level to debug

### DIFF
--- a/forest/shared/src/logger/mod.rs
+++ b/forest/shared/src/logger/mod.rs
@@ -76,7 +76,7 @@ pub fn setup_logger(
         .map_err(|e| format!("Unable to create loki layer: {e}"))
         .unwrap();
         loki_task = Some(task);
-        Some(layer.with_filter(LevelFilter::TRACE))
+        Some(layer.with_filter(LevelFilter::DEBUG))
     } else {
         None
     };


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- changed the default loki level to debug; otherwise, Forest crashes after a while in a container. Probably the amount of logs generated is more than the container limit. It would be nice to have it parametrised in the future, but not crashing is a good start. :)


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
