### PR TITLE
downgrade fetching param files confirmations to debug

### DIFF
--- a/utils/paramfetch/src/lib.rs
+++ b/utils/paramfetch/src/lib.rs
@@ -167,7 +167,7 @@ async fn fetch_params(path: &Path, info: &ParameterData) -> Result<(), anyhow::E
         Ok(fetch_params_inner(&url, path).await?)
     })
     .await;
-    info!("Done fetching param file {:?} from {}", path, gw);
+    debug!("Done fetching param file {:?} from {}", path, gw);
     result
 }
 


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- downgrade the param file confirmations a bit. With a fresh container it starts with a massive attack of confirmations

```
❯ docker run --init -it --rm --network host --volume forest-db:/home/forest/.local/share/forest  ghcr.io/chainsafe/forest:volume-test --encrypt-keystore false --chain calibnet --auto-download-snapshot
2023-02-16T17:58:03.256803Z  INFO forest: Using default calibnet config
2023-02-16T17:58:03.257746Z  INFO forest::daemon: Starting Forest daemon, version 0.6.0+git.5df3e5c03
2023-02-16T17:58:03.257767Z  INFO forest_libp2p::service: Networking keystore not found!
2023-02-16T17:58:03.257899Z  INFO forest_utils::io: Permissions set to 0600 on File { fd: 8, path: "/home/forest/.local/share/forest/libp2p/keypair", read: false, write: true }
2023-02-16T17:58:03.258041Z  INFO forest::daemon: PeerId: 12D3KooWNSsztSaSiwEytcbLG62UYrLkeh1CsaE8G8D5ztLNRa2d
2023-02-16T17:58:03.258055Z  WARN forest::daemon: Warning: Keystore encryption disabled!
2023-02-16T17:58:03.258086Z  WARN forest_key_management::keystore: Keystore does not exist, initializing new keystore at: "/home/forest/.local/share/forest/keystore.json"
2023-02-16T17:58:03.258124Z  INFO forest_utils::io: Permissions set to 0600 on File { fd: 8, path: "/home/forest/.local/share/forest/keystore.json", read: false, write: true }
2023-02-16T17:58:03.259057Z  INFO forest::daemon: Admin token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXSwiZXhwIjoxNjgxNzU0MjgzfQ.IcAboXT1FJwKTbK01uW5xnn3XeOQyZV8lM2rJmdipWk
2023-02-16T17:58:03.274099Z  INFO forest::daemon: Prometheus server started at 0.0.0.0:6116
2023-02-16T17:58:03.278009Z  INFO forest_genesis: Initialized genesis: BlockHeader: Cid(bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4)
2023-02-16T17:58:03.278091Z  WARN forest_chain::store::chain_store: No previous chain state found
2023-02-16T17:58:03.278170Z  INFO forest::daemon: Using network :: calibnet
2023-02-16T17:58:03.278991Z  INFO forest_chain_sync::chain_muxer: Evaluating network head...
2023-02-16T17:58:03.279035Z  INFO forest::daemon: JSON-RPC endpoint started at 127.0.0.1:1234
2023-02-16T17:58:03.279090Z  INFO forest_rpc: Ready for RPC connections
2023-02-16T17:58:03.279482Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-proof-of-spacetime-fallback-merkletree-poseidon_hasher-8-0-0-3ea05428c9d11689f23529cde32fd30aabd50f7d2c93657c1d3650bca3e8ea9e.vk" from https://proofs.filecoin.io/ipfs/
2023-02-16T17:58:03.279769Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-proof-of-spacetime-fallback-merkletree-poseidon_hasher-8-0-0-7d739b8cf60f1b0709eeebee7730e297683552e4b69cab6984ec0285663c5781.vk" from https://proofs.filecoin.io/ipfs/
2023-02-16T17:58:03.279797Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-stacked-proof-of-replication-merkletree-poseidon_hasher-8-0-0-sha256_hasher-032d3138d22506ec0082ed72b2dcba18df18477904e35bafee82b3793b06832f.vk" from https://proofs.filecoin.io/ipfs/ 
2023-02-16T17:58:03.279836Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-stacked-proof-of-replication-merkletree-poseidon_hasher-8-0-0-sha256_hasher-6babf46ce344ae495d558e7770a585b2382d54f225af8ed0397b8be7c3fcd472.vk" from https://proofs.filecoin.io/ipfs/ 
2023-02-16T17:58:03.279846Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-proof-of-spacetime-fallback-merkletree-poseidon_hasher-8-0-0-0170db1f394b35d995252228ee359194b13199d259380541dc529fb0099096b0.vk" from https://proofs.filecoin.io/ipfs/
2023-02-16T17:58:03.279849Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-proof-of-spacetime-fallback-merkletree-poseidon_hasher-8-8-0-559e581f022bb4e4ec6e719e563bf0e026ad6de42e56c18714a2c692b1b88d7e.vk" from https://proofs.filecoin.io/ipfs/
2023-02-16T17:58:03.279874Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-proof-of-spacetime-fallback-merkletree-poseidon_hasher-8-8-2-2627e4006b67f99cef990c0a47d5426cb7ab0a0ad58fc1061547bf2d28b09def.vk" from https://proofs.filecoin.io/ipfs/
2023-02-16T17:58:03.279924Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-stacked-proof-of-replication-merkletree-poseidon_hasher-8-0-0-sha256_hasher-ecd683648512ab1765faa2a5f14bab48f676e633467f0aa8aad4b55dcb0652bb.vk" from https://proofs.filecoin.io/ipfs/ 
2023-02-16T17:58:03.279937Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-empty-sector-update-merkletree-poseidon_hasher-8-8-2-102e1444a7e9a97ebf1e3d6855dcc77e66c011ea66f936d9b2c508f87f2f83a7.vk" from https://proofs.filecoin.io/ipfs/
2023-02-16T17:58:03.279988Z  INFO forest_paramfetch: Fetching param file "/home/forest/.local/share/forest/filecoin-proof-parameters/v28-fil-inner-product-v1.srs" from https://proofs.filecoin.io/ipfs/
```


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
