### PR TITLE
chore: favor parking_lot::{Mutex,RwLock} over std ones

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -2,4 +2,6 @@
 disallowed-types = [
   { path = "std::collections::HashMap", reason = "use ahash::HashMap instead" },
   { path = "std::collections::HashSet", reason = "use ahash::HashSet instead" },
+  { path = "std::sync::RwLock", reason = "use parking_lot::RwLock instead" },
+  { path = "std::sync::Mutex", reason = "use parking_lot::Mutex instead" },
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
+checksum = "2bd379e511536bad07447f899300aa526e9bae8e6f66dc5e5ca45d7587b7c1ec"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -587,7 +587,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -1037,7 +1037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40f9ca3698b2e4cb7c15571db0abc5551dca417a21ae8140460b50309bb2cc62"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -3450,7 +3450,7 @@ dependencies = [
  "ahash 0.8.3",
  "base64 0.21.0",
  "cid",
- "derive_builder 0.11.2",
+ "derive_builder 0.12.0",
  "forest_beacon",
  "forest_crypto",
  "forest_encoding",
@@ -3608,7 +3608,7 @@ dependencies = [
  "time 0.3.18",
  "tokio",
  "toml 0.7.2",
- "tower-http",
+ "tower-http 0.4.0",
  "tracing-appender",
  "tracing-loki",
  "tracing-subscriber",
@@ -4220,6 +4220,7 @@ dependencies = [
  "lru 0.9.0",
  "num",
  "num-traits",
+ "parking_lot 0.12.1",
  "prometheus",
  "serde",
  "thiserror",
@@ -4310,6 +4311,7 @@ dependencies = [
  "hyper-rustls",
  "libc",
  "log",
+ "parking_lot 0.12.1",
  "pbr",
  "pin-project-lite 0.2.9",
  "quickcheck",
@@ -5098,9 +5100,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.6",
-]
 
 [[package]]
 name = "hashbrown"
@@ -5247,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
@@ -8060,7 +8059,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "nix 0.26.2",
- "rand 0.7.3",
+ "rand 0.8.5",
  "winapi",
 ]
 
@@ -9905,6 +9904,25 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "pin-project-lite 0.2.9",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "bitflags",
+ "bytes 1.4.0",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
  "httpdate",
  "mime",
  "mime_guess",
@@ -9912,9 +9930,9 @@ dependencies = [
  "pin-project-lite 0.2.9",
  "tokio",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ cid = { version = "0.8", default-features = false, features = ["std"] }
 clap = { version = "4.0", features = ["derive"] }
 console-subscriber = { version = "0.1", features = ["parking_lot"] }
 cs_serde_bytes = "0.12.2"
-derive_builder = "0.11"
+derive_builder = "0.12"
 dialoguer = "0.10.2"
 digest = "0.10.5"
 directories = "4.0.1"
@@ -138,7 +138,7 @@ tokio = "1.24"
 tokio-stream = "0.1"
 tokio-util = "0.7.0"
 toml = "0.7"
-tower-http = "0.3"
+tower-http = "0.4"
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-loki = { version = "0.2", default-features = false, features = ["compat-0-2-1", "rustls"] }

--- a/blockchain/state_manager/Cargo.toml
+++ b/blockchain/state_manager/Cargo.toml
@@ -39,6 +39,7 @@ lazy_static.workspace = true
 lru.workspace = true
 num-traits.workspace = true
 num.workspace = true
+parking_lot.workspace = true
 prometheus.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true

--- a/utils/forest_utils/Cargo.toml
+++ b/utils/forest_utils/Cargo.toml
@@ -21,6 +21,7 @@ hyper-rustls.workspace = true
 hyper.workspace = true
 libc = "0.2"
 log.workspace = true
+parking_lot.workspace = true
 pbr = "1.1"
 pin-project-lite.workspace = true
 quickcheck.workspace = true

--- a/utils/forest_utils/src/io/progress_bar.rs
+++ b/utils/forest_utils/src/io/progress_bar.rs
@@ -1,7 +1,8 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
-use std::{cell::RefCell, io::Stdout, str::FromStr, sync::RwLock, time::Duration};
+use std::{cell::RefCell, io::Stdout, str::FromStr, time::Duration};
 
+use parking_lot::RwLock;
 pub use pbr::Units;
 use serde::{Deserialize, Serialize};
 
@@ -95,17 +96,12 @@ impl ProgressBar {
 
     /// Sets the visibility of progress bars (globally).
     pub fn set_progress_bars_visibility(visibility: ProgressBarVisibility) {
-        *PROGRESS_BAR_VISIBILITY
-            .write()
-            .expect("write must not fail") = visibility;
+        *PROGRESS_BAR_VISIBILITY.write() = visibility;
     }
 
     /// Checks the global variable if progress bar should be shown.
     fn should_display() -> bool {
-        match *PROGRESS_BAR_VISIBILITY
-            .read()
-            .expect("read should not fail")
-        {
+        match *PROGRESS_BAR_VISIBILITY.read() {
             ProgressBarVisibility::Always => true,
             ProgressBarVisibility::Auto => atty::is(atty::Stream::Stdout),
             ProgressBarVisibility::Never => false,


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- replace `std::sync::{Mutex, RwLock}` with `parking_lot::{Mutex, RwLock}`
- update clippy rules


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2599


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
