### PR TITLE
use paritydb by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Notable updates:
 * [keystore] Allow specifying the encryption passphrase via environmental variable. [#2514](https://github.com/ChainSafe/forest/pull/2514)
 * [forest daemon] The `--skip-load` flag must be now called with a boolean indicating its value. [#2577](https://github.com/ChainSafe/forest/pull/2577)
 * [cli] Calibnet network needs to be specified for most commands, including `sync wait` and `snapshot export`. [#2579](https://github.com/ChainSafe/forest/pull/2579)
+* [daemon] Switch to ParityDb as the default backend for the Forest daemon. All clients must re-import the snapshot. The old database must be deleted manually - it is located in `$(forest-cli config dump | grep data_dir | cut -d' ' -f3)/<NETWORK>/rocksdb`. [#2606](https://github.com/ChainSafe/forest/pull/2606)
 
 ### Removed
 * [forest daemon] Removed `--halt-after-import` and `--auto-download-snapshot` from configuration. They are now strictly a CLI option. [#2577](https://github.com/ChainSafe/forest/pull/2577)

--- a/Makefile
+++ b/Makefile
@@ -14,20 +14,20 @@ install-daemon:
 
 install: install-cli install-daemon
 
-# Installs Forest binaries with ParityDb backend
-install-with-paritydb:
-	cargo install --locked --path forest/daemon --force --no-default-features --features forest_fil_cns,paritydb
-	cargo install --locked --path forest/cli --force --no-default-features --features paritydb
+# Installs Forest binaries with RocksDb backend
+install-with-rocksdb:
+	cargo install --locked --path forest/daemon --force --no-default-features --features forest_fil_cns,rocksdb
+	cargo install --locked --path forest/cli --force --no-default-features --features rocksdb
 
 # Installs Forest binaries with Jemalloc global allocator
 install-with-jemalloc:
-	cargo install --locked --path forest/daemon --force --no-default-features --features forest_fil_cns,paritydb,jemalloc
-	cargo install --locked --path forest/cli --force --no-default-features --features paritydb,jemalloc
+	cargo install --locked --path forest/daemon --force --features jemalloc
+	cargo install --locked --path forest/cli --force --features jemalloc
 
 # Installs Forest binaries with MiMalloc global allocator
 install-with-mimalloc:
-	cargo install --locked --path forest/daemon --force --no-default-features --features forest_fil_cns,paritydb,mimalloc
-	cargo install --locked --path forest/cli --force --no-default-features --features paritydb,mimalloc
+	cargo install --locked --path forest/daemon --force --features mimalloc
+	cargo install --locked --path forest/cli --force --features mimalloc
 
 install-deps:
 	apt-get update -y
@@ -96,7 +96,7 @@ lint-clippy:
 	cargo clippy -p forest_libp2p_bitswap --all-targets -- -D warnings -W clippy::unused_async -W clippy::redundant_else
 	cargo clippy -p forest_libp2p_bitswap --all-targets --features tokio -- -D warnings -W clippy::unused_async -W clippy::redundant_else
 	cargo clippy --features slow_tests,submodule_tests --all-targets -- -D warnings -W clippy::unused_async -W clippy::redundant_else
-	cargo clippy --all-targets --no-default-features --features forest_deleg_cns,paritydb,instrumented_kernel -- -D warnings -W clippy::unused_async -W clippy::redundant_else
+	cargo clippy --all-targets --no-default-features --features forest_deleg_cns,rocksdb,instrumented_kernel -- -D warnings -W clippy::unused_async -W clippy::redundant_else
 
 # Formats Rust and TOML files
 fmt:

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -63,7 +63,7 @@ assert_cmd.workspace = true
 rand.workspace = true
 
 [features]
-default = ["rocksdb"]
+default = ["paritydb"]
 rocksdb = ["forest_cli_shared/rocksdb", "forest_db/rocksdb"]
 paritydb = ["forest_cli_shared/paritydb", "forest_db/paritydb"]
 slow_tests = []

--- a/forest/daemon/Cargo.toml
+++ b/forest/daemon/Cargo.toml
@@ -56,7 +56,7 @@ tokio = { workspace = true, features = ["sync", "macros", "rt", "signal"] }
 assert_cmd.workspace = true
 
 [features]
-default = ["forest_fil_cns", "rocksdb"]
+default = ["forest_fil_cns", "paritydb"]
 rocksdb = ["forest_db/rocksdb", "forest_cli_shared/rocksdb"]
 paritydb = ["forest_db/paritydb", "forest_cli_shared/paritydb"]
 insecure_post = ["forest_fil_cns/insecure_post"]

--- a/node/db/src/parity_db.rs
+++ b/node/db/src/parity_db.rs
@@ -76,7 +76,7 @@ impl Store for ParityDb {
         self.db.commit(tx).map_err(Error::from)
     }
 
-    /// [ParityDB::commit] API is doing extra allocations on keys,
+    /// [parity_db::Db::commit] API is doing extra allocations on keys,
     /// See <https://docs.rs/crate/parity-db/0.4.3/source/src/db.rs>
     fn bulk_write(
         &self,

--- a/utils/statediff/Cargo.toml
+++ b/utils/statediff/Cargo.toml
@@ -41,4 +41,4 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 [features]
 paritydb = ["forest_db/paritydb"]
 rocksdb = ["forest_db/rocksdb"]
-default = ["rocksdb"]
+default = ["paritydb"]


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- Switch to ParityDb as the default.


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest/issues/2576


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->
If you were using the defaults, you must re-import the snapshot and delete the old rocksdb directory.

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
