### PR TITLE
Consume upstream `quickcheck` implementation for `PoStProof`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,7 +3506,7 @@ dependencies = [
  "fvm_ipld_car",
  "fvm_ipld_encoding 0.2.3",
  "fvm_shared 2.0.0",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "libipld",
  "log",
  "lru 0.9.0",
@@ -3549,7 +3549,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_shared 2.0.0",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "lru 0.9.0",
@@ -3775,12 +3775,12 @@ dependencies = [
  "forest_networks",
  "forest_shim",
  "fvm 2.2.0",
- "fvm 3.0.0-rc.1",
+ "fvm 3.0.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 2.0.0",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "num",
@@ -3834,7 +3834,7 @@ dependencies = [
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 2.0.0",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "multihash",
  "num",
  "num-bigint",
@@ -3952,7 +3952,7 @@ dependencies = [
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 2.0.0",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "rand 0.8.5",
  "serde",
 ]
@@ -3978,11 +3978,11 @@ dependencies = [
  "forest_state_manager",
  "forest_utils",
  "futures",
- "fvm 3.0.0-rc.1",
+ "fvm 3.0.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_shared 2.0.0",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "log",
  "lru 0.9.0",
  "num",
@@ -4077,7 +4077,7 @@ dependencies = [
  "futures",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "hex",
  "http",
  "jsonrpc-v2",
@@ -4153,14 +4153,15 @@ dependencies = [
  "cid",
  "filecoin-proofs-api",
  "fvm 2.2.0",
- "fvm 3.0.0-rc.1",
+ "fvm 3.0.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 2.0.0",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "num-bigint",
  "num-traits",
+ "quickcheck",
  "serde",
  "serde_json",
 ]
@@ -4191,7 +4192,7 @@ dependencies = [
  "forest_utils",
  "futures",
  "fvm 2.2.0",
- "fvm 3.0.0-rc.1",
+ "fvm 3.0.0",
  "fvm_ipld_amt 0.5.1",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
@@ -4578,8 +4579,8 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0-rc.1"
-source = "git+https://github.com/ChainSafe/ref-fvm?branch=lemmih-wibbles#4bc36ea0268be894e2103c8791b75f5542b9326a"
+version = "3.0.0"
+source = "git+https://github.com/ChainSafe/ref-fvm?branch=lemmih-wibbles#2bd2bd557bf0a318ea1b4fa076e6cdaba11fb2e9"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -4594,7 +4595,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "minstant",
@@ -4853,10 +4854,11 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.20"
-source = "git+https://github.com/ChainSafe/ref-fvm?branch=lemmih-wibbles#4bc36ea0268be894e2103c8791b75f5542b9326a"
+version = "3.0.0"
+source = "git+https://github.com/ChainSafe/ref-fvm?branch=lemmih-wibbles#2bd2bd557bf0a318ea1b4fa076e6cdaba11fb2e9"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "bitflags",
  "blake2b_simd",
  "bls-signatures",
@@ -4875,6 +4877,7 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
+ "quickcheck",
  "serde",
  "serde_repr",
  "serde_tuple",

--- a/utils/forest_shim/Cargo.toml
+++ b/utils/forest_shim/Cargo.toml
@@ -16,9 +16,10 @@ fvm_ipld_blockstore.workspace = true
 fvm_ipld_encoding.workspace = true
 fvm_ipld_encoding3 = { package = "fvm_ipld_encoding", version = "0.3" }
 fvm_shared.workspace = true
-fvm_shared3 = { workspace = true, features = ["proofs"] }
+fvm_shared3 = { workspace = true, features = ["proofs", "arb"] }
 num-bigint.workspace = true
 num-traits.workspace = true
+quickcheck.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/utils/forest_shim/src/sector.rs
+++ b/utils/forest_shim/src/sector.rs
@@ -207,6 +207,12 @@ impl From<SectorSize> for SectorSizeV2 {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct PoStProof(PoStProofV3);
 
+impl quickcheck::Arbitrary for PoStProof {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        PoStProof(PoStProofV3::arbitrary(g))
+    }
+}
+
 impl PoStProof {
     pub fn new(reg_post_proof: RegisteredPoStProof, proof_bytes: Vec<u8>) -> Self {
         PoStProof(PoStProofV3 {

--- a/utils/json/Cargo.toml
+++ b/utils/json/Cargo.toml
@@ -35,6 +35,7 @@ ahash.workspace = true
 arbitrary.workspace = true
 forest_test_utils.workspace = true
 fvm_shared = { workspace = true, features = ["arb"] }
+fvm_shared3 = { workspace = true, features = ["arb"] }
 num-bigint = { workspace = true, features = ["quickcheck"] }
 quickcheck.workspace = true
 quickcheck_macros.workspace = true

--- a/utils/json/src/sector.rs
+++ b/utils/json/src/sector.rs
@@ -106,46 +106,15 @@ pub mod json {
 
 #[cfg(test)]
 mod tests {
-    use forest_shim::{
-        sector::{PoStProof, RegisteredPoStProof},
-        Inner,
-    };
+    use forest_shim::sector::PoStProof;
     use quickcheck_macros::quickcheck;
     use serde_json;
 
-    #[derive(Clone, Debug, PartialEq)]
-    struct PoStProofWrapper {
-        postproof: PoStProof,
-    }
-
-    type RegisteredPoStProofFVM = <RegisteredPoStProof as Inner>::FVM;
-
-    impl quickcheck::Arbitrary for PoStProofWrapper {
-        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            let registered_postproof = g
-                .choose(&[
-                    RegisteredPoStProofFVM::StackedDRGWinning2KiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWinning8MiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWinning512MiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWinning32GiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWinning64GiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWindow2KiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWindow8MiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWindow512MiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWindow32GiBV1,
-                    RegisteredPoStProofFVM::StackedDRGWindow64GiBV1,
-                ])
-                .unwrap();
-            let postproof = PoStProof::new((*registered_postproof).into(), Vec::arbitrary(g));
-            PoStProofWrapper { postproof }
-        }
-    }
-
     #[quickcheck]
-    fn postproof_roundtrip(postproof: PoStProofWrapper) {
+    fn postproof_roundtrip(postproof: PoStProof) {
         let serialized: String =
-            forest_test_utils::to_string_with!(&postproof.postproof, super::json::serialize);
+            forest_test_utils::to_string_with!(&postproof, super::json::serialize);
         let parsed = forest_test_utils::from_str_with!(&serialized, super::json::deserialize);
-        assert_eq!(postproof.postproof, parsed);
+        assert_eq!(postproof, parsed);
     }
 }


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- Remove custom quickcheck implementation for `PoStProof` and instead use the implementation in `fvm_shared`.


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes respective part of associated task in #2143 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->
N/A

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
