### PR TITLE
fix(db): pin paritydb to v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7096,9 +7096,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df89dd8311063c54ae4e03d9aeb597b04212a57e82c339344130a9cad9b3e2d9"
+checksum = "dd684a725651d9588ef21f140a328b6b4f64e646b2e931f3e6f14f75eedf9980"
 dependencies = [
  "blake2",
  "crc32fast",
@@ -7110,7 +7110,6 @@ dependencies = [
  "memmap2",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "siphasher",
  "snap",
 ]
 

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -38,7 +38,7 @@ serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 
 # optional
-parity-db = { version = "0.4", default-features = false, optional = true }
+parity-db = { version = "=0.4.3", default-features = false, optional = true }
 rocksdb = { version = "0.20", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary of changes
<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- To get rid of a potential lookup bug in v0.4.4

To reproduce the bug, run `forest-cli snapshot export --dry-run` against a running forest daemon that is in sync with mainnet.  I constantly get `cid not found` error

P.S. I encountered the same issue before v0.4.4 was released when using a patch version between v0.4.3 and v0.4.4.  See [here](https://github.com/ChainSafe/forest/pull/2524#issuecomment-1426229800)


## Reference issue to close (if applicable)
<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->
Closes 


## Other information and links
<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist
<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
