### PR TITLE
fix(ci): remove protoc from all places

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,11 +90,6 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
-      - name: Install Protoc (MacOS)
-        if: contains(matrix.os, 'macos')
-        run: |
-          brew install protobuf
-          protoc --version
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 COPY --from=xx / /
 
 # install dependencies
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential clang protobuf-compiler cmake
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential clang cmake
 
 # export TARGETPLATFORM
 ARG TARGETPLATFORM

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -21,7 +21,7 @@ FROM alpine AS build-env
 
 # Install dependencies
 RUN apk update
-RUN apk add git curl protobuf make cmake gcc clang clang-dev musl-dev opencl-icd-loader-dev
+RUN apk add git curl make cmake gcc clang clang-dev musl-dev opencl-icd-loader-dev
 RUN update-ca-certificates
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install-with-mimalloc:
 
 install-deps:
 	apt-get update -y
-	apt-get install --no-install-recommends -y build-essential clang protobuf-compiler ocl-icd-opencl-dev aria2 cmake
+	apt-get install --no-install-recommends -y build-essential clang ocl-icd-opencl-dev aria2 cmake
 
 install-lint-tools:
 	cargo install --locked taplo-cli

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Install [rustup](https://rustup.rs/)
 - OS Base-Devel/Build-Essential
 - Clang compiler
 - OpenCL bindings
-- [Protoc](https://github.com/protocolbuffers/protobuf/releases/)
 
 ### Ubuntu (20.04)
 
@@ -76,7 +75,7 @@ sudo make install-deps
 or
 
 ```
-sudo apt install build-essential clang ocl-icd-opencl-dev protobuf-compiler cmake
+sudo apt install build-essential clang ocl-icd-opencl-dev cmake
 ```
 
 ### Archlinux
@@ -85,19 +84,16 @@ sudo apt install build-essential clang ocl-icd-opencl-dev protobuf-compiler cmak
 sudo pacman -S base-devel clang ocl-icd openssl
 ```
 
-NOTE: protobuf needs to be installed manually, and protoc needs to present in
-PATH
-
 ### Fedora (36)
 
 ```
-sudo dnf install -y clang-devel ocl-icd-devel protobuf-compiler cmake
+sudo dnf install -y clang-devel ocl-icd-devel cmake
 ```
 
 ### Alpine
 
 ```
-apk add git curl protobuf make cmake gcc clang clang-dev musl-dev opencl-icd-loader-dev
+apk add git curl make cmake gcc clang clang-dev musl-dev opencl-icd-loader-dev
 ```
 
 ## Installation


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

`protoc` is no longer needed to build the latest `rust-libp2p`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the
      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
      up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
