### PR TITLE
chore: use `Blockstore` instead of `Store`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,7 +3762,6 @@ dependencies = [
  "anyhow",
  "cid",
  "forest_blocks",
- "forest_db",
  "forest_state_manager",
  "forest_utils",
  "futures",

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -352,6 +352,12 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Db> {
         },
     }
 
+    // For convenience, flush the database after we've potentially loaded a new
+    // snapshot. This ensures the snapshot won't have to be re-imported if
+    // Forest is interrupted. As of writing, flushing only affects RocksDB and
+    // is a no-op with ParityDB.
+    state_manager.blockstore().flush()?;
+
     // Halt
     if opts.halt_after_import {
         // Cancel all async services

--- a/node/db/src/parity_db.rs
+++ b/node/db/src/parity_db.rs
@@ -142,8 +142,7 @@ impl Blockstore for ParityDb {
     {
         let values = blocks
             .into_iter()
-            .map(|(k, v)| (k.to_bytes(), v.as_ref().to_vec()))
-            .collect::<Vec<_>>();
+            .map(|(k, v)| (k.to_bytes(), v.as_ref().to_vec()));
         self.bulk_write(values).map_err(|e| e.into())
     }
 }

--- a/utils/genesis/Cargo.toml
+++ b/utils/genesis/Cargo.toml
@@ -13,7 +13,6 @@ testing = []
 anyhow.workspace = true
 cid.workspace = true
 forest_blocks.workspace = true
-forest_db.workspace = true
 forest_state_manager.workspace = true
 forest_utils.workspace = true
 futures.workspace = true


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->
Changes introduced in this pull request:
- Optimize `put_many_keyed` for ParityDB to avoid an unnecessary clone of the written data.
- Remove unnecessary `Store` trait constraints.
- Hoist out `blockstore.flush()` and document why we use it.
- Remove out-dated performance comments.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
