### PR TITLE
chore: upgrade paritydb to 0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7299,9 +7299,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd684a725651d9588ef21f140a328b6b4f64e646b2e931f3e6f14f75eedf9980"
+checksum = "00bfb81cf5c90a222db2fb7b3a7cbf8cc7f38dfb6647aca4d98edf8281f56ed5"
 dependencies = [
  "blake2",
  "crc32fast",
@@ -7313,6 +7313,7 @@ dependencies = [
  "memmap2",
  "parking_lot 0.12.1",
  "rand 0.8.5",
+ "siphasher",
  "snap",
 ]
 

--- a/node/db/Cargo.toml
+++ b/node/db/Cargo.toml
@@ -38,7 +38,7 @@ serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 
 # optional
-parity-db = { version = "=0.4.3", default-features = false, optional = true }
+parity-db = { version = "0.4.6", default-features = false, optional = true }
 rocksdb = { version = "0.20", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- [x] Manually verified that `forest-cli snapshot export --dry-run` works fine with `parity-db@0.4.6`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes  https://github.com/ChainSafe/forest/issues/2690

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the
      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
      up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
