### PR TITLE
Add better logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,7 +4193,6 @@ dependencies = [
  "forest_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared 2.3.0",
  "libipld-core 0.14.0",
  "serde",
  "serde_json",

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -10,6 +10,7 @@ use log::info;
 use num::BigInt;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use super::{Block, BlockHeader, Error, Ticket};
 
@@ -31,6 +32,13 @@ impl TipsetKeys {
     /// Returns tipset header `cids`
     pub fn cids(&self) -> &[Cid] {
         &self.cids
+    }
+}
+
+impl fmt::Display for TipsetKeys {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = self.cids().into_iter().map(|cid| cid.to_string()).collect::<Vec<_>>().join(", ");
+        write!(f, "[{}]", s)
     }
 }
 
@@ -216,9 +224,9 @@ impl Tipset {
                 ticket.vrfproof < other_ticket.vrfproof
             });
         if broken {
-            info!("weight tie broken in favour of {:?}", self.key());
+            info!("Weight tie broken in favour of {}", self.key());
         } else {
-            info!("weight tie left unbroken, default to {:?}", other.key());
+            info!("Weight tie left unbroken, default to {}", other.key());
         }
         broken
     }

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -1,6 +1,8 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::fmt;
+
 use ahash::{HashSet, HashSetExt};
 use cid::Cid;
 use forest_shim::address::Address;
@@ -10,7 +12,6 @@ use log::info;
 use num::BigInt;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use super::{Block, BlockHeader, Error, Ticket};
 
@@ -37,7 +38,12 @@ impl TipsetKeys {
 
 impl fmt::Display for TipsetKeys {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = self.cids().into_iter().map(|cid| cid.to_string()).collect::<Vec<_>>().join(", ");
+        let s = self
+            .cids()
+            .into_iter()
+            .map(|cid| cid.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
         write!(f, "[{}]", s)
     }
 }

--- a/blockchain/blocks/src/tipset.rs
+++ b/blockchain/blocks/src/tipset.rs
@@ -40,7 +40,7 @@ impl fmt::Display for TipsetKeys {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = self
             .cids()
-            .into_iter()
+            .iter()
             .map(|cid| cid.to_string())
             .collect::<Vec<_>>()
             .join(", ");

--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -271,7 +271,7 @@ where
 
         if new_weight > curr_weight {
             // TODO potentially need to deal with re-orgs here
-            info!("New heaviest tipset: {:?}", ts.key());
+            info!("New heaviest tipset! {} (EPOCH = {})", ts.key(), ts.epoch());
             self.set_heaviest_tipset(ts)?;
         }
         Ok(())

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -996,7 +996,7 @@ fn sync_tipset<DB: Blockstore + Clone + Sync + Send + 'static, C: Consensus>(
         )
         .await
         {
-            error!("Sync messages check state failed for single tipset");
+            warn!("Sync messages check state failed for single tipset");
             return Err(e);
         }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Demote error log to warning when sync messages check state failed for single tipset
- Add better display when a heaviest tipset is found

E.g.
```
2023-03-23T09:09:31.597841Z  INFO forest_chain_sync::tipset_syncer: Fork detected, searching for a common ancestor between the local chain and the network chain    
2023-03-23T09:09:31.597943Z  INFO forest_chain_sync::tipset_syncer: Validating tipset: EPOCH = 407873, N blocks = 1    
2023-03-23T09:09:31.597966Z  WARN forest_chain_sync::tipset_syncer: Validating block [CID = bafy2bzacebk7rwhxfiajj3cpcurpc3rlhnjygsczgto7oqgobkl4xu2y6so22] in EPOCH = 407873 failed: Loading tipset parent from the store failed: Key for header not found    
2023-03-23T09:09:31.597973Z  WARN forest_chain_sync::tipset_syncer: Sync messages check state failed for single tipset    
2023-03-23T09:09:31.597977Z ERROR forest_chain_sync::tipset_syncer: Syncing tipset range [407873, 407873] failed: Loading tipset parent from the store failed: Key for header not found    
Downloading headers 0 / 0 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.00 % 0.00/s 2023-03-23T09:09:32.555868Z  INFO forest_chain_sync::tipset_syncer: Fork detected, searching for a common ancestor between the local chain and the network chain    
2023-03-23T09:10:13.814747Z  INFO forest_chain_sync::tipset_syncer: Validating tipset: EPOCH = 407871, N blocks = 4    
2023-03-23T09:10:14.736142Z  INFO forest_chain_sync::tipset_syncer: Validating tipset: EPOCH = 407872, N blocks = 3    
2023-03-23T09:10:14.750181Z  INFO forest_chain_sync::tipset_syncer: Validating tipset: EPOCH = 407873, N blocks = 1    
2023-03-23T09:10:14.874964Z  INFO forest_chain::store::chain_store: New heaviest tipset! [bafy2bzaceb7nnbv34uslnav55yoshafpo6rfmvx322vnpcmu3yqrkcylcmzha] (EPOCH = 407873)    
2023-03-23T09:10:14.875180Z  INFO forest_chain_sync::tipset_syncer: Successfully synced tipset range: [407873, 407873]
```


## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #2278

Some of the errors were fixed by #2692. The rest of errors are legit (those are mostly coming from single tipsets).

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the
      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
      up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
