### PR TITLE
fix: clean and validate auxiliary state files

### DIFF
--- a/forest/cli/src/cli/db_cmd.rs
+++ b/forest/cli/src/cli/db_cmd.rs
@@ -51,7 +51,7 @@ impl DBCommands {
                 Ok(())
             }
             Self::Clean { force } => {
-                let dir = db_root(&chain_path(config));
+                let dir = chain_path(config);
                 if !dir.is_dir() {
                     println!(
                         "Aborted. Database path {} is not a valid directory",


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Validate the heaviest tipset (which is stored separately from the blockstore).
- Clean all db files when running `forest-cli db clean`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #2694 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the
      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
      up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
