### PR TITLE
fix(gc): do not run GC when heaviest tipset is not stored in current db space

### DIFF
--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -179,6 +179,7 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Rolli
         let get_tipset = move || {
             let ts = chain_store.heaviest_tipset().as_ref().clone();
             let current_db = &chain_store.blockstore().current();
+            // Make sure the tipset is stored in the current database space and not being deleted. block GC otherwise
             if ts
                 .key()
                 .cids()

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -179,7 +179,8 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Rolli
         let get_tipset = move || {
             let ts = chain_store.heaviest_tipset().as_ref().clone();
             let current_db = &chain_store.blockstore().current();
-            // Make sure the tipset is stored in the current database space and not being deleted. block GC otherwise
+            // Make sure the tipset is stored in the current database space and not being
+            // deleted. block GC otherwise
             if ts
                 .key()
                 .cids()

--- a/node/db/src/rolling/gc.rs
+++ b/node/db/src/rolling/gc.rs
@@ -87,6 +87,7 @@ where
     F: Fn() -> anyhow::Result<Tipset> + Send + Sync + 'static,
 {
     db: RollingDB,
+    /// Gets the tipset that `fn walk_snapshot` walks back from
     get_tipset: F,
     lock: Mutex<()>,
     gc_tx: flume::Sender<flume::Sender<anyhow::Result<()>>>,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- do not run GC when heaviest tipset is not stored in current db space, otherwise, forest will run into some unrecoverable state

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the
      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
      up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
