### PR TITLE
feat: add `fn heaviest_finalized_tipset` to `ChainStore`

### DIFF
--- a/blockchain/chain/src/store/chain_store.rs
+++ b/blockchain/chain/src/store/chain_store.rs
@@ -242,6 +242,19 @@ where
             .expect("Failed to load heaviest tipset")
     }
 
+    /// Returns the heaviest finalized tipset by walking back from the currently
+    /// tracked heaviest tipset by FINALITY(900) epochs.
+    pub fn heaviest_finalized_tipset(&self) -> anyhow::Result<Arc<Tipset>> {
+        const FINALITY_EPOCHS: i64 = 900;
+
+        let mut ts = self.heaviest_tipset();
+        for _i in 0..FINALITY_EPOCHS {
+            ts = self.tipset_from_keys(ts.parents())?;
+        }
+
+        Ok(ts)
+    }
+
     /// Returns a reference to the publisher of head changes.
     pub fn publisher(&self) -> &Publisher<HeadChange> {
         &self.publisher


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

Add `fn heaviest_finalized_tipset` to `ChainStore` so that during GC we could check and ensure `heaviest_finalized_tipset` exists in the current DB space and never get deleted.   Change the [tipset check logic](https://github.com/ChainSafe/forest/pull/2724/files#diff-b36dc5aaddbd079edb780b9259815c30048d1a0fd67aa2b0201494af6edd17bdR184) here once the other PR is merged

### Assumptions:
1. The chain can be split into 2 parts:
  a. epoch(genesis) to epoch(head - FINALITY(900)), which is immutable.
  b. epoch(head - FINALITY(900)) to epoch(head), which is mutable.
2. It could cause problems when GC deletes data from the mutable part of the chain
3. It will not cause problems when GC only deletes data from the immutable part of the chain

### Solution:
Run GC only when the entire mutable part of the chain is stored in the current DB space and will not be deleted.
(Above will be included in the subsequent PR that implements the check)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the
      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
      up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
