### PR TITLE
chore: Add a closer tipset checkpoint on calibnet

### DIFF
--- a/blockchain/chain/src/store/index.rs
+++ b/blockchain/chain/src/store/index.rs
@@ -71,8 +71,10 @@ pub(super) mod checkpoint_tipsets {
         let mut map = HashMap::new();
         const CALIBNET_CHECKPOINT_41000: TipsetKeyHash = "1a11a07d427348cc14eaa901de1ba9c6a4e18400bb557f5a0fabbcb22352319e31a7bc988a92525339f84275c0ef6dfbffcb50bb9d9843701875eecfa3ccb069";
         const CALIBNET_CHECKPOINT_84000: TipsetKeyHash = "326a645e679bc590118c80778588ff8d4e4a13eb7db25fe7a2fc3fbdcd97cf751fc4ee6c11f9f2ee97717eb15cb98771b944581ef329cb0dc6802dc81190e017";
+        const CALIBNET_CHECKPOINT_424000: TipsetKeyHash = "8cab45fd441c1fb68d2fd7e45d5e9ef9a5d3b45f68b414ab3e244233dd8e37fc4dacffc8966b2dc8804d4abf92c8a57efda743e26db6805a77a4feac19478293";
         add_calibnet!(map, CALIBNET_CHECKPOINT_41000);
         add_calibnet!(map, CALIBNET_CHECKPOINT_84000);
+        add_calibnet!(map, CALIBNET_CHECKPOINT_424000);
         map
     });
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Adds a closer tipset checkpoint at epoch 424000 for calibnet.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation,
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the
      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
      up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
