### PR TITLE
fix(gc): check chain finality before triggering gc

### DIFF
--- a/documentation/src/developer_documentation/state_migration_spike.md
+++ b/documentation/src/developer_documentation/state_migration_spike.md
@@ -3,7 +3,8 @@
 ### What is state migration?
 
 State migration is a process where the `StateTree` contents are transformed from
-an older form to a newer form. Certain Actors may need to be created or migrated as well.
+an older form to a newer form. Certain Actors may need to be created or migrated
+as well.
 
 ### Why do we need to migrate?
 
@@ -19,8 +20,14 @@ https://github.com/filecoin-project/ref-fvm/pull/1062
 We need to upgrade the `StateTree` which is represented as
 `HAMT<Cid, ActorState>` to the latest version.
 
-On top of that, we need to migrate certain actors. In the case of NV18 upgrade, it's the [init](https://github.com/filecoin-project/go-state-types/blob/d8fdbda2ad86de55bcde7f567c6da9c5f430c7a1/builtin/v10/migration/init.go#L32) and [system](https://github.com/filecoin-project/go-state-types/blob/master/builtin/v10/migration/system.go#L24) actor.
-[EAM](https://github.com/filecoin-project/go-state-types/blob/master/builtin/v10/migration/eam.go) actor needs to be created.
+On top of that, we need to migrate certain actors. In the case of NV18 upgrade,
+it's the
+[init](https://github.com/filecoin-project/go-state-types/blob/d8fdbda2ad86de55bcde7f567c6da9c5f430c7a1/builtin/v10/migration/init.go#L32)
+and
+[system](https://github.com/filecoin-project/go-state-types/blob/master/builtin/v10/migration/system.go#L24)
+actor.
+[EAM](https://github.com/filecoin-project/go-state-types/blob/master/builtin/v10/migration/eam.go)
+actor needs to be created.
 
 ### When to upgrade?
 

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -177,7 +177,11 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Rolli
         let db = db.clone();
         let chain_store = chain_store.clone();
         let get_tipset = move || chain_store.heaviest_tipset().as_ref().clone();
-        Arc::new(DbGarbageCollector::new(db, get_tipset))
+        Arc::new(DbGarbageCollector::new(
+            db,
+            config.chain.policy.chain_finality,
+            get_tipset,
+        ))
     };
 
     if !opts.no_gc {

--- a/node/db/src/rolling/gc.rs
+++ b/node/db/src/rolling/gc.rs
@@ -182,6 +182,19 @@ where
     /// 2. writes blocks that are absent from the `current` database to it
     /// 3. delete `old` database(s)
     /// 4. sets `current` database to a newly created one
+    ///
+    /// ## Data Safety
+    /// The blockchain consists of an immutable part (tipsets that are at least
+    /// 900 epochs older than the current head) and a mutable part (tipsets
+    /// that are within the most recent 900 epochs). Deleting data from the
+    /// mutable part of the chain can be problematic, so that we record the
+    /// exact epoch at which a new current db space is created, and only perform
+    /// garbage collection when this creation epoch has become immutable (at
+    /// least 900 epochs older than the current head), thus the old db space
+    /// that will be deleted at the end of garbage collection only contains
+    /// immutable or finalized part of the chain, from which all block data that
+    /// is marked as unreachable will not become reachable because of the
+    /// chain being mutated later
     async fn collect_once(&self) -> anyhow::Result<()> {
         let tipset = (self.get_tipset)();
 

--- a/node/db/src/rolling/gc.rs
+++ b/node/db/src/rolling/gc.rs
@@ -187,14 +187,14 @@ where
     /// The blockchain consists of an immutable part (tipsets that are at least
     /// 900 epochs older than the current head) and a mutable part (tipsets
     /// that are within the most recent 900 epochs). Deleting data from the
-    /// mutable part of the chain can be problematic, therefore we record the
-    /// exact epoch at which a new current db space is created, and only perform
+    /// mutable part of the chain can be problematic; therefore, we record the
+    /// exact epoch at which a new current database space is created, and only perform
     /// garbage collection when this creation epoch has become immutable (at
-    /// least 900 epochs older than the current head), thus the old db space
+    /// least 900 epochs older than the current head), thus the old database space
     /// that will be deleted at the end of garbage collection only contains
     /// immutable or finalized part of the chain, from which all block data that
     /// is marked as unreachable will not become reachable because of the
-    /// chain being mutated later
+    /// chain being mutated later.
     async fn collect_once(&self) -> anyhow::Result<()> {
         let tipset = (self.get_tipset)();
 

--- a/node/db/src/rolling/gc.rs
+++ b/node/db/src/rolling/gc.rs
@@ -187,7 +187,7 @@ where
     /// The blockchain consists of an immutable part (tipsets that are at least
     /// 900 epochs older than the current head) and a mutable part (tipsets
     /// that are within the most recent 900 epochs). Deleting data from the
-    /// mutable part of the chain can be problematic, so that we record the
+    /// mutable part of the chain can be problematic, therefore we record the
     /// exact epoch at which a new current db space is created, and only perform
     /// garbage collection when this creation epoch has become immutable (at
     /// least 900 epochs older than the current head), thus the old db space

--- a/node/db/src/rolling/gc.rs
+++ b/node/db/src/rolling/gc.rs
@@ -186,7 +186,7 @@ where
         let tipset = (self.get_tipset)();
 
         if self.db.current_creation_epoch() + self.chain_finality >= tipset.epoch() {
-            anyhow::bail!("Cancelling GC: the old DB space contains non-finalized chain parts");
+            anyhow::bail!("Cancelling GC: the old DB space contains unfinalized chain parts");
         }
 
         let guard = self.lock.try_lock();

--- a/node/db/src/rolling/gc.rs
+++ b/node/db/src/rolling/gc.rs
@@ -188,13 +188,13 @@ where
     /// 900 epochs older than the current head) and a mutable part (tipsets
     /// that are within the most recent 900 epochs). Deleting data from the
     /// mutable part of the chain can be problematic; therefore, we record the
-    /// exact epoch at which a new current database space is created, and only perform
-    /// garbage collection when this creation epoch has become immutable (at
-    /// least 900 epochs older than the current head), thus the old database space
-    /// that will be deleted at the end of garbage collection only contains
-    /// immutable or finalized part of the chain, from which all block data that
-    /// is marked as unreachable will not become reachable because of the
-    /// chain being mutated later.
+    /// exact epoch at which a new current database space is created, and only
+    /// perform garbage collection when this creation epoch has become
+    /// immutable (at least 900 epochs older than the current head), thus
+    /// the old database space that will be deleted at the end of garbage
+    /// collection only contains immutable or finalized part of the chain,
+    /// from which all block data that is marked as unreachable will not
+    /// become reachable because of the chain being mutated later.
     async fn collect_once(&self) -> anyhow::Result<()> {
         let tipset = (self.get_tipset)();
 

--- a/node/db/src/rolling/impls.rs
+++ b/node/db/src/rolling/impls.rs
@@ -192,6 +192,7 @@ impl RollingDB {
     /// the dangling `old` DB.
     pub(super) fn next_current(&self, current_epoch: i64) -> anyhow::Result<()> {
         let new_db_name = Uuid::new_v4().simple().to_string();
+        info!("Setting {new_db_name} as current db");
         let db = open_db(&self.db_root.join(&new_db_name), &self.db_config)?;
         *self.old.write() = self.current.read().clone();
         *self.current.write() = db;

--- a/node/db/src/rolling/impls.rs
+++ b/node/db/src/rolling/impls.rs
@@ -190,7 +190,7 @@ impl RollingDB {
 
     /// Sets `current` as `old`, and sets a new DB as `current`, finally delete
     /// the dangling `old` DB.
-    pub(crate) fn next_current(&self) -> anyhow::Result<()> {
+    pub(super) fn next_current(&self, current_epoch: i64) -> anyhow::Result<()> {
         let new_db_name = Uuid::new_v4().simple().to_string();
         let db = open_db(&self.db_root.join(&new_db_name), &self.db_config)?;
         *self.old.write() = self.current.read().clone();
@@ -200,10 +200,15 @@ impl RollingDB {
         let old_db_path = self.db_root.join(&db_index_inner_mut.old);
         db_index_inner_mut.old = db_index_inner_mut.current.clone();
         db_index_inner_mut.current = new_db_name;
+        db_index_inner_mut.current_creation_epoch = current_epoch;
         db_index.sync()?;
         delete_db(&old_db_path);
 
         Ok(())
+    }
+
+    pub(super) fn current_creation_epoch(&self) -> i64 {
+        self.db_index.read().inner().current_creation_epoch
     }
 
     pub fn total_size_in_bytes(&self) -> anyhow::Result<u64> {
@@ -298,7 +303,7 @@ mod tests {
             if i == split_index {
                 sleep(Duration::from_millis(1));
                 println!("Creating a new current db");
-                rolling_db.next_current()?;
+                rolling_db.next_current(0)?;
                 println!("Created a new current db");
             }
             rolling_db.put_keyed(k, block)?;
@@ -312,7 +317,7 @@ mod tests {
             );
         }
 
-        rolling_db.next_current()?;
+        rolling_db.next_current(0)?;
 
         for (i, (k, _)) in pairs.iter().enumerate() {
             if i < split_index {

--- a/node/db/src/rolling/mod.rs
+++ b/node/db/src/rolling/mod.rs
@@ -46,5 +46,7 @@ pub struct RollingDB {
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct DbIndex {
     current: String,
+    #[serde(default = "Default::default")]
+    current_creation_epoch: i64,
     old: String,
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Add `current_creation_epoch` to db metadata
- Add checks to ensure GC can only be performed when the old db sapce does not contain any mutable part of the chain
- Docs on gc data safety

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/2729

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the
      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
      up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
