### PR TITLE
fix: improve linebreak handling in github templates

### DIFF
--- a/.github/.prettierrc
+++ b/.github/.prettierrc
@@ -1,0 +1,1 @@
+proseWrap: never

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,10 +25,9 @@ Closes
 
 - [ ] I have performed a self-review of my own code,
 - [ ] I have made corresponding changes to the documentation,
-- [ ] I have added tests that prove my fix is effective or that my feature works
-      (if possible),
-- [ ] I have made sure the
-      [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is
-      up-to-date. All user-facing changes should be reflected in this document.
+- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
+- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.
 
 <!-- Thank you 🔥 -->
+
+[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- GitHub treats newlines as line breaks in issues and PRs (but not in standalone markdown documents).
- This PR disables word-wrapping in our github templates to avoid unintended line breaks.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works  (if possible),
- [x] I have made sure the [CHANGELOG](https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md) is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->
