### PR TITLE
fix: tweak the logic of loading admin token in gen_coerage_report.sh

### DIFF
--- a/scripts/gen_coverage_report.sh
+++ b/scripts/gen_coverage_report.sh
@@ -14,6 +14,7 @@
 set +e
 
 TMP_DIR=$(mktemp --directory)
+TOKEN_PATH="/tmp/forest_admin_token"
 
 function cleanup {
   # echo Removing temporary directory $TMP_DIR
@@ -35,7 +36,7 @@ cov forest --chain calibnet --encrypt-keystore false --import-snapshot "$SNAPSHO
 cov forest-cli --chain calibnet db clean --force
 cov forest-cli --chain calibnet snapshot fetch --aria2 -s "$TMP_DIR"
 SNAPSHOT_PATH=$(find "$TMP_DIR" -name \*.car | head -n 1)
-cov forest --chain calibnet --encrypt-keystore false --import-snapshot "$SNAPSHOT_PATH" --height=-200 --detach --track-peak-rss
+cov forest --chain calibnet --encrypt-keystore false --import-snapshot "$SNAPSHOT_PATH" --height=-200 --detach --track-peak-rss --save-token "$TOKEN_PATH"
 cov forest-cli sync wait
 cov forest-cli sync status
 cov forest-cli chain validate-tipset-checkpoints
@@ -46,8 +47,8 @@ cov forest-cli attach --exec 'showPeers()'
 cov forest-cli net listen
 cov forest-cli net peers
 
-# This is rather ugly. Is there a better way of managing the tokens?
-TOKEN=$(grep "Admin token" forest.out  | cut -d ' ' -f 7)
+# Load the admin token
+TOKEN=$(cat "$TOKEN_PATH")
 
 # Get default address
 DEFAULT_ADDR=$(cov forest-cli --token "$TOKEN" wallet default)


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

tweak the logic of loading admin token in gen_coerage_report.sh, came across this while working on  https://github.com/ChainSafe/forest/pull/2754

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
