### PR TITLE
fix(ci): move sccache-action to before installing cargo bins

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Apt Dependencies
         uses: nick-fields/retry@v2
         with:
@@ -28,10 +32,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "node/forest_libp2p/bitswap/tests/go-app/go.mod"
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
-        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
-        continue-on-error: true
       - name: Run cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Apt Dependencies
         uses: nick-fields/retry@v2
         with:
@@ -39,10 +43,6 @@ jobs:
         run: make install-doc-tools
         env:
           RUSTFLAGS: "-Cstrip=symbols"
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
-        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
-        continue-on-error: true
       - name: Execute MDBook
         run: make mdbook-build
       - name: Build rustdoc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,10 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Apt Dependencies
         uses: nick-fields/retry@v2
         with:
@@ -66,10 +70,6 @@ jobs:
         run: make install-lint-tools-ci
         env:
           RUSTFLAGS: "-Cstrip=symbols"
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
-        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
-        continue-on-error: true
       - run: make lint-all
         env:
           CC: "sccache clang"
@@ -113,16 +113,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
       - name: Apt Dependencies
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 3
           command: sudo make install-deps
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
-        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
-        continue-on-error: true
       - name: build and install binaries
         run: make install
         env:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

Move `sccache-action` to before installing cargo bins to avoid potential failures when certain binaries need to be built from source

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
