### PR TITLE
fix(ci): remove `cache-cargo-bin` from lint job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,6 @@ jobs:
           command: |
             sudo make install-deps
             sudo apt-get install -y libclang-dev # required dep for cargo-spellcheck
-      - uses: hanabi1224/cache-cargo-bin-action@v1.0.0
       - name: Install Lint tools
         run: make install-lint-tools-ci
         env:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- remove `cache-cargo-bin` from lint job

The cache action does not work with `cargo binstall` because the latter does not update cargo bin index under `~/.cargo/.crates2.json` and does not check the existence of the installed binary

```console
➜  forest git:(main) ✗ cargo binstall --no-confirm taplo-cli
 INFO resolve: Resolving package: 'taplo-cli'
 INFO resolve: taplo-cli v0.8.0 is already installed, use --force to override
 INFO Done in 619.288521ms
➜  forest git:(main) ✗ rm ~/.cargo/bin/taplo
➜  forest git:(main) ✗  cargo binstall --no-confirm taplo-cli
 INFO resolve: Resolving package: 'taplo-cli'
 INFO resolve: taplo-cli v0.8.0 is already installed, use --force to override
 INFO Done in 531.552454ms
➜  forest git:(main) ✗ which taplo
taplo not found
➜  forest git:(main) ✗
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
