### PR TITLE
Fix Forest when using a config file to run calibnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,15 @@
 
 ### Changed
 
+- [#2796] (https://github.com/ChainSafe/forest/pull/2796): Remove ability to use
+  at the same time `--chain` and `--config` flags for forest binary.
+
 ### Removed
 
 ### Fixed
+
+- [#2796] (https://github.com/ChainSafe/forest/pull/2796): Fix issue when
+  running Forest on calibnet using a configuration file only.
 
 ## Forest v0.8.1 "Cold Exposure"
 

--- a/forest/shared/src/cli/config.rs
+++ b/forest/shared/src/cli/config.rs
@@ -7,7 +7,7 @@ use std::{path::PathBuf, sync::Arc};
 use forest_chain_sync::SyncConfig;
 use forest_db::db_engine::DbConfig;
 use forest_libp2p::Libp2pConfig;
-use forest_networks::ChainConfig;
+use forest_networks::{ChainConfig, NetworkChain};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -195,6 +195,18 @@ pub struct Config {
     pub log: LogConfig,
     pub snapshot_fetch: SnapshotFetchConfig,
     pub tokio: TokioConfig,
+}
+
+impl Config {
+    pub fn from_chain(network_type: &NetworkChain) -> Self {
+        match network_type {
+            NetworkChain::Mainnet => Config::default(),
+            NetworkChain::Calibnet => Config {
+                chain: Arc::new(ChainConfig::calibnet()),
+                ..Config::default()
+            },
+        }
+    }
 }
 
 impl Config {

--- a/forest/shared/src/cli/mod.rs
+++ b/forest/shared/src/cli/mod.rs
@@ -38,7 +38,7 @@ OPTIONS:
 ";
 
 /// CLI options
-#[derive(Debug, Parser)]
+#[derive(Default, Debug, Parser)]
 pub struct CliOpts {
     /// A TOML file containing relevant configurations
     #[arg(short, long)]
@@ -428,5 +428,20 @@ mod tests {
                 (vec!["myth", "entities"], "baz"),
             ]
         );
+    }
+
+    #[test]
+    fn combination_of_following_flags_should_fail() {
+        // Check for --chain and --config
+        let mut options = CliOpts::default();
+        options.config = Some("config.toml".into());
+        options.chain = Some(NetworkChain::Calibnet);
+        assert!(options.to_config().is_err());
+
+        // Check for --import_snapshot and --import_chain
+        let mut options = CliOpts::default();
+        options.import_snapshot = Some("snapshot.car".into());
+        options.import_chain = Some("snapshot.car".into());
+        assert!(options.to_config().is_err());
     }
 }

--- a/forest/shared/src/cli/mod.rs
+++ b/forest/shared/src/cli/mod.rs
@@ -433,15 +433,19 @@ mod tests {
     #[test]
     fn combination_of_following_flags_should_fail() {
         // Check for --chain and --config
-        let mut options = CliOpts::default();
-        options.config = Some("config.toml".into());
-        options.chain = Some(NetworkChain::Calibnet);
+        let options = CliOpts {
+            config: Some("config.toml".into()),
+            chain: Some(NetworkChain::Calibnet),
+            ..Default::default()
+        };
         assert!(options.to_config().is_err());
 
         // Check for --import_snapshot and --import_chain
-        let mut options = CliOpts::default();
-        options.import_snapshot = Some("snapshot.car".into());
-        options.import_chain = Some("snapshot.car".into());
+        let options = CliOpts {
+            import_snapshot: Some("snapshot.car".into()),
+            import_chain: Some("snapshot.car".into()),
+            ..Default::default()
+        };
         assert!(options.to_config().is_err());
     }
 }

--- a/forest/shared/src/cli/mod.rs
+++ b/forest/shared/src/cli/mod.rs
@@ -140,6 +140,10 @@ pub struct CliOpts {
 
 impl CliOpts {
     pub fn to_config(&self) -> Result<(Config, Option<ConfigPath>), anyhow::Error> {
+        if self.config.is_some() && self.chain.is_some() {
+            anyhow::bail!("Can't use a config file and chain flag at the same time!")
+        }
+
         let path = find_config_path(self);
         let mut cfg: Config = match &path {
             Some(path) => {

--- a/forest/shared/src/logger/mod.rs
+++ b/forest/shared/src/logger/mod.rs
@@ -28,6 +28,12 @@ impl LoggingColor {
     }
 }
 
+impl Default for LoggingColor {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
 impl FromStr for LoggingColor {
     type Err = anyhow::Error;
 

--- a/networks/src/lib.rs
+++ b/networks/src/lib.rs
@@ -41,7 +41,7 @@ impl FromStr for NetworkChain {
         match s {
             "mainnet" => Ok(NetworkChain::Mainnet),
             "calibnet" => Ok(NetworkChain::Calibnet),
-            _ => Err(anyhow::anyhow!("unsupported network chain")),
+            name => Err(anyhow::anyhow!("unsupported network chain: {name}")),
         }
     }
 }

--- a/networks/src/lib.rs
+++ b/networks/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
+use anyhow::Error;
 use cid::Cid;
 use fil_actors_runtime_v10::runtime::Policy;
 use forest_beacon::{BeaconPoint, BeaconSchedule, DrandBeacon, DrandConfig};
@@ -24,6 +25,26 @@ const CALIBNET_ETH_CHAIN_ID: u64 = 314159;
 
 /// Newest network version for all networks
 pub const NEWEST_NETWORK_VERSION: NetworkVersion = NetworkVersion::V17;
+
+/// The `filecoin` network chain. In general only `mainnet` and its chain
+/// information should be considered stable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkChain {
+    Mainnet,
+    Calibnet,
+}
+
+impl FromStr for NetworkChain {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "mainnet" => Ok(NetworkChain::Mainnet),
+            "calibnet" => Ok(NetworkChain::Calibnet),
+            _ => Err(anyhow::anyhow!("unsupported network chain")),
+        }
+    }
+}
 
 /// Defines the meaningful heights of the protocol.
 #[derive(Debug, Display, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Add a proper enum for representing network chain
- Fix Forest when using toml file to run calibnet
- Disallow usage of flags `--config` and `--chain` at the same time

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

Related to issue we are facing in https://github.com/ChainSafe/forest/pull/2367#issuecomment-1520158028

Note the reason we need the fix on `main` branch is because the benchmark script is always compiling a fresh version of forest using `main`.

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
