### PR TITLE
Add print of message after sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3663,6 +3663,7 @@ dependencies = [
  "forest_utils",
  "fs_extra",
  "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.2.3",
  "fvm_shared 2.3.0",
  "hex",
  "human-repr",

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -39,6 +39,7 @@ forest_shim.workspace = true
 forest_utils.workspace = true
 fs_extra.workspace = true
 fvm_ipld_blockstore.workspace = true
+fvm_ipld_encoding.workspace = true
 fvm_shared = { workspace = true, default-features = false }
 hex.workspace = true
 human-repr.workspace = true

--- a/forest/cli/src/cli/send_cmd.rs
+++ b/forest/cli/src/cli/send_cmd.rs
@@ -60,7 +60,7 @@ impl SendCommand {
         };
 
         let signed_msg_json = mpool_push_message(
-            (MessageJson(message.clone().into()), None),
+            (MessageJson(message.into()), None),
             &config.client.rpc_token,
         )
         .await

--- a/forest/cli/src/cli/send_cmd.rs
+++ b/forest/cli/src/cli/send_cmd.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use forest_json::message::json::MessageJson;
 use forest_rpc_client::{mpool_push_message, wallet_default_address};
+use fvm_ipld_encoding::Cbor;
 use fvm_shared::{address::Address, econ::TokenAmount, message::Message, METHOD_SEND};
 use num::BigInt;
 
@@ -58,12 +59,14 @@ impl SendCommand {
             ..Default::default()
         };
 
-        mpool_push_message(
-            (MessageJson(message.into()), None),
+        let signed_msg_json = mpool_push_message(
+            (MessageJson(message.clone().into()), None),
             &config.client.rpc_token,
         )
         .await
         .map_err(handle_rpc_err)?;
+
+        println!("{}", signed_msg_json.0.cid().unwrap());
 
         Ok(())
     }

--- a/scripts/calibnet_health_check.sh
+++ b/scripts/calibnet_health_check.sh
@@ -150,7 +150,9 @@ echo "Listing wallet balances"
 $FOREST_CLI_PATH wallet list
 
 echo "Sending FIL to the above address"
-$FOREST_CLI_PATH send "$ADDR_TWO" "$FIL_AMT"
+MSG=$($FOREST_CLI_PATH send "$ADDR_TWO" "$FIL_AMT")
+echo "Resulting message:"
+echo "$MSG"
 
 echo "Checking balance of $ADDR_TWO..."
 

--- a/scripts/calibnet_health_check.sh
+++ b/scripts/calibnet_health_check.sh
@@ -151,7 +151,7 @@ $FOREST_CLI_PATH wallet list
 
 echo "Sending FIL to the above address"
 MSG=$($FOREST_CLI_PATH send "$ADDR_TWO" "$FIL_AMT")
-echo "Resulting message:"
+echo "Message cid:"
 echo "$MSG"
 
 echo "Checking balance of $ADDR_TWO..."


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Add printing of message cid in send subcommand (like in Lotus)
- Print message cid after send in calibnet health check script

This should help us troubleshooting by tracking the message on a block explorer:

<img width="870" alt="Screenshot 2023-04-27 at 14 52 03" src="https://user-images.githubusercontent.com/28275831/234867674-26fe1166-133c-4ffb-8804-5891055274fa.png">


## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
