### PR TITLE
fix: work-around for address parsing bug in the FVM

### DIFF
--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -77,7 +77,8 @@ fn unblock_parent_process() -> anyhow::Result<()> {
 pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<RollingDB> {
     {
         // UGLY HACK:
-        // This bypasses a bug in the FVM.
+        // This bypasses a bug in the FVM. Can be removed once the address parsing is
+        // fixed in the FVM.
         use forest_shim::address::Network;
         let bls_zero_addr = Network::Mainnet.parse_address("f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a").unwrap();
         assert!(bls_zero_addr.is_bls_zero_address());

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -75,6 +75,13 @@ fn unblock_parent_process() -> anyhow::Result<()> {
 
 /// Starts daemon process
 pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<RollingDB> {
+    {
+        // UGLY HACK:
+        // This bypasses a bug in the FVM.
+        use forest_shim::address::Network;
+        let bls_zero_addr = Network::Mainnet.parse_address("f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a").unwrap();
+        assert!(bls_zero_addr.is_bls_zero_address());
+    }
     if config.chain.name == "calibnet" {
         forest_shim::address::set_current_network(forest_shim::address::Network::Testnet);
     }

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -77,8 +77,8 @@ fn unblock_parent_process() -> anyhow::Result<()> {
 pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<RollingDB> {
     {
         // UGLY HACK:
-        // This bypasses a bug in the FVM. Can be removed once the address parsing is
-        // fixed in the FVM.
+        // This bypasses a bug in the FVM. Can be removed once the address parsing
+        // correctly takes the network into account.
         use forest_shim::address::Network;
         let bls_zero_addr = Network::Mainnet.parse_address("f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a").unwrap();
         assert!(bls_zero_addr.is_bls_zero_address());

--- a/vm/interpreter/src/vm.rs
+++ b/vm/interpreter/src/vm.rs
@@ -327,11 +327,6 @@ where
 
         let unsigned = msg.message().clone();
         let raw_length = msg.marshal_cbor().expect("encoding error").len();
-        // set the current network to mainnet. This doesn't affect message execution but
-        // it does get around a bug in the FVM. The code can be deleted once the FVM has
-        // been fixed.
-        let prev_network = forest_shim::address::current_network();
-        forest_shim::address::set_current_network(forest_shim::address::Network::Mainnet);
         let ret: ApplyRet = match self {
             VM::VM2 { fvm_executor, .. } => fvm_executor
                 .execute_message(
@@ -348,7 +343,6 @@ where
                 )?
                 .into(),
         };
-        forest_shim::address::set_current_network(prev_network);
 
         let exit_code = ret.msg_receipt().exit_code();
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:
- bypass bug in the `is_bls_zero_address` function from the FVM.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
