### PR TITLE
fix: allow --config and --chain to be used at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@
 
 ### Changed
 
-- [#2796] (https://github.com/ChainSafe/forest/pull/2796): Remove ability to use
-  at the same time `--chain` and `--config` flags for forest binary.
-
 ### Removed
 
 ### Fixed

--- a/forest/shared/src/cli/mod.rs
+++ b/forest/shared/src/cli/mod.rs
@@ -8,13 +8,14 @@ mod snapshot_fetch;
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use ahash::HashSet;
 use byte_unit::Byte;
 use clap::Parser;
 use directories::ProjectDirs;
-use forest_networks::NetworkChain;
+use forest_networks::{ChainConfig, NetworkChain};
 use forest_utils::io::{read_file_to_string, read_toml, ProgressBarVisibility};
 use log::error;
 use num::BigInt;
@@ -140,10 +141,6 @@ pub struct CliOpts {
 
 impl CliOpts {
     pub fn to_config(&self) -> Result<(Config, Option<ConfigPath>), anyhow::Error> {
-        if self.config.is_some() && self.chain.is_some() {
-            anyhow::bail!("Can't use a config file and chain flag at the same time!")
-        }
-
         let path = find_config_path(self);
         let mut cfg: Config = match &path {
             Some(path) => {
@@ -152,15 +149,15 @@ impl CliOpts {
                 // Parse and return the configuration file
                 read_toml(&toml)?
             }
-            None => {
-                if let Some(chain) = &self.chain {
-                    Config::from_chain(chain)
-                } else {
-                    // Create the default `mainnet` configuration.
-                    Config::default()
-                }
-            }
+            None => Config::default(),
         };
+
+        match &self.chain {
+            // override the chain configuration
+            Some(NetworkChain::Mainnet) => cfg.chain = Arc::new(ChainConfig::calibnet()),
+            Some(NetworkChain::Calibnet) => cfg.chain = Arc::new(ChainConfig::mainnet()),
+            _ => {}
+        }
 
         if let Some(genesis_file) = &self.genesis {
             cfg.client.genesis_file = Some(genesis_file.to_owned());

--- a/forest/shared/src/cli/mod.rs
+++ b/forest/shared/src/cli/mod.rs
@@ -154,8 +154,8 @@ impl CliOpts {
 
         match &self.chain {
             // override the chain configuration
-            Some(NetworkChain::Mainnet) => cfg.chain = Arc::new(ChainConfig::calibnet()),
-            Some(NetworkChain::Calibnet) => cfg.chain = Arc::new(ChainConfig::mainnet()),
+            Some(NetworkChain::Calibnet) => cfg.chain = Arc::new(ChainConfig::calibnet()),
+            Some(NetworkChain::Mainnet) => cfg.chain = Arc::new(ChainConfig::mainnet()),
             _ => {}
         }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The `--config` flag and `--chain` flag must be usable at the same time.
- The way we handle networks is completely broken. This PR is a band-aid solution.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
