### PR TITLE
optimize unused deps lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,8 +48,8 @@ jobs:
           CXX: "sccache clang++"
 
   lint-all:
-    name: All lint checks (lint audit spellcheck udeps)
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    name: All lint checks
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -37,14 +37,13 @@ install-lint-tools:
 	cargo install --locked taplo-cli
 	cargo install --locked cargo-audit
 	cargo install --locked cargo-spellcheck
-	cargo install --locked cargo-udeps
 
 install-lint-tools-ci:
 	wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
 	tar xzf cargo-binstall-x86_64-unknown-linux-musl.tgz
 	cp cargo-binstall ~/.cargo/bin/cargo-binstall
 
-	cargo binstall --no-confirm taplo-cli cargo-udeps cargo-spellcheck cargo-audit
+	cargo binstall --no-confirm taplo-cli cargo-spellcheck cargo-audit
 
 install-doc-tools:
 	cargo install --locked mdbook
@@ -76,13 +75,10 @@ clean:
 	@echo "Done cleaning."
 
 # Lints with everything we have in our CI arsenal
-lint-all: lint audit spellcheck udeps
+lint-all: lint audit spellcheck
 
 audit:
 	cargo audit --ignore RUSTSEC-2020-0071
-
-udeps:
-	cargo udeps --all-targets --features submodule_tests,instrumented_kernel
 
 spellcheck:
 	cargo spellcheck --code 1

--- a/README.md
+++ b/README.md
@@ -229,9 +229,6 @@ cargo install taplo-cli --locked
 # Scanning dependencies for security vulnerabilities
 cargo install cargo-audit
 
-# Unused dependencies check
-cargo install cargo-udeps --locked
-
 # Spellcheck
 cargo install cargo-spellcheck
 ```

--- a/node/forest_libp2p/bitswap/Cargo.toml
+++ b/node/forest_libp2p/bitswap/Cargo.toml
@@ -44,11 +44,6 @@ anyhow.workspace = true
 protobuf-codegen = "3.2"
 walkdir = "2.3"
 
-[package.metadata.cargo-udeps.ignore]
-normal = ["async-std"]
-development = []
-build = []
-
 [features]
 default = []
 

--- a/scripts/find_unused_deps.rb
+++ b/scripts/find_unused_deps.rb
@@ -31,13 +31,13 @@ Dir.glob('**/*.toml').each do |file|
       crates.add crate_name
     end
   end
+
+  # Load all the source code from the crate into an in-memory array
+  # to improve performance.
+  source_code = Dir.glob("#{crate_dir}/**/*.rs").map { |rs| File.read(rs) }
   crates.each do |crate|
-    used = false
     pattern = get_pattern(crate)
-    Dir.glob("#{crate_dir}/**/*.rs").each do |rs|
-      used |= File.read(rs).match?(pattern)
-    end
-    unless used || excluded?(crates, crate)
+    unless source_code.any? { |line| line.match?(pattern) } || excluded?(crates, crate)
       puts "Protentially unused: #{crate} in #{crate_dir}"
       exit_code = 1
     end


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- by moving the source code of each crate into memory, we can save quite a bit of time. On my machine it was taking 30s before and now it takes 3s,
- remove `udeps` as it is redundant given our script,
- move lint job to a GH worker cut costs,

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
