### PR TITLE
feat: get rid of three slow-tests by using dummy signatures

### DIFF
--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -702,7 +702,7 @@ mod test_selection {
         head_change,
         msgpool::{
             test_provider::{mock_block, TestApi},
-            tests::create_smsg,
+            tests::{create_fake_smsg, create_smsg},
         },
     };
 
@@ -1059,7 +1059,6 @@ mod test_selection {
         }
     }
 
-    #[cfg(feature = "slow_tests")]
     #[tokio::test]
     async fn test_optimal_msg_selection1() {
         // this test uses just a single actor sending messages with a low tq
@@ -1109,10 +1108,10 @@ mod test_selection {
         // order his messages first
         for i in 0..(n_msgs as usize) {
             let bias = (n_msgs as usize - i) / 3;
-            let m = create_smsg(
+            let m = create_fake_smsg(
+                &mpool,
                 &a2,
                 &a1,
-                &mut w1,
                 i as u64,
                 TEST_GAS_LIMIT,
                 (1 + i % 3 + bias) as u64,
@@ -1138,7 +1137,6 @@ mod test_selection {
         }
     }
 
-    #[cfg(feature = "slow_tests")]
     #[tokio::test]
     async fn test_optimal_msg_selection2() {
         let mut joinset = JoinSet::new();
@@ -1185,19 +1183,19 @@ mod test_selection {
         let n_msgs = 5 * fvm_shared::BLOCK_GAS_LIMIT / TEST_GAS_LIMIT;
         for i in 0..n_msgs as usize {
             let bias = (n_msgs as usize - i) / 3;
-            let m = create_smsg(
+            let m = create_fake_smsg(
+                &mpool,
                 &a2,
                 &a1,
-                &mut w1,
                 i as u64,
                 TEST_GAS_LIMIT,
                 (200000 + i % 3 + bias) as u64,
             );
             mpool.add(m).unwrap();
-            let m = create_smsg(
+            let m = create_fake_smsg(
+                &mpool,
                 &a1,
                 &a2,
-                &mut w2,
                 i as u64,
                 TEST_GAS_LIMIT,
                 (190000 + i % 3 + bias) as u64,
@@ -1243,16 +1241,13 @@ mod test_selection {
             }
         }
 
-        dbg!(n_from1, n_from2);
-
         if n_from1 > n_from2 {
             panic!("Expected more msgs from a2 than a1");
         }
     }
 
-    #[cfg(feature = "slow_tests")]
     #[tokio::test]
-    async fn test_optimal_message_selection3() {
+    async fn test_optimal_msg_selection3() {
         let mut joinset = JoinSet::new();
         // this test uses 10 actors sending a block of messages to each other, with the
         // the first actors paying higher gas premium than the subsequent
@@ -1308,10 +1303,10 @@ mod test_selection {
             for j in 0..n_actors {
                 let premium =
                     500000 + 10000 * (n_actors - j) + (n_msgs + 2 - i) / (30 * n_actors) + i % 3;
-                let m = create_smsg(
-                    &actors[(j % n_actors) as usize],
+                let m = create_fake_smsg(
+                    &mpool,
                     &actors[j as usize],
-                    &mut wallets[j as usize],
+                    &actors[j as usize],
                     i as u64,
                     TEST_GAS_LIMIT,
                     premium as u64,

--- a/blockchain/message_pool/src/msgpool/selection.rs
+++ b/blockchain/message_pool/src/msgpool/selection.rs
@@ -887,9 +887,6 @@ mod test_selection {
     }
 
     #[tokio::test]
-    // #[ignore = "test is incredibly slow"]
-    // TODO optimize logic tested in this function
-    #[cfg(feature = "slow_tests")]
     async fn message_selection_trimming() {
         let mut joinset = JoinSet::new();
         let mpool = make_test_mpool(&mut joinset);
@@ -932,19 +929,19 @@ mod test_selection {
         // make many small chains for the two actors
         for i in 0..nmsgs {
             let bias = (nmsgs - i) / 3;
-            let m = create_smsg(
+            let m = create_fake_smsg(
+                &mpool,
                 &a2,
                 &a1,
-                &mut w1,
                 i as u64,
                 TEST_GAS_LIMIT,
                 (1 + i % 3 + bias) as u64,
             );
             mpool.add(m).unwrap();
-            let m = create_smsg(
+            let m = create_fake_smsg(
+                &mpool,
                 &a1,
                 &a2,
-                &mut w2,
                 i as u64,
                 TEST_GAS_LIMIT,
                 (1 + i % 3 + bias) as u64,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The `test_optimal_msg_selection` tests were quite slow (~90seconds on my box) because they created and verified a bunch of signatures.
- Using dummy signatures reduced the total runtime to less than 2 seconds.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
