### PR TITLE
remove avx2 and fma flags from build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,13 +16,13 @@ incremental = true
 # clang has been listed as prerequisite in the doc
 linker = "clang"
 # enable avx2 by default since it's avaiable on almost all x86_64 CPUs
-rustflags = ["-Ctarget-feature=+avx2,+fma", "-Zshare-generics=y", "--cfg", "tokio_unstable"]
+rustflags = ["-Zshare-generics=y", "--cfg", "tokio_unstable"]
 
 [target.x86_64-unknown-linux-musl]
 # clang has been listed as prerequisite in the doc
 linker = "clang"
 # enable avx2 by default since it's avaiable on almost all x86_64 CPUs
-rustflags = ["-Ctarget-feature=+avx2,+fma", "-Zshare-generics=y", "--cfg", "tokio_unstable"]
+rustflags = ["-Zshare-generics=y", "--cfg", "tokio_unstable"]
 
 [target.x86_64-apple-darwin]
 # zld might help here


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
