### PR TITLE
fix: abstract out actor state type convertion logic in state_migration

### DIFF
--- a/vm/state_migration/src/common/mod.rs
+++ b/vm/state_migration/src/common/mod.rs
@@ -50,3 +50,14 @@ pub(crate) trait ActorMigration<BS: Blockstore + Clone + Send + Sync> {
 /// Post migration action to be executed after the state migration.
 pub(crate) type PostMigrationAction<BS> =
     Arc<dyn Fn(&BS, &mut StateTree<BS>) -> anyhow::Result<()> + Send + Sync>;
+
+/// Trait that migrates from one data structure to another, similar to
+/// [std::convert::TryInto] trait but taking an extra block store parameter
+pub(crate) trait TypeMigration<BS: Blockstore + Clone + Send + Sync, From, To> {
+    fn migrate_type(from: From, store: &BS) -> anyhow::Result<To>;
+}
+
+/// Struct that implements [TypeMigration] for different type pairs. Prefer to
+/// use a single struct so that the compiler could catch duplicate
+/// implementations
+pub(crate) struct TypeMigrator;

--- a/vm/state_migration/src/common/mod.rs
+++ b/vm/state_migration/src/common/mod.rs
@@ -52,12 +52,12 @@ pub(crate) type PostMigrationAction<BS> =
     Arc<dyn Fn(&BS, &mut StateTree<BS>) -> anyhow::Result<()> + Send + Sync>;
 
 /// Trait that migrates from one data structure to another, similar to
-/// [std::convert::TryInto] trait but taking an extra block store parameter
+/// [`std::convert::TryInto`] trait but taking an extra block store parameter
 pub(crate) trait TypeMigration<BS: Blockstore + Clone + Send + Sync, From, To> {
     fn migrate_type(from: From, store: &BS) -> anyhow::Result<To>;
 }
 
-/// Struct that implements [TypeMigration] for different type pairs. Prefer to
-/// use a single struct so that the compiler could catch duplicate
+/// Type that implements [`TypeMigration`] for different type pairs. Prefer
+/// using a single `struct` so that the compiler could catch duplicate
 /// implementations
 pub(crate) struct TypeMigrator;

--- a/vm/state_migration/src/common/mod.rs
+++ b/vm/state_migration/src/common/mod.rs
@@ -53,8 +53,8 @@ pub(crate) type PostMigrationAction<BS> =
 
 /// Trait that migrates from one data structure to another, similar to
 /// [`std::convert::TryInto`] trait but taking an extra block store parameter
-pub(crate) trait TypeMigration<BS: Blockstore + Clone + Send + Sync, From, To> {
-    fn migrate_type(from: From, store: &BS) -> anyhow::Result<To>;
+pub(crate) trait TypeMigration<From, To> {
+    fn migrate_type(from: From, store: &impl Blockstore) -> anyhow::Result<To>;
 }
 
 /// Type that implements [`TypeMigration`] for different type pairs. Prefer

--- a/vm/state_migration/src/lib.rs
+++ b/vm/state_migration/src/lib.rs
@@ -15,6 +15,7 @@ use fvm_ipld_blockstore::Blockstore;
 pub(crate) mod common;
 mod nv18;
 mod nv19;
+mod type_migrations;
 
 type RunMigration<DB> = fn(&ChainConfig, &DB, &Cid, ChainEpoch) -> anyhow::Result<Cid>;
 

--- a/vm/state_migration/src/nv19/miner.rs
+++ b/vm/state_migration/src/nv19/miner.rs
@@ -7,13 +7,14 @@
 use std::sync::Arc;
 
 use cid::{multihash::Code::Blake2b256, Cid};
-use fil_actor_miner_v10::{MinerInfo, State as StateV10};
-use fil_actor_miner_v11::{MinerInfo as MinerInfoV11, State as StateV11};
-use forest_shim::sector::convert_window_post_proof_v1_to_v1p1;
+use fil_actor_miner_v10::State as MinerStateOld;
+use fil_actor_miner_v11::State as MinerStateNew;
 use forest_utils::db::BlockstoreExt;
 use fvm_ipld_blockstore::Blockstore;
 
-use crate::common::{ActorMigration, ActorMigrationInput, ActorMigrationOutput};
+use crate::common::{
+    ActorMigration, ActorMigrationInput, ActorMigrationOutput, TypeMigration, TypeMigrator,
+};
 
 pub struct MinerMigrator(Cid);
 
@@ -29,70 +30,11 @@ impl<BS: Blockstore + Clone + Send + Sync> ActorMigration<BS> for MinerMigrator 
         store: BS,
         input: ActorMigrationInput,
     ) -> anyhow::Result<ActorMigrationOutput> {
-        let in_state: StateV10 = store
+        let in_state: MinerStateOld = store
             .get_obj(&input.head)?
             .ok_or_else(|| anyhow::anyhow!("Miner actor: could not read v10 state"))?;
 
-        let in_info: MinerInfo = store
-            .get_obj(&in_state.info)?
-            .ok_or_else(|| anyhow::anyhow!("Miner info: could not read v10 state"))?;
-
-        let out_proof_type = convert_window_post_proof_v1_to_v1p1(in_info.window_post_proof_type)
-            .map_err(|e| anyhow::anyhow!(e))?;
-
-        let out_info = MinerInfoV11 {
-            owner: in_info.owner,
-            worker: in_info.worker,
-            control_addresses: in_info.control_addresses,
-            pending_worker_key: in_info.pending_worker_key.map(|key| {
-                fil_actor_miner_v11::WorkerKeyChange {
-                    new_worker: key.new_worker,
-                    effective_at: key.effective_at,
-                }
-            }),
-            peer_id: in_info.peer_id,
-            multi_address: in_info.multi_address,
-            window_post_proof_type: out_proof_type,
-            sector_size: in_info.sector_size,
-            window_post_partition_sectors: in_info.window_post_partition_sectors,
-            consensus_fault_elapsed: in_info.consensus_fault_elapsed,
-            pending_owner_address: in_info.pending_owner_address,
-            beneficiary: in_info.beneficiary,
-            beneficiary_term: fil_actor_miner_v11::BeneficiaryTerm {
-                quota: in_info.beneficiary_term.quota,
-                used_quota: in_info.beneficiary_term.used_quota,
-                expiration: in_info.beneficiary_term.expiration,
-            },
-            pending_beneficiary_term: in_info.pending_beneficiary_term.map(|term| {
-                fil_actor_miner_v11::PendingBeneficiaryChange {
-                    new_beneficiary: term.new_beneficiary,
-                    new_quota: term.new_quota,
-                    new_expiration: term.new_expiration,
-                    approved_by_beneficiary: term.approved_by_beneficiary,
-                    approved_by_nominee: term.approved_by_nominee,
-                }
-            }),
-        };
-
-        let out_info_cid = store.put_obj(&out_info, Blake2b256)?;
-
-        let out_state = StateV11 {
-            info: out_info_cid,
-            pre_commit_deposits: in_state.pre_commit_deposits,
-            locked_funds: in_state.locked_funds,
-            vesting_funds: in_state.vesting_funds,
-            fee_debt: in_state.fee_debt,
-            initial_pledge: in_state.initial_pledge,
-            pre_committed_sectors: in_state.pre_committed_sectors,
-            pre_committed_sectors_cleanup: in_state.pre_committed_sectors_cleanup,
-            allocated_sectors: in_state.allocated_sectors,
-            sectors: in_state.sectors,
-            proving_period_start: in_state.proving_period_start,
-            current_deadline: in_state.current_deadline,
-            deadlines: in_state.deadlines,
-            early_terminations: in_state.early_terminations,
-            deadline_cron_active: in_state.deadline_cron_active,
-        };
+        let out_state: MinerStateNew = TypeMigrator::migrate_type(in_state, &store)?;
 
         let new_head = store.put_obj(&out_state, Blake2b256)?;
 

--- a/vm/state_migration/src/type_migrations/init/mod.rs
+++ b/vm/state_migration/src/type_migrations/init/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+mod state_v9_to_v10;

--- a/vm/state_migration/src/type_migrations/init/state_v9_to_v10.rs
+++ b/vm/state_migration/src/type_migrations/init/state_v9_to_v10.rs
@@ -12,11 +12,8 @@ use fvm_ipld_blockstore::Blockstore;
 
 use crate::common::{TypeMigration, TypeMigrator};
 
-impl<BS> TypeMigration<BS, InitStateV9, InitStateV10> for TypeMigrator
-where
-    BS: Blockstore + Clone + Send + Sync,
-{
-    fn migrate_type(from: InitStateV9, store: &BS) -> anyhow::Result<InitStateV10> {
+impl TypeMigration<InitStateV9, InitStateV10> for TypeMigrator {
+    fn migrate_type(from: InitStateV9, store: &impl Blockstore) -> anyhow::Result<InitStateV10> {
         let mut in_addr_map: Map<_, ActorID> =
             make_map_with_root(&from.address_map, &store).map_err(|e| anyhow::anyhow!("{e}"))?;
 

--- a/vm/state_migration/src/type_migrations/init/state_v9_to_v10.rs
+++ b/vm/state_migration/src/type_migrations/init/state_v9_to_v10.rs
@@ -1,0 +1,38 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fil_actor_init_v10::State as InitStateV10;
+use fil_actor_init_v9::State as InitStateV9;
+use fil_actors_runtime_v10::{make_map_with_root, Map};
+use forest_shim::{
+    address::{Address, PAYLOAD_HASH_LEN},
+    state_tree::ActorID,
+};
+use fvm_ipld_blockstore::Blockstore;
+
+use crate::common::{TypeMigration, TypeMigrator};
+
+impl<BS> TypeMigration<BS, InitStateV9, InitStateV10> for TypeMigrator
+where
+    BS: Blockstore + Clone + Send + Sync,
+{
+    fn migrate_type(from: InitStateV9, store: &BS) -> anyhow::Result<InitStateV10> {
+        let mut in_addr_map: Map<_, ActorID> =
+            make_map_with_root(&from.address_map, &store).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let actor_id = from.next_id;
+        let eth_zero_addr = Address::new_delegated(
+            Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR.id()?,
+            &[0; PAYLOAD_HASH_LEN],
+        )?;
+        in_addr_map.set(eth_zero_addr.to_bytes().into(), actor_id)?;
+
+        let out_state = InitStateV10 {
+            address_map: in_addr_map.flush()?,
+            next_id: from.next_id + 1,
+            network_name: from.network_name,
+        };
+
+        Ok(out_state)
+    }
+}

--- a/vm/state_migration/src/type_migrations/miner/mod.rs
+++ b/vm/state_migration/src/type_migrations/miner/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+mod state_v10_to_v11;

--- a/vm/state_migration/src/type_migrations/miner/state_v10_to_v11.rs
+++ b/vm/state_migration/src/type_migrations/miner/state_v10_to_v11.rs
@@ -1,0 +1,81 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use cid::multihash::Code::Blake2b256;
+use fil_actor_miner_v10::{MinerInfo, State as MinerStateV10};
+use fil_actor_miner_v11::{MinerInfo as MinerInfoV11, State as MinerStateV11};
+use forest_shim::sector::convert_window_post_proof_v1_to_v1p1;
+use forest_utils::db::BlockstoreExt;
+use fvm_ipld_blockstore::Blockstore;
+
+use crate::common::{TypeMigration, TypeMigrator};
+
+impl<BS> TypeMigration<BS, MinerStateV10, MinerStateV11> for TypeMigrator
+where
+    BS: Blockstore + Clone + Send + Sync,
+{
+    fn migrate_type(in_state: MinerStateV10, store: &BS) -> anyhow::Result<MinerStateV11> {
+        let in_info: MinerInfo = store
+            .get_obj(&in_state.info)?
+            .ok_or_else(|| anyhow::anyhow!("Miner info: could not read v10 state"))?;
+
+        let out_proof_type = convert_window_post_proof_v1_to_v1p1(in_info.window_post_proof_type)
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+        let out_info = MinerInfoV11 {
+            owner: in_info.owner,
+            worker: in_info.worker,
+            control_addresses: in_info.control_addresses,
+            pending_worker_key: in_info.pending_worker_key.map(|key| {
+                fil_actor_miner_v11::WorkerKeyChange {
+                    new_worker: key.new_worker,
+                    effective_at: key.effective_at,
+                }
+            }),
+            peer_id: in_info.peer_id,
+            multi_address: in_info.multi_address,
+            window_post_proof_type: out_proof_type,
+            sector_size: in_info.sector_size,
+            window_post_partition_sectors: in_info.window_post_partition_sectors,
+            consensus_fault_elapsed: in_info.consensus_fault_elapsed,
+            pending_owner_address: in_info.pending_owner_address,
+            beneficiary: in_info.beneficiary,
+            beneficiary_term: fil_actor_miner_v11::BeneficiaryTerm {
+                quota: in_info.beneficiary_term.quota,
+                used_quota: in_info.beneficiary_term.used_quota,
+                expiration: in_info.beneficiary_term.expiration,
+            },
+            pending_beneficiary_term: in_info.pending_beneficiary_term.map(|term| {
+                fil_actor_miner_v11::PendingBeneficiaryChange {
+                    new_beneficiary: term.new_beneficiary,
+                    new_quota: term.new_quota,
+                    new_expiration: term.new_expiration,
+                    approved_by_beneficiary: term.approved_by_beneficiary,
+                    approved_by_nominee: term.approved_by_nominee,
+                }
+            }),
+        };
+
+        let out_info_cid = store.put_obj(&out_info, Blake2b256)?;
+
+        let out_state = MinerStateV11 {
+            info: out_info_cid,
+            pre_commit_deposits: in_state.pre_commit_deposits,
+            locked_funds: in_state.locked_funds,
+            vesting_funds: in_state.vesting_funds,
+            fee_debt: in_state.fee_debt,
+            initial_pledge: in_state.initial_pledge,
+            pre_committed_sectors: in_state.pre_committed_sectors,
+            pre_committed_sectors_cleanup: in_state.pre_committed_sectors_cleanup,
+            allocated_sectors: in_state.allocated_sectors,
+            sectors: in_state.sectors,
+            proving_period_start: in_state.proving_period_start,
+            current_deadline: in_state.current_deadline,
+            deadlines: in_state.deadlines,
+            early_terminations: in_state.early_terminations,
+            deadline_cron_active: in_state.deadline_cron_active,
+        };
+
+        Ok(out_state)
+    }
+}

--- a/vm/state_migration/src/type_migrations/miner/state_v10_to_v11.rs
+++ b/vm/state_migration/src/type_migrations/miner/state_v10_to_v11.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::multihash::Code::Blake2b256;
-use fil_actor_miner_v10::{MinerInfo, State as MinerStateV10};
+use fil_actor_miner_v10::{MinerInfo as MinerInfoV10, State as MinerStateV10};
 use fil_actor_miner_v11::{MinerInfo as MinerInfoV11, State as MinerStateV11};
 use forest_shim::sector::convert_window_post_proof_v1_to_v1p1;
 use forest_utils::db::BlockstoreExt;
@@ -12,7 +12,7 @@ use crate::common::{TypeMigration, TypeMigrator};
 
 impl TypeMigration<MinerStateV10, MinerStateV11> for TypeMigrator {
     fn migrate_type(from: MinerStateV10, store: &impl Blockstore) -> anyhow::Result<MinerStateV11> {
-        let in_info: MinerInfo = store
+        let in_info: MinerInfoV10 = store
             .get_obj(&from.info)?
             .ok_or_else(|| anyhow::anyhow!("Miner info: could not read v10 state"))?;
 

--- a/vm/state_migration/src/type_migrations/miner/state_v10_to_v11.rs
+++ b/vm/state_migration/src/type_migrations/miner/state_v10_to_v11.rs
@@ -10,11 +10,8 @@ use fvm_ipld_blockstore::Blockstore;
 
 use crate::common::{TypeMigration, TypeMigrator};
 
-impl<BS> TypeMigration<BS, MinerStateV10, MinerStateV11> for TypeMigrator
-where
-    BS: Blockstore + Clone + Send + Sync,
-{
-    fn migrate_type(from: MinerStateV10, store: &BS) -> anyhow::Result<MinerStateV11> {
+impl TypeMigration<MinerStateV10, MinerStateV11> for TypeMigrator {
+    fn migrate_type(from: MinerStateV10, store: &impl Blockstore) -> anyhow::Result<MinerStateV11> {
         let in_info: MinerInfo = store
             .get_obj(&from.info)?
             .ok_or_else(|| anyhow::anyhow!("Miner info: could not read v10 state"))?;

--- a/vm/state_migration/src/type_migrations/miner/state_v10_to_v11.rs
+++ b/vm/state_migration/src/type_migrations/miner/state_v10_to_v11.rs
@@ -14,9 +14,9 @@ impl<BS> TypeMigration<BS, MinerStateV10, MinerStateV11> for TypeMigrator
 where
     BS: Blockstore + Clone + Send + Sync,
 {
-    fn migrate_type(in_state: MinerStateV10, store: &BS) -> anyhow::Result<MinerStateV11> {
+    fn migrate_type(from: MinerStateV10, store: &BS) -> anyhow::Result<MinerStateV11> {
         let in_info: MinerInfo = store
-            .get_obj(&in_state.info)?
+            .get_obj(&from.info)?
             .ok_or_else(|| anyhow::anyhow!("Miner info: could not read v10 state"))?;
 
         let out_proof_type = convert_window_post_proof_v1_to_v1p1(in_info.window_post_proof_type)
@@ -60,20 +60,20 @@ where
 
         let out_state = MinerStateV11 {
             info: out_info_cid,
-            pre_commit_deposits: in_state.pre_commit_deposits,
-            locked_funds: in_state.locked_funds,
-            vesting_funds: in_state.vesting_funds,
-            fee_debt: in_state.fee_debt,
-            initial_pledge: in_state.initial_pledge,
-            pre_committed_sectors: in_state.pre_committed_sectors,
-            pre_committed_sectors_cleanup: in_state.pre_committed_sectors_cleanup,
-            allocated_sectors: in_state.allocated_sectors,
-            sectors: in_state.sectors,
-            proving_period_start: in_state.proving_period_start,
-            current_deadline: in_state.current_deadline,
-            deadlines: in_state.deadlines,
-            early_terminations: in_state.early_terminations,
-            deadline_cron_active: in_state.deadline_cron_active,
+            pre_commit_deposits: from.pre_commit_deposits,
+            locked_funds: from.locked_funds,
+            vesting_funds: from.vesting_funds,
+            fee_debt: from.fee_debt,
+            initial_pledge: from.initial_pledge,
+            pre_committed_sectors: from.pre_committed_sectors,
+            pre_committed_sectors_cleanup: from.pre_committed_sectors_cleanup,
+            allocated_sectors: from.allocated_sectors,
+            sectors: from.sectors,
+            proving_period_start: from.proving_period_start,
+            current_deadline: from.current_deadline,
+            deadlines: from.deadlines,
+            early_terminations: from.early_terminations,
+            deadline_cron_active: from.deadline_cron_active,
         };
 
         Ok(out_state)

--- a/vm/state_migration/src/type_migrations/mod.rs
+++ b/vm/state_migration/src/type_migrations/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+mod init;
+mod miner;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/2801

Changes introduced in this pull request:

- Abstract out actor type conversion logic as it seems to be agnostic to network upgrade

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
