### PR TITLE
Aatifsyed/2883 build profiles are too aggressive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ members = [
   "utils/forest_utils",
   "utils/forest_shim",
 ]
-resolver = "2"
 
 [workspace.dependencies]
 ahash = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ members = [
   "utils/forest_shim",
 ]
 
+# We need this even though we have edition = "2021" because we're a virtual manifest
+# https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
+resolver = "2"
+
 [workspace.dependencies]
 ahash = "0.8"
 anes = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,16 +191,9 @@ forest_test_utils = { path = "./utils/test_utils" }
 forest_utils = { path = "./utils/forest_utils" }
 
 [profile.dev]
-debug = 0
 split-debuginfo = "unpacked"
-
-[profile.quick]
-inherits = "release"
-opt-level = 1
-lto = "off"
 
 [profile.release]
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip
 strip = true
-panic = "abort"
 overflow-checks = true


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Don't abort the process on panic
- Keep debug info in debug builds
- Remove unused `quick` profile

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
