### PR TITLE
remove uncompressed from filops snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 
 ### Removed
 
+- [#2888](https://github.com/ChainSafe/forest/issues/2888): FILOps is no longer
+  serving uncompressed snapshots. Removed support for them in both `forest` and
+  `forest-cli`.
+
 ### Fixed
 
 ## Forest v0.8.2 "The Way"

--- a/forest/shared/src/cli/config.rs
+++ b/forest/shared/src/cli/config.rs
@@ -69,9 +69,7 @@ pub struct SnapshotFetchConfig {
 
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
 pub struct FilecoinSnapshotFetchConfig {
-    pub mainnet: Url,
     pub mainnet_compressed: Url,
-    pub calibnet: Url,
     pub calibnet_compressed: Url,
 }
 
@@ -80,21 +78,12 @@ impl Default for FilecoinSnapshotFetchConfig {
         // unfallible unwrap as we know that the value is correct
         // <https://lotus.filecoin.io/lotus/manage/chain-management/#lightweight-snapshot>
         Self {
-            /// Default `mainnet` snapshot URL. The assumption is that it will
-            /// redirect once and will contain a `sha256sum` file
-            /// with the same URL (but different extension).
-            mainnet: Url::try_from("https://snapshots.mainnet.filops.net/minimal/latest").unwrap(),
             mainnet_compressed: Url::try_from(
-                "https://snapshots.mainnet.filops.net/minimal/latest.zst",
+                "https://snapshots.mainnet.filops.net/minimal/latest",
             )
             .unwrap(),
-            /// Default `calibnet` snapshot URL. The assumption is that it will
-            /// redirect once and will contain a `sha256sum` file
-            /// with the same URL (but different extension).
-            calibnet: Url::try_from("https://snapshots.calibrationnet.filops.net/minimal/latest")
-                .unwrap(),
             calibnet_compressed: Url::try_from(
-                "https://snapshots.calibrationnet.filops.net/minimal/latest.zst",
+                "https://snapshots.calibrationnet.filops.net/minimal/latest",
             )
             .unwrap(),
         }

--- a/scripts/tests/forest_cli_check.sh
+++ b/scripts/tests/forest_cli_check.sh
@@ -14,7 +14,7 @@ $FOREST_CLI_PATH fetch-params --keys
 echo "Downloading zstd compressed snapshot without aria2"
 $FOREST_CLI_PATH --chain calibnet snapshot fetch --provider filecoin --compressed -s "$SNAPSHOT_DIRECTORY"
 echo "Downloading snapshot without aria2"
-$FOREST_CLI_PATH --chain calibnet snapshot fetch --provider filecoin -s "$SNAPSHOT_DIRECTORY"
+$FOREST_CLI_PATH --chain calibnet snapshot fetch -s "$SNAPSHOT_DIRECTORY"
 echo "Cleaning up snapshots"
 $FOREST_CLI_PATH --chain calibnet snapshot clean -s "$SNAPSHOT_DIRECTORY" --force
 echo "Cleaning up snapshots again"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- FILOps is no longer serving uncompressed snapshots and their `latest` is redirecting to a compressed one. Adapted Forest logic to this.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
