### PR TITLE
Ban usage of `fvm` and `fvm3` crates outside of `forest_shim`

### DIFF
--- a/scripts/linters/find_banned_deps.rb
+++ b/scripts/linters/find_banned_deps.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'toml-rb'
+
+# Iterate over all TOML files in the repository
+Dir.glob('**/*.toml').each do |file|
+  # Create an exception for `forest_shim` (only place `fvm` & `fvm3` are allowed).
+  next unless file != 'utils/forest_shim/Cargo.toml'
+
+  toml = TomlRB.load_file(file)
+
+  toml['dependencies']&.each do |dep|
+    puts "[#{dep[0]}] is being used in [#{file}], but this crate is banned!" if dep[0] == 'fvm' || dep[0] == 'fvm3'
+  end
+end


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- New script for the lint checks to check for banned crates.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes associated task in #2713 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->
This script can also be modified and used to address issue #2820 

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
