### PR TITLE
remove unused rpc port

### DIFF
--- a/blockchain/consensus/deleg_cns/configs/delegator-config.toml
+++ b/blockchain/consensus/deleg_cns/configs/delegator-config.toml
@@ -37,7 +37,6 @@ bootstrap_peers = ["/ip4/127.0.0.1/tcp/2340/p2p/12D3KooWNEmsCbySkVBbZhX12kxommT3
 data_dir = "/tmp/forest-delegator-data-dir"
 enable_rpc = false
 # Ports altered from the proposer so the nodes can run side by side.
-rpc_port = 1235
 metrics_address = "127.0.0.1:6117"
 rpc_address = "127.0.0.1:1235"
 

--- a/forest/shared/src/cli/client.rs
+++ b/forest/shared/src/cli/client.rs
@@ -21,7 +21,6 @@ pub struct Client {
     pub data_dir: PathBuf,
     pub genesis_file: Option<String>,
     pub enable_rpc: bool,
-    pub rpc_port: u16,
     pub rpc_token: Option<String>,
     /// If this is true, then we do not validate the imported snapshot.
     /// Otherwise, we validate and compute the states.
@@ -50,7 +49,6 @@ impl Default for Client {
             data_dir: dir.data_dir().to_path_buf(),
             genesis_file: None,
             enable_rpc: true,
-            rpc_port: DEFAULT_PORT,
             rpc_token: None,
             snapshot_path: None,
             snapshot: false,

--- a/forest/shared/src/cli/config.rs
+++ b/forest/shared/src/cli/config.rs
@@ -250,7 +250,6 @@ mod test {
                     data_dir: PathBuf::arbitrary(g),
                     genesis_file: Option::arbitrary(g),
                     enable_rpc: bool::arbitrary(g),
-                    rpc_port: u16::arbitrary(g),
                     rpc_token: Option::arbitrary(g),
                     snapshot: bool::arbitrary(g),
                     snapshot_height: Option::arbitrary(g),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- this field was superseded in the past by `rpc_address` containing both the IP and the port of the RPC endpoint. It is unused now and ripe for removal.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
