### PR TITLE
feat: add PostMigrator trait to allow post migrators to carry states

### DIFF
--- a/vm/state_migration/src/common/mod.rs
+++ b/vm/state_migration/src/common/mod.rs
@@ -48,9 +48,13 @@ pub(crate) trait ActorMigration<BS: Blockstore + Clone + Send + Sync> {
     ) -> anyhow::Result<ActorMigrationOutput>;
 }
 
-/// Post migration action to be executed after the state migration.
-pub(crate) type PostMigrationAction<BS> =
-    Arc<dyn Fn(&BS, &mut StateTree<BS>) -> anyhow::Result<()> + Send + Sync>;
+/// Trait that defines the interface for actor migration job to be executed after the state migration.
+pub(crate) trait PostMigrator<BS: Blockstore>: Send + Sync {
+    fn post_migrate_state(&self, store: &BS, actors_out: &mut StateTree<BS>) -> anyhow::Result<()>;
+}
+
+/// Sized wrapper of [`PostMigrator`].
+pub(crate) type PostMigratorArc<BS> = Arc<dyn PostMigrator<BS>>;
 
 /// Trait that migrates from one data structure to another, similar to
 /// [`std::convert::TryInto`] trait but taking an extra block store parameter

--- a/vm/state_migration/src/common/state_migration.rs
+++ b/vm/state_migration/src/common/state_migration.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use ahash::{HashMap, HashMapExt};
+use ahash::HashMap;
 use cid::Cid;
 use forest_shim::{clock::ChainEpoch, state_tree::StateTree};
 use fvm_ipld_blockstore::Blockstore;
@@ -22,20 +22,22 @@ pub(crate) struct StateMigration<BS> {
 }
 
 impl<BS: Blockstore + Clone + Send + Sync> StateMigration<BS> {
-    pub(crate) fn new(
-        verifier: Option<MigrationVerifier<BS>>,
-        post_migrators: Vec<PostMigratorArc<BS>>,
-    ) -> Self {
+    pub(crate) fn new(verifier: Option<MigrationVerifier<BS>>) -> Self {
         Self {
-            migrations: HashMap::new(),
+            migrations: Default::default(),
             verifier,
-            post_migrators,
+            post_migrators: Default::default(),
         }
     }
 
     /// Inserts a new migrator into the migration specification.
     pub(crate) fn add_migrator(&mut self, prior_cid: Cid, migrator: Migrator<BS>) {
         self.migrations.insert(prior_cid, migrator);
+    }
+
+    /// Inserts a new post migrator into the post migration specification.
+    pub(crate) fn add_post_migrator(&mut self, post_migrator: PostMigratorArc<BS>) {
+        self.post_migrators.push(post_migrator);
     }
 
     pub(crate) fn migrate_state_tree(

--- a/vm/state_migration/src/nv18/eam.rs
+++ b/vm/state_migration/src/nv18/eam.rs
@@ -9,23 +9,26 @@ use forest_shim::{
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 
+use crate::common::PostMigrator;
+
 use super::SystemStateNew;
 
-/// Creates the Ethereum Account Manager actor in the state tree.
-pub fn create_eam_actor<BS: Blockstore + Clone + Send + Sync>(
-    store: &BS,
-    actors_out: &mut StateTree<BS>,
-) -> anyhow::Result<()> {
-    let sys_actor = actors_out
-        .get_actor(&Address::SYSTEM_ACTOR)?
-        .ok_or_else(|| anyhow::anyhow!("Couldn't get sys actor state"))?;
-    let sys_state: SystemStateNew = store
-        .get_cbor(&sys_actor.state)?
-        .ok_or_else(|| anyhow::anyhow!("Couldn't get statev10"))?;
+pub struct EamPostMigrator;
 
-    let manifest = ManifestV3::load(&store, &sys_state.builtin_actors, 1)?;
+impl<BS: Blockstore + Clone> PostMigrator<BS> for EamPostMigrator {
+    /// Creates the Ethereum Account Manager actor in the state tree.
+    fn post_migrate_state(&self, store: &BS, actors_out: &mut StateTree<BS>) -> anyhow::Result<()> {
+        let sys_actor = actors_out
+            .get_actor(&Address::SYSTEM_ACTOR)?
+            .ok_or_else(|| anyhow::anyhow!("Couldn't get sys actor state"))?;
+        let sys_state: SystemStateNew = store
+            .get_cbor(&sys_actor.state)?
+            .ok_or_else(|| anyhow::anyhow!("Couldn't get statev10"))?;
 
-    let eam_actor = ActorState::new_empty(*manifest.get_eam_code(), None);
-    actors_out.set_actor(&Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR, eam_actor)?;
-    Ok(())
+        let manifest = ManifestV3::load(&store, &sys_state.builtin_actors, 1)?;
+
+        let eam_actor = ActorState::new_empty(*manifest.get_eam_code(), None);
+        actors_out.set_actor(&Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR, eam_actor)?;
+        Ok(())
+    }
 }

--- a/vm/state_migration/src/nv18/eth_account.rs
+++ b/vm/state_migration/src/nv18/eth_account.rs
@@ -10,45 +10,48 @@ use forest_shim::{
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 
+use crate::common::PostMigrator;
+
 use super::SystemStateNew;
 
-/// Creates the Ethereum Account actor in the state tree.
-pub fn create_eth_account_actor<BS: Blockstore + Clone + Send + Sync>(
-    store: &BS,
-    actors_out: &mut StateTree<BS>,
-) -> anyhow::Result<()> {
-    let init_actor = actors_out
-        .get_actor(&Address::INIT_ACTOR)?
-        .ok_or_else(|| anyhow::anyhow!("Couldn't get init actor state"))?;
-    let init_state: fil_actor_init_state::v10::State = store
-        .get_cbor(&init_actor.state)?
-        .ok_or_else(|| anyhow::anyhow!("Couldn't get statev10"))?;
+pub struct EthAccountPostMigrator;
 
-    let eth_zero_addr =
-        Address::new_delegated(Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR.id()?, &[0; 20])?;
-    let eth_zero_addr_id = init_state
-        .resolve_address(&store, &eth_zero_addr.into())?
-        .ok_or_else(|| anyhow!("failed to get eth zero actor"))?;
+impl<BS: Blockstore + Clone> PostMigrator<BS> for EthAccountPostMigrator {
+    /// Creates the Ethereum Account actor in the state tree.
+    fn post_migrate_state(&self, store: &BS, actors_out: &mut StateTree<BS>) -> anyhow::Result<()> {
+        let init_actor = actors_out
+            .get_actor(&Address::INIT_ACTOR)?
+            .ok_or_else(|| anyhow::anyhow!("Couldn't get init actor state"))?;
+        let init_state: fil_actor_init_state::v10::State = store
+            .get_cbor(&init_actor.state)?
+            .ok_or_else(|| anyhow::anyhow!("Couldn't get statev10"))?;
 
-    let system_actor = actors_out
-        .get_actor(&Address::new_id(0))?
-        .ok_or_else(|| anyhow!("failed to get system actor"))?;
+        let eth_zero_addr =
+            Address::new_delegated(Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR.id()?, &[0; 20])?;
+        let eth_zero_addr_id = init_state
+            .resolve_address(&store, &eth_zero_addr.into())?
+            .ok_or_else(|| anyhow!("failed to get eth zero actor"))?;
 
-    let system_actor_state = store
-        .get_cbor::<SystemStateNew>(&system_actor.state)?
-        .ok_or_else(|| anyhow!("failed to get system actor state"))?;
+        let system_actor = actors_out
+            .get_actor(&Address::new_id(0))?
+            .ok_or_else(|| anyhow!("failed to get system actor"))?;
 
-    let manifest_data = system_actor_state.builtin_actors;
-    let new_manifest = ManifestV3::load(&store, &manifest_data, 1)?;
+        let system_actor_state = store
+            .get_cbor::<SystemStateNew>(&system_actor.state)?
+            .ok_or_else(|| anyhow!("failed to get system actor state"))?;
 
-    let eth_account_actor = ActorState::new(
-        *new_manifest.get_ethaccount_code(),
-        fil_actors_shared::v10::runtime::EMPTY_ARR_CID,
-        Default::default(),
-        0,
-        Some(eth_zero_addr),
-    );
+        let manifest_data = system_actor_state.builtin_actors;
+        let new_manifest = ManifestV3::load(&store, &manifest_data, 1)?;
 
-    actors_out.set_actor(&eth_zero_addr_id.into(), eth_account_actor)?;
-    Ok(())
+        let eth_account_actor = ActorState::new(
+            *new_manifest.get_ethaccount_code(),
+            fil_actors_shared::v10::runtime::EMPTY_ARR_CID,
+            Default::default(),
+            0,
+            Some(eth_zero_addr),
+        );
+
+        actors_out.set_actor(&eth_zero_addr_id.into(), eth_account_actor)?;
+        Ok(())
+    }
 }

--- a/vm/state_migration/src/nv18/migration.rs
+++ b/vm/state_migration/src/nv18/migration.rs
@@ -15,10 +15,10 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 
 use super::{
-    eam::create_eam_actor, eth_account::create_eth_account_actor, init, system, verifier::Verifier,
+    eam::EamPostMigrator, eth_account::EthAccountPostMigrator, init, system, verifier::Verifier,
     ManifestNew, ManifestOld, SystemStateOld,
 };
-use crate::common::{migrators::nil_migrator, PostMigrationAction, StateMigration};
+use crate::common::{migrators::nil_migrator, PostMigratorArc, StateMigration};
 impl<BS: Blockstore + Clone + Send + Sync> StateMigration<BS> {
     pub fn add_nv18_migrations(
         &mut self,
@@ -92,12 +92,10 @@ where
     let verifier = Arc::new(Verifier::default());
 
     // Add post-migration steps
-    let post_migration_actions = [create_eam_actor, create_eth_account_actor]
-        .into_iter()
-        .map(|action| Arc::new(action) as PostMigrationAction<DB>)
-        .collect();
+    let post_migrators: Vec<PostMigratorArc<DB>> =
+        vec![Arc::new(EamPostMigrator), Arc::new(EthAccountPostMigrator)];
 
-    let mut migration = StateMigration::<DB>::new(Some(verifier), post_migration_actions);
+    let mut migration = StateMigration::<DB>::new(Some(verifier), post_migrators);
     migration.add_nv18_migrations(blockstore.clone(), state, &new_manifest_cid)?;
 
     let actors_in = StateTree::new_from_root(blockstore.clone(), state)?;

--- a/vm/state_migration/src/nv18/migration.rs
+++ b/vm/state_migration/src/nv18/migration.rs
@@ -18,7 +18,7 @@ use super::{
     eam::EamPostMigrator, eth_account::EthAccountPostMigrator, init, system, verifier::Verifier,
     ManifestNew, ManifestOld, SystemStateOld,
 };
-use crate::common::{migrators::nil_migrator, PostMigratorArc, StateMigration};
+use crate::common::{migrators::nil_migrator, StateMigration};
 impl<BS: Blockstore + Clone + Send + Sync> StateMigration<BS> {
     pub fn add_nv18_migrations(
         &mut self,
@@ -58,6 +58,11 @@ impl<BS: Blockstore + Clone + Send + Sync> StateMigration<BS> {
             system::system_migrator(new_manifest_data, *new_manifest.get_system_code()),
         );
 
+        // Add post-migration steps
+        self.add_post_migrator(Arc::new(EamPostMigrator));
+
+        self.add_post_migrator(Arc::new(EthAccountPostMigrator));
+
         Ok(())
     }
 }
@@ -91,11 +96,7 @@ where
     // Add migration specification verification
     let verifier = Arc::new(Verifier::default());
 
-    // Add post-migration steps
-    let post_migrators: Vec<PostMigratorArc<DB>> =
-        vec![Arc::new(EamPostMigrator), Arc::new(EthAccountPostMigrator)];
-
-    let mut migration = StateMigration::<DB>::new(Some(verifier), post_migrators);
+    let mut migration = StateMigration::<DB>::new(Some(verifier));
     migration.add_nv18_migrations(blockstore.clone(), state, &new_manifest_cid)?;
 
     let actors_in = StateTree::new_from_root(blockstore.clone(), state)?;

--- a/vm/state_migration/src/nv19/migration.rs
+++ b/vm/state_migration/src/nv19/migration.rs
@@ -94,7 +94,7 @@ where
     // Add migration specification verification
     let verifier = Arc::new(Verifier::default());
 
-    let mut migration = StateMigration::<DB>::new(Some(verifier), vec![]);
+    let mut migration = StateMigration::<DB>::new(Some(verifier));
     migration.add_nv19_migrations(blockstore.clone(), state, &new_manifest_cid)?;
 
     let actors_in = StateTree::new_from_root(blockstore.clone(), state)?;


### PR DESCRIPTION
## Summary of changes

As part of https://github.com/ChainSafe/forest/issues/2801

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Refactor `PostMigrationAction` into `PostMigrator` trait so that the migrator struct can carry states, which makes nv17 migrations much easier. More specifically, see verifreg and market migration: https://github.com/filecoin-project/go-state-types/blob/master/builtin/v9/migration/top.go#L294
- Will update docs altogether after nv17 migration

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
