### PR TITLE
feat: use the KeepAlive libp2p behavior

### DIFF
--- a/node/forest_libp2p/src/behaviour.rs
+++ b/node/forest_libp2p/src/behaviour.rs
@@ -15,7 +15,7 @@ use libp2p::{
     kad::QueryId,
     metrics::{Metrics, Recorder},
     ping,
-    swarm::NetworkBehaviour,
+    swarm::{NetworkBehaviour, keep_alive},
     Multiaddr,
 };
 use log::warn;
@@ -36,6 +36,7 @@ pub(crate) struct ForestBehaviour {
     discovery: DiscoveryBehaviour,
     ping: ping::Behaviour,
     identify: identify::Behaviour,
+    keep_alive: keep_alive::Behaviour,
     pub(super) hello: HelloBehaviour,
     pub(super) chain_exchange: ChainExchangeBehaviour,
     pub(super) bitswap: BitswapBehaviour,
@@ -105,6 +106,7 @@ impl ForestBehaviour {
                 identify::Config::new("ipfs/0.1.0".into(), local_key.public())
                     .with_agent_version(format!("forest-{}", FOREST_VERSION_STRING.as_str())),
             ),
+            keep_alive: keep_alive::Behaviour::default(),
             bitswap,
             hello: HelloBehaviour::default(),
             chain_exchange: ChainExchangeBehaviour::default(),

--- a/node/forest_libp2p/src/service.rs
+++ b/node/forest_libp2p/src/service.rs
@@ -798,6 +798,7 @@ async fn handle_forest_behaviour_event<DB>(
         }
         ForestBehaviourEvent::Ping(ping_event) => handle_ping_event(ping_event, peer_manager).await,
         ForestBehaviourEvent::Identify(_) => {}
+        ForestBehaviourEvent::KeepAlive(_) => {}
         ForestBehaviourEvent::ChainExchange(ce_event) => {
             handle_chain_exchange_event(
                 &mut swarm.behaviour_mut().chain_exchange,


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:
- Enable the `KeepAlive` libp2p behavior. This allows us to stay connected to peers in a network even when we aren't sending or receiving a lot of messages.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
