### PR TITLE
chore: add blocking version of compute_tipset_state

### DIFF
--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -463,7 +463,7 @@ where
                     let no_func =
                         None::<fn(&Cid, &ChainMessage, &ApplyRet) -> Result<(), anyhow::Error>>;
                     let ts_state = self
-                        .compute_tipset_state_non_blocking(Arc::clone(tipset), no_func)
+                        .compute_tipset_state(Arc::clone(tipset), no_func)
                         .await?;
                     debug!("Completed tipset state calculation {:?}", tipset.cids());
                     ts_state
@@ -614,7 +614,7 @@ where
             Ok(())
         };
         let result = self
-            .compute_tipset_state_non_blocking(Arc::clone(ts), Some(callback))
+            .compute_tipset_state(Arc::clone(ts), Some(callback))
             .await;
 
         if let Err(error_message) = result {
@@ -738,7 +738,7 @@ where
     /// Performs a state transition, and returns the state and receipt root of
     /// the transition.
     #[instrument(skip(self, callback))]
-    pub async fn compute_tipset_state_non_blocking<CB: 'static>(
+    pub async fn compute_tipset_state<CB: 'static>(
         self: &Arc<Self>,
         tipset: Arc<Tipset>,
         callback: Option<CB>,
@@ -747,13 +747,13 @@ where
         CB: FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), anyhow::Error> + Send,
     {
         let sm = Arc::clone(self);
-        tokio::task::spawn_blocking(move || sm.compute_tipset_state(tipset, callback)).await?
+        tokio::task::spawn_blocking(move || sm.compute_tipset_state_blocking(tipset, callback)).await?
     }
 
     /// Performs a state transition, and returns the state and receipt root of
     /// the transition.
     #[instrument(skip(self, callback))]
-    pub fn compute_tipset_state<CB: 'static>(
+    pub fn compute_tipset_state_blocking<CB: 'static>(
         self: &Arc<Self>,
         tipset: Arc<Tipset>,
         callback: Option<CB>,

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -747,7 +747,8 @@ where
         CB: FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), anyhow::Error> + Send,
     {
         let sm = Arc::clone(self);
-        tokio::task::spawn_blocking(move || sm.compute_tipset_state_blocking(tipset, callback)).await?
+        tokio::task::spawn_blocking(move || sm.compute_tipset_state_blocking(tipset, callback))
+            .await?
     }
 
     /// Performs a state transition, and returns the state and receipt root of

--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -368,7 +368,7 @@ where
         rand: R,
         base_fee: TokenAmount,
         mut callback: Option<CB>,
-        tipset: &Arc<Tipset>,
+        tipset: Arc<Tipset>,
     ) -> Result<CidPair, anyhow::Error>
     where
         R: Rand + Rand_v3 + Clone + 'static,
@@ -388,7 +388,7 @@ where
                 self.genesis_info
                     .get_circulating_supply(epoch, &db, &state_root)?,
                 self.reward_calc.clone(),
-                chain_epoch_root(Arc::clone(self), Arc::clone(tipset)),
+                chain_epoch_root(Arc::clone(self), Arc::clone(&tipset)),
                 &self.engine_v2,
                 &self.engine_v3,
                 Arc::clone(self.chain_config()),
@@ -462,7 +462,9 @@ where
                     // generic constants are not implemented yet this is a lowcost method for now
                     let no_func =
                         None::<fn(&Cid, &ChainMessage, &ApplyRet) -> Result<(), anyhow::Error>>;
-                    let ts_state = self.compute_tipset_state(tipset, no_func).await?;
+                    let ts_state = self
+                        .compute_tipset_state_non_blocking(Arc::clone(tipset), no_func)
+                        .await?;
                     debug!("Completed tipset state calculation {:?}", tipset.cids());
                     ts_state
                 };
@@ -611,7 +613,9 @@ where
             }
             Ok(())
         };
-        let result = self.compute_tipset_state(ts, Some(callback)).await;
+        let result = self
+            .compute_tipset_state_non_blocking(Arc::clone(ts), Some(callback))
+            .await;
 
         if let Err(error_message) = result {
             if error_message.to_string() != ERROR_MSG {
@@ -734,9 +738,24 @@ where
     /// Performs a state transition, and returns the state and receipt root of
     /// the transition.
     #[instrument(skip(self, callback))]
-    pub async fn compute_tipset_state<CB: 'static>(
+    pub async fn compute_tipset_state_non_blocking<CB: 'static>(
         self: &Arc<Self>,
-        tipset: &Arc<Tipset>,
+        tipset: Arc<Tipset>,
+        callback: Option<CB>,
+    ) -> Result<CidPair, Error>
+    where
+        CB: FnMut(&Cid, &ChainMessage, &ApplyRet) -> Result<(), anyhow::Error> + Send,
+    {
+        let sm = Arc::clone(self);
+        tokio::task::spawn_blocking(move || sm.compute_tipset_state(tipset, callback)).await?
+    }
+
+    /// Performs a state transition, and returns the state and receipt root of
+    /// the transition.
+    #[instrument(skip(self, callback))]
+    pub fn compute_tipset_state<CB: 'static>(
+        self: &Arc<Self>,
+        tipset: Arc<Tipset>,
         callback: Option<CB>,
     ) -> Result<CidPair, Error>
     where
@@ -780,27 +799,22 @@ where
 
         let blocks = self
             .chain_store()
-            .block_msgs_for_tipset(tipset)
+            .block_msgs_for_tipset(&tipset)
             .map_err(|e| Error::Other(e.to_string()))?;
 
         let sm = Arc::clone(self);
         let sr = *first_block.state_root();
         let epoch = first_block.epoch();
-        let ts_cloned = Arc::clone(tipset);
-        tokio::task::spawn_blocking(move || {
-            Ok(sm.apply_blocks(
-                parent_epoch,
-                &sr,
-                &blocks,
-                epoch,
-                chain_rand,
-                base_fee,
-                callback,
-                &ts_cloned,
-            )?)
-        })
-        .await
-        .map_err(|e| Error::Other(format!("failed to apply blocks: {e}")))?
+        Ok(sm.apply_blocks(
+            parent_epoch,
+            &sr,
+            &blocks,
+            epoch,
+            chain_rand,
+            base_fee,
+            callback,
+            tipset,
+        )?)
     }
 
     /// Check if tipset had executed the message, by loading the receipt based


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:
- Split `compute_tipset_state` into blocking and non-blocking variants. The blocking version will be used in the devnet PR.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
