### PR TITLE
Add display of gas limit in error message

### DIFF
--- a/vm/message/src/message.rs
+++ b/vm/message/src/message.rs
@@ -33,7 +33,10 @@ pub fn valid_for_block_inclusion(
         anyhow::bail!("gas_fee_cap less than gas_premium");
     }
     if msg.gas_limit > BLOCK_GAS_LIMIT {
-        anyhow::bail!("gas_limit cannot be greater than block gas limit");
+        anyhow::bail!(
+            "gas_limit {} cannot be greater than block gas limit",
+            msg.gas_limit
+        );
     }
 
     if Gas::new(msg.gas_limit) < min_gas {


### PR DESCRIPTION
## Summary of changes

This could help to understand a new sending message issue in my PR #2942:

```
Listing wallet balances
Address Default Balance
t1ac6ndwj6nghqbmtbovvnwcqo577p6ox2pt52q2y X ~300 FIL
t1yusp6qhul2zxoztryhw3wvojdzdxm3vojqo3eui 500 attoFIL
Creating a new address to send FIL to
t1r2iigaetickksh722gbem4kijx6agp2pumes3li
Listing wallet balances
Address Default Balance
t1ac6ndwj6nghqbmtbovvnwcqo577p6ox2pt52q2y X ~300 FIL
t1r2iigaetickksh722gbem4kijx6agp2pumes3li 0 FIL
t1yusp6qhul2zxoztryhw3wvojdzdxm3vojqo3eui 500 attoFIL
Sending FIL to the above address
Error: {"code":0,"message":"gas_limit cannot be greater than block gas limit"}
```

Changes introduced in this pull request:

- Add display of gas limit in error message

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
