### PR TITLE
fix: remove tracing annotation for `compute_tipset_state_blocking`

### DIFF
--- a/blockchain/state_manager/src/lib.rs
+++ b/blockchain/state_manager/src/lib.rs
@@ -737,7 +737,7 @@ where
 
     /// Performs a state transition, and returns the state and receipt root of
     /// the transition.
-    #[instrument(skip(self, callback))]
+    #[instrument(skip(self, tipset, callback))]
     pub async fn compute_tipset_state<CB: 'static>(
         self: &Arc<Self>,
         tipset: Arc<Tipset>,
@@ -753,7 +753,6 @@ where
 
     /// Performs a state transition, and returns the state and receipt root of
     /// the transition.
-    #[instrument(skip(self, callback))]
     pub fn compute_tipset_state_blocking<CB: 'static>(
         self: &Arc<Self>,
         tipset: Arc<Tipset>,


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:
- Limit the context of the `compute_tipset_state` span
- Remove the span annotation for `compute_tipset_state_blocking`. The span isn't set as expected when running the function in a separate, blocking thread.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
