### PR TITLE
feat: improve ctrl-c handling to deal with blocking threads and terminal shenanigans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@
 
 ### Fixed
 
+- [#2950](https://github.com/ChainSafe/forest/pull/2950): Fix cases where ctrl-c
+  would be ignored.
+
 ## Forest v0.8.2 "The Way"
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,6 +3969,7 @@ name = "forest_utils"
 version = "0.8.2"
 dependencies = [
  "ahash 0.8.3",
+ "anes",
  "anyhow",
  "async-compression",
  "async-fs",
@@ -4008,6 +4009,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.6",
  "tempfile",
+ "termios",
  "thiserror",
  "tokio",
  "toml 0.7.4",
@@ -8999,6 +9001,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,7 +3048,6 @@ dependencies = [
  "pretty_assertions",
  "quickcheck",
  "rand 0.8.5",
- "rpassword",
  "rustyline",
  "serde",
  "serde_json",
@@ -3099,7 +3098,6 @@ dependencies = [
  "lazy_static",
  "log",
  "raw_sync",
- "rpassword",
  "serde_json",
  "shared_memory",
  "tempfile",
@@ -7809,17 +7807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rpassword"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
-dependencies = [
- "libc",
- "rtoolbox",
- "winapi",
-]
-
-[[package]]
 name = "rtcp"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7843,16 +7830,6 @@ dependencies = [
  "nix 0.24.3",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,7 +3063,6 @@ dependencies = [
 name = "forest-daemon"
 version = "0.8.2"
 dependencies = [
- "anes",
  "anyhow",
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,6 @@ quickcheck_macros = "1"
 rand = "0.8"
 rayon = "1.5"
 regex = "1.8"
-rpassword = "7.2"
 serde = { version = "1.0", default-features = false }
 serde_ipld_dagcbor = "0.2"
 serde_json = "1.0"

--- a/forest/cli/Cargo.toml
+++ b/forest/cli/Cargo.toml
@@ -51,7 +51,6 @@ log.workspace = true
 multibase.workspace = true
 nom = "7.1.3"
 num.workspace = true
-rpassword.workspace = true
 rustyline = "10.1.1"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/forest/daemon/Cargo.toml
+++ b/forest/daemon/Cargo.toml
@@ -46,7 +46,6 @@ fvm_ipld_blockstore.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 raw_sync = "0.1"
-rpassword.workspace = true
 serde_json.workspace = true
 shared_memory = "0.12"
 tempfile.workspace = true

--- a/forest/daemon/Cargo.toml
+++ b/forest/daemon/Cargo.toml
@@ -12,7 +12,6 @@ name = "forest"
 path = "src/main.rs"
 
 [dependencies]
-anes.workspace = true
 anyhow.workspace = true
 atty.workspace = true
 cfg-if.workspace = true

--- a/forest/daemon/src/cli/mod.rs
+++ b/forest/daemon/src/cli/mod.rs
@@ -1,13 +1,9 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::io::Write;
-
-use anes::execute;
 use clap::Parser;
 use forest_cli_shared::cli::{CliOpts, HELP_MESSAGE};
 use forest_utils::version::FOREST_VERSION_STRING;
-use tokio::{signal, task};
 
 /// CLI structure generated when interacting with Forest binary
 #[derive(Parser)]
@@ -17,16 +13,4 @@ pub struct Cli {
     #[clap(flatten)]
     pub opts: CliOpts,
     pub cmd: Option<String>,
-}
-
-pub fn set_sigint_handler() {
-    task::spawn(async {
-        let _ = signal::ctrl_c().await;
-
-        // the cursor can go missing if we hit ctrl-c during a prompt, so we always
-        // restore it
-        let mut stdout = std::io::stdout();
-        #[allow(clippy::question_mark)]
-        execute!(&mut stdout, anes::ShowCursor).unwrap();
-    });
 }

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -78,9 +78,18 @@ pub(super) async fn start_interruptable(opts: CliOpts, config: Config) -> anyhow
 
     let result = tokio::select! {
         ret = start(opts, config, shutdown_send) => ret,
-        _ = tokio::signal::ctrl_c() => Err(anyhow::anyhow!("ctrl-c interrupt")),
-        _ = terminate.recv() => Ok(()),
-        _ = shutdown_recv.recv() => Ok(()),
+        _ = tokio::signal::ctrl_c() => {
+            info!("Keyboard interrupt.");
+            Ok(())
+        },
+        _ = terminate.recv() => {
+            info!("Received SIGTERM.");
+            Ok(())
+        },
+        _ = shutdown_recv.recv() => {
+            info!("Client requested the node to shutdown.");
+            Ok(())
+        },
     };
     forest_utils::io::terminal_cleanup();
     result

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -627,6 +627,7 @@ async fn create_keystore(config: &Config) -> anyhow::Result<KeyStore> {
     }
 }
 
+// Prompt for password in a blocking thread such that tokio can still process interrupts.
 async fn password_prompt(prompt: impl Into<String>) -> anyhow::Result<String> {
     let prompt: String = prompt.into();
     Ok(tokio::task::spawn_blocking(|| {

--- a/forest/daemon/src/daemon.rs
+++ b/forest/daemon/src/daemon.rs
@@ -4,7 +4,7 @@
 use std::{io::prelude::*, net::TcpListener, path::PathBuf, sync::Arc, time, time::Duration};
 
 use anyhow::Context;
-use dialoguer::{theme::ColorfulTheme, Confirm};
+use dialoguer::{theme::ColorfulTheme, Confirm, Password};
 use forest_auth::{create_token, generate_priv_key, ADMIN, JWT_IDENTIFIER};
 use forest_blocks::Tipset;
 use forest_chain::ChainStore;
@@ -19,7 +19,7 @@ use forest_cli_shared::{
 use forest_daemon::bundle::load_bundles;
 use forest_db::{
     db_engine::{db_root, open_proxy_db},
-    rolling::{DbGarbageCollector, RollingDB},
+    rolling::DbGarbageCollector,
     Store,
 };
 use forest_genesis::{get_network_name_from_genesis, import_chain, read_genesis_header};
@@ -47,8 +47,6 @@ use tokio::{
     time::sleep,
 };
 
-use super::cli::set_sigint_handler;
-
 // Initialize Consensus
 #[cfg(not(any(feature = "forest_fil_cns", feature = "forest_deleg_cns")))]
 compile_error!("No consensus feature enabled; use e.g. `--feature forest_fil_cns` to pick one.");
@@ -73,8 +71,27 @@ fn unblock_parent_process() -> anyhow::Result<()> {
         .map_err(|err| anyhow::anyhow!("{err}"))
 }
 
+// Start the daemon and abort if we're interrupted by ctrl-c, SIGTERM, or `forest-cli shutdown`.
+pub(super) async fn start_interruptable(opts: CliOpts, config: Config) -> anyhow::Result<()> {
+    let mut terminate = signal(SignalKind::terminate())?;
+    let (shutdown_send, mut shutdown_recv) = tokio::sync::mpsc::channel(1);
+
+    let result = tokio::select! {
+        ret = start(opts, config, shutdown_send) => ret,
+        _ = tokio::signal::ctrl_c() => Err(anyhow::anyhow!("ctrl-c interrupt")),
+        _ = terminate.recv() => Ok(()),
+        _ = shutdown_recv.recv() => Ok(()),
+    };
+    forest_utils::io::terminal_cleanup();
+    result
+}
+
 /// Starts daemon process
-pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<RollingDB> {
+pub(super) async fn start(
+    opts: CliOpts,
+    config: Config,
+    shutdown_send: tokio::sync::mpsc::Sender<()>,
+) -> anyhow::Result<()> {
     {
         // UGLY HACK:
         // This bypasses a bug in the FVM. Can be removed once the address parsing
@@ -86,11 +103,6 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Rolli
     if config.chain.is_testnet() {
         forest_shim::address::set_current_network(forest_shim::address::Network::Testnet);
     }
-
-    set_sigint_handler();
-
-    let (shutdown_send, mut shutdown_recv) = tokio::sync::mpsc::channel(1);
-    let mut terminate = signal(SignalKind::terminate())?;
 
     info!(
         "Starting Forest daemon, version {}",
@@ -124,7 +136,7 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Rolli
     // from.
     info!("PeerId: {}", PeerId::from(net_keypair.public()));
 
-    let mut keystore = create_keystore(&config)?;
+    let mut keystore = create_keystore(&config).await?;
 
     if keystore.get(JWT_IDENTIFIER).is_err() {
         keystore.put(JWT_IDENTIFIER.to_owned(), generate_priv_key())?;
@@ -252,7 +264,7 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Rolli
     };
 
     if opts.exit_after_init {
-        return Ok(db);
+        return Ok(());
     }
 
     // XXX: This code has to be run before starting the background services.
@@ -385,26 +397,7 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Rolli
 
     let config = maybe_fetch_snapshot(should_fetch_snapshot, config).await?;
 
-    tokio::select! {
-        ret = sync_from_snapshot(&config, &state_manager).fuse() => {
-            if let Err(err) = ret {
-                services.shutdown().await;
-                return Err(err);
-            }
-        },
-        _ = tokio::signal::ctrl_c() => {
-            services.shutdown().await;
-            return Ok(db);
-        },
-        _ = terminate.recv() => {
-            services.shutdown().await;
-            return Ok(db);
-        },
-        _ = shutdown_recv.recv() => {
-            services.shutdown().await;
-            return Ok(db);
-        },
-    }
+    sync_from_snapshot(&config, &state_manager).await?;
 
     // For convenience, flush the database after we've potentially loaded a new
     // snapshot. This ensures the snapshot won't have to be re-imported if
@@ -416,23 +409,14 @@ pub(super) async fn start(opts: CliOpts, config: Config) -> anyhow::Result<Rolli
     if opts.halt_after_import {
         // Cancel all async services
         services.shutdown().await;
-        return Ok(db);
+        return Ok(());
     }
 
     services.spawn(p2p_service.run());
 
     // blocking until any of the services returns an error,
-    // or CTRL-C is pressed
-    tokio::select! {
-        err = propagate_error(&mut services).fuse() => error!("services failure: {}", err),
-        _ = tokio::signal::ctrl_c() => {},
-        _ = terminate.recv() => {},
-        _ = shutdown_recv.recv() => {},
-    }
-
-    services.shutdown().await;
-
-    Ok(db)
+    let err = propagate_error(&mut services).await;
+    anyhow::bail!("services failure: {}", err);
 }
 
 /// Generates, prints and optionally writes to a file the administrator JWT
@@ -517,13 +501,13 @@ async fn prompt_snapshot_or_die(
     let should_download = if !auto_download_snapshot && atty::is(atty::Stream::Stdin) {
         let required_size: u64 = snapshot_fetch_size(config).await?;
         let required_size = to_size_string(&required_size.into())?;
-        Confirm::with_theme(&ColorfulTheme::default())
+        tokio::task::spawn_blocking(move || Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt(
                     format!("Forest needs a snapshot to sync with the network. Would you like to download one now? Required disk space {required_size}."),
                 )
                 .default(false)
                 .interact()
-                .unwrap_or_default()
+            ).await??
     } else {
         auto_download_snapshot
     };
@@ -580,7 +564,7 @@ fn get_actual_chain_name(internal_network_name: &str) -> &str {
     }
 }
 
-fn create_keystore(config: &Config) -> anyhow::Result<KeyStore> {
+async fn create_keystore(config: &Config) -> anyhow::Result<KeyStore> {
     let passphrase = std::env::var(FOREST_KEYSTORE_PHRASE_ENV);
     let is_interactive = atty::is(atty::Stream::Stdin);
 
@@ -600,10 +584,13 @@ fn create_keystore(config: &Config) -> anyhow::Result<KeyStore> {
     // encrypted keystore, interactive, passphrase not provided
     } else if config.client.encrypt_keystore && passphrase.is_err() && is_interactive {
         loop {
-            print!("Enter the keystore passphrase: ");
-            std::io::stdout().flush()?;
-
-            let passphrase = read_password()?;
+            let passphrase = tokio::task::spawn_blocking(|| {
+                Password::with_theme(&ColorfulTheme::default())
+                    .allow_empty_password(true)
+                    .with_prompt("Enter the keystore passphrase")
+                    .interact()
+            })
+            .await??;
 
             let data_dir = PathBuf::from(&config.client.data_dir).join(ENCRYPTED_KEYSTORE_NAME);
             if !data_dir.exists() {

--- a/utils/forest_utils/Cargo.toml
+++ b/utils/forest_utils/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 
 [dependencies]
 ahash.workspace = true
+anes.workspace = true
 anyhow.workspace = true
 async-compression.workspace = true
 async-fs.workspace = true
@@ -46,6 +47,9 @@ tokio = { workspace = true, features = ["fs"] }
 toml.workspace = true
 tracing.workspace = true
 url.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+termios = "0.3"
 
 [dev-dependencies]
 cs_serde_bytes = "0.12.2"

--- a/utils/forest_utils/src/io/mod.rs
+++ b/utils/forest_utils/src/io/mod.rs
@@ -89,3 +89,24 @@ where
     let new_struct: S = toml::from_str(toml_string)?;
     Ok(new_struct)
 }
+
+// When reading a password or prompting a yes/no answer, we change the terminal
+// settings by hiding the cursor or turning off the character echo.
+// Unfortunately, if we're interrupted, these settings are not restored. This
+// function attempts to restore terminal settings to sensible values. However,
+// if SIGKILL kills Forest, there's nothing we can do, and it'll be up to the
+// user to restore their terminal.
+pub fn terminal_cleanup() {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        use termios::*;
+        let fd = std::io::stdin().as_raw_fd();
+        let mut termios = Termios::from_fd(fd).unwrap();
+
+        termios.c_lflag |= ECHO;
+        let _ = tcsetattr(fd, TCSAFLUSH, &termios);
+    }
+    let mut stdout = std::io::stdout();
+    let _ = anes::execute!(&mut stdout, anes::ShowCursor);
+}

--- a/utils/forest_utils/src/io/mod.rs
+++ b/utils/forest_utils/src/io/mod.rs
@@ -102,10 +102,10 @@ pub fn terminal_cleanup() {
         use std::os::fd::AsRawFd;
         use termios::*;
         let fd = std::io::stdin().as_raw_fd();
-        let mut termios = Termios::from_fd(fd).unwrap();
-
-        termios.c_lflag |= ECHO;
-        let _ = tcsetattr(fd, TCSAFLUSH, &termios);
+        if let Ok(mut termios) = Termios::from_fd(fd) {
+            termios.c_lflag |= ECHO;
+            let _ = tcsetattr(fd, TCSAFLUSH, &termios);
+        }
     }
     let mut stdout = std::io::stdout();
     let _ = anes::execute!(&mut stdout, anes::ShowCursor);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:
- Always shut down tokio using `shutdown_timeout`. Otherwise, we will wait indefinitely for blocking threads.
- Wrap blocking calls in `spawn_blocking`.
- Clean up terminal settings if Forest is interrupted.
- Replace `rpassword` with `dialoguer`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
