### PR TITLE
[WIP] Automate Comparison of Checksums for Forest and Lotus Snapshots

### DIFF
--- a/scripts/benchmark_db/bench.rb
+++ b/scripts/benchmark_db/bench.rb
@@ -237,11 +237,11 @@ def benchmarks_loop(benchmarks, options, bench_metrics)
     bench_metrics[bench.name] = bench.metrics
 
     puts "\n"
-  rescue StandardError, Interrupt
-    @logger.error('Fiasco during benchmark run. Exiting...')
-    # Delete snapshot if downloaded, but not if user-provided.
-    FileUtils.rm_f(@snapshot_path) if @snapshot_downloaded
-    exit(1)
+  # rescue StandardError, Interrupt
+  #   @logger.error('Fiasco during benchmark run. Exiting...')
+  #   # Delete snapshot if downloaded, but not if user-provided.
+  #   FileUtils.rm_f(@snapshot_path) if @snapshot_downloaded
+  #   exit(1)
   end
 end
 
@@ -285,7 +285,7 @@ raise "The file '#{@snapshot_path}' does not exist" if @snapshot_path && !File.f
 
 # Download snapshot if a snapshot path is not specified by the user.
 begin
-  if @snapshot_path.nil? && !options[:checksum]
+  if @snapshot_path.nil?
     @logger.info 'No snapshot provided, downloading one'
     download_snapshot(chain: options[:chain])
     @logger.info "Snapshot successfully downloaded to: #{@snapshot_path}"
@@ -317,14 +317,10 @@ if options[:daily]
   ]
   run_benchmarks(selection, options)
 elsif options[:checksum]
-  # Download Lotus snapshot for import to Forest and checksum comparison.
-  @logger.info 'Downloading Lotus snapshot'
-  download_snapshot(chain: options[:chain])
-  @logger.info "Snapshot successfully downloaded to: #{@snapshot_path}"
-  @snapshot_downloaded = true
-  options[:snapshot_path] = @snapshot_path
-  # Run Forest client, export snapshot, and compare checksums.
+  # Run Forest client and export snapshot.
   run_benchmarks([ForestBenchmark.new(name: 'forest')], options)
+  # Run Lotus and export snapshot at same height as Forest snapshot.
+  run_benchmarks([LotusBenchmark.new(name: 'lotus')], options)
 else
   # Benchmarks for database metrics.
   selection = Set[]

--- a/scripts/benchmark_db/bench.rb
+++ b/scripts/benchmark_db/bench.rb
@@ -25,7 +25,7 @@ SNAPSHOT_REGEXES = [
   %r{/(?<height>\d+)_*}
 ].freeze
 
-HEIGHTS_TO_VALIDATE = 40
+TIPSETS_TO_VALIDATE = 40
 
 MINUTE = 60
 HOUR = MINUTE * MINUTE
@@ -34,14 +34,14 @@ HOUR = MINUTE * MINUTE
 
 # Define default options and parse command line options.
 options = {
-  heights: HEIGHTS_TO_VALIDATE,
+  tipsets: TIPSETS_TO_VALIDATE,
   pattern: 'baseline',
   chain: 'mainnet'
 }
 OptionParser.new do |opts|
   opts.banner = 'Usage: bench.rb [options] snapshot'
   opts.on('--dry-run', 'Only print the commands that will be run') { |v| options[:dry_run] = v }
-  opts.on('--heights [Integer]', Integer, 'Number of heights to validate') { |v| options[:heights] = v }
+  opts.on('--tipsets [Integer]', Integer, 'Number of tipsets to validate') { |v| options[:tipsets] = v }
   opts.on('--pattern [String]', 'Run benchmarks that match the pattern') { |v| options[:pattern] = v }
   opts.on('--chain [String]', 'Choose network chain [default: mainnet]') { |v| options[:chain] = v }
   opts.on('--tempdir [String]', 'Specify a custom directory for running benchmarks') { |v| options[:tempdir] = v }
@@ -230,7 +230,7 @@ end
 # run metrics, and assign metrics for each benchmark.
 def benchmarks_loop(benchmarks, options, bench_metrics)
   benchmarks.each do |bench|
-    bench.dry_run, bench.snapshot_path, bench.heights, bench.chain = bench_loop_assignments(options)
+    bench.dry_run, bench.snapshot_path, bench.tipsets, bench.chain = bench_loop_assignments(options)
     bench.run(options[:daily], @snapshot_downloaded)
 
     bench_metrics[bench.name] = bench.metrics
@@ -246,7 +246,7 @@ end
 
 # Helper function for to create assignments for `benchmarks_loop` function.
 def bench_loop_assignments(options)
-  [options[:dry_run], options[:snapshot_path], options[:heights], options[:chain]]
+  [options[:dry_run], options[:snapshot_path], options[:tipsets], options[:chain]]
 end
 
 # Run benchmarks and write to `CSV` if daily or markdown file if `DB` benchmarks.

--- a/scripts/benchmark_db/benchmark_base.rb
+++ b/scripts/benchmark_db/benchmark_base.rb
@@ -149,7 +149,7 @@ end
 module RunCommands
   # Create and call proper validation command, then write results to metrics.
   def run_validation_step(options, args, metrics)
-    unless options[:daily]
+    unless options[:daily] || options[:checksum]
       validate_command = splice_args(@validate_command, args)
       metrics[:validate] = exec_command(validate_command)
       return

--- a/scripts/benchmark_db/benchmark_base.rb
+++ b/scripts/benchmark_db/benchmark_base.rb
@@ -104,7 +104,7 @@ module BuildCommands
   # path, and start epoch for building and running client.
   def build_substitution_hash
     height = snapshot_height(@snapshot_path)
-    start = height - @heights
+    start = height - @tipsets
 
     return { c: '<tbd>', s: '<tbd>', h: start } if @dry_run
 
@@ -159,7 +159,7 @@ module RunCommands
     new_metrics = exec_command(validate_online_command, self)
     new_metrics[:tpm] =
       new_metrics[:num_epochs] ? new_metrics[:num_epochs] / online_validation_secs : 'n/a'
-    new_metrics[:tpm] = new_metrics[:tpm].ceil(3)
+    new_metrics[:tpm] = new_metrics[:tpm].ceil(3) unless @dry_run
     metrics[:validate_online] = new_metrics
   end
 
@@ -256,7 +256,7 @@ class BenchmarkBase
   include BuildCommands
   include RunCommands
   attr_reader :name, :metrics
-  attr_accessor :dry_run, :snapshot_path, :heights, :chain
+  attr_accessor :dry_run, :snapshot_path, :tipsets, :chain
 
   def initialize(name:, config: {})
     @name = name

--- a/scripts/benchmark_db/benchmark_base.rb
+++ b/scripts/benchmark_db/benchmark_base.rb
@@ -40,7 +40,7 @@ module ExecCommands
         status = benchmark.start_export_command
         if !status.nil?
           @logger.info 'Exporting snapshot'
-          #TODO: export snapshot
+          syscall(*@export_command)
           break
         end
         sleep 5
@@ -213,6 +213,7 @@ module RunCommands
 
       args = build_artefacts
       @sync_status_command = splice_args(@sync_status_command, args)
+      @export_command = splice_args(@export_command, args)
 
       forest_init(args) if @name == 'forest'
 

--- a/scripts/benchmark_db/forest_bench.rb
+++ b/scripts/benchmark_db/forest_bench.rb
@@ -88,6 +88,9 @@ class ForestBenchmark < BenchmarkBase
     @sync_status_command = [
       target_cli, '--config', '%<c>s', 'sync', 'status'
     ]
+    #TODO: previously used `--tipset` flag to set export height, but this is no
+    # longer supported.
+    @export_command = [target_cli, 'snapshot', 'export']
     @metrics = Concurrent::Hash.new
   end
 end

--- a/scripts/benchmark_db/forest_bench.rb
+++ b/scripts/benchmark_db/forest_bench.rb
@@ -88,8 +88,6 @@ class ForestBenchmark < BenchmarkBase
     @sync_status_command = [
       target_cli, '--config', '%<c>s', 'sync', 'status'
     ]
-    #TODO: previously used `--tipset` flag to set export height, but this is no
-    # longer supported.
     @export_command = [target_cli, 'snapshot', 'export']
     @metrics = Concurrent::Hash.new
   end


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- We are already running both Forest and Lotus with the benchmark script, so this PR will extend that script to export a snapshot during the Forest client run and compare the checksum against the downloaded Lotus snapshot's checksum.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #2559 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
