### PR TITLE
remove redundant snapshot export check

### DIFF
--- a/scripts/tests/calibnet_export_check.sh
+++ b/scripts/tests/calibnet_export_check.sh
@@ -9,9 +9,6 @@ source "$(dirname "$0")/harness.sh"
 
 forest_init
 
-echo "Exporting uncompressed snapshot"
-$FOREST_CLI_PATH snapshot export
-
 echo "Exporting zstd compressed snapshot"
 $FOREST_CLI_PATH snapshot export
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Forest no longer supports uncompressed snapshot export. The test does not match the comments anyway.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
