### PR TITLE
fix: remove #[allow(deprecated)]

### DIFF
--- a/src/daemon/daemon.rs
+++ b/src/daemon/daemon.rs
@@ -130,9 +130,9 @@ pub(super) async fn start(
             let file = write_to_file(
                 &gen_keypair
                     .clone()
-                    .into_ed25519()
-                    .ok_or(anyhow::anyhow!("couldn't convert keypair to ed25519"))?
-                    .encode(),
+                    .try_into_ed25519()
+                    .context("couldn't convert keypair to ed25519")?
+                    .to_bytes(),
                 &path,
                 "keypair",
             )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![recursion_limit = "1024"]
 #![allow(
-    deprecated,
     unused,
     clippy::upper_case_acronyms,
     clippy::enum_variant_names,

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -34,8 +34,7 @@ use libp2p::{
     noise, ping,
     request_response::{self, RequestId, ResponseChannel},
     swarm::{SwarmBuilder, SwarmEvent},
-    yamux::YamuxConfig,
-    PeerId, Swarm, Transport,
+    yamux, PeerId, Swarm, Transport,
 };
 use log::{debug, error, info, trace, warn};
 use tokio_stream::wrappers::IntervalStream;
@@ -840,7 +839,7 @@ pub fn build_transport(local_key: Keypair) -> anyhow::Result<Boxed<(PeerId, Stre
     Ok(transport
         .upgrade(core::upgrade::Version::V1)
         .authenticate(auth_config)
-        .multiplex(YamuxConfig::default())
+        .multiplex(yamux::Config::default())
         .timeout(Duration::from_secs(20))
         .boxed())
 }

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -829,12 +829,7 @@ pub fn build_transport(local_key: Keypair) -> anyhow::Result<Boxed<(PeerId, Stre
     let transport =
         libp2p::websocket::WsConfig::new(build_dns_tcp()?).or_transport(build_dns_tcp()?);
 
-    let auth_config = {
-        let dh_keys = noise::Keypair::<noise::X25519Spec>::new()
-            .into_authentic(&local_key)
-            .context("Noise key generation failed")?;
-        noise::NoiseConfig::xx(dh_keys).into_authenticated()
-    };
+    let auth_config = noise::Config::new(&local_key).context("Noise key generation failed")?;
 
     Ok(transport
         .upgrade(core::upgrade::Version::V1)

--- a/src/libp2p_bitswap/tests/go_compat.rs
+++ b/src/libp2p_bitswap/tests/go_compat.rs
@@ -33,7 +33,7 @@ mod tests {
         let transport = tcp::tokio::Transport::default()
             .upgrade(core::upgrade::Version::V1)
             .authenticate(noise::NoiseAuthenticated::xx(&id_keys).unwrap())
-            .multiplex(yamux::YamuxConfig::default())
+            .multiplex(yamux::Config::default())
             .timeout(TIMEOUT)
             .boxed();
         let behaviour = BitswapBehaviour::new(&[b"/test/ipfs/bitswap/1.2.0"], Default::default());

--- a/src/libp2p_bitswap/tests/go_compat.rs
+++ b/src/libp2p_bitswap/tests/go_compat.rs
@@ -32,7 +32,7 @@ mod tests {
         let peer_id = PeerId::from(id_keys.public());
         let transport = tcp::tokio::Transport::default()
             .upgrade(core::upgrade::Version::V1)
-            .authenticate(noise::NoiseAuthenticated::xx(&id_keys).unwrap())
+            .authenticate(noise::Config::new(&id_keys).unwrap())
             .multiplex(yamux::Config::default())
             .timeout(TIMEOUT)
             .boxed();

--- a/src/libp2p_bitswap/tests/request_manager.rs
+++ b/src/libp2p_bitswap/tests/request_manager.rs
@@ -104,7 +104,7 @@ mod tests {
         let peer_id = PeerId::from(id_keys.public());
         let transport = tcp::tokio::Transport::default()
             .upgrade(core::upgrade::Version::V1)
-            .authenticate(noise::NoiseAuthenticated::xx(&id_keys)?)
+            .authenticate(noise::Config::new(&id_keys)?)
             .multiplex(yamux::Config::default())
             .timeout(TIMEOUT)
             .boxed();

--- a/src/libp2p_bitswap/tests/request_manager.rs
+++ b/src/libp2p_bitswap/tests/request_manager.rs
@@ -105,7 +105,7 @@ mod tests {
         let transport = tcp::tokio::Transport::default()
             .upgrade(core::upgrade::Version::V1)
             .authenticate(noise::NoiseAuthenticated::xx(&id_keys)?)
-            .multiplex(yamux::YamuxConfig::default())
+            .multiplex(yamux::Config::default())
             .timeout(TIMEOUT)
             .boxed();
         let behaviour = BitswapBehaviour::new(&[b"/test/ipfs/bitswap/1.0.0"], Default::default());


### PR DESCRIPTION
Broken out of #3011 to be easy to revert in case the networking is broken