### PR TITLE
fix forest_db_size metric regression

### DIFF
--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -19,10 +19,10 @@ impl DBCollector {
     pub fn new(db_directory: PathBuf) -> Self {
         let mut descs: Vec<Desc> = vec![];
         let db_size = Gauge::with_opts(Opts::new(
-            "crate::db_size",
+            "forest_db_size",
             "Size of Forest database in bytes",
         ))
-        .expect("Creating crate::db_size gauge must succeed");
+        .expect("Creating forest_db_size gauge must succeed");
         descs.extend(db_size.desc().into_iter().cloned());
         Self {
             db_directory,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Brings back the previous name for the DB size metric. It should not have been changed. This resulted in a regression in the dashboard: 
![image](https://github.com/ChainSafe/forest/assets/9642092/265cd4c1-9476-4b90-8ca2-6c3f3e3df041)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
