### PR TITLE
fix recent rubocop release warnings

### DIFF
--- a/scripts/benchmark_db/bench.rb
+++ b/scripts/benchmark_db/bench.rb
@@ -179,9 +179,9 @@ end
 # Helper function to create assignments for `download_and_move` function.
 def download_and_move_assignments(url)
   filename = url.match(/(\d+_.+)/)[1]
-  checksum_url = url.sub(/\.car\.zst/, '.sha256sum')
+  checksum_url = url.sub('.car.zst', '.sha256sum')
   checksum_filename = checksum_url.match(/(\d+_.+)/)[1]
-  decompressed_filename = filename.sub(/\.car\.zst/, '.car')
+  decompressed_filename = filename.sub('.car.zst', '.car')
   [filename, checksum_url, checksum_filename, decompressed_filename]
 end
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- [new Rubocop version was released](https://github.com/rubocop/rubocop/releases/tag/v1.53.0) and at the moment we lack a lockfile. I fixed the new minor offences. 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
