### PR TITLE
Add malloc metrics route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,6 +2939,7 @@ dependencies = [
  "termios",
  "thiserror",
  "ticker",
+ "tikv-jemalloc-sys",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ tap = "1"
 tempfile = "3.4"
 thiserror = "1.0"
 ticker = "0.1"
+tikv-jemalloc-sys = { version = "0.5", optional = true }
 tikv-jemallocator = { version = "0.5", optional = true }
 tokio = { version = "1", features = ['full'] }
 tokio-stream = { version = "0.1", features = ["fs", "io-util"] }
@@ -230,7 +231,7 @@ benchmark-private = []               # see lib.rs::benchmark_private
 
 # Allocator
 rustalloc = []
-jemalloc = ["dep:tikv-jemallocator"]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-sys"]
 mimalloc = ["dep:mimalloc"]
 
 [[bench]]

--- a/src/cli_shared/mod.rs
+++ b/src/cli_shared/mod.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 pub use mimalloc;
 #[cfg(feature = "jemalloc")]
 pub use tikv_jemallocator;
+#[cfg(feature = "jemalloc")]
+pub use tikv_jemalloc_sys;
 
 /// Gets chain data directory
 pub fn chain_path(config: &crate::cli_shared::cli::Config) -> PathBuf {

--- a/src/cli_shared/mod.rs
+++ b/src/cli_shared/mod.rs
@@ -9,9 +9,9 @@ use std::path::PathBuf;
 #[cfg(feature = "mimalloc")]
 pub use mimalloc;
 #[cfg(feature = "jemalloc")]
-pub use tikv_jemallocator;
-#[cfg(feature = "jemalloc")]
 pub use tikv_jemalloc_sys;
+#[cfg(feature = "jemalloc")]
+pub use tikv_jemallocator;
 
 /// Gets chain data directory
 pub fn chain_path(config: &crate::cli_shared::cli::Config) -> PathBuf {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -111,7 +111,7 @@ where
             let string_ptr = ptr as *mut String;
             unsafe {
                 let stats = String::from_utf8_lossy(
-                    std::ffi::CStr::from_ptr(message as *const i8).to_bytes(),
+                    std::ffi::CStr::from_ptr(message as *const c_char).to_bytes(),
                 );
                 (*string_ptr).push_str(&stats);
             }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -117,7 +117,7 @@ where
             }
         }
 
-        metrics.push_str("# Jemalloc statistics:\n".into());
+        metrics.push_str("# Jemalloc statistics:\n");
 
         let string_ptr: *mut String = &mut metrics;
         unsafe {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Add malloc metrics

Use `http://localhost:6116/stats/malloc` in your browser to give you stats from the memory allocator (if supported):

```
# Jemalloc statistics:
___ Begin jemalloc statistics ___
Version: "5.3.0-0-g54eaed1d8b56b1aa528be3bdd1877e59c56fa90c"
Build-time option settings
  config.cache_oblivious: true
  config.debug: false
  config.fill: true
  config.lazy_lock: false
  config.malloc_conf: ""
  config.opt_safety_checks: false
  config.prof: false
  config.prof_libgcc: false
  config.prof_libunwind: false
  config.stats: true
  config.utrace: false
  config.xmalloc: false
Run-time option settings
  opt.abort: false
  opt.abort_conf: false
  opt.cache_oblivious: true
  opt.confirm_conf: false
  opt.retain: false
  opt.dss: "secondary"
  opt.narenas: 32
  opt.percpu_arena: "disabled"
  opt.oversize_threshold: 8388608
  opt.hpa: false
  opt.hpa_slab_max_alloc: 65536
  opt.hpa_hugification_threshold: 1992294
  opt.hpa_hugify_delay_ms: 10000
  opt.hpa_min_purge_interval_ms: 5000
  opt.hpa_dirty_mult: "0.25"
  opt.hpa_sec_nshards: 4
  opt.hpa_sec_max_alloc: 32768
  opt.hpa_sec_max_bytes: 262144
  opt.hpa_sec_bytes_after_flush: 131072
  opt.hpa_sec_batch_fill_extra: 0
  opt.metadata_thp: "disabled"
  opt.mutex_max_spin: 600
  opt.dirty_decay_ms: 10000 (arenas.dirty_decay_ms: 10000)
  opt.muzzy_decay_ms: 0 (arenas.muzzy_decay_ms: 0)
  opt.lg_extent_max_active_fit: 6
  opt.junk: "false"
  opt.zero: false
  opt.tcache: true
  opt.tcache_max: 32768
  opt.tcache_nslots_small_min: 20
  opt.tcache_nslots_small_max: 200
  opt.tcache_nslots_large: 20
  opt.lg_tcache_nslots_mul: 1
  opt.tcache_gc_incr_bytes: 65536
  opt.tcache_gc_delay_bytes: 0
  opt.lg_tcache_flush_small_div: 1
  opt.lg_tcache_flush_large_div: 1
  opt.thp: "not supported"
  opt.stats_print: false
  opt.stats_print_opts: ""
  opt.stats_print: false
  opt.stats_print_opts: ""
  opt.stats_interval: -1
  opt.stats_interval_opts: ""
  opt.zero_realloc: "alloc"
Arenas: 33
Quantum size: 16
Page size: 16384
Maximum thread-cached size class: 32768
Number of bin size classes: 44
Number of thread-cache bin size classes: 41
Number of large size classes: 188
Allocated: 99805408, active: 163594240, metadata: 10508672 (n_thp 0), resident: 468942848, mapped: 534888448, retained: 0
Count of realloc(non-null-ptr, 0) calls: 0
Background threads: 0, num_runs: 0, run_interval: 0 ns
                           n_lock_ops (#/sec)       n_waiting (#/sec)      n_spin_acq (#/sec)  n_owner_switch (#/sec)   total_wait_ns   (#/sec)     max_wait_ns  max_n_thds
background_thread                   0       0               0       0               0       0               0       0               0         0               0           0
max_per_bg_thd                      0       0               0       0               0       0               0       0               0         0               0           0
ctl                            204266  204266               0       0               0       0               2       2               0         0               0           0
prof                                0       0               0       0               0       0               0       0               0         0               0           0
prof_thds_data                      0       0               0       0               0       0               0       0               0         0               0           0
prof_dump                           0       0               0       0               0       0               0       0               0         0               0           0
prof_recent_alloc                   0       0               0       0               0       0               0       0               0         0               0           0
prof_recent_dump                    0       0               0       0               0       0               0       0               0         0               0           0
prof_stats                          0       0               0       0               0       0               0       0               0         0               0           0
Merged arenas stats:
assigned threads: 63
uptime: 168061895
dss allocation precedence: "N/A"
decaying:  time       npages       sweeps     madvises       purged
   dirty:   N/A        18182            8           27        13082
   muzzy:   N/A            0            0            0            0
                            allocated         nmalloc   (#/sec)         ndalloc   (#/sec)       nrequests   (#/sec)           nfill   (#/sec)          nflush   (#/sec)
small:                       68233440         3175234   3175234         3060856   3060856        14266360  14266360          420627    420627          110545    110545
large:                       31571968           31659     31659           31566     31566           31659     31659           31659     31659               0         0
total:                       99805408         3206893   3206893         3092422   3092422        14298019  14298019          452286    452286          110545    110545
...
```



This could help us with:

- troubleshooting memory issues
- understand what goes on behind the scenes
- tune performances

To tweak some build-time option like `narenas` we can do:

1. export JEMALLOC_SYS_WITH_MALLOC_CONF="narenas:2"
2. cargo clean -p tikv-jemalloc-sys
3. cargo build --release

We should then see the value in the stats.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
