### PR TITLE
remove cmake from dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # install dependencies
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y build-essential clang cmake curl ca-certificates
+    apt-get install --no-install-recommends -y build-essential clang curl ca-certificates
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -21,7 +21,7 @@ FROM alpine:3 AS build-env
 
 # Install dependencies
 RUN apk update && \
-    apk add --no-cache git curl make cmake gcc clang clang-dev musl-dev
+    apk add --no-cache git curl make gcc clang clang-dev musl-dev
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install-with-mimalloc:
 
 install-deps:
 	apt-get update -y
-	apt-get install --no-install-recommends -y build-essential clang aria2 cmake
+	apt-get install --no-install-recommends -y build-essential clang aria2
 
 install-lint-tools:
 	cargo install --locked taplo-cli

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sudo make install-deps
 or
 
 ```
-sudo apt install build-essential clang cmake
+sudo apt install build-essential clang
 ```
 
 ### Archlinux
@@ -82,13 +82,13 @@ sudo pacman -S base-devel clang
 ### Fedora (36)
 
 ```
-sudo dnf install -y clang-devel cmake
+sudo dnf install -y clang-devel
 ```
 
 ### Alpine
 
 ```
-apk add git curl make cmake gcc clang clang-dev musl-dev
+apk add git curl make gcc clang clang-dev musl-dev
 ```
 
 ## Installation

--- a/documentation/src/basic_usage.md
+++ b/documentation/src/basic_usage.md
@@ -12,14 +12,13 @@ Forest Docker image (explained in detail [here](docker.md)).
 
 - Rust - install via [rustup](https://rustup.rs/)
 - OS Base-Devel/Build-Essential
-- CMake
 - Clang compiler
 - OpenCL bindings
 
 For Ubuntu, you can install the dependencies (excluding Rust) with:
 
 ```shell
-sudo apt install build-essential clang cmake
+sudo apt install build-essential clang
 ```
 
 ### Optional runtime dependencies


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- as noticed by @lemmih in https://github.com/ChainSafe/forest/pull/3091#pullrequestreview-1503305118, `cmake` is no longer a dependency of Forest (it was, indirectly, some time ago).

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
