### PR TITLE
chore: remove the `BigInt` intermediate type

### DIFF
--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -262,7 +262,7 @@ where
             let request = HelloRequest {
                 heaviest_tip_set: heaviest.cids().to_vec(),
                 heaviest_tipset_height: heaviest.epoch(),
-                heaviest_tipset_weight: heaviest.weight().clone().into(),
+                heaviest_tipset_weight: heaviest.weight().clone(),
                 genesis_cid: genesis_block_cid,
             };
             let (peer_id, moment_sent, response) =

--- a/src/shim/bigint.rs
+++ b/src/shim/bigint.rs
@@ -1,31 +1,5 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::ops::{Deref, DerefMut};
-
 pub use fvm_shared3::bigint::bigint_ser::{BigIntDe, BigIntSer};
-use fvm_shared3::bigint::{bigint_ser, BigInt as BigInt_v3};
-use serde::{Deserialize, Serialize};
-
-#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct BigInt(#[serde(with = "bigint_ser")] BigInt_v3);
-
-impl Deref for BigInt {
-    type Target = BigInt_v3;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for BigInt {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl From<BigInt_v3> for BigInt {
-    fn from(other: BigInt_v3) -> Self {
-        BigInt(other)
-    }
-}
+pub use num::BigInt;


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:

- `BigInt` is always `num::BigInt`, we don't need to create a local copy.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
