### PR TITLE
fix: cleanup unneccesary store borrow in nv17 migration code

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -41,37 +41,6 @@ pub trait Store {
     }
 }
 
-impl<BS: Store> Store for &BS {
-    fn read<K>(&self, key: K) -> Result<Option<Vec<u8>>, Error>
-    where
-        K: AsRef<[u8]>,
-    {
-        (*self).read(key)
-    }
-
-    fn write<K, V>(&self, key: K, value: V) -> Result<(), Error>
-    where
-        K: AsRef<[u8]>,
-        V: AsRef<[u8]>,
-    {
-        (*self).write(key, value)
-    }
-
-    fn exists<K>(&self, key: K) -> Result<bool, Error>
-    where
-        K: AsRef<[u8]>,
-    {
-        (*self).exists(key)
-    }
-
-    fn bulk_write(
-        &self,
-        values: impl IntoIterator<Item = (impl Into<Vec<u8>>, impl Into<Vec<u8>>)>,
-    ) -> Result<(), Error> {
-        (*self).bulk_write(values)
-    }
-}
-
 /// Traits for collecting DB stats
 pub trait DBStatistics {
     fn get_statistics(&self) -> Option<String> {

--- a/src/state_migration/nv17/datacap.rs
+++ b/src/state_migration/nv17/datacap.rs
@@ -34,7 +34,7 @@ impl<BS: Blockstore + Clone> PostMigrator<BS> for DataCapPostMigrator {
     fn post_migrate_state(&self, store: &BS, actors_out: &mut StateTree<BS>) -> anyhow::Result<()> {
         use fil_actors_shared::v9::builtin::HAMT_BIT_WIDTH;
 
-        let verified_clients = fil_actors_shared::v8::make_map_with_root::<_, BigInt>(
+        let verified_clients = fil_actors_shared::v8::make_map_with_root::<BS, BigInt>(
             &self.verifreg_state.verified_clients,
             store,
         )?;
@@ -42,7 +42,7 @@ impl<BS: Blockstore + Clone> PostMigrator<BS> for DataCapPostMigrator {
         let mut token_supply: num_bigint::BigInt = Zero::zero();
 
         let mut balances_map =
-            fil_actors_shared::v9::make_empty_map::<_, BigInt>(store, HAMT_BIT_WIDTH);
+            fil_actors_shared::v9::make_empty_map::<BS, BigInt>(store, HAMT_BIT_WIDTH);
 
         let mut allowances_map = fil_actors_shared::v9::make_empty_map(store, HAMT_BIT_WIDTH);
 
@@ -53,7 +53,7 @@ impl<BS: Blockstore + Clone> PostMigrator<BS> for DataCapPostMigrator {
             balances_map.set(key.clone(), token_amount.into())?;
 
             let mut allowances_map_entry =
-                fil_actors_shared::v9::make_empty_map::<_, BigInt>(store, HAMT_BIT_WIDTH);
+                fil_actors_shared::v9::make_empty_map::<BS, BigInt>(store, HAMT_BIT_WIDTH);
             allowances_map_entry.set(
                 BytesKey(fil_actors_shared::v9::builtin::STORAGE_MARKET_ACTOR_ADDR.payload_bytes()),
                 INFINITE_ALLOWANCE.clone().into(),

--- a/src/state_migration/nv17/datacap.rs
+++ b/src/state_migration/nv17/datacap.rs
@@ -36,15 +36,15 @@ impl<BS: Blockstore + Clone> PostMigrator<BS> for DataCapPostMigrator {
 
         let verified_clients = fil_actors_shared::v8::make_map_with_root::<_, BigInt>(
             &self.verifreg_state.verified_clients,
-            &store,
+            store,
         )?;
 
         let mut token_supply: num_bigint::BigInt = Zero::zero();
 
         let mut balances_map =
-            fil_actors_shared::v9::make_empty_map::<_, BigInt>(&store, HAMT_BIT_WIDTH);
+            fil_actors_shared::v9::make_empty_map::<_, BigInt>(store, HAMT_BIT_WIDTH);
 
-        let mut allowances_map = fil_actors_shared::v9::make_empty_map(&store, HAMT_BIT_WIDTH);
+        let mut allowances_map = fil_actors_shared::v9::make_empty_map(store, HAMT_BIT_WIDTH);
 
         verified_clients.for_each(|addr_key, value| {
             let key = hamt_addr_key_to_key(addr_key)?;
@@ -53,7 +53,7 @@ impl<BS: Blockstore + Clone> PostMigrator<BS> for DataCapPostMigrator {
             balances_map.set(key.clone(), token_amount.into())?;
 
             let mut allowances_map_entry =
-                fil_actors_shared::v9::make_empty_map::<_, BigInt>(&store, HAMT_BIT_WIDTH);
+                fil_actors_shared::v9::make_empty_map::<_, BigInt>(store, HAMT_BIT_WIDTH);
             allowances_map_entry.set(
                 BytesKey(fil_actors_shared::v9::builtin::STORAGE_MARKET_ACTOR_ADDR.payload_bytes()),
                 INFINITE_ALLOWANCE.clone().into(),

--- a/src/state_migration/nv17/miner.rs
+++ b/src/state_migration/nv17/miner.rs
@@ -776,7 +776,7 @@ mod tests {
         ensure!(verifreg_cid.to_string() == "bafkqaftgnfwc6obpozsxe2lgnfswi4tfm5uxg5dspe");
         let mut verifreg_state =
             fil_actor_verifreg_state::v8::State::new(&store, verifreg_root.into())?;
-        let mut verified_clients = fil_actors_shared::v8::make_empty_map::<_, BigInt>(
+        let mut verified_clients = fil_actors_shared::v8::make_empty_map::<BS, BigInt>(
             &store,
             fil_actors_shared::v8::builtin::HAMT_BIT_WIDTH,
         );

--- a/src/state_migration/nv17/miner.rs
+++ b/src/state_migration/nv17/miner.rs
@@ -125,7 +125,7 @@ impl MinerMigrator {
         let market_proposals = fil_actors_shared::v8::Array::<
             fil_actor_market_state::v8::DealProposal,
             _,
-        >::load(&self.market_proposals, &store)?;
+        >::load(&self.market_proposals, store)?;
 
         let old_precommit_on_chain_infos =
             fil_actors_shared::v8::make_map_with_root_and_bitwidth::<

--- a/src/state_migration/nv17/verifreg_market.rs
+++ b/src/state_migration/nv17/verifreg_market.rs
@@ -103,7 +103,7 @@ impl<BS: Blockstore + Clone> PostMigrator<BS> for VerifregMarketPostMigrator {
             )?;
         }
 
-        let mut empty_map = fil_actors_shared::v9::make_empty_map::<_, ()>(store, HAMT_BIT_WIDTH);
+        let mut empty_map = fil_actors_shared::v9::make_empty_map::<BS, ()>(store, HAMT_BIT_WIDTH);
         let verifreg_state_v9 = fil_actor_verifreg_state::v9::State {
             root_key: self.verifreg_state_v8.root_key,
             verifiers: self.verifreg_state_v8.verifiers,
@@ -117,7 +117,7 @@ impl<BS: Blockstore + Clone> PostMigrator<BS> for VerifregMarketPostMigrator {
 
         // `migrateMarket`
         let mut pending_deal_allocation_id_map =
-            fil_actors_shared::v9::make_empty_map::<_, i64>(store, HAMT_BIT_WIDTH);
+            fil_actors_shared::v9::make_empty_map::<BS, i64>(store, HAMT_BIT_WIDTH);
         for (deal_id, allocation_id) in deal_allocation_tuples {
             pending_deal_allocation_id_map
                 .set(fil_actors_shared::v9::u64_key(deal_id), allocation_id as _)?;

--- a/src/state_migration/nv17/verifreg_market.rs
+++ b/src/state_migration/nv17/verifreg_market.rs
@@ -41,7 +41,7 @@ impl<BS: Blockstore + Clone> PostMigrator<BS> for VerifregMarketPostMigrator {
         let market_proposals = fil_actors_shared::v8::Array::<
             fil_actor_market_state::v8::DealProposal,
             _,
-        >::load(&self.market_state_v8.proposals, &store)?;
+        >::load(&self.market_state_v8.proposals, store)?;
 
         let mut next_allocation_id: fil_actor_verifreg_state::v9::AllocationID = 1;
         let mut allocations_map_map = HashMap::default();

--- a/src/state_migration/nv19/power.rs
+++ b/src/state_migration/nv19/power.rs
@@ -42,7 +42,7 @@ impl<BS: Blockstore + Clone + Send + Sync> ActorMigration<BS> for PowerMigrator 
 
         let in_claims = make_map_with_root_and_bitwidth(&in_state.claims, &store, HAMT_BIT_WIDTH)?;
 
-        let empty_claims = make_empty_map::<_, ()>(&store, HAMT_BIT_WIDTH).flush()?;
+        let empty_claims = make_empty_map::<BS, ()>(&store, HAMT_BIT_WIDTH).flush()?;
 
         let mut out_claims =
             make_map_with_root_and_bitwidth(&empty_claims, &store, HAMT_BIT_WIDTH)?;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- cleanup unneccesary store borrows that are not caught by clippy
- cleanup `Store` impl for borrows

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
