### PR TITLE
fix: disable abort on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,8 @@ lto = "off"
 [profile.release]
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip
 strip = true
-panic = "abort"
+# The FVM relies on catching panics. See: tracking issue here
+panic = "unwind"
 overflow-checks = true
 
 # These should be refactored (probably removed) in #2984

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ lto = "off"
 [profile.release]
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip
 strip = true
-# The FVM relies on catching panics. See: tracking issue here
+# The FVM relies on catching panics. See: https://github.com/ChainSafe/forest/issues/3153
 panic = "unwind"
 overflow-checks = true
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- FVM relies on unwinding panics.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #2684 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
