### PR TITLE
Implement `forest-cli db dump` and re-organize the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 
 ### Breaking
 
+- [#3093](https://github.com/ChainSafe/forest/issues/3093): Implement
+  `forest-cli db dump` which changed the database organisation to use multiple
+  columns. The database will need to be recreated.
+
 ### Added
 
 - [#3166](https://github.com/ChainSafe/forest/issues/3166): Add

--- a/documentation/src/snapshot_export.md
+++ b/documentation/src/snapshot_export.md
@@ -48,3 +48,13 @@ compressed.
 
 For mainnet, you should expect a file of over 50 GB. For calibnet, you should
 expect a file of around 1-2 GB.
+
+## Dumping the database
+
+Another possible approach of exporting a snapshot is to dump all the IPLD
+entries from the database into a CAR file. Such file is importable by the
+Filecoin nodes but may contain dangling blocks.
+
+```shell
+forest-cli db dump
+```

--- a/scripts/tests/calibnet_export_check.sh
+++ b/scripts/tests/calibnet_export_check.sh
@@ -1,22 +1,32 @@
 #!/usr/bin/env bash
 # This script is checking the correctness of 
-# the snapshot export feature.
+# the snapshot export and db dump features.
 # It requires both the `forest` and `forest-cli` binaries to be in the PATH.
 
-set -e
+set -eu
 
 source "$(dirname "$0")/harness.sh"
 
 forest_init
 
 echo "Cleaning up the initial snapshot"
-rm -rf ./*.car.*
+rm --force --verbose ./*.{car,car.zst,sha256sum}
 
 echo "Exporting zstd compressed snapshot"
 $FOREST_CLI_PATH snapshot export
+
+echo "Dumping the database to a CAR file"
+$FOREST_CLI_PATH db dump
 
 echo "Testing snapshot validity"
 zstd --test ./*.car.zst
 
 echo "Verifying snapshot checksum"
 sha256sum --check ./*.sha256sum
+
+echo "Validating CAR files"
+zstd --decompress ./*.car.zst
+for f in *.car; do
+  echo "Validating CAR file $f"
+  $FOREST_CLI_PATH --chain calibnet snapshot validate "$f"
+done

--- a/src/db/errors.rs
+++ b/src/db/errors.rs
@@ -35,3 +35,9 @@ impl From<Error> for String {
         e.to_string()
     }
 }
+
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        Error::Other(e.to_string())
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -48,6 +48,27 @@ pub trait DBStatistics {
     }
 }
 
+#[async_trait::async_trait]
+pub trait Dump {
+    /// Returns the total number of entries from the database that can be exported.
+    /// This is a costly operation and should be used sparingly.
+    fn total_exportable_entries(&self) -> anyhow::Result<u64>;
+
+    /// Returns the current progress of the database dump,
+    /// if it is in progress. Otherwise, returns None.
+    /// The tuple is in form (current, total).
+    //fn get_progress(&self) -> Option<(u64, u64)>;
+
+    /// Writes the exportable entries from the database to the provided writer.
+    async fn write_exportable<W>(
+        &self,
+        writer: W,
+        tipset: &crate::blocks::Tipset,
+    ) -> anyhow::Result<()>
+    where
+        W: futures::AsyncWrite + Send + Unpin + 'static;
+}
+
 pub mod db_engine {
     use std::path::{Path, PathBuf};
 

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -1,17 +1,57 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::ops::DerefMut;
+use std::sync::atomic;
 use std::{path::PathBuf, sync::Arc};
 
-use crate::libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
-use anyhow::anyhow;
-use cid::Cid;
-use fvm_ipld_blockstore::Blockstore;
-use parity_db::{CompressionType, Db, Operation, Options};
-use tracing::warn;
-
 use super::errors::Error;
-use crate::db::{parity_db_config::ParityDbConfig, DBStatistics, Store};
+use crate::blocks::Tipset;
+use crate::db::{parity_db_config::ParityDbConfig, DBStatistics, Dump, Store};
+use crate::libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
+use crate::utils::io::progress_bar::ProgressBarCurrentTotalPair;
+
+use anyhow::anyhow;
+use cid::multihash::Code::Blake2b256;
+use cid::multihash::MultihashDigest;
+use cid::Cid;
+use futures_util::AsyncWriteExt;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_car::CarHeader;
+use fvm_ipld_encoding::DAG_CBOR;
+use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
+use parity_db::{CompressionType, Db, Operation, Options};
+use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
+use tracing::{debug, info, warn};
+
+/// This is specific to Forest's `ParityDb` usage.
+/// It is used to determine which column to use for a given entry type.
+#[derive(Copy, Clone, Debug, Display, PartialEq, FromRepr, EnumIter)]
+#[repr(u8)]
+enum DbColumn {
+    /// Column for storing IPLD data with `Blake2b256` hash and `DAG_CBOR` codec.
+    /// Most entries in the `blockstore` will be stored in this column.
+    GraphDagCborBlake2b256,
+    /// Column for storing other IPLD data (different codec or hash function).
+    /// It allows key retrieval at the cost of degraded performance. Given that
+    /// there will be a small number of entries in this column, the performance
+    /// degradation is negligible.
+    GraphFull,
+    /// Column for storing anything non-IPLD data. This column is not exportable.
+    Other,
+}
+
+impl DbColumn {
+    const fn is_exportable(&self) -> bool {
+        match self {
+            DbColumn::GraphDagCborBlake2b256 | DbColumn::GraphFull => true,
+            DbColumn::Other => false,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct ParityDb {
@@ -31,7 +71,6 @@ fn compression_type_from_str(s: &str) -> anyhow::Result<CompressionType> {
 
 impl ParityDb {
     fn to_options(path: PathBuf, config: &ParityDbConfig) -> anyhow::Result<Options> {
-        const COLUMNS: usize = 1;
         let compression = compression_type_from_str(&config.compression_type)?;
         Ok(Options {
             path,
@@ -39,8 +78,9 @@ impl ParityDb {
             sync_data: true,
             stats: config.enable_statistics,
             salt: None,
-            columns: (0..COLUMNS)
-                .map(|_| parity_db::ColumnOptions {
+            columns: vec![
+                // GraphDagCborBlake2b256
+                parity_db::ColumnOptions {
                     // The `preimage` flag tells ParityDB that a given value always has the same
                     // key. With this flag enabled, ParityDB can short-circuit insertions when the
                     // keys already exist in the database (as opposed to updating the value).
@@ -50,10 +90,23 @@ impl ParityDb {
                     // scenarios.
                     preimage: true,
                     compression,
-                    // btree_index: true,
                     ..Default::default()
-                })
-                .collect(),
+                },
+                // GraphFull
+                parity_db::ColumnOptions {
+                    preimage: true,
+                    // This is needed for key retrieval.
+                    btree_index: true,
+                    compression,
+                    ..Default::default()
+                },
+                // Other
+                parity_db::ColumnOptions {
+                    preimage: true,
+                    compression,
+                    ..Default::default()
+                },
+            ],
             compression_threshold: [(0, 128)].into_iter().collect(),
         })
     }
@@ -65,14 +118,54 @@ impl ParityDb {
             statistics_enabled: opts.stats,
         })
     }
+
+    /// Returns an appropriate column variant based on the information
+    /// in the Cid.
+    fn choose_column(cid: &Cid) -> DbColumn {
+        match cid.codec() {
+            DAG_CBOR if cid.hash().code() == u64::from(Blake2b256) => {
+                DbColumn::GraphDagCborBlake2b256
+            }
+            _ => DbColumn::GraphFull,
+        }
+    }
+
+    fn read_column<K>(&self, key: K, column: DbColumn) -> anyhow::Result<Option<Vec<u8>>>
+    where
+        K: AsRef<[u8]>,
+    {
+        self.db
+            .get(column as u8, key.as_ref())
+            .map_err(|e| anyhow!("error from column {column}: {e}"))
+    }
+
+    fn write_column<K, V>(&self, key: K, value: V, column: DbColumn) -> anyhow::Result<()>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        let tx = [(column as u8, key.as_ref(), Some(value.as_ref().to_vec()))];
+        self.db
+            .commit(tx)
+            .map_err(|e| anyhow!("error writing to column {column}: {e}"))
+    }
+
+    /// Poor man's check if the column is indexed. There doesn't seem to be
+    /// an exposed API to do it cleanly.
+    fn is_column_indexed(&self, column: DbColumn) -> bool {
+        self.db.iter(column as u8).is_ok()
+    }
 }
 
+/// The assumption is that the methods from this trait are not used in the
+/// `Blockstore` context. All writes and reads through this interface will
+/// go through a column dedicated for non-IPLD data.
 impl Store for ParityDb {
     fn read<K>(&self, key: K) -> Result<Option<Vec<u8>>, Error>
     where
         K: AsRef<[u8]>,
     {
-        self.db.get(0, key.as_ref()).map_err(Error::from)
+        self.read_column(key, DbColumn::Other).map_err(Error::from)
     }
 
     fn write<K, V>(&self, key: K, value: V) -> Result<(), Error>
@@ -80,8 +173,8 @@ impl Store for ParityDb {
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
     {
-        let tx = [(0, key.as_ref(), Some(value.as_ref().to_vec()))];
-        self.db.commit(tx).map_err(Error::from)
+        self.write_column(key, value, DbColumn::Other)
+            .map_err(Error::from)
     }
 
     /// [`parity_db::Db::commit`] API is doing extra allocations on keys,
@@ -92,7 +185,7 @@ impl Store for ParityDb {
     ) -> Result<(), Error> {
         let tx = values
             .into_iter()
-            .map(|(k, v)| (0, Operation::Set(k.into(), v.into())));
+            .map(|(k, v)| (DbColumn::Other as u8, Operation::Set(k.into(), v.into())));
         self.db.commit_changes(tx).map_err(Error::from)
         // <https://docs.rs/crate::db/parity-db/0.4.3/source/src/db.rs>
         // ```
@@ -118,20 +211,33 @@ impl Store for ParityDb {
     where
         K: AsRef<[u8]>,
     {
-        self.db
-            .get_size(0, key.as_ref())
-            .map(|size| size.is_some())
-            .map_err(Error::from)
+        Ok(DbColumn::iter()
+            .filter_map(|col| self.db.get_size(col as u8, key.as_ref()).ok())
+            .any(|size| size.is_some()))
     }
 }
 
 impl Blockstore for ParityDb {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
-        self.read(k.to_bytes()).map_err(|e| e.into())
+        let column = Self::choose_column(k);
+        match column {
+            DbColumn::GraphDagCborBlake2b256 | DbColumn::GraphFull => {
+                self.read_column(k.to_bytes(), column)
+            }
+            DbColumn::Other => panic!("invalid column for IPLD data"),
+        }
     }
 
     fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
-        self.write(k.to_bytes(), block).map_err(|e| e.into())
+        let column = Self::choose_column(k);
+
+        match column {
+            // We can put the data directly into the database without any encoding.
+            DbColumn::GraphDagCborBlake2b256 | DbColumn::GraphFull => {
+                self.write_column(k.to_bytes(), block, column)
+            }
+            DbColumn::Other => panic!("invalid column for IPLD data"),
+        }
     }
 
     fn put_many_keyed<D, I>(&self, blocks: I) -> anyhow::Result<()>
@@ -140,10 +246,20 @@ impl Blockstore for ParityDb {
         D: AsRef<[u8]>,
         I: IntoIterator<Item = (Cid, D)>,
     {
-        let values = blocks
+        let values = blocks.into_iter().map(|(k, v)| {
+            let column = Self::choose_column(&k);
+            match column {
+                DbColumn::GraphDagCborBlake2b256 | DbColumn::Other | DbColumn::GraphFull => {
+                    (column, k.to_bytes(), v.as_ref().to_vec())
+                }
+            }
+        });
+        let tx = values
             .into_iter()
-            .map(|(k, v)| (k.to_bytes(), v.as_ref().to_vec()));
-        self.bulk_write(values).map_err(|e| e.into())
+            .map(|(col, k, v)| (col as u8, Operation::Set(k, v)));
+        self.db
+            .commit_changes(tx)
+            .map_err(|e| anyhow!("error bulk writing: {e}"))
     }
 }
 
@@ -189,11 +305,247 @@ impl DBStatistics for ParityDb {
     }
 }
 
+lazy_static! {
+    pub static ref DATABASE_DUMP_PROGRESS: ProgressBarCurrentTotalPair = Default::default();
+}
+
+#[async_trait::async_trait]
+impl Dump for ParityDb {
+    fn total_exportable_entries(&self) -> anyhow::Result<u64> {
+        // Get total number of exportable entries in the DB.
+        // Theoretically, if the statistics are enabled we could get it
+        // directly from the DB. In practice, the values turned out
+        // to be slightly off. Plus, the statistics are normally disabled
+        // for performance reasons.
+        let mut total_entries = 0;
+
+        for col in DbColumn::iter().filter(|col| col.is_exportable()) {
+            if self.is_column_indexed(col) {
+                let mut iter = self.db.iter(col as u8)?;
+                while let Ok(Some(_)) = iter.next() {
+                    total_entries += 1;
+                }
+            } else {
+                self.db
+                    .iter_column_while(col as u8, |_| {
+                        total_entries += 1;
+                        true
+                    })
+                    .map_err(|e| anyhow!("error iterating over column: {e}"))?;
+            }
+        }
+
+        Ok(total_entries)
+    }
+
+    /// Exports selected columns from the database to a writer.
+    /// Caveat: recent DB commits may not be exported due to internal limitations
+    /// of the underlying database.
+    async fn write_exportable<W>(&self, writer: W, tipset: &Tipset) -> anyhow::Result<()>
+    where
+        W: futures::AsyncWrite + Send + Unpin + 'static,
+    {
+        // We are modifying a global static variable, so we need to make sure
+        // that only one export is in progress at any given time.
+        // This should be handled on the RPC level, but we add this check
+        // here as a safety measure.
+        static LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+        let _locked = LOCK
+            .try_lock()
+            .map_err(|e| anyhow!("another export is in progress: {e}"))?;
+
+        let total_entries = self.total_exportable_entries()?;
+        info!("Exporting {} entries from the DB", total_entries);
+
+        let progress_inc = || {
+            DATABASE_DUMP_PROGRESS
+                .0
+                .fetch_add(1, atomic::Ordering::Relaxed);
+        };
+
+        DATABASE_DUMP_PROGRESS.0.store(0, atomic::Ordering::Relaxed);
+        DATABASE_DUMP_PROGRESS
+            .1
+            .store(total_entries, atomic::Ordering::Relaxed);
+
+        let writer = Arc::new(tokio::sync::Mutex::new(writer));
+        let writer_clone = writer.clone();
+
+        // This is a a bit arbitrary, increasing this does not significantly affect performance.
+        const CHANNEL_CAP: usize = 1000;
+        let (tx, rx) = flume::bounded(CHANNEL_CAP);
+        let header = CarHeader::from(tipset.key().cids().to_vec());
+
+        let mut tasks = JoinSet::new();
+
+        tasks.spawn(async move {
+            let mut writer = writer_clone.lock().await;
+            let mut stream = rx.stream();
+            let writer = writer.deref_mut();
+            header
+                .write_stream_async(writer, &mut stream)
+                .await
+                .map_err(|e| anyhow!("error writing to car file: {e}"))
+        });
+
+        // This may be a bit overkill with two columns, but the idea here is to have an exhaustive
+        // match over all variants, so that we don't forget to handle a new column
+        // in the export when we add it.
+        for col in DbColumn::iter().filter(|col| col.is_exportable()) {
+            let tx_clone = tx.clone();
+            let db = self.db.clone();
+
+            debug!("Starting to iterate the {col} column");
+            match col {
+                DbColumn::GraphDagCborBlake2b256 => {
+                    tasks.spawn_blocking(move || {
+                        let mut error_iterating = None;
+                        db.iter_column_while(col as u8, |item| {
+                            let cid = Cid::new_v1(DAG_CBOR, Blake2b256.digest(&item.value));
+                            // an error means that all receivers have been dropped
+                            // this means our write will fail, so we should stop iterating
+                            if let Err(e) = tx_clone.send((cid, item.value)) {
+                                error_iterating = Some(e);
+                                false
+                            } else {
+                                progress_inc();
+                                true
+                            }
+                        })?;
+
+                        if let Some(e) = error_iterating {
+                            Err(e.into())
+                        } else {
+                            Ok::<_, anyhow::Error>(())
+                        }
+                    });
+                }
+                DbColumn::GraphFull => {
+                    tasks.spawn(async move {
+                        let mut iter = db.iter(col as u8)?;
+                        while let Ok(Some(entry)) = iter.next() {
+                            let (cid, block) = (Cid::try_from(entry.0)?, entry.1);
+                            tx_clone.send_async((cid, block)).await?;
+                            progress_inc();
+                        }
+                        Ok::<_, anyhow::Error>(())
+                    });
+                }
+                DbColumn::Other => {
+                    panic!("Other column is not exportable");
+                }
+            }
+            debug!("Finished iterating the {col} column");
+        }
+
+        drop(tx);
+
+        while let Some(res) = tasks.join_next().await {
+            let _out = res?;
+        }
+
+        let mut writer = writer.lock().await;
+        writer.flush().await?;
+        writer.close().await?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use fvm_ipld_car::CarReader;
     use parity_db::CompressionType;
+    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+    use crate::{
+        blocks::BlockHeader, db::tests::db_utils::parity::TempParityDB, shim::address::Address,
+    };
 
     use super::*;
+
+    #[test]
+    fn total_exportable_entries_with_stats_test() -> anyhow::Result<()> {
+        let mut db = TempParityDB::new();
+        let data = b"h'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn";
+
+        assert_eq!(0, db.total_exportable_entries()?);
+
+        // write to the simplified column, this should be counted
+        db.put_keyed(&Cid::new_v1(DAG_CBOR, Blake2b256.digest(data)), data)?;
+
+        db.force_flush();
+        assert_eq!(1, db.total_exportable_entries()?);
+
+        // write to the full column, this should be counted
+        db.put_keyed(
+            &Cid::new_v1(DAG_CBOR, cid::multihash::Code::Sha2_256.digest(data)),
+            data,
+        )?;
+        db.force_flush();
+        assert_eq!(2, db.total_exportable_entries()?);
+
+        // write to the other column, this should NOT be counted
+        db.write("dagon", "bloop")?;
+        db.force_flush();
+        assert_eq!(2, db.total_exportable_entries()?);
+
+        Ok(())
+    }
+
+    // This test will:
+    // * write important entries to the database,
+    // * dump the database to a CAR file,
+    // * read the CAR file and verify that the entries are present
+    #[tokio::test]
+    async fn write_exportable_test() -> anyhow::Result<()> {
+        let mut db = TempParityDB::new();
+        let data = [
+            b"h'nglui mglw'nafh Cthulhu R'lyeh".to_vec(),
+            b"wgah'nagl fhtagn".to_vec(),
+        ];
+
+        db.put_keyed(
+            &Cid::new_v1(DAG_CBOR, Blake2b256.digest(&data[0])),
+            &data[0],
+        )?;
+        db.put_keyed(
+            &Cid::new_v1(DAG_CBOR, cid::multihash::Code::Sha2_256.digest(&data[1])),
+            &data[1],
+        )?;
+
+        db.force_flush();
+
+        let temp_path = tempfile::NamedTempFile::new()?;
+        let car_file = tokio::fs::File::create(temp_path.path()).await?;
+
+        let header = BlockHeader::builder()
+            .miner_address(Address::new_id(0))
+            .build()
+            .unwrap();
+        let tipset = Tipset::new(vec![header]).unwrap();
+
+        db.write_exportable(car_file.compat_write(), &tipset)
+            .await?;
+
+        let file_reader = tokio::fs::File::open(temp_path.path()).await?;
+        let mut car = CarReader::new(file_reader.compat()).await?;
+        let header = &car.header;
+        assert_eq!(header.roots.len(), 1);
+        assert_eq!(header.roots[0], tipset.key().cids()[0]);
+
+        let mut blocks = Vec::new();
+        while let Some(block) = car.next_block().await? {
+            blocks.push(block);
+        }
+
+        assert_eq!(blocks.len(), data.len());
+        for (i, block) in blocks.iter().enumerate() {
+            assert_eq!(block.data, data[i]);
+        }
+
+        Ok(())
+    }
 
     #[test]
     fn compression_type_from_str_test() {
@@ -210,6 +562,30 @@ mod test {
             } else {
                 assert!(expected.is_err());
             }
+        }
+    }
+
+    #[test]
+    fn choose_column_test() {
+        let data = [0u8; 32];
+        let cases = [
+            (
+                Cid::new_v1(DAG_CBOR, Blake2b256.digest(&data)),
+                DbColumn::GraphDagCborBlake2b256,
+            ),
+            (
+                Cid::new_v1(fvm_ipld_encoding::CBOR, Blake2b256.digest(&data)),
+                DbColumn::GraphFull,
+            ),
+            (
+                Cid::new_v1(DAG_CBOR, cid::multihash::Code::Sha2_256.digest(&data)),
+                DbColumn::GraphFull,
+            ),
+        ];
+
+        for (cid, expected) in cases {
+            let actual = ParityDb::choose_column(&cid);
+            assert_eq!(expected, actual);
         }
     }
 }

--- a/src/db/rolling/impls.rs
+++ b/src/db/rolling/impls.rs
@@ -157,6 +157,24 @@ impl FileBackedObject for DbIndex {
     }
 }
 
+#[async_trait::async_trait]
+impl Dump for RollingDB {
+    fn total_exportable_entries(&self) -> anyhow::Result<u64> {
+        Dump::total_exportable_entries(&self.current())
+    }
+
+    async fn write_exportable<W>(
+        &self,
+        writer: W,
+        tipset: &crate::blocks::Tipset,
+    ) -> anyhow::Result<()>
+    where
+        W: futures::AsyncWrite + Send + Unpin + 'static,
+    {
+        Dump::write_exportable(&self.current(), writer, tipset).await
+    }
+}
+
 impl RollingDB {
     pub fn load_or_create(db_root: PathBuf, db_config: DbConfig) -> anyhow::Result<Self> {
         if !db_root.exists() {

--- a/src/ipld/util.rs
+++ b/src/ipld/util.rs
@@ -4,14 +4,14 @@
 use std::{
     collections::VecDeque,
     future::Future,
-    sync::{
-        atomic::{self, AtomicU64},
-        Arc,
-    },
+    sync::atomic::{self},
 };
 
-use crate::blocks::{BlockHeader, Tipset};
 use crate::utils::io::progress_log::WithProgressRaw;
+use crate::{
+    blocks::{BlockHeader, Tipset},
+    utils::io::progress_bar::ProgressBarCurrentTotalPair,
+};
 use cid::Cid;
 use fvm_ipld_encoding::from_slice;
 use lazy_static::lazy_static;
@@ -93,8 +93,6 @@ where
 
     Ok(())
 }
-
-pub type ProgressBarCurrentTotalPair = Arc<(AtomicU64, AtomicU64)>;
 
 lazy_static! {
     pub static ref WALK_SNAPSHOT_PROGRESS_EXPORT: ProgressBarCurrentTotalPair = Default::default();

--- a/src/rpc/db_api.rs
+++ b/src/rpc/db_api.rs
@@ -2,9 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::beacon::Beacon;
+use crate::blocks::tipset_keys_json::TipsetKeysJson;
+use crate::chain::DBDump;
+use crate::db::Dump;
 use crate::rpc_api::{data_types::RPCState, db_api::*};
 use fvm_ipld_blockstore::Blockstore;
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
+use once_cell::sync::Lazy;
+use tempfile::NamedTempFile;
+use tokio::sync::Mutex;
+use tokio_util::compat::TokioAsyncReadCompatExt;
 
 pub(in crate::rpc) async fn db_gc<DB: Blockstore + Clone + Send + Sync + 'static, B: Beacon>(
     data: Data<RPCState<DB, B>>,
@@ -13,5 +20,44 @@ pub(in crate::rpc) async fn db_gc<DB: Blockstore + Clone + Send + Sync + 'static
     let (tx, rx) = flume::bounded(1);
     data.gc_event_tx.send_async(tx).await?;
     rx.recv_async().await??;
+    Ok(())
+}
+
+pub(in crate::rpc) async fn db_dump<DB: Blockstore + Clone + Send + Sync + 'static, B: Beacon>(
+    data: Data<RPCState<DB, B>>,
+    Params(DBDumpParams {
+        epoch,
+        output_path,
+        tipset_keys: TipsetKeysJson(tsk),
+        compression,
+    }): Params<DBDumpParams>,
+) -> Result<DBDumpResult, JsonRpcError>
+where
+    DB: Dump,
+{
+    static LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    let _locked = LOCK.try_lock();
+    if _locked.is_err() {
+        return Err(JsonRpcError::Provided {
+            code: http::StatusCode::SERVICE_UNAVAILABLE.as_u16() as _,
+            message: "Another db dump job is in progress",
+        });
+    }
+
+    let output_dir = output_path.parent().ok_or_else(|| JsonRpcError::Provided {
+        code: http::StatusCode::INTERNAL_SERVER_ERROR.as_u16() as _,
+        message: "Failed to determine snapshot export directory",
+    })?;
+    let temp_path = NamedTempFile::new_in(output_dir)?.into_temp_path();
+    let head = data.chain_store.tipset_from_keys(&tsk)?;
+    let start_ts = data.chain_store.tipset_by_height(epoch, head, true)?;
+    let file = tokio::fs::File::create(&temp_path).await?;
+    data.chain_store
+        .dump_db_as_car(file.compat(), &start_ts, compression)
+        .await?;
+
+    temp_path.persist(output_path)?;
+
     Ok(())
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -50,7 +50,7 @@ pub async fn start_rpc<DB, B, S>(
     shutdown_send: Sender<()>,
 ) -> Result<(), JSONRPCError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore + crate::db::Dump + Clone + Send + Sync + 'static,
     B: Beacon,
     S: Scale + 'static,
 {
@@ -137,6 +137,7 @@ where
             .with_method(NET_DISCONNECT, net_api::net_disconnect::<DB, B>)
             // DB API
             .with_method(DB_GC, db_api::db_gc::<DB, B>)
+            .with_method(DB_DUMP, db_api::db_dump::<DB, B>)
             // Progress API
             .with_method(GET_PROGRESS, progress_api::get_progress)
             // Node API

--- a/src/rpc/progress_api.rs
+++ b/src/rpc/progress_api.rs
@@ -5,12 +5,12 @@
 
 use std::sync::atomic;
 
-use crate::ipld::{
-    ProgressBarCurrentTotalPair, WALK_SNAPSHOT_PROGRESS_DB_GC, WALK_SNAPSHOT_PROGRESS_EXPORT,
-};
+use crate::db::parity_db::DATABASE_DUMP_PROGRESS;
+use crate::ipld::{WALK_SNAPSHOT_PROGRESS_DB_GC, WALK_SNAPSHOT_PROGRESS_EXPORT};
 use crate::rpc_api::progress_api::{GetProgressParams, GetProgressResult, GetProgressType};
 
 use crate::rpc::*;
+use crate::utils::io::progress_bar::ProgressBarCurrentTotalPair;
 
 pub(in crate::rpc) async fn get_progress(
     Params((typ,)): Params<GetProgressParams>,
@@ -18,6 +18,7 @@ pub(in crate::rpc) async fn get_progress(
     let tracker: &ProgressBarCurrentTotalPair = match typ {
         GetProgressType::SnapshotExport => &WALK_SNAPSHOT_PROGRESS_EXPORT,
         GetProgressType::DatabaseGarbageCollection => &WALK_SNAPSHOT_PROGRESS_DB_GC,
+        GetProgressType::DatabaseDump => &DATABASE_DUMP_PROGRESS,
     };
 
     Ok((

--- a/src/rpc_client/db_ops.rs
+++ b/src/rpc_client/db_ops.rs
@@ -9,3 +9,10 @@ use crate::rpc_client::call;
 pub async fn db_gc(params: DBGCParams, auth_token: &Option<String>) -> Result<DBGCResult, Error> {
     call(DB_GC, params, auth_token).await
 }
+
+pub async fn db_dump(
+    params: DBDumpParams,
+    auth_token: &Option<String>,
+) -> Result<DBGCResult, Error> {
+    call(DB_DUMP, params, auth_token).await
+}

--- a/src/utils/io/progress_bar.rs
+++ b/src/utils/io/progress_bar.rs
@@ -2,12 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 // JANK(aatifsyed): I don't really understand why this module exists, a lot of
 // the code looks wrong
-use std::{io::Stdout, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    io::Stdout,
+    str::FromStr,
+    sync::{atomic::AtomicU64, Arc},
+    time::Duration,
+};
 
 use is_terminal::IsTerminal;
+
 use parking_lot::{Mutex, RwLock};
 pub use pbr::Units;
 use serde::{Deserialize, Serialize};
+
+pub type ProgressBarCurrentTotalPair = Arc<(AtomicU64, AtomicU64)>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- implemented `forest-cli db dump` subcommand. While the idea is promising, at the moment it is not more performant than a regular `snapshot export`.
- re-organized the database to use three columns instead of one:
  - Simplified column for DAG-CBOR Blake2b256 entries which is > 99% percent of what goes into the database,
  - Full column for other Cid-keyed entries. This column is BTree indexed, allowing key retrieval at the cost of performance. Given that there are not many entries of such type, it is okay.
  - Another column, for writing arbitrary key-values.


## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3093

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
