### PR TITLE
Consume upstream `quickcheck` implementation for `Cid`

### DIFF
--- a/src/blocks/gossip_block.rs
+++ b/src/blocks/gossip_block.rs
@@ -17,13 +17,10 @@ pub struct GossipBlock {
 #[cfg(test)]
 impl quickcheck::Arbitrary for GossipBlock {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        let bls_cids: Vec<Cid> = Vec::arbitrary(g);
-        let secp_cids: Vec<Cid> = Vec::arbitrary(g);
-
         Self {
             header: BlockHeader::arbitrary(g),
-            bls_messages: bls_cids,
-            secpk_messages: secp_cids,
+            bls_messages: Vec::arbitrary(g),
+            secpk_messages: Vec::arbitrary(g),
         }
     }
 }

--- a/src/blocks/gossip_block.rs
+++ b/src/blocks/gossip_block.rs
@@ -17,12 +17,8 @@ pub struct GossipBlock {
 #[cfg(test)]
 impl quickcheck::Arbitrary for GossipBlock {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        use crate::blocks::ArbitraryCid;
-        let arbitrary_cids: Vec<ArbitraryCid> = Vec::arbitrary(g);
-        let bls_cids: Vec<Cid> = arbitrary_cids.iter().map(|cid| cid.0).collect();
-
-        let arbitrary_cids: Vec<ArbitraryCid> = Vec::arbitrary(g);
-        let secp_cids: Vec<Cid> = arbitrary_cids.iter().map(|cid| cid.0).collect();
+        let bls_cids: Vec<Cid> = Vec::arbitrary(g);
+        let secp_cids: Vec<Cid> = Vec::arbitrary(g);
 
         Self {
             header: BlockHeader::arbitrary(g),

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -19,19 +19,6 @@ pub use ticket::Ticket;
 pub use tipset::*;
 
 #[cfg(test)]
-#[derive(Clone)]
-struct ArbitraryCid(cid::Cid);
-
-#[cfg(test)]
-impl quickcheck::Arbitrary for ArbitraryCid {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        ArbitraryCid(cid::Cid::new_v1(
-            u64::arbitrary(g),
-            cid::multihash::Multihash::wrap(u64::arbitrary(g), &[u8::arbitrary(g)]).unwrap(),
-        ))
-    }
-}
-#[cfg(test)]
 mod tests {
     mod header_json_test;
     mod serialization_vectors;

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -109,12 +109,10 @@ mod property_tests {
         tipset_keys_json::TipsetKeysJson,
         Tipset, TipsetKeys,
     };
-    use crate::blocks::ArbitraryCid;
 
     impl quickcheck::Arbitrary for TipsetKeys {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            let arbitrary_cids: Vec<ArbitraryCid> = Vec::arbitrary(g);
-            let cids: Vec<Cid> = arbitrary_cids.iter().map(|cid| cid.0).collect();
+            let cids: Vec<Cid> = Vec::arbitrary(g);
             Self { cids }
         }
     }

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -112,8 +112,7 @@ mod property_tests {
 
     impl quickcheck::Arbitrary for TipsetKeys {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            let cids: Vec<Cid> = Vec::arbitrary(g);
-            Self { cids }
+            Self { cids: Vec::arbitrary(g) }
         }
     }
 

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -100,7 +100,6 @@ impl quickcheck::Arbitrary for Tipset {
 
 #[cfg(test)]
 mod property_tests {
-    use cid::Cid;
     use quickcheck_macros::quickcheck;
     use serde_json;
 

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -111,7 +111,9 @@ mod property_tests {
 
     impl quickcheck::Arbitrary for TipsetKeys {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            Self { cids: Vec::arbitrary(g) }
+            Self {
+                cids: Vec::arbitrary(g),
+            }
         }
     }
 

--- a/src/json/cid.rs
+++ b/src/json/cid.rs
@@ -105,20 +105,10 @@ mod tests {
 
     use super::*;
 
-    impl quickcheck::Arbitrary for CidJson {
-        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            let cid = Cid::new_v1(
-                u64::arbitrary(g),
-                cid::multihash::Multihash::wrap(u64::arbitrary(g), &[u8::arbitrary(g)]).unwrap(),
-            );
-            CidJson(cid)
-        }
-    }
-
     #[quickcheck]
-    fn cid_roundtrip(cid: CidJson) {
-        let serialized = crate::to_string_with!(&cid.0, serialize);
+    fn cid_roundtrip(cid: Cid) {
+        let serialized = crate::to_string_with!(&cid, serialize);
         let parsed: Cid = crate::from_str_with!(&serialized, deserialize);
-        assert_eq!(cid.0, parsed);
+        assert_eq!(cid, parsed);
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:
- Remove custom quickcheck implementation for `Cid` and use the upstream implementation

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes associated task in #2143 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->
N/A

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
