### PR TITLE
feat: stream messages into the tipset validator

### DIFF
--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -181,7 +181,7 @@ impl Tipset {
     }
 
     /// Constructs and returns a full tipset if messages from storage exists
-    pub fn fill_tipset(&self, store: impl Blockstore) -> Option<FullTipset> {
+    pub fn fill_from_blockstore(&self, store: impl Blockstore) -> Option<FullTipset> {
         // Collect all messages before moving tipset.
         let messages = self
             .blocks()

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -183,7 +183,7 @@ impl Tipset {
     /// Constructs and returns a full tipset if messages from storage exists
     pub fn fill_tipset(&self, store: impl Blockstore) -> Option<FullTipset> {
         // Collect all messages before moving tipset.
-        let messages: Vec<(Vec<_>, Vec<_>)> = self
+        let messages = self
             .blocks()
             .iter()
             .map(|h| crate::chain::store::block_messages(&store, h))

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -180,15 +180,14 @@ impl Tipset {
             .transpose()?)
     }
 
-    /// Constructs and returns a full tipset if messages from storage exists -
-    /// non self version
+    /// Constructs and returns a full tipset if messages from storage exists
     pub fn fill_tipset(&self, store: impl Blockstore) -> Option<FullTipset> {
         // Collect all messages before moving tipset.
         let messages: Vec<(Vec<_>, Vec<_>)> = self
             .blocks()
             .iter()
             .map(|h| crate::chain::store::block_messages(&store, h))
-            .collect::<Result<Vec<_>,_>>()
+            .collect::<Result<Vec<_>, _>>()
             .ok()?;
 
         // Zip messages with blocks
@@ -205,7 +204,9 @@ impl Tipset {
             .collect();
 
         // the given tipset has already been verified, so this cannot fail
-        Some(FullTipset::new(blocks).unwrap())
+        Some(FullTipset::new(blocks).expect(
+            "block headers have already been verified when the Tipset so this check cannot fail",
+        ))
     }
 
     /// Returns epoch of the tipset.

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -182,7 +182,7 @@ impl Tipset {
 
     /// Constructs and returns a full tipset if messages from storage exists
     pub fn fill_from_blockstore(&self, store: impl Blockstore) -> Option<FullTipset> {
-        // Find tipset messages. If any are mnissing, return `None`.
+        // Find tipset messages. If any are missing, return `None`.
         let blocks = self
             .blocks()
             .iter()

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -204,9 +204,10 @@ impl Tipset {
             .collect();
 
         // the given tipset has already been verified, so this cannot fail
-        Some(FullTipset::new(blocks).expect(
-            "block headers have already been verified so this check cannot fail",
-        ))
+        Some(
+            FullTipset::new(blocks)
+                .expect("block headers have already been verified so this check cannot fail"),
+        )
     }
 
     /// Returns epoch of the tipset.

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -205,7 +205,7 @@ impl Tipset {
 
         // the given tipset has already been verified, so this cannot fail
         Some(FullTipset::new(blocks).expect(
-            "block headers have already been verified when the Tipset so this check cannot fail",
+            "block headers have already been verified so this check cannot fail",
         ))
     }
 

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -27,7 +27,8 @@ use crate::state_manager::{is_valid_for_sending, Error as StateManagerError, Sta
 use crate::utils::io::WithProgressRaw;
 use ahash::{HashMap, HashMapExt, HashSet};
 use cid::Cid;
-use futures::{stream::FuturesUnordered, Stream, StreamExt, TryFutureExt};
+use futures::stream::TryStreamExt as _;
+use futures::{stream, stream::FuturesUnordered, Stream, StreamExt, TryFutureExt};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::to_vec;
 use nonempty::NonEmpty;
@@ -1014,11 +1015,10 @@ fn sync_tipset<DB: Blockstore + Clone + Sync + Send + 'static, C: Consensus>(
 }
 
 async fn fetch_batch<DB: Blockstore + Clone + Send + Sync + 'static, C: Consensus>(
-    batch: &[Arc<Tipset>],
+    batch: Vec<Arc<Tipset>>,
     network: &SyncNetworkContext<DB>,
-    chainstore: &ChainStore<DB>,
-    s: &flume::Sender<FullTipset>,
-) -> Result<(), TipsetRangeSyncerError<C>> {
+    db: &DB,
+) -> Result<Vec<FullTipset>, TipsetRangeSyncerError<C>> {
     // Tipsets in `batch` are already in chronological order
     if let Some(head) = batch.last() {
         let epoch = head.epoch();
@@ -1031,6 +1031,7 @@ async fn fetch_batch<DB: Blockstore + Clone + Send + Sync + 'static, C: Consensu
             .await
             .map_err(TipsetRangeSyncerError::NetworkMessageQueryFailed)?;
 
+        let mut result = Vec::new();
         // Since the bundle only has messages, we have to put the headers in them
         for (messages, tipset) in compacted_messages.into_iter().rev().zip(batch.iter()) {
             // Construct full tipset from fetched messages
@@ -1044,17 +1045,17 @@ async fn fetch_batch<DB: Blockstore + Clone + Send + Sync + 'static, C: Consensu
 
             // Persist the messages in the store
             if let Some(m) = bundle.messages {
-                crate::chain::persist_objects(chainstore.blockstore(), &m.bls_msgs)?;
-                crate::chain::persist_objects(chainstore.blockstore(), &m.secp_msgs)?;
+                crate::chain::persist_objects(db, &m.bls_msgs)?;
+                crate::chain::persist_objects(db, &m.secp_msgs)?;
             } else {
                 warn!("ChainExchange request for messages returned null messages");
             }
-
-            s.send_async(full_tipset).await?;
+            result.push(full_tipset);
         }
+        Ok(result)
+    } else {
+        Ok(vec![])
     }
-
-    Ok(())
 }
 
 /// Going forward along the tipsets, try to load the messages in them from the
@@ -1072,61 +1073,42 @@ async fn sync_messages_check_state<DB: Blockstore + Clone + Send + Sync + 'stati
     genesis: &Tipset,
     invalid_block_strategy: InvalidBlockStrategy,
 ) -> Result<(), TipsetRangeSyncerError<C>> {
-    let task_chainstore = chainstore.clone();
     let request_window = state_manager.chain_config().request_window;
-    // Spawn a background task for the chain_exchange message requests
+    let db = chainstore.blockstore();
 
-    let (s, r) = flume::bounded(request_window * 4);
-    let handle = tokio::task::spawn(async move {
-        let mut batch: Vec<Arc<Tipset>> = Vec::with_capacity(request_window);
-
-        // Visit tipsets in chronological order
-        for tipset in tipsets.into_iter().rev() {
-            // If the current tipset batch is empty and we already have the
-            // messages for the current tipset, skip the download and send
-            // it directly to the validator.
-            if batch.is_empty() {
-                if let Some(full_tipset) = task_chainstore.fill_tipset(&tipset) {
-                    s.send_async(full_tipset).await?;
-                    continue;
-                }
+    // Stream through the tipsets from lowest epoch to highest epoch
+    stream::iter(tipsets.into_iter().rev())
+        // Chunk tipsets in batches (default batch size is 8)
+        .chunks(request_window)
+        // Request batches from the p2p network
+        .map(|batch| 
+            fetch_batch::<_, C>(batch, &network, db)
+        )
+        // run 64 batches concurrently
+        .buffered(64)
+        // validate each full tipset in each batch
+        .try_for_each(|batch| async {
+            for full_tipset in batch {
+                let current_epoch = full_tipset.epoch();
+                let timer = metrics::TIPSET_PROCESSING_TIME.start_timer();
+                validate_tipset::<_, C>(
+                    consensus.clone(),
+                    state_manager.clone(),
+                    &chainstore,
+                    bad_block_cache,
+                    full_tipset.clone(),
+                    genesis,
+                    invalid_block_strategy,
+                )
+                .await?;
+                drop(timer);
+                chainstore.set_heaviest_tipset(Arc::new(full_tipset.into_tipset()))?;
+                tracker.write().set_epoch(current_epoch);
+                metrics::LAST_VALIDATED_TIPSET_EPOCH.set(current_epoch as u64);
             }
-
-            // Request tipset messages via chain_exchange
-            batch.push(tipset);
-            if batch.len() == request_window {
-                fetch_batch(&batch, &network, &task_chainstore, &s).await?;
-                batch.clear();
-            }
-        }
-        // Fetch last batch
-        fetch_batch(&batch, &network, &task_chainstore, &s).await?;
-
-        Ok(())
-    });
-
-    // Validation loop
-    while let Ok(full_tipset) = r.recv_async().await {
-        let current_epoch = full_tipset.epoch();
-        {
-            let _timer = metrics::TIPSET_PROCESSING_TIME.start_timer();
-            validate_tipset::<_, C>(
-                consensus.clone(),
-                state_manager.clone(),
-                &chainstore,
-                bad_block_cache,
-                full_tipset.clone(),
-                genesis,
-                invalid_block_strategy,
-            )
-            .await?;
-        }
-        chainstore.set_heaviest_tipset(Arc::new(full_tipset.into_tipset()))?;
-        tracker.write().set_epoch(current_epoch);
-        metrics::LAST_VALIDATED_TIPSET_EPOCH.set(current_epoch as u64);
-    }
-
-    handle.await?
+            Ok(())
+        })
+        .await
 }
 
 /// Validates full blocks in the tipset in parallel (since the messages are not

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1024,7 +1024,7 @@ async fn fetch_batch<DB: Blockstore, C: Consensus>(
     // network request. It's quite rare that we already have the messages. It
     // only happens when the local database has been seeded with the
     // information.
-    if let Some(cached) = batch.iter().map(|tipset| tipset.fill_tipset(db)).collect() {
+    if let Some(cached) = batch.iter().map(|tipset| tipset.fill_from_blockstore(db)).collect() {
         return Ok(cached);
     }
 

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1022,7 +1022,11 @@ async fn fetch_batch<DB: Blockstore, C: Consensus>(
     network: &SyncNetworkContext<DB>,
     db: &DB,
 ) -> Result<Vec<FullTipset>, TipsetRangeSyncerError<C>> {
-    if let Some(cached) = batch.iter().map(|tipset| tipset.fill_from_blockstore(db)).collect() {
+    if let Some(cached) = batch
+        .iter()
+        .map(|tipset| tipset.fill_from_blockstore(db))
+        .collect()
+    {
         // user has already seeded the database with this information (or we're
         // recovering from e.g a crash)
         return Ok(cached);

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1014,6 +1014,7 @@ fn sync_tipset<DB: Blockstore + Clone + Sync + Send + 'static, C: Consensus>(
     })
 }
 
+/// Ask peers for the [`Message`]s that these [`Tipset`]s should contain
 async fn fetch_batch<DB: Blockstore, C: Consensus>(
     batch: Vec<Arc<Tipset>>,
     network: &SyncNetworkContext<DB>,

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1014,7 +1014,7 @@ fn sync_tipset<DB: Blockstore + Clone + Sync + Send + 'static, C: Consensus>(
     })
 }
 
-async fn fetch_batch<DB: Blockstore + Clone + Send + Sync + 'static, C: Consensus>(
+async fn fetch_batch<DB: Blockstore, C: Consensus>(
     batch: Vec<Arc<Tipset>>,
     network: &SyncNetworkContext<DB>,
     db: &DB,

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1014,7 +1014,9 @@ fn sync_tipset<DB: Blockstore + Clone + Sync + Send + 'static, C: Consensus>(
     })
 }
 
-/// Ask peers for the [`Message`]s that these [`Tipset`]s should contain
+/// Ask peers for the [`Message`]s that these [`Tipset`]s should contain.
+/// Requests covering too many tipsets may be rejected. As of 2023-07-13,
+/// requesting for 8 tipsets works fine but requesting for 64 is flaky.
 async fn fetch_batch<DB: Blockstore, C: Consensus>(
     batch: Vec<Arc<Tipset>>,
     network: &SyncNetworkContext<DB>,

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1019,12 +1019,9 @@ async fn fetch_batch<DB: Blockstore, C: Consensus>(
     network: &SyncNetworkContext<DB>,
     db: &DB,
 ) -> Result<Vec<FullTipset>, TipsetRangeSyncerError<C>> {
-    // If all of the tipsets can be populated with messages from the local
-    // database, do so. If any of them cannot, move forward with the full
-    // network request. It's quite rare that we already have the messages. It
-    // only happens when the local database has been seeded with the
-    // information.
     if let Some(cached) = batch.iter().map(|tipset| tipset.fill_from_blockstore(db)).collect() {
+        // user has already seeded the database with this information (or we're
+        // recovering from e.g a crash)
         return Ok(cached);
     }
 

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1038,7 +1038,7 @@ async fn fetch_batch<DB: Blockstore, C: Consensus>(
             .await
             .map_err(TipsetRangeSyncerError::NetworkMessageQueryFailed)?;
 
-        // Since the bundle only has messages, we have to put the headers in them
+        // inflate our tipsets with the messages from the wire format
         compacted_messages
             .into_iter()
             .rev()

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1040,9 +1040,8 @@ async fn fetch_batch<DB: Blockstore, C: Consensus>(
             .await
             .map_err(TipsetRangeSyncerError::NetworkMessageQueryFailed)?;
 
-        let mut result = Vec::new();
         // Since the bundle only has messages, we have to put the headers in them
-        for (messages, tipset) in compacted_messages.into_iter().rev().zip(batch.iter()) {
+        compacted_messages.into_iter().rev().zip(batch.iter()).map(|(messages, tipset)| {
             // Construct full tipset from fetched messages
             let bundle = TipsetBundle {
                 blocks: tipset.blocks().to_vec(),
@@ -1059,9 +1058,8 @@ async fn fetch_batch<DB: Blockstore, C: Consensus>(
             } else {
                 warn!("ChainExchange request for messages returned null messages");
             }
-            result.push(full_tipset);
-        }
-        Ok(result)
+            Ok(full_tipset)
+        }).collect()
     } else {
         Ok(vec![])
     }

--- a/src/libp2p/chain_exchange/message.rs
+++ b/src/libp2p/chain_exchange/message.rs
@@ -151,6 +151,7 @@ pub struct CompactedMessages {
     /// Unsigned BLS messages.
     pub bls_msgs: Vec<Message>,
     /// Describes which block each message belongs to.
+    /// if `bls_msg_includes[2] = vec![5]` then `block[2]` contains `bls_msgs[5]`
     pub bls_msg_includes: Vec<Vec<u64>>,
 
     /// Signed SECP messages.
@@ -212,6 +213,7 @@ impl TryFrom<&TipsetBundle> for FullTipset {
 
 /// Constructs a [`FullTipset`] from headers and compacted messages from a
 /// bundle.
+// TODO(aatifsyed): refactor
 fn fts_from_bundle_parts(
     headers: Vec<BlockHeader>,
     messages: Option<&CompactedMessages>,

--- a/src/libp2p/chain_exchange/message.rs
+++ b/src/libp2p/chain_exchange/message.rs
@@ -213,7 +213,6 @@ impl TryFrom<&TipsetBundle> for FullTipset {
 
 /// Constructs a [`FullTipset`] from headers and compacted messages from a
 /// bundle.
-// TODO(aatifsyed): refactor
 fn fts_from_bundle_parts(
     headers: Vec<BlockHeader>,
     messages: Option<&CompactedMessages>,

--- a/src/libp2p/chain_exchange/message.rs
+++ b/src/libp2p/chain_exchange/message.rs
@@ -151,7 +151,7 @@ pub struct CompactedMessages {
     /// Unsigned BLS messages.
     pub bls_msgs: Vec<Message>,
     /// Describes which block each message belongs to.
-    /// if `bls_msg_includes[2] = vec![5]` then `block[2]` contains `bls_msgs[5]`
+    /// if `bls_msg_includes[2] = vec![5]` then `TipsetBundle.blocks[2]` contains `bls_msgs[5]`
     pub bls_msg_includes: Vec<Vec<u64>>,
 
     /// Signed SECP messages.


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:
- request a stream of messages and pipe them directly into the validator
- syncing from 2 day old snapshot goes from 10m 30s to 3m 50s on my machine. Almost entirely CPU bound.
- no performance difference when syncing to mainnet - we're already CPU bound.
- a buffer size of 64 is fairly aggressive but it only uses a bounded amount of memory.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
