### PR TITLE
fix: update send command instructions in Docker docs

### DIFF
--- a/documentation/src/docker.md
+++ b/documentation/src/docker.md
@@ -57,6 +57,9 @@ References: [1](https://en.wikipedia.org/wiki/Memory_paging#Swappiness)
 ❯ docker run --init -it --rm --entrypoint forest-cli ghcr.io/chainsafe/forest:latest --help
 ```
 
+Also see the [CLI documentation](./cli.md) for more details about commands and
+their usage.
+
 ### Create a Forest node running calibration network. Then list all connected peers.
 
 ```shell
@@ -152,10 +155,11 @@ Create another wallet
 t1wa7lgs7b3p5a26abkgpxwjpw67tx4fbsryg6tca
 ```
 
-Send 10 FIL from the original wallet to the new one
+Send 10 FIL from the original wallet to the new one (default unit for the amount
+in send command is FIL).
 
 ```shell
-❯ docker exec -it forest forest-cli --chain calibnet --token $JWT_TOKEN send --from t1uvqpa2jgic7fhhko3w4wf3kxj36qslvqrk2ln5i t1wa7lgs7b3p5a26abkgpxwjpw67tx4fbsryg6tca 10000000000000000000
+❯ docker exec -it forest forest-cli --chain calibnet --token $JWT_TOKEN send --from t1uvqpa2jgic7fhhko3w4wf3kxj36qslvqrk2ln5i t1wa7lgs7b3p5a26abkgpxwjpw67tx4fbsryg6tca 10
 ```
 
 Verify the balance of the new address.


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Missed a spot where the changes to the `send` command require doc updates. Also added a link to the CLI docs in the Docker instructions.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
