### PR TITLE
refactor: separate `ChainStore` and `ChainIndex`

### DIFF
--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -34,7 +34,6 @@ use fvm_ipld_amt::Amtv0 as Amt;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_car::CarHeader;
 use fvm_ipld_encoding::CborStore;
-use lru::LruCache;
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::{
@@ -665,8 +664,6 @@ where
         Ok((lbts, *next_ts.parent_state()))
     }
 }
-
-pub(in crate::chain) type TipsetCache = Mutex<LruCache<TipsetKeys, Arc<Tipset>>>;
 
 /// Returns a Tuple of BLS messages of type `UnsignedMessage` and SECP messages
 /// of type `SignedMessage`

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -9,7 +9,6 @@ use crate::interpreter::BlockMessages;
 use crate::ipld::{walk_snapshot, WALK_SNAPSHOT_PROGRESS_EXPORT};
 use crate::libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
 use crate::message::{ChainMessage, Message as MessageTrait, SignedMessage};
-use crate::metrics;
 use crate::networks::{ChainConfig, NetworkChain};
 use crate::shim::clock::ChainEpoch;
 use crate::shim::{
@@ -133,6 +132,7 @@ where
     ) -> Result<Self> {
         let (publisher, _) = broadcast::channel(SINK_CAP);
         let ts_cache = Arc::new(Mutex::new(LruCache::new(DEFAULT_TIPSET_CACHE_SIZE)));
+        let chain_index = ChainIndex::new(ts_cache, Arc::clone(&db));
         let file_backed_genesis = Mutex::new(FileBacked::new(
             *genesis_block_header.cid(),
             chain_data_root.join("GENESIS"),
@@ -143,7 +143,7 @@ where
                 || TipsetKeys::new(vec![*genesis_block_header.cid()]),
                 None,
             )?;
-            let is_valid = tipset_from_keys(&ts_cache, &db, head_store.inner()).is_ok();
+            let is_valid = chain_index.load_tipset(head_store.inner()).is_ok();
             if !is_valid {
                 // If the stored HEAD is invalid, reset it to the genesis tipset.
                 head_store.set_inner(TipsetKeys::new(vec![*genesis_block_header.cid()]))?;
@@ -159,7 +159,7 @@ where
 
         let cs = Self {
             publisher,
-            chain_index: ChainIndex::new(ts_cache, Arc::clone(&db)),
+            chain_index,
             tipset_tracker: TipsetTracker::new(Arc::clone(&db), chain_config),
             db,
             file_backed_genesis,
@@ -671,32 +671,6 @@ where
 }
 
 pub(in crate::chain) type TipsetCache = Mutex<LruCache<TipsetKeys, Arc<Tipset>>>;
-
-/// Loads a tipset from memory given the tipset keys and cache.
-pub(in crate::chain) fn tipset_from_keys<BS>(
-    cache: &TipsetCache,
-    store: &BS,
-    tsk: &TipsetKeys,
-) -> Result<Arc<Tipset>, Error>
-where
-    BS: Blockstore,
-{
-    if let Some(ts) = cache.lock().get(tsk) {
-        metrics::LRU_CACHE_HIT
-            .with_label_values(&[metrics::values::TIPSET])
-            .inc();
-        return Ok(ts.clone());
-    }
-
-    let ts = Tipset::load(store, tsk)?.ok_or(Error::NotFound(String::from("Key for header")))?;
-    // construct new Tipset to return
-    let ts = Arc::new(ts);
-    cache.lock().put(tsk.clone(), ts.clone());
-    metrics::LRU_CACHE_MISS
-        .with_label_values(&[metrics::values::TIPSET])
-        .inc();
-    Ok(ts)
-}
 
 /// Returns a Tuple of BLS messages of type `UnsignedMessage` and SECP messages
 /// of type `SignedMessage`

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::{num::NonZeroUsize, ops::DerefMut, path::Path, sync::Arc, time::SystemTime};
+use std::{ops::DerefMut, path::Path, sync::Arc, time::SystemTime};
 
 use crate::beacon::{BeaconEntry, IGNORE_DRAND_VAR};
 use crate::blocks::{BlockHeader, Tipset, TipsetKeys, TxMeta};
@@ -35,7 +35,6 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_car::CarHeader;
 use fvm_ipld_encoding::CborStore;
 use lru::LruCache;
-use nonzero_ext::nonzero;
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::{
@@ -53,8 +52,6 @@ use crate::chain::Scale;
 
 // A cap on the size of the future_sink
 const SINK_CAP: usize = 200;
-
-const DEFAULT_TIPSET_CACHE_SIZE: NonZeroUsize = nonzero!(8192usize);
 
 /// Disambiguate the type to signify that we are expecting a delta and not an actual epoch/height
 /// while maintaining the same type.
@@ -131,8 +128,7 @@ where
         chain_data_root: &Path,
     ) -> Result<Self> {
         let (publisher, _) = broadcast::channel(SINK_CAP);
-        let ts_cache = Arc::new(Mutex::new(LruCache::new(DEFAULT_TIPSET_CACHE_SIZE)));
-        let chain_index = ChainIndex::new(ts_cache, Arc::clone(&db));
+        let chain_index = ChainIndex::new(Arc::clone(&db));
         let file_backed_genesis = Mutex::new(FileBacked::new(
             *genesis_block_header.cid(),
             chain_data_root.join("GENESIS"),

--- a/src/chain/store/index.rs
+++ b/src/chain/store/index.rs
@@ -12,7 +12,7 @@ use nonzero_ext::nonzero;
 use parking_lot::Mutex;
 use tracing::info;
 
-use crate::chain::{Error, TipsetCache};
+use crate::chain::{Error};
 
 const DEFAULT_TIPSET_CACHE_SIZE: NonZeroUsize = nonzero!(8192usize);
 
@@ -100,12 +100,14 @@ pub mod checkpoint_tipsets {
 /// `Lookback` entry to cache in the `ChainIndex`. Stores all relevant info when
 /// doing `lookbacks`.
 #[derive(Clone, PartialEq, Debug)]
-pub(in crate::chain) struct LookbackEntry {
+struct LookbackEntry {
     tipset: Arc<Tipset>,
     parent_height: ChainEpoch,
     target_height: ChainEpoch,
     target: TipsetKeys,
 }
+
+type TipsetCache = Mutex<LruCache<TipsetKeys, Arc<Tipset>>>;
 
 /// Keeps look-back tipsets in cache at a given interval `skip_length` and can
 /// be used to look-back at the chain to retrieve an old tipset.

--- a/src/chain/store/index.rs
+++ b/src/chain/store/index.rs
@@ -12,7 +12,7 @@ use nonzero_ext::nonzero;
 use parking_lot::Mutex;
 use tracing::info;
 
-use crate::chain::{Error};
+use crate::chain::Error;
 
 const DEFAULT_TIPSET_CACHE_SIZE: NonZeroUsize = nonzero!(8192usize);
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Move `tipset_from_keys` from `ChainStore` into `ChainIndex`. This is where it belongs, conceptually.
- I'll rewrite all of `ChainIndex` in a follow-up PR.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
