### PR TITLE
Use `Lazy<Cid>` for `GENESIS_CID`s rather than a string

### DIFF
--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -283,14 +283,11 @@ impl Tipset {
             serde_yaml::from_str(include_str!("../../build/known_blocks.yaml")).unwrap()
         });
 
-        let calibnet_cid = *calibnet::GENESIS_CID;
-        let mainnet_cid = *mainnet::GENESIS_CID;
-
         for tipset in self.clone().chain(&store) {
             // Search for known calibnet and mainnet blocks
             for (genesis_cid, known_blocks) in [
-                (calibnet_cid, &headers.calibnet),
-                (mainnet_cid, &headers.mainnet),
+                (*calibnet::GENESIS_CID, &headers.calibnet),
+                (*mainnet::GENESIS_CID, &headers.mainnet),
             ] {
                 if let Some(known_block_cid) = known_blocks.get(&tipset.epoch()) {
                     if known_block_cid == &tipset.min_ticket_block().cid().to_string() {

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -15,7 +15,6 @@ use num::BigInt;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use tracing::info;
-use once_cell::sync::Lazy;
 
 use super::{Block, BlockHeader, Error, Ticket};
 
@@ -284,8 +283,8 @@ impl Tipset {
             serde_yaml::from_str(include_str!("../../build/known_blocks.yaml")).unwrap()
         });
 
-        let calibnet_cid = *Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID");
-        let mainnet_cid = *Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID");
+        let calibnet_cid = *calibnet::GENESIS_CID;
+        let mainnet_cid = *mainnet::GENESIS_CID;
 
         for tipset in self.clone().chain(&store) {
             // Search for known calibnet and mainnet blocks

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -14,8 +14,8 @@ use fvm_ipld_encoding::CborStore;
 use num::BigInt;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 use tracing::info;
+use once_cell::sync::Lazy;
 
 use super::{Block, BlockHeader, Error, Ticket};
 
@@ -284,8 +284,8 @@ impl Tipset {
             serde_yaml::from_str(include_str!("../../build/known_blocks.yaml")).unwrap()
         });
 
-        let calibnet_cid = Cid::from_str(calibnet::GENESIS_CID).unwrap();
-        let mainnet_cid = Cid::from_str(mainnet::GENESIS_CID).unwrap();
+        let calibnet_cid = *Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID");
+        let mainnet_cid = *Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID");
 
         for tipset in self.clone().chain(&store) {
             // Search for known calibnet and mainnet blocks

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -48,6 +48,7 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::info;
+use once_cell::sync::Lazy;
 
 #[derive(Debug, Subcommand)]
 pub enum ArchiveCommands {
@@ -275,9 +276,9 @@ impl ArchiveInfo {
             }
 
             if tipset.epoch() == 0 {
-                if tipset.min_ticket_block().cid().to_string() == calibnet::GENESIS_CID {
+                if tipset.min_ticket_block().cid() == Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID") {
                     network = "calibnet".into();
-                } else if tipset.min_ticket_block().cid().to_string() == mainnet::GENESIS_CID {
+                } else if tipset.min_ticket_block().cid() == Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID") {
                     network = "mainnet".into();
                 }
             }
@@ -290,9 +291,9 @@ impl ArchiveInfo {
             if may_skip {
                 match tipset.genesis(&store).ok() {
                     Some(genesis_block) => {
-                        if genesis_block.cid().to_string() == calibnet::GENESIS_CID {
+                        if genesis_block.cid() == Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID") {
                             network = "calibnet".into();
-                        } else if genesis_block.cid().to_string() == mainnet::GENESIS_CID {
+                        } else if genesis_block.cid() == Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID") {
                             network = "mainnet".into();
                         }
                     }
@@ -322,9 +323,9 @@ fn print_checkpoints(snapshot: PathBuf) -> anyhow::Result<()> {
     let root = Tipset::load_required(&store, &TipsetKeys::new(store.roots()))?;
 
     let genesis = root.genesis(&store)?;
-    let chain_name = if genesis.cid().to_string() == calibnet::GENESIS_CID {
+    let chain_name = if genesis.cid() == Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID") {
         NetworkChain::Calibnet
-    } else if genesis.cid().to_string() == mainnet::GENESIS_CID {
+    } else if genesis.cid() == Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID") {
         NetworkChain::Mainnet
     } else {
         bail!("Unrecognizable genesis block");

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -48,7 +48,6 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::info;
-use once_cell::sync::Lazy;
 
 #[derive(Debug, Subcommand)]
 pub enum ArchiveCommands {
@@ -276,9 +275,9 @@ impl ArchiveInfo {
             }
 
             if tipset.epoch() == 0 {
-                if tipset.min_ticket_block().cid() == Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID") {
+                if tipset.min_ticket_block().cid() == &*calibnet::GENESIS_CID {
                     network = "calibnet".into();
-                } else if tipset.min_ticket_block().cid() == Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID") {
+                } else if tipset.min_ticket_block().cid() == &*mainnet::GENESIS_CID {
                     network = "mainnet".into();
                 }
             }
@@ -291,9 +290,9 @@ impl ArchiveInfo {
             if may_skip {
                 match tipset.genesis(&store).ok() {
                     Some(genesis_block) => {
-                        if genesis_block.cid() == Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID") {
+                        if genesis_block.cid() == &*calibnet::GENESIS_CID {
                             network = "calibnet".into();
-                        } else if genesis_block.cid() == Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID") {
+                        } else if genesis_block.cid() == &*mainnet::GENESIS_CID {
                             network = "mainnet".into();
                         }
                     }
@@ -323,9 +322,9 @@ fn print_checkpoints(snapshot: PathBuf) -> anyhow::Result<()> {
     let root = Tipset::load_required(&store, &TipsetKeys::new(store.roots()))?;
 
     let genesis = root.genesis(&store)?;
-    let chain_name = if genesis.cid() == Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID") {
+    let chain_name = if genesis.cid() == &*calibnet::GENESIS_CID {
         NetworkChain::Calibnet
-    } else if genesis.cid() == Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID") {
+    } else if genesis.cid() == &*mainnet::GENESIS_CID {
         NetworkChain::Mainnet
     } else {
         bail!("Unrecognizable genesis block");

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -26,6 +26,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tracing::info;
+use once_cell::sync::Lazy;
 
 #[derive(Debug, Subcommand)]
 pub enum SnapshotCommands {
@@ -355,9 +356,9 @@ where
     );
 
     fn match_genesis_block(block_cid: Cid) -> Result<NetworkChain> {
-        if block_cid.to_string() == calibnet::GENESIS_CID {
+        if block_cid == *Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID") {
             Ok(NetworkChain::Calibnet)
-        } else if block_cid.to_string() == mainnet::GENESIS_CID {
+        } else if block_cid == *Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID") {
             Ok(NetworkChain::Mainnet)
         } else {
             bail!("Unrecognizable genesis block");

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -26,7 +26,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tracing::info;
-use once_cell::sync::Lazy;
 
 #[derive(Debug, Subcommand)]
 pub enum SnapshotCommands {
@@ -356,9 +355,9 @@ where
     );
 
     fn match_genesis_block(block_cid: Cid) -> Result<NetworkChain> {
-        if block_cid == *Lazy::get(&calibnet::GENESIS_CID).expect("failed to get calibnet genesis CID") {
+        if block_cid == *calibnet::GENESIS_CID {
             Ok(NetworkChain::Calibnet)
-        } else if block_cid == *Lazy::get(&mainnet::GENESIS_CID).expect("failed to get mainnet genesis CID") {
+        } else if block_cid == *mainnet::GENESIS_CID {
             Ok(NetworkChain::Mainnet)
         } else {
             bail!("Unrecognizable genesis block");

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -3,9 +3,9 @@
 
 use cid::Cid;
 use lazy_static::lazy_static;
-use url::Url;
 use once_cell::sync::Lazy;
 use std::str::FromStr;
+use url::Url;
 
 use super::{drand::DRAND_MAINNET, DrandPoint, Height, HeightInfo};
 use crate::networks::ActorBundleInfo;
@@ -13,7 +13,9 @@ use crate::networks::ActorBundleInfo;
 /// Default genesis car file bytes.
 pub const DEFAULT_GENESIS: &[u8] = include_bytes!("genesis.car");
 /// Genesis CID
-pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| Cid::from_str("bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4").unwrap());
+pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| {
+    Cid::from_str("bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4").unwrap()
+});
 
 /// Default bootstrap peer ids.
 pub const DEFAULT_BOOTSTRAP: &[&str] =

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -4,6 +4,8 @@
 use cid::Cid;
 use lazy_static::lazy_static;
 use url::Url;
+use once_cell::sync::Lazy;
+use std::str::FromStr;
 
 use super::{drand::DRAND_MAINNET, DrandPoint, Height, HeightInfo};
 use crate::networks::ActorBundleInfo;
@@ -11,7 +13,7 @@ use crate::networks::ActorBundleInfo;
 /// Default genesis car file bytes.
 pub const DEFAULT_GENESIS: &[u8] = include_bytes!("genesis.car");
 /// Genesis CID
-pub const GENESIS_CID: &str = "bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4";
+pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| Cid::from_str("bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4").unwrap());
 
 /// Default bootstrap peer ids.
 pub const DEFAULT_BOOTSTRAP: &[&str] =

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -4,9 +4,9 @@
 use crate::shim::clock::ChainEpoch;
 use cid::Cid;
 use lazy_static::lazy_static;
-use url::Url;
 use once_cell::sync::Lazy;
 use std::str::FromStr;
+use url::Url;
 
 use super::{
     drand::{DRAND_INCENTINET, DRAND_MAINNET},
@@ -19,7 +19,9 @@ const SMOKE_HEIGHT: ChainEpoch = 51000;
 /// Default genesis car file bytes.
 pub const DEFAULT_GENESIS: &[u8] = include_bytes!("genesis.car");
 /// Genesis CID
-pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| Cid::from_str("bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2").unwrap());
+pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| {
+    Cid::from_str("bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2").unwrap()
+});
 
 /// Default bootstrap peer ids.
 pub const DEFAULT_BOOTSTRAP: &[&str] =

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -5,6 +5,8 @@ use crate::shim::clock::ChainEpoch;
 use cid::Cid;
 use lazy_static::lazy_static;
 use url::Url;
+use once_cell::sync::Lazy;
+use std::str::FromStr;
 
 use super::{
     drand::{DRAND_INCENTINET, DRAND_MAINNET},
@@ -17,7 +19,7 @@ const SMOKE_HEIGHT: ChainEpoch = 51000;
 /// Default genesis car file bytes.
 pub const DEFAULT_GENESIS: &[u8] = include_bytes!("genesis.car");
 /// Genesis CID
-pub const GENESIS_CID: &str = "bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2";
+pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| Cid::from_str("bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2").unwrap());
 
 /// Default bootstrap peer ids.
 pub const DEFAULT_BOOTSTRAP: &[&str] =

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -176,7 +176,7 @@ impl ChainConfig {
         use mainnet::*;
         Self {
             network: NetworkChain::Mainnet,
-            genesis_cid: Some(GENESIS_CID.to_owned()),
+            genesis_cid: Some(GENESIS_CID.to_string()),
             bootstrap_peers: DEFAULT_BOOTSTRAP.iter().map(|x| x.to_string()).collect(),
             block_delay_secs: EPOCH_DURATION_SECONDS as u64,
             propagation_delay_secs: 10,
@@ -192,7 +192,7 @@ impl ChainConfig {
         use calibnet::*;
         Self {
             network: NetworkChain::Calibnet,
-            genesis_cid: Some(GENESIS_CID.to_owned()),
+            genesis_cid: Some(GENESIS_CID.to_string()),
             bootstrap_peers: DEFAULT_BOOTSTRAP.iter().map(|x| x.to_string()).collect(),
             block_delay_secs: EPOCH_DURATION_SECONDS as u64,
             propagation_delay_secs: 10,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Change `GENESIS_CID`s to use `Lazy<Cid>` type rather than a string slice.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3230 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
