### PR TITLE
fix re-creating libp2p keypair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 
 ### Fixed
 
+- [#3248](https://github.com/ChainSafe/forest/issues/3248): Fixed Forest being
+  unable to re-create its libp2p keypair from file and always changing its
+  `PeerId`.
+
 ## Forest v0.11.1 "Dagny Taggart"
 
 ## Forest v0.11.0 "Hypersonic"

--- a/src/libp2p/keypair.rs
+++ b/src/libp2p/keypair.rs
@@ -1,0 +1,130 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use tracing::{info, trace};
+
+use crate::{
+    libp2p::Keypair,
+    utils::io::{read_file_to_vec, write_to_file},
+};
+use std::{fs, path::Path};
+
+const KEYPAIR_FILE: &str = "keypair";
+
+/// Returns the libp2p key-pair for the node, generating a new one if it doesn't exist
+/// in the data directory.
+pub fn get_or_create_keypair(data_dir: &Path) -> anyhow::Result<Keypair> {
+    match get_keypair(data_dir) {
+        Some(keypair) => Ok(keypair),
+        None => create_and_save_keypair(data_dir),
+    }
+}
+
+/// Creates and saves a new `ED25519` key-pair to the given path.
+/// If an older key-pair exists, it will be backed-up.
+/// Returns the generated key-pair.
+fn create_and_save_keypair(path: &Path) -> anyhow::Result<Keypair> {
+    let gen_keypair = crate::libp2p::ed25519::Keypair::generate();
+
+    let keypair_path = path.join(KEYPAIR_FILE);
+    if keypair_path.exists() {
+        let mut backup_path = keypair_path.clone();
+        backup_path.set_extension("bak");
+
+        info!("Backing up existing keypair to {}", backup_path.display());
+        fs::rename(keypair_path, &backup_path)?;
+    }
+
+    let file = write_to_file(&gen_keypair.to_bytes(), path, KEYPAIR_FILE)?;
+    // Restrict permissions on files containing private keys
+    crate::utils::io::set_user_perm(&file)?;
+
+    Ok(gen_keypair.into())
+}
+
+// Fetch key-pair from disk, returning none if it cannot be decoded.
+fn get_keypair(data_dir: &Path) -> Option<Keypair> {
+    let path_to_file = data_dir.join(KEYPAIR_FILE);
+    match read_file_to_vec(&path_to_file) {
+        Err(e) => {
+            info!("Networking keystore not found!");
+            trace!("Error {e}");
+            None
+        }
+        Ok(mut vec) => match crate::libp2p::ed25519::Keypair::try_from_bytes(&mut vec) {
+            Ok(kp) => {
+                info!("Recovered libp2p keypair from {}", path_to_file.display());
+                Some(kp.into())
+            }
+            Err(e) => {
+                info!("Could not decode networking keystore!");
+                info!("Error {e}");
+                None
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::remove_file;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_get_or_create_keypair() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let path_to_file = dir.path().join(KEYPAIR_FILE);
+
+        // Test that a keypair is generated and saved to disk
+        let keypair = get_or_create_keypair(dir.path())?;
+        assert!(path_to_file.exists());
+
+        // Test that the same keypair is returned if it already exists
+        let keypair2 = get_or_create_keypair(dir.path())?;
+        assert_eq!(keypair.public(), keypair2.public());
+        assert_eq!(
+            keypair.clone().try_into_ed25519()?.to_bytes(),
+            keypair2.try_into_ed25519()?.to_bytes()
+        );
+
+        // Test that a new keypair is generated if the file is deleted
+        remove_file(&path_to_file)?;
+        let keypair3 = get_or_create_keypair(dir.path())?;
+        assert_ne!(keypair.public(), keypair3.public());
+        assert_ne!(
+            keypair.try_into_ed25519()?.to_bytes(),
+            keypair3.try_into_ed25519()?.to_bytes()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_backup_keypair() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let path_to_file = dir.path().join(KEYPAIR_FILE);
+
+        // Test that a keypair is generated and saved to disk
+        let keypair = create_and_save_keypair(dir.path())?;
+        assert!(path_to_file.exists());
+
+        // corrupt the existing keypair file
+        fs::write(
+            &path_to_file,
+            b"Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn",
+        )?;
+
+        // Test that a new keypair is generated if the file is corrupted
+        // and the old file is backed up
+        let keypair2 = get_or_create_keypair(dir.path())?;
+        assert_ne!(keypair.public(), keypair2.public());
+        assert_ne!(
+            keypair.try_into_ed25519()?.to_bytes(),
+            keypair2.try_into_ed25519()?.to_bytes()
+        );
+        assert!(path_to_file.exists());
+        assert!(dir.path().join(format!("{}.bak", KEYPAIR_FILE)).exists());
+        Ok(())
+    }
+}

--- a/src/libp2p/mod.rs
+++ b/src/libp2p/mod.rs
@@ -7,6 +7,7 @@ mod config;
 mod discovery;
 mod gossip_params;
 pub mod hello;
+pub mod keypair;
 mod metrics;
 mod peer_manager;
 pub mod rpc;

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::{
-    path::Path,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -13,7 +12,6 @@ use crate::libp2p_bitswap::{
     request_manager::BitswapRequestManager, BitswapStoreRead, BitswapStoreReadWrite,
 };
 use crate::message::SignedMessage;
-use crate::utils::io::read_file_to_vec;
 use ahash::{HashMap, HashSet};
 use anyhow::Context;
 use cid::Cid;
@@ -834,26 +832,4 @@ pub fn build_transport(local_key: Keypair) -> anyhow::Result<Boxed<(PeerId, Stre
         .multiplex(yamux::Config::default())
         .timeout(Duration::from_secs(20))
         .boxed())
-}
-
-/// Fetch key-pair from disk, returning none if it cannot be decoded.
-pub fn get_keypair(path: &Path) -> Option<Keypair> {
-    match read_file_to_vec(path) {
-        Err(e) => {
-            info!("Networking keystore not found!");
-            trace!("Error {:?}", e);
-            None
-        }
-        Ok(mut vec) => match Keypair::ed25519_from_bytes(&mut vec) {
-            Ok(kp) => {
-                info!("Recovered libp2p keypair from {:?}", &path);
-                Some(kp)
-            }
-            Err(e) => {
-                info!("Could not decode networking keystore!");
-                trace!("Error {:?}", e);
-                None
-            }
-        },
-    }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Forest is now able to re-create the keypair from file and thanks to this, keep the same PeerId,
- added tests so that the regression in this is caught,
- corrupted keypairs are not immediately overwritten but backed up.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3248

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
