### PR TITLE
chore: replace `unsigned_varint` with custom implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,7 +2962,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
- "tokio-util 0.6.10",
  "tokio-util 0.7.8",
  "toml 0.7.6",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
  "fvm_shared 2.5.0",
  "fvm_shared 3.4.0",
  "indexmap 1.9.3",
- "integer-encoding",
+ "integer-encoding 3.0.4",
  "num-derive 0.3.3",
  "num-traits",
  "serde",
@@ -2621,7 +2621,7 @@ dependencies = [
  "fvm_ipld_hamt",
  "fvm_shared 2.5.0",
  "fvm_shared 3.4.0",
- "integer-encoding",
+ "integer-encoding 3.0.4",
  "lazy_static",
  "num-derive 0.3.3",
  "num-traits",
@@ -2894,6 +2894,7 @@ dependencies = [
  "humantime",
  "indexmap 1.9.3",
  "indicatif",
+ "integer-encoding 4.0.0",
  "is-terminal",
  "itertools 0.11.0",
  "jsonrpc-v2",
@@ -3333,7 +3334,7 @@ dependencies = [
  "futures",
  "fvm_ipld_blockstore 0.2.0",
  "fvm_ipld_encoding 0.4.0",
- "integer-encoding",
+ "integer-encoding 3.0.4",
  "serde",
  "thiserror",
 ]
@@ -4009,6 +4010,12 @@ dependencies = [
  "async-trait",
  "futures-util",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924df4f0e24e2e7f9cdd90babb0b96f93b20f3ecfa949ea9e6613756b8c8e1bf"
 
 [[package]]
 name = "interceptor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ tap = "1"
 tempfile = "3.4"
 thiserror = "1.0"
 ticker = "0.1"
+integer-encoding = "4.0"
 tikv-jemallocator = { version = "0.5", optional = true }
 tokio = { version = "1", features = ['full'] }
 tokio-stream = { version = "0.1", features = ["fs", "io-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,9 +161,6 @@ tikv-jemallocator = { version = "0.5", optional = true }
 tokio = { version = "1", features = ['full'] }
 tokio-stream = { version = "0.1", features = ["fs", "io-util"] }
 tokio-util = { version = "0.7.0", features = ["compat"] }
-tokio-util-06 = { package = "tokio-util", version = "0.6.0", features = [
-  "codec",
-] } # https://github.com/paritytech/unsigned-varint/pull/59
 toml = "0.7"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ human-repr = "1.0"
 humantime = "2.1.0"
 indexmap = { version = "1.9", features = ["serde-1"] }
 indicatif = { version = "0.17.3", features = ["tokio"] }
+integer-encoding = "4.0"
 is-terminal = "0.4"
 itertools = "0.11.0"
 jsonrpc-v2 = { version = "0.11", default-features = false, features = ["easy-errors", "macros", "bytes-v05"] }
@@ -156,7 +157,6 @@ tap = "1"
 tempfile = "3.4"
 thiserror = "1.0"
 ticker = "0.1"
-integer-encoding = "4.0"
 tikv-jemallocator = { version = "0.5", optional = true }
 tokio = { version = "1", features = ['full'] }
 tokio-stream = { version = "0.1", features = ["fs", "io-util"] }

--- a/src/car_backed_blockstore.rs
+++ b/src/car_backed_blockstore.rs
@@ -71,8 +71,7 @@ use std::{
     ops::ControlFlow,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_util::codec::{BytesCodec, FramedWrite};
-use tokio_util_06::codec::FramedRead;
+use tokio_util::codec::{BytesCodec, FramedWrite, FramedRead};
 use tracing::{debug, trace};
 
 use crate::utils::{try_collate, Collate};
@@ -653,7 +652,7 @@ pub async fn zstd_compress_varint_manyframe(
     zstd_frame_size_tripwire: usize,
     zstd_compression_level: u16,
 ) -> io::Result<usize> {
-    type VarintFrameCodec = unsigned_varint::codec::UviBytes<BytesMut>;
+    type VarintFrameCodec = crate::utils::encoding::UviBytes;
     let mut count = 0;
     try_collate(
         FramedRead::new(reader, VarintFrameCodec::default()),

--- a/src/car_backed_blockstore.rs
+++ b/src/car_backed_blockstore.rs
@@ -71,7 +71,7 @@ use std::{
     ops::ControlFlow,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_util::codec::{BytesCodec, FramedWrite, FramedRead};
+use tokio_util::codec::{BytesCodec, FramedRead, FramedWrite};
 use tracing::{debug, trace};
 
 use crate::utils::{try_collate, Collate};

--- a/src/car_backed_blockstore.rs
+++ b/src/car_backed_blockstore.rs
@@ -535,10 +535,11 @@ fn read_block_data_location_and_skip(
 ///        reader end ►│
 /// ```
 fn read_varint_body_length_or_eof(mut reader: impl Read) -> io::Result<Option<u32>> {
-    match reader.read_varint() {
-        Ok(n) => Ok(Some(n)),
-        Err(e) if matches!(e.kind(), std::io::ErrorKind::UnexpectedEof) => Ok(None),
-        Err(e) => Err(e),
+    let mut byte = [0u8; 1]; // detect EOF
+    match reader.read(&mut byte)? {
+        0 => Ok(None),
+        1 => (byte.chain(reader)).read_varint().map(Some),
+        _ => unreachable!(),
     }
 }
 

--- a/src/car_backed_blockstore.rs
+++ b/src/car_backed_blockstore.rs
@@ -6,7 +6,7 @@
 //! CARs are made of concatenations of _varint frames_. Each varint frame is a
 //! concatenation of the _body length_ as an
 //! [varint](https://docs.rs/integer-encoding/4.0.0/integer_encoding/trait.VarInt.html),
-//! and the _frame body_ itself. [`crate::utils::encoding::UviBytes`] can be
+//! and the _frame body_ itself. [`crate::utils::encoding::uvibytes::UviBytes`] can be
 //! used to read frames piecewise into memory.
 //!
 //! ```text

--- a/src/car_backed_blockstore.rs
+++ b/src/car_backed_blockstore.rs
@@ -3,9 +3,11 @@
 
 //! # Varint frames
 //!
-//! CARs are made of concatenations of _varint frames_.
-//! Each varint frame is a concatenation of the _body length_ as an [`unsigned_varint`], and the _frame body_ itself.
-//! [`unsigned_varint::codec`] can be used to read frames piecewise into memory.
+//! CARs are made of concatenations of _varint frames_. Each varint frame is a
+//! concatenation of the _body length_ as an
+//! [varint](https://docs.rs/integer-encoding/4.0.0/integer_encoding/trait.VarInt.html),
+//! and the _frame body_ itself. [`crate::utils::encoding::UviBytes`] can be
+//! used to read frames piecewise into memory.
 //!
 //! ```text
 //!        varint frame
@@ -536,7 +538,7 @@ fn read_varint_body_length_or_eof(mut reader: impl Read) -> io::Result<Option<u3
     match reader.read_varint() {
         Ok(n) => Ok(Some(n)),
         Err(e) if matches!(e.kind(), std::io::ErrorKind::UnexpectedEof) => Ok(None),
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }
 

--- a/src/car_backed_blockstore.rs
+++ b/src/car_backed_blockstore.rs
@@ -644,7 +644,7 @@ pub async fn zstd_compress_varint_manyframe(
     zstd_frame_size_tripwire: usize,
     zstd_compression_level: u16,
 ) -> io::Result<usize> {
-    type VarintFrameCodec = crate::utils::encoding::UviBytes;
+    type VarintFrameCodec = crate::utils::encoding::uvibytes::UviBytes;
     let mut count = 0;
     try_collate(
         FramedRead::new(reader, VarintFrameCodec::default()),

--- a/src/car_backed_blockstore.rs
+++ b/src/car_backed_blockstore.rs
@@ -57,6 +57,7 @@ use futures::{StreamExt as _, TryStreamExt as _};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_car::CarHeader;
 use indexmap::IndexMap;
+use integer_encoding::VarInt;
 use itertools::Itertools as _;
 use parking_lot::Mutex;
 use std::{
@@ -697,9 +698,8 @@ fn zstd_compress_fold_varint_frame(
     mut encoder: zstd::Encoder<Writer<BytesMut>>,
     body: BytesMut,
 ) -> zstd::Encoder<Writer<BytesMut>> {
-    let mut header = unsigned_varint::encode::usize_buffer();
     encoder
-        .write_all(unsigned_varint::encode::usize(body.len(), &mut header))
+        .write_all(&body.len().encode_var_vec())
         .expect("BytesMut has infallible IO");
     encoder
         .write_all(&body)

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -216,12 +216,12 @@ impl SnapshotCommands {
                 compression_level,
                 frame_size,
             } => {
-                // We've got a binary blob, and we're not exactly sure if it's compressed, and we can't just peek the header:
-                // For example, the zstsd magic bytes are a valid varint frame prefix:
-                assert_eq!(
-                    unsigned_varint::io::read_usize(&[0xFD, 0x2F, 0xB5, 0x28][..]).unwrap(),
-                    6141,
-                );
+                // // We've got a binary blob, and we're not exactly sure if it's compressed, and we can't just peek the header:
+                // // For example, the zstsd magic bytes are a valid varint frame prefix:
+                // assert_eq!(
+                //     unsigned_varint::io::read_usize(&[0xFD, 0x2F, 0xB5, 0x28][..]).unwrap(),
+                //     6141,
+                // );
                 // so the best thing to do is to just try compressed and then uncompressed.
                 use car_backed_blockstore::zstd_compress_varint_manyframe;
                 use tokio::fs::File;

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -216,12 +216,14 @@ impl SnapshotCommands {
                 compression_level,
                 frame_size,
             } => {
-                // // We've got a binary blob, and we're not exactly sure if it's compressed, and we can't just peek the header:
-                // // For example, the zstsd magic bytes are a valid varint frame prefix:
-                // assert_eq!(
-                //     unsigned_varint::io::read_usize(&[0xFD, 0x2F, 0xB5, 0x28][..]).unwrap(),
-                //     6141,
-                // );
+                // We've got a binary blob, and we're not exactly sure if it's compressed, and we can't just peek the header:
+                // For example, the zstsd magic bytes are a valid varint frame prefix:
+                assert_eq!(
+                    <usize as integer_encoding::VarInt>::decode_var(&[0xFD, 0x2F, 0xB5, 0x28])
+                        .unwrap()
+                        .1,
+                    6141,
+                );
                 // so the best thing to do is to just try compressed and then uncompressed.
                 use car_backed_blockstore::zstd_compress_varint_manyframe;
                 use tokio::fs::File;

--- a/src/shim/address.rs
+++ b/src/shim/address.rs
@@ -12,6 +12,7 @@ use data_encoding_macro::new_encoding;
 use fvm_shared2::address::Address as Address_v2;
 use fvm_shared3::address::Address as Address_v3;
 pub use fvm_shared3::address::{Error, Network, Payload, Protocol, BLS_PUB_LEN, PAYLOAD_HASH_LEN};
+use integer_encoding::VarInt;
 use lazy_static::lazy_static;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
@@ -224,10 +225,7 @@ impl Display for Address {
                 write_payload(
                     f,
                     protocol,
-                    Some(unsigned_varint::encode::u64(
-                        addr.namespace(),
-                        &mut unsigned_varint::encode::u64_buffer(),
-                    )),
+                    Some(&addr.namespace().encode_var_vec()),
                     addr.subaddress(),
                 )
             }

--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -3,13 +3,11 @@
 
 use crate::shim::address::Address;
 use blake2b_simd::Params;
-use bytes::{Buf, BufMut, Bytes, BytesMut};
 use filecoin_proofs_api::ProverId;
 use fvm_ipld_encoding::strict_bytes::{Deserialize, Serialize};
-use integer_encoding::VarInt;
 pub use serde::{de, ser, Deserializer, Serializer};
-use std::io;
-use tokio_util::codec::{Decoder, Encoder};
+
+pub mod uvibytes;
 
 /// `serde_bytes` with max length check
 pub mod serde_byte_array {
@@ -83,122 +81,17 @@ pub fn prover_id_from_u64(id: u64) -> ProverId {
     prover_id
 }
 
-// Unsigned VarInt (Uvi) Bytes
-pub struct UviBytes {
-    // cache for varint frame size
-    len: Option<usize>,
-    // content size limit, defaults to 128MiB
-    limit: usize,
-}
 
-impl UviBytes {
-    pub fn new_with_limit(limit: usize) -> Self {
-        UviBytes { len: None, limit }
-    }
-}
-
-impl Default for UviBytes {
-    fn default() -> Self {
-        UviBytes::new_with_limit(128 * 1024 * 1024)
-    }
-}
-
-impl Decoder for UviBytes {
-    type Item = BytesMut;
-    type Error = io::Error;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        if self.len.is_none() {
-            if let Some((n, size)) = usize::decode_var(src) {
-                src.advance(size);
-                self.len = Some(n);
-            } else if src.len() >= std::mem::size_of::<usize>() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid uvi frame",
-                ));
-            }
-        }
-        if let Some(n) = self.len.take() {
-            if n > self.limit {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!("uvi frame size limit exceeded, decode {}", n),
-                ));
-            }
-            if n <= src.len() {
-                return Ok(Some(src.split_to(n)));
-            }
-            src.reserve(n - src.len());
-            self.len = Some(n);
-        }
-        Ok(None)
-    }
-}
-
-impl Encoder<Bytes> for UviBytes {
-    type Error = io::Error;
-
-    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        if item.remaining() > self.limit {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!("uvi frame size limit exceeded, encode {}", item.remaining()),
-            ));
-        }
-        dst.reserve(item.remaining() + item.remaining().required_space());
-        let mut buffer = [0; 16];
-        let len = item.remaining().encode_var(&mut buffer);
-        dst.extend_from_slice(&buffer[0..len]);
-        dst.put(item);
-        Ok(())
-    }
-}
 
 #[cfg(test)]
 mod tests {
     use anyhow::{ensure, Result};
-    use quickcheck_macros::quickcheck;
     use rand::Rng;
     use serde::{Deserialize, Serialize};
 
     use super::*;
     use crate::utils::encoding::serde_byte_array::BYTE_ARRAY_MAX_LEN;
 
-    #[test]
-    fn uvibytes_encode_size_limit() {
-        assert!(UviBytes::new_with_limit(10)
-            .encode(Bytes::from_static(&[0; 1024]), &mut BytesMut::new())
-            .is_err());
-    }
-
-    #[test]
-    fn uvibytes_decode_size_limit() {
-        let mut bytes = BytesMut::new();
-        UviBytes::default()
-            .encode(Bytes::from_static(&[0; 1024]), &mut bytes)
-            .unwrap();
-        assert!(UviBytes::new_with_limit(10).decode(&mut bytes).is_err());
-    }
-
-    #[test]
-    fn uvibytes_partial_decode() {
-        let mut bytes: BytesMut = BytesMut::from(&[u8::MAX][0..]);
-        assert_eq!(
-            UviBytes::new_with_limit(10).decode(&mut bytes).unwrap(),
-            None
-        );
-    }
-
-    #[quickcheck]
-    fn uvibytes_roundtrip(data: Vec<u8>) {
-        let mut buffer = BytesMut::new();
-        UviBytes::default()
-            .encode(Bytes::from(data.clone()), &mut buffer)
-            .unwrap();
-        let out = UviBytes::default().decode(&mut buffer).unwrap().unwrap();
-        assert_eq!(data, out.to_vec());
-    }
 
     #[test]
     fn vector_hashing() {

--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -81,8 +81,6 @@ pub fn prover_id_from_u64(id: u64) -> ProverId {
     prover_id
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use anyhow::{ensure, Result};
@@ -91,7 +89,6 @@ mod tests {
 
     use super::*;
     use crate::utils::encoding::serde_byte_array::BYTE_ARRAY_MAX_LEN;
-
 
     #[test]
     fn vector_hashing() {

--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -3,9 +3,13 @@
 
 use crate::shim::address::Address;
 use blake2b_simd::Params;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use filecoin_proofs_api::ProverId;
 use fvm_ipld_encoding::strict_bytes::{Deserialize, Serialize};
+use integer_encoding::VarInt;
 pub use serde::{de, ser, Deserializer, Serializer};
+use std::io;
+use tokio_util::codec::{Decoder, Encoder};
 
 /// `serde_bytes` with max length check
 pub mod serde_byte_array {
@@ -182,6 +186,68 @@ mod tests {
 
         ensure!(serde_json::to_string_pretty(&a)? == serde_json::to_string_pretty(&b)?);
 
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+// Unsigned VarInt (Uvi) Bytes
+pub struct UviBytes {
+    // cache for varint frame size
+    len: Option<usize>,
+}
+
+impl UviBytes {
+    // TODO: Make this a parameter in `UviBytes`
+    const SIZE_LIMIT: usize = 128 * 1024 * 1024;
+}
+
+impl Decoder for UviBytes {
+    type Item = BytesMut;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if self.len.is_none() {
+            if let Some((n, size)) = usize::decode_var(src) {
+                src.advance(size);
+                self.len = Some(n);
+            } else if src.len() >= std::mem::size_of::<usize>() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid uvi frame",
+                ));
+            }
+        }
+        if let Some(n) = self.len.take() {
+            if n > UviBytes::SIZE_LIMIT {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("uvi frame size limit exceeded, decode {}", n),
+                ));
+            }
+            if n <= src.len() {
+                return Ok(Some(src.split_to(n)));
+            }
+            src.reserve(n - src.len());
+            self.len = Some(n);
+        }
+        Ok(None)
+    }
+}
+
+impl Encoder<Bytes> for UviBytes {
+    type Error = io::Error;
+
+    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        if item.remaining() > UviBytes::SIZE_LIMIT {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("uvi frame size limit exceeded, encode {}", item.remaining()),
+            ));
+        }
+        item.remaining().encode_var(dst);
+        dst.reserve(item.remaining());
+        dst.put(item);
         Ok(())
     }
 }

--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -83,14 +83,122 @@ pub fn prover_id_from_u64(id: u64) -> ProverId {
     prover_id
 }
 
+// Unsigned VarInt (Uvi) Bytes
+pub struct UviBytes {
+    // cache for varint frame size
+    len: Option<usize>,
+    // content size limit, defaults to 128MiB
+    limit: usize,
+}
+
+impl UviBytes {
+    pub fn new_with_limit(limit: usize) -> Self {
+        UviBytes { len: None, limit }
+    }
+}
+
+impl Default for UviBytes {
+    fn default() -> Self {
+        UviBytes::new_with_limit(128 * 1024 * 1024)
+    }
+}
+
+impl Decoder for UviBytes {
+    type Item = BytesMut;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if self.len.is_none() {
+            if let Some((n, size)) = usize::decode_var(src) {
+                src.advance(size);
+                self.len = Some(n);
+            } else if src.len() >= std::mem::size_of::<usize>() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid uvi frame",
+                ));
+            }
+        }
+        if let Some(n) = self.len.take() {
+            if n > self.limit {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("uvi frame size limit exceeded, decode {}", n),
+                ));
+            }
+            if n <= src.len() {
+                return Ok(Some(src.split_to(n)));
+            }
+            src.reserve(n - src.len());
+            self.len = Some(n);
+        }
+        Ok(None)
+    }
+}
+
+impl Encoder<Bytes> for UviBytes {
+    type Error = io::Error;
+
+    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        if item.remaining() > self.limit {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("uvi frame size limit exceeded, encode {}", item.remaining()),
+            ));
+        }
+        dst.reserve(item.remaining() + item.remaining().required_space());
+        let mut buffer = [0; 16];
+        let len = item.remaining().encode_var(&mut buffer);
+        dst.extend_from_slice(&buffer[0..len]);
+        dst.put(item);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::{ensure, Result};
+    use quickcheck_macros::quickcheck;
     use rand::Rng;
     use serde::{Deserialize, Serialize};
 
     use super::*;
     use crate::utils::encoding::serde_byte_array::BYTE_ARRAY_MAX_LEN;
+
+    #[test]
+    fn uvibytes_encode_size_limit() {
+        assert!(UviBytes::new_with_limit(10)
+            .encode(Bytes::from_static(&[0; 1024]), &mut BytesMut::new())
+            .is_err());
+    }
+
+    #[test]
+    fn uvibytes_decode_size_limit() {
+        let mut bytes = BytesMut::new();
+        UviBytes::default()
+            .encode(Bytes::from_static(&[0; 1024]), &mut bytes)
+            .unwrap();
+        assert!(UviBytes::new_with_limit(10).decode(&mut bytes).is_err());
+    }
+
+    #[test]
+    fn uvibytes_partial_decode() {
+        let mut bytes: BytesMut = BytesMut::from(&[u8::MAX][0..]);
+        assert_eq!(
+            UviBytes::new_with_limit(10).decode(&mut bytes).unwrap(),
+            None
+        );
+    }
+
+    #[quickcheck]
+    fn uvibytes_roundtrip(data: Vec<u8>) {
+        let mut buffer = BytesMut::new();
+        UviBytes::default()
+            .encode(Bytes::from(data.clone()), &mut buffer)
+            .unwrap();
+        let out = UviBytes::default().decode(&mut buffer).unwrap().unwrap();
+        assert_eq!(data, out.to_vec());
+    }
 
     #[test]
     fn vector_hashing() {
@@ -186,73 +294,6 @@ mod tests {
 
         ensure!(serde_json::to_string_pretty(&a)? == serde_json::to_string_pretty(&b)?);
 
-        Ok(())
-    }
-}
-
-// Unsigned VarInt (Uvi) Bytes
-pub struct UviBytes {
-    // cache for varint frame size
-    len: Option<usize>,
-    // content size limit, defaults to 128MiB
-    limit: usize,
-}
-
-impl Default for UviBytes {
-    fn default() -> Self {
-        UviBytes {
-            len: None,
-            limit: 128 * 1024 * 1024,
-        }
-    }
-}
-
-impl Decoder for UviBytes {
-    type Item = BytesMut;
-    type Error = io::Error;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        if self.len.is_none() {
-            if let Some((n, size)) = usize::decode_var(src) {
-                src.advance(size);
-                self.len = Some(n);
-            } else if src.len() >= std::mem::size_of::<usize>() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid uvi frame",
-                ));
-            }
-        }
-        if let Some(n) = self.len.take() {
-            if n > self.limit {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!("uvi frame size limit exceeded, decode {}", n),
-                ));
-            }
-            if n <= src.len() {
-                return Ok(Some(src.split_to(n)));
-            }
-            src.reserve(n - src.len());
-            self.len = Some(n);
-        }
-        Ok(None)
-    }
-}
-
-impl Encoder<Bytes> for UviBytes {
-    type Error = io::Error;
-
-    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        if item.remaining() > self.limit {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!("uvi frame size limit exceeded, encode {}", item.remaining()),
-            ));
-        }
-        item.remaining().encode_var(dst);
-        dst.reserve(item.remaining());
-        dst.put(item);
         Ok(())
     }
 }

--- a/src/utils/encoding/uvibytes.rs
+++ b/src/utils/encoding/uvibytes.rs
@@ -1,0 +1,124 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use integer_encoding::VarInt;
+pub use serde::{de, ser, Deserializer, Serializer};
+use std::io;
+use tokio_util::codec::{Decoder, Encoder};
+
+
+// Unsigned VarInt (Uvi) Bytes
+pub struct UviBytes {
+    // cache for varint frame size
+    len: Option<usize>,
+    // content size limit, defaults to 128MiB
+    limit: usize,
+}
+
+impl UviBytes {
+    pub fn new_with_limit(limit: usize) -> Self {
+        UviBytes { len: None, limit }
+    }
+}
+
+impl Default for UviBytes {
+    fn default() -> Self {
+        UviBytes::new_with_limit(128 * 1024 * 1024)
+    }
+}
+
+impl Decoder for UviBytes {
+    type Item = BytesMut;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if self.len.is_none() {
+            if let Some((n, size)) = usize::decode_var(src) {
+                src.advance(size);
+                self.len = Some(n);
+            } else if src.len() >= std::mem::size_of::<usize>() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid uvi frame",
+                ));
+            }
+        }
+        if let Some(n) = self.len.take() {
+            if n > self.limit {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("uvi frame size limit exceeded, decode {}", n),
+                ));
+            }
+            if n <= src.len() {
+                return Ok(Some(src.split_to(n)));
+            }
+            src.reserve(n - src.len());
+            self.len = Some(n);
+        }
+        Ok(None)
+    }
+}
+
+impl Encoder<Bytes> for UviBytes {
+    type Error = io::Error;
+
+    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        if item.remaining() > self.limit {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("uvi frame size limit exceeded, encode {}", item.remaining()),
+            ));
+        }
+        dst.reserve(item.remaining() + item.remaining().required_space());
+        let mut buffer = [0; 16];
+        let len = item.remaining().encode_var(&mut buffer);
+        dst.extend_from_slice(&buffer[0..len]);
+        dst.put(item);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quickcheck_macros::quickcheck;
+
+    use super::*;
+
+    #[test]
+    fn uvibytes_encode_size_limit() {
+        assert!(UviBytes::new_with_limit(10)
+            .encode(Bytes::from_static(&[0; 1024]), &mut BytesMut::new())
+            .is_err());
+    }
+
+    #[test]
+    fn uvibytes_decode_size_limit() {
+        let mut bytes = BytesMut::new();
+        UviBytes::default()
+            .encode(Bytes::from_static(&[0; 1024]), &mut bytes)
+            .unwrap();
+        assert!(UviBytes::new_with_limit(10).decode(&mut bytes).is_err());
+    }
+
+    #[test]
+    fn uvibytes_partial_decode() {
+        let mut bytes: BytesMut = BytesMut::from(&[u8::MAX][0..]);
+        assert_eq!(
+            UviBytes::new_with_limit(10).decode(&mut bytes).unwrap(),
+            None
+        );
+    }
+
+    #[quickcheck]
+    fn uvibytes_roundtrip(data: Vec<u8>) {
+        let mut buffer = BytesMut::new();
+        UviBytes::default()
+            .encode(Bytes::from(data.clone()), &mut buffer)
+            .unwrap();
+        let out = UviBytes::default().decode(&mut buffer).unwrap().unwrap();
+        assert_eq!(data, out.to_vec());
+    }
+
+}

--- a/src/utils/encoding/uvibytes.rs
+++ b/src/utils/encoding/uvibytes.rs
@@ -7,7 +7,6 @@ pub use serde::{de, ser, Deserializer, Serializer};
 use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 
-
 // Unsigned VarInt (Uvi) Bytes
 pub struct UviBytes {
     // cache for varint frame size
@@ -120,5 +119,4 @@ mod tests {
         let out = UviBytes::default().decode(&mut buffer).unwrap().unwrap();
         assert_eq!(data, out.to_vec());
     }
-
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The `unsigned_varint` crate appears to be unmaintained. Let's roll our own varint encoder and decoder.
- `libp2p_bitswap` still uses `unsigned_varint` and I don't want to modify the code.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
