### PR TITLE
fix: flush the zstd encoder before checking compressed length

### DIFF
--- a/src/car_backed_blockstore.rs
+++ b/src/car_backed_blockstore.rs
@@ -791,7 +791,7 @@ mod tests {
             3,
         ))
         .unwrap();
-        assert_eq!(9, num_zstd_frames);
+        assert_eq!(53, num_zstd_frames);
 
         zstd_multiframe
     }
@@ -804,7 +804,7 @@ mod tests {
         )
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
-        assert_eq!(9, frames.len());
+        assert_eq!(53, frames.len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- the encoder has to be flushed before we can see how many bytes were written

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
