### PR TITLE
fix: run go mod vendor in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,8 @@ test-release: go-mod
 test-all: test test-release
 
 go-mod:
-	(cd $(PWD)/src/libp2p_bitswap/tests/go-app && go mod vendor) || echo "Some tests require Go 1.20.x to be installed, follow instructions at https://go.dev/dl/"
+	(cd $(PWD)/src/libp2p_bitswap/tests/go-app && go mod vendor) || \
+	(echo "Some tests require Go 1.20.x to be installed, follow instructions at https://go.dev/dl/" && exit 1)
 
 smoke-test:
 	./scripts/smoke_test.sh

--- a/Makefile
+++ b/Makefile
@@ -90,17 +90,20 @@ release:
 docker-run:
 	docker build -t forest:latest -f ./Dockerfile . && docker run forest
 
-test:
+test: go-mod
 	cargo nextest run
 
 	# nextest doesn't run doctests https://github.com/nextest-rs/nextest/issues/16
 	# see also lib.rs::doctest_private
 	cargo test --doc --features doctest-private
 
-test-release:
+test-release: go-mod
 	cargo nextest run --release
 
 test-all: test test-release
+
+go-mod:
+	(cd $(PWD)/src/libp2p_bitswap/tests/go-app && go mod vendor) || echo "Some tests require Go 1.20.x to be installed, follow instructions at https://go.dev/dl/"
 
 smoke-test:
 	./scripts/smoke_test.sh


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Run `go mod vendor` in Makefile to mitigate test timeout

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
