### PR TITLE
fix(test): make file_writer_fs_buf_writer faster

### DIFF
--- a/src/utils/io/writer_checksum.rs
+++ b/src/utils/io/writer_checksum.rs
@@ -128,7 +128,7 @@ mod test {
         let temp_file = async_fs::File::create(temp_file_path.path()).await?;
         let mut temp_file_writer =
             AsyncWriterWithChecksum::<Sha256, _>::new(BufWriter::new(temp_file), true);
-        for _ in 0..(1024 * 256) {
+        for _ in 0..1024 {
             let mut bytes = [0; 1024];
             OsRng.fill_bytes(&mut bytes);
             temp_file_writer.write_all(&bytes).await?;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- make file_writer_fs_buf_writer faster by reducing the input size

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
