### PR TITLE
fix: don't decompress files unless necessary

### DIFF
--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -7,6 +7,7 @@ use crate::blocks::{BlockHeader, TipsetKeys};
 use crate::chain::index::ResolveNullTipset;
 use crate::cli_shared::cli::{BufferSize, ChunkSize};
 use crate::state_manager::StateManager;
+use crate::utils::net;
 use anyhow::bail;
 use cid::Cid;
 use futures::{sink::SinkExt, stream, AsyncRead, Stream, StreamExt};
@@ -96,7 +97,7 @@ where
     info!("Importing chain from snapshot at: {path}");
     // start import
     let stopwatch = time::Instant::now();
-    let reader = crate::utils::net::reader(path).await?;
+    let reader = net::decompress_if_needed(net::reader(path).await?).await?;
 
     let (cids, n_records) = load_and_retrieve_header(
         sm.blockstore().clone(),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- When downloading without `aria2c`, we would always decompressed the data. This is the wrong behavior when fetching a snapshot.
- The new code only decompresses _if_ we explicitly ask for it.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
