### PR TITLE
fix: use stable hash algorithm

### DIFF
--- a/src/utils/db/car_index/hash.rs
+++ b/src/utils/db/car_index/hash.rs
@@ -38,17 +38,15 @@ impl From<Cid> for Hash {
         // // let mut hasher = DefaultHasher::new();
         // // std::hash::Hash::hash(&cid, &mut hasher);
         // // Hash::from(hasher.finish())
-        let mut chunks = cid
-            .hash()
+        cid.hash()
             .digest()
             .chunks_exact(8)
             .map(<[u8; 8]>::try_from)
-            .map(Result::ok);
-        let mut hash: u64 = cid.codec() ^ cid.hash().code();
-        while let Some(chunk) = chunks.next().flatten() {
-            hash ^= u64::from_le_bytes(chunk);
-        }
-        Hash::from(hash)
+            .filter_map(Result::ok)
+            .fold(cid.codec() ^ cid.hash().code(), |hash, chunk| {
+                hash ^ u64::from_le_bytes(chunk)
+            })
+            .into()
     }
 }
 

--- a/src/utils/db/car_index/hash.rs
+++ b/src/utils/db/car_index/hash.rs
@@ -100,6 +100,8 @@ impl Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::cid::CidCborExt;
+    use cid::multihash::{Code, MultihashDigest};
     use quickcheck::{Arbitrary, Gen};
     use quickcheck_macros::quickcheck;
     use std::num::NonZeroUsize;
@@ -108,6 +110,11 @@ mod tests {
         fn arbitrary(g: &mut Gen) -> Hash {
             Hash::from(u64::arbitrary(g))
         }
+    }
+
+    #[quickcheck]
+    fn hash_may_not_be_invalid(cid: Cid) {
+        assert_ne!(Hash::from(cid), Hash::INVALID);
     }
 
     #[quickcheck]
@@ -162,5 +169,47 @@ mod tests {
     fn hash_distance_2() {
         // If Hash(0) is at position 4 then it is 4 places away from where it wants to be.
         assert_eq!(Hash(0).distance(4, 10), 4);
+    }
+
+    // The hashes must be static. If any of these tests fail, the index version
+    // number must be bumped.
+    #[test]
+    fn known_hashes() {
+        assert_eq!(Hash::from(Cid::default()), Hash(0));
+        assert_eq!(
+            Hash::from(Cid::from_cbor_blake2b256(&"forest").unwrap()),
+            Hash(7060553106844083342)
+        );
+        assert_eq!(
+            Hash::from(Cid::from_cbor_blake2b256(&"lotus").unwrap()),
+            Hash(10998694778601859716)
+        );
+        assert_eq!(
+            Hash::from(Cid::from_cbor_blake2b256(&"libp2p").unwrap()),
+            Hash(15878333306608412239)
+        );
+        assert_eq!(
+            Hash::from(Cid::from_cbor_blake2b256(&"ChainSafe").unwrap()),
+            Hash(17464860692676963753)
+        );
+        assert_eq!(
+            Hash::from(Cid::from_cbor_blake2b256(&"haskell").unwrap()),
+            Hash(10392497608425502268)
+        );
+        assert_eq!(
+            Hash::from(Cid::new_v1(0xAB, Code::Identity.digest(&[]))),
+            Hash(170)
+        );
+        assert_eq!(
+            Hash::from(Cid::new_v1(0xAC, Code::Identity.digest(&[1, 2, 3, 4]))),
+            Hash(171)
+        );
+        assert_eq!(
+            Hash::from(Cid::new_v1(
+                0xAD,
+                Code::Identity.digest(&[1, 2, 3, 4, 5, 6, 7, 8])
+            )),
+            Hash(578437695752307371)
+        );
     }
 }

--- a/src/utils/db/car_index/index_header.rs
+++ b/src/utils/db/car_index/index_header.rs
@@ -17,7 +17,8 @@ pub struct IndexHeader {
 
 impl IndexHeader {
     pub const SIZE: usize = 32;
-    pub const MAGIC_NUMBER: u64 = 0xdeadbeef;
+    // 0xdeadbeef + 0 used a different hash algorithm
+    pub const MAGIC_NUMBER: u64 = 0xdeadbeef + 1;
 
     pub fn read(reader: &mut impl Read) -> Result<IndexHeader> {
         let mut buffer = [0; Self::SIZE];


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The default hasher is not stable over time. CIDs are stable so use them in the ForestCAR.zst format.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
