### PR TITLE
feat: generate .forest.car.zst files by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   lookup errors instead of silently ignoring them.
 - [#2999](https://github.com/ChainSafe/forest/issues/2999): Restored `--tipset`
   flag to `forest-cli snapshot export` to allow export at a specific tipset.
+- [#3283](https://github.com/ChainSafe/forest/pull/3283): All generated car
+  files use the new forest.car.zst format.
 
 ### Removed
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -3,58 +3,43 @@
 pub mod store;
 mod weight;
 use crate::blocks::Tipset;
+use crate::db::car::forest;
 use crate::ipld::stream_chain;
 use crate::utils::io::{AsyncWriterWithChecksum, Checksum};
 use anyhow::{Context, Result};
-use async_compression::futures::write::ZstdEncoder;
 use digest::Digest;
-use futures::future::Either;
-use futures::{io::BufWriter, AsyncWrite, AsyncWriteExt};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_car::CarHeader;
-use std::sync::Arc;
+use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 
 pub use self::{store::*, weight::*};
 
-pub async fn export<W, D>(
-    db: impl Blockstore + Send + Sync,
+pub async fn export<D: Digest>(
+    db: impl Blockstore,
     tipset: &Tipset,
     lookup_depth: ChainEpochDelta,
-    writer: W,
-    compressed: bool,
+    writer: impl AsyncWrite + Unpin,
     skip_checksum: bool,
-) -> Result<Option<digest::Output<D>>, Error>
-where
-    D: Digest + Send + 'static,
-    W: AsyncWrite + Send + Unpin + 'static,
-{
-    let store = Arc::new(db);
-    use futures::StreamExt;
-    let writer = AsyncWriterWithChecksum::<D, _>::new(BufWriter::new(writer), !skip_checksum);
-    let mut writer = if compressed {
-        Either::Left(ZstdEncoder::new(writer))
-    } else {
-        Either::Right(writer)
-    };
-
+) -> Result<Option<digest::Output<D>>, Error> {
     let stateroot_lookup_limit = tipset.epoch() - lookup_depth;
+    let roots = tipset.key().cids().to_vec();
 
-    let mut stream = stream_chain(&store, tipset.clone().chain(&store), stateroot_lookup_limit)
-        .map(|result| result.unwrap()); // FIXME: use a sink that supports TryStream.
-    let header = CarHeader::from(tipset.key().cids().to_vec());
-    header
-        .write_stream_async(&mut writer, &mut stream)
-        .await
-        .map_err(|e| Error::Other(format!("Failed to write blocks in export: {e}")))?;
+    // Wrap writer in optional checksum calculator
+    let mut writer = AsyncWriterWithChecksum::<D, _>::new(BufWriter::new(writer), !skip_checksum);
 
+    // Stream stateroots in range stateroot_lookup_limit..=tipset.epoch(). Also
+    // stream all block headers until genesis.
+    let blocks = stream_chain(&db, tipset.clone().chain(&db), stateroot_lookup_limit);
+
+    // Encode Ipld key-value pairs in zstd frames
+    let frames = forest::Encoder::compress_stream(8000usize.next_power_of_two(), 3, blocks);
+
+    // Write zstd frames and include a skippable index
+    forest::Encoder::write(&mut writer, roots, frames).await?;
+
+    // Flush to ensure everything has been successfully written
     writer.flush().await.context("failed to flush")?;
-    writer.close().await.context("failed to close")?;
 
-    let digest = match &mut writer {
-        Either::Left(left) => left.get_mut().finalize().await,
-        Either::Right(right) => right.finalize().await,
-    }
-    .map_err(|e| Error::Other(e.to_string()))?;
+    let digest = writer.finalize().map_err(|e| Error::Other(e.to_string()))?;
 
     Ok(digest)
 }

--- a/src/chain/store/errors.rs
+++ b/src/chain/store/errors.rs
@@ -59,6 +59,12 @@ impl From<anyhow::Error> for Error {
     }
 }
 
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Other(e.to_string())
+    }
+}
+
 impl<T> From<flume::SendError<T>> for Error {
     fn from(e: flume::SendError<T>) -> Self {
         Error::Other(e.to_string())

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -32,9 +32,10 @@ use crate::chain::ChainEpochDelta;
 use crate::cli_shared::{snapshot, snapshot::TrustedVendor};
 use crate::db::car::AnyCar;
 use crate::networks::{calibnet, mainnet, ChainConfig, NetworkChain};
+use crate::shim::clock::EPOCH_DURATION_SECONDS;
 use crate::shim::clock::{ChainEpoch, EPOCHS_IN_DAY};
 use anyhow::{bail, Context as _};
-use chrono::Utc;
+use chrono::NaiveDateTime;
 use clap::Subcommand;
 use fvm_ipld_blockstore::Blockstore;
 use indicatif::ProgressIterator;
@@ -43,7 +44,6 @@ use sha2::Sha256;
 use std::io::{self, Read, Seek};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::info;
 
 #[derive(Debug, Subcommand)]
@@ -106,13 +106,24 @@ impl ArchiveCommands {
 
 // This does nothing if the output path is a file. If it is a directory - it produces the following:
 // `./forest_snapshot_{chain}_{year}-{month}-{day}_height_{epoch}.car.zst`.
-fn build_output_path(chain: String, epoch: ChainEpoch, output_path: PathBuf) -> PathBuf {
+fn build_output_path(
+    chain: String,
+    genesis_timestamp: u64,
+    epoch: ChainEpoch,
+    output_path: PathBuf,
+) -> PathBuf {
     match output_path.is_dir() {
         true => output_path.join(snapshot::filename(
             TrustedVendor::Forest,
             chain,
-            Utc::now().date_naive(),
+            NaiveDateTime::from_timestamp_opt(
+                genesis_timestamp as i64 + epoch * EPOCH_DURATION_SECONDS,
+                0,
+            )
+            .unwrap_or_default()
+            .into(),
             epoch,
+            true,
         )),
         false => output_path.clone(),
     }
@@ -154,7 +165,8 @@ async fn do_export<ReaderT: Read + Seek + Send + Sync>(
         .tipset_by_height(epoch, ts, ResolveNullTipset::TakeOlder)
         .context("unable to get a tipset at given height")?;
 
-    let output_path = build_output_path(network.to_string(), epoch, output_path);
+    let output_path =
+        build_output_path(network.to_string(), genesis.timestamp(), epoch, output_path);
 
     let writer = tokio::fs::File::create(&output_path)
         .await
@@ -168,7 +180,7 @@ async fn do_export<ReaderT: Read + Seek + Send + Sync>(
         output_path.to_str().unwrap_or_default()
     );
 
-    crate::chain::export::<_, Sha256>(store, &ts, depth, writer.compat(), true, true).await?;
+    crate::chain::export::<Sha256>(store, &ts, depth, writer, true).await?;
 
     Ok(())
 }
@@ -341,6 +353,7 @@ mod tests {
     use fvm_ipld_car::CarReader;
     use tempfile::TempDir;
     use tokio::io::BufReader;
+    use tokio_util::compat::TokioAsyncReadCompatExt;
 
     #[test]
     fn archive_info_calibnet() {
@@ -377,6 +390,7 @@ mod tests {
         .unwrap();
         let file = tokio::fs::File::open(build_output_path(
             NetworkChain::Calibnet.to_string(),
+            0,
             0,
             output_path.path().into(),
         ))

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -377,6 +377,12 @@ mod tests {
         assert_eq!(info.epoch, 0);
     }
 
+    fn genesis_timestamp(reader: impl Read + Seek) -> u64 {
+        let db = crate::db::car::PlainCar::new(reader).unwrap();
+        let ts = Tipset::load_required(&db, &TipsetKeys::new(db.roots())).unwrap();
+        ts.genesis(&db).unwrap().timestamp()
+    }
+
     #[tokio::test]
     async fn export() {
         let output_path = TempDir::new().unwrap();
@@ -390,7 +396,7 @@ mod tests {
         .unwrap();
         let file = tokio::fs::File::open(build_output_path(
             NetworkChain::Calibnet.to_string(),
-            0,
+            genesis_timestamp(std::io::Cursor::new(calibnet::DEFAULT_GENESIS)),
             0,
             output_path.path().into(),
         ))

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -19,6 +19,7 @@ use crate::utils::proofs_api::paramfetch::ensure_params_downloaded;
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use clap::Subcommand;
+use futures::TryStreamExt;
 use fvm_ipld_blockstore::Blockstore;
 use human_repr::HumanCount;
 use std::path::{Path, PathBuf};
@@ -108,6 +109,7 @@ impl SnapshotCommands {
                         chain_name,
                         Utc::now().date_naive(),
                         epoch,
+                        true,
                     )),
                     false => output_path.clone(),
                 };
@@ -207,7 +209,7 @@ impl SnapshotCommands {
                 let frames = crate::db::car::forest::Encoder::compress_stream(
                     frame_size,
                     compression_level,
-                    block_stream,
+                    block_stream.map_err(anyhow::Error::from),
                 );
                 crate::db::car::forest::Encoder::write(&mut dest, roots, frames).await?;
                 dest.flush().await?;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `forest-cli snapshot export` generates `.forest.car.zst` output,
- `forest-cli archive export` generates `.forest.car.zst` output.
- bug fix: use tipset timestamp (rather than `now()`) when exporting.

It's more work to generate `.forest.car.zst` files but the new encoder is much faster than the old one. All in all, exporting is now a lot faster and the generated compressed files can be loaded directly into Forest.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
