### PR TITLE
fix: simplify blockstore type constraint in RPC APIs

### DIFF
--- a/src/message_pool/msgpool/provider.rs
+++ b/src/message_pool/msgpool/provider.rs
@@ -60,12 +60,9 @@ pub struct MpoolRpcProvider<DB> {
 
 impl<DB> MpoolRpcProvider<DB>
 where
-    DB: Blockstore + Clone + Sync + Send,
+    DB: Blockstore,
 {
-    pub fn new(subscriber: Publisher<HeadChange>, sm: Arc<StateManager<DB>>) -> Self
-    where
-        DB: Blockstore + Clone,
-    {
+    pub fn new(subscriber: Publisher<HeadChange>, sm: Arc<StateManager<DB>>) -> Self {
         MpoolRpcProvider { subscriber, sm }
     }
 }
@@ -73,7 +70,7 @@ where
 #[async_trait]
 impl<DB> Provider for MpoolRpcProvider<DB>
 where
-    DB: Blockstore + Clone + Sync + Send + 'static,
+    DB: Blockstore + Sync + Send + 'static,
 {
     fn subscribe_head_changes(&self) -> Subscriber<HeadChange> {
         self.subscriber.subscribe()

--- a/src/rpc/beacon_api.rs
+++ b/src/rpc/beacon_api.rs
@@ -14,7 +14,7 @@ pub(in crate::rpc) async fn beacon_get_entry<DB>(
     Params(params): Params<BeaconGetEntryParams>,
 ) -> Result<BeaconGetEntryResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (first,) = params;
     let (_, beacon) = data.beacon.beacon_for_epoch(first)?;

--- a/src/rpc/chain_api.rs
+++ b/src/rpc/chain_api.rs
@@ -30,7 +30,7 @@ pub(in crate::rpc) async fn chain_get_message<DB>(
     Params(params): Params<ChainGetMessageParams>,
 ) -> Result<ChainGetMessageResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (CidJson(msg_cid),) = params;
     let ret: Message = data
@@ -53,7 +53,7 @@ pub(in crate::rpc) async fn chain_export<DB>(
     }): Params<ChainExportParams>,
 ) -> Result<ChainExportResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     lazy_static::lazy_static! {
         static ref LOCK: Mutex<()> = Mutex::new(());
@@ -112,7 +112,7 @@ pub(in crate::rpc) async fn chain_read_obj<DB>(
     Params(params): Params<ChainReadObjParams>,
 ) -> Result<ChainReadObjResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (CidJson(obj_cid),) = params;
     let ret = data
@@ -128,7 +128,7 @@ pub(in crate::rpc) async fn chain_has_obj<DB>(
     Params(params): Params<ChainHasObjParams>,
 ) -> Result<ChainHasObjResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (CidJson(obj_cid),) = params;
     Ok(data.state_manager.blockstore().get(&obj_cid)?.is_some())
@@ -139,7 +139,7 @@ pub(in crate::rpc) async fn chain_get_block_messages<DB>(
     Params(params): Params<ChainGetBlockMessagesParams>,
 ) -> Result<ChainGetBlockMessagesResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (CidJson(blk_cid),) = params;
     let blk: BlockHeader = data
@@ -173,7 +173,7 @@ pub(in crate::rpc) async fn chain_get_tipset_by_height<DB>(
     Params(params): Params<ChainGetTipsetByHeightParams>,
 ) -> Result<ChainGetTipsetByHeightResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (height, tsk) = params;
     let ts = data.state_manager.chain_store().tipset_from_keys(&tsk)?;
@@ -189,7 +189,7 @@ pub(in crate::rpc) async fn chain_get_genesis<DB>(
     data: Data<RPCState<DB>>,
 ) -> Result<ChainGetGenesisResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let genesis = data.state_manager.chain_store().genesis();
     let gen_ts = Arc::new(Tipset::from(genesis));
@@ -200,7 +200,7 @@ pub(in crate::rpc) async fn chain_head<DB>(
     data: Data<RPCState<DB>>,
 ) -> Result<ChainHeadResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let heaviest = data.state_manager.chain_store().heaviest_tipset();
     Ok(TipsetJson(heaviest))
@@ -211,7 +211,7 @@ pub(in crate::rpc) async fn chain_get_block<DB>(
     Params(params): Params<ChainGetBlockParams>,
 ) -> Result<ChainGetBlockResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (CidJson(blk_cid),) = params;
     let blk: BlockHeader = data
@@ -227,7 +227,7 @@ pub(in crate::rpc) async fn chain_get_tipset<DB>(
     Params(params): Params<ChainGetTipSetParams>,
 ) -> Result<ChainGetTipSetResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (TipsetKeysJson(tsk),) = params;
     let ts = data.state_manager.chain_store().tipset_from_keys(&tsk)?;
@@ -238,7 +238,7 @@ pub(in crate::rpc) async fn chain_get_name<DB>(
     data: Data<RPCState<DB>>,
 ) -> Result<ChainGetNameResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     Ok(data.state_manager.chain_config().network.to_string())
 }
@@ -250,7 +250,7 @@ pub(in crate::rpc) async fn chain_set_head<DB>(
     Params(params): Params<ChainSetHeadParams>,
 ) -> Result<ChainSetHeadResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (params,) = params;
     let new_head = data.state_manager.chain_store().tipset_from_keys(&params)?;

--- a/src/rpc/common_api.rs
+++ b/src/rpc/common_api.rs
@@ -34,7 +34,7 @@ pub(in crate::rpc) async fn shutdown(
 }
 
 /// gets start time from network
-pub(in crate::rpc) async fn start_time<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn start_time<DB: Blockstore>(
     data: Data<RPCState<DB>>,
 ) -> Result<StartTimeResult, JsonRpcError> {
     Ok(data.start_time)

--- a/src/rpc/db_api.rs
+++ b/src/rpc/db_api.rs
@@ -5,7 +5,7 @@ use crate::rpc_api::{data_types::RPCState, db_api::*};
 use fvm_ipld_blockstore::Blockstore;
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
 
-pub(in crate::rpc) async fn db_gc<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn db_gc<DB: Blockstore>(
     data: Data<RPCState<DB>>,
     Params(_): Params<DBGCParams>,
 ) -> Result<DBGCResult, JsonRpcError> {

--- a/src/rpc/gas_api.rs
+++ b/src/rpc/gas_api.rs
@@ -26,7 +26,7 @@ pub(in crate::rpc) async fn gas_estimate_fee_cap<DB>(
     Params(params): Params<GasEstimateFeeCapParams>,
 ) -> Result<GasEstimateFeeCapResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (MessageJson(msg), max_queue_blks, TipsetKeysJson(tsk)) = params;
 
@@ -40,7 +40,7 @@ fn estimate_fee_cap<DB>(
     _tsk: TipsetKeys,
 ) -> Result<TokenAmount, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let ts = data.state_manager.chain_store().heaviest_tipset();
 
@@ -62,7 +62,7 @@ pub(in crate::rpc) async fn gas_estimate_gas_premium<DB>(
     Params(params): Params<GasEstimateGasPremiumParams>,
 ) -> Result<GasEstimateGasPremiumResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (nblocksincl, AddressJson(_sender), _gas_limit, TipsetKeysJson(_tsk)) = params;
     estimate_gas_premium::<DB>(&data, nblocksincl)
@@ -75,7 +75,7 @@ async fn estimate_gas_premium<DB>(
     mut nblocksincl: u64,
 ) -> Result<TokenAmount, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     if nblocksincl == 0 {
         nblocksincl = 1;
@@ -161,7 +161,7 @@ pub(in crate::rpc) async fn gas_estimate_gas_limit<DB>(
     Params(params): Params<GasEstimateGasLimitParams>,
 ) -> Result<GasEstimateGasLimitResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore + Send + Sync + 'static,
 {
     let (MessageJson(msg), TipsetKeysJson(tsk)) = params;
     estimate_gas_limit::<DB>(&data, msg, tsk).await
@@ -173,7 +173,7 @@ async fn estimate_gas_limit<DB>(
     _: TipsetKeys,
 ) -> Result<i64, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore + Send + Sync + 'static,
 {
     let mut msg = msg;
     msg.set_gas_limit(BLOCK_GAS_LIMIT);
@@ -215,7 +215,7 @@ pub(in crate::rpc) async fn gas_estimate_message_gas<DB>(
     Params(params): Params<GasEstimateMessageGasParams>,
 ) -> Result<GasEstimateMessageGasResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore + Send + Sync + 'static,
 {
     let (MessageJson(msg), spec, TipsetKeysJson(tsk)) = params;
     estimate_message_gas::<DB>(&data, msg, spec, tsk)
@@ -230,7 +230,7 @@ pub(in crate::rpc) async fn estimate_message_gas<DB>(
     tsk: TipsetKeys,
 ) -> Result<Message, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore + Send + Sync + 'static,
 {
     let mut msg = msg;
     if msg.gas_limit == 0 {

--- a/src/rpc/net_api.rs
+++ b/src/rpc/net_api.rs
@@ -14,7 +14,7 @@ use fvm_ipld_blockstore::Blockstore;
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
 use tracing::error;
 
-pub(in crate::rpc) async fn net_addrs_listen<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn net_addrs_listen<DB: Blockstore>(
     data: Data<RPCState<DB>>,
 ) -> Result<NetAddrsListenResult, JsonRpcError> {
     let (tx, rx) = oneshot::channel();
@@ -31,7 +31,7 @@ pub(in crate::rpc) async fn net_addrs_listen<DB: Blockstore + Clone + Send + Syn
     })
 }
 
-pub(in crate::rpc) async fn net_peers<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn net_peers<DB: Blockstore>(
     data: Data<RPCState<DB>>,
 ) -> Result<NetPeersResult, JsonRpcError> {
     let (tx, rx) = oneshot::channel();
@@ -53,7 +53,7 @@ pub(in crate::rpc) async fn net_peers<DB: Blockstore + Clone + Send + Sync + 'st
     Ok(connections)
 }
 
-pub(in crate::rpc) async fn net_connect<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn net_connect<DB: Blockstore>(
     data: Data<RPCState<DB>>,
     Params(params): Params<NetConnectParams>,
 ) -> Result<NetConnectResult, JsonRpcError> {
@@ -77,7 +77,7 @@ pub(in crate::rpc) async fn net_connect<DB: Blockstore + Clone + Send + Sync + '
     }
 }
 
-pub(in crate::rpc) async fn net_disconnect<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn net_disconnect<DB: Blockstore>(
     data: Data<RPCState<DB>>,
     Params(params): Params<NetDisconnectParams>,
 ) -> Result<NetDisconnectResult, JsonRpcError> {

--- a/src/rpc/node_api.rs
+++ b/src/rpc/node_api.rs
@@ -8,7 +8,7 @@ use crate::rpc_api::{data_types::RPCState, node_api::NodeStatusResult};
 use fvm_ipld_blockstore::Blockstore;
 use jsonrpc_v2::{Data, Error as JsonRpcError};
 
-pub(in crate::rpc) async fn node_status<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn node_status<DB: Blockstore>(
     data: Data<RPCState<DB>>,
 ) -> Result<NodeStatusResult, JsonRpcError> {
     let mut node_status = NodeStatusResult::default();

--- a/src/rpc/state_api.rs
+++ b/src/rpc/state_api.rs
@@ -31,7 +31,7 @@ use tokio_util::compat::TokioAsyncReadCompatExt;
 // defaulting to Full).
 
 /// runs the given message and returns its result without any persisted changes.
-pub(in crate::rpc) async fn state_call<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn state_call<DB: Blockstore + Send + Sync + 'static>(
     data: Data<RPCState<DB>>,
     Params(params): Params<StateCallParams>,
 ) -> Result<StateCallResult, JsonRpcError> {
@@ -47,7 +47,7 @@ pub(in crate::rpc) async fn state_call<DB: Blockstore + Clone + Send + Sync + 's
 
 /// returns the result of executing the indicated message, assuming it was
 /// executed in the indicated tipset.
-pub(in crate::rpc) async fn state_replay<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn state_replay<DB: Blockstore + Send + Sync + 'static>(
     data: Data<RPCState<DB>>,
     Params(params): Params<StateReplayParams>,
 ) -> Result<StateReplayResult, JsonRpcError> {
@@ -68,7 +68,7 @@ pub(in crate::rpc) async fn state_replay<DB: Blockstore + Clone + Send + Sync + 
 }
 
 /// gets network name from state manager
-pub(in crate::rpc) async fn state_network_name<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn state_network_name<DB: Blockstore>(
     data: Data<RPCState<DB>>,
 ) -> Result<StateNetworkNameResult, JsonRpcError> {
     let state_manager = &data.state_manager;
@@ -79,9 +79,7 @@ pub(in crate::rpc) async fn state_network_name<DB: Blockstore + Clone + Send + S
         .map_err(|e| e.into())
 }
 
-pub(in crate::rpc) async fn state_get_network_version<
-    DB: Blockstore + Clone + Send + Sync + 'static,
->(
+pub(in crate::rpc) async fn state_get_network_version<DB: Blockstore>(
     data: Data<RPCState<DB>>,
     Params(params): Params<StateNetworkVersionParams>,
 ) -> Result<StateNetworkVersionResult, JsonRpcError> {
@@ -92,7 +90,7 @@ pub(in crate::rpc) async fn state_get_network_version<
 
 /// looks up the Escrow and Locked balances of the given address in the Storage
 /// Market
-pub(in crate::rpc) async fn state_market_balance<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn state_market_balance<DB: Blockstore + Send + Sync + 'static>(
     data: Data<RPCState<DB>>,
     Params(params): Params<StateMarketBalanceParams>,
 ) -> Result<StateMarketBalanceResult, JsonRpcError> {
@@ -107,7 +105,7 @@ pub(in crate::rpc) async fn state_market_balance<DB: Blockstore + Clone + Send +
         .map_err(|e| e.into())
 }
 
-pub(in crate::rpc) async fn state_market_deals<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn state_market_deals<DB: Blockstore>(
     data: Data<RPCState<DB>>,
     Params(params): Params<StateMarketDealsParams>,
 ) -> Result<StateMarketDealsResult, JsonRpcError> {
@@ -143,7 +141,7 @@ pub(in crate::rpc) async fn state_market_deals<DB: Blockstore + Clone + Send + S
 }
 
 /// returns the message receipt for the given message
-pub(in crate::rpc) async fn state_get_receipt<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn state_get_receipt<DB: Blockstore + Send + Sync + 'static>(
     data: Data<RPCState<DB>>,
     Params(params): Params<StateGetReceiptParams>,
 ) -> Result<StateGetReceiptResult, JsonRpcError> {
@@ -161,7 +159,7 @@ pub(in crate::rpc) async fn state_get_receipt<DB: Blockstore + Clone + Send + Sy
 }
 /// looks back in the chain for a message. If not found, it blocks until the
 /// message arrives on chain, and gets to the indicated confidence depth.
-pub(in crate::rpc) async fn state_wait_msg<DB: Blockstore + Clone + Send + Sync + 'static>(
+pub(in crate::rpc) async fn state_wait_msg<DB: Blockstore + Send + Sync + 'static>(
     data: Data<RPCState<DB>>,
     Params(params): Params<StateWaitMsgParams>,
 ) -> Result<StateWaitMsgResult, JsonRpcError> {
@@ -199,7 +197,7 @@ pub(in crate::rpc) async fn state_wait_msg<DB: Blockstore + Clone + Send + Sync 
 /// This function has two primary uses: (1) Downloading specific state-roots when Forest deviates
 /// from the mainline blockchain, (2) fetching historical state-trees to verify past versions of the
 /// consensus rules.
-pub(in crate::rpc) async fn state_fetch_root<DB: Blockstore + Clone + Sync + Send + 'static>(
+pub(in crate::rpc) async fn state_fetch_root<DB: Blockstore + Sync + Send + 'static>(
     data: Data<RPCState<DB>>,
     Params((CidJson(root_cid), save_to_file)): Params<StateFetchRootParams>,
 ) -> Result<StateFetchRootResult, JsonRpcError> {

--- a/src/rpc/wallet_api.rs
+++ b/src/rpc/wallet_api.rs
@@ -18,7 +18,7 @@ pub(in crate::rpc) async fn wallet_balance<DB>(
     Params(params): Params<WalletBalanceParams>,
 ) -> Result<WalletBalanceResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore,
 {
     let (addr_str,) = params;
     let address = Address::from_str(&addr_str)?;
@@ -179,7 +179,7 @@ pub(in crate::rpc) async fn wallet_sign<DB>(
     Params(params): Params<WalletSignParams>,
 ) -> Result<WalletSignResult, JsonRpcError>
 where
-    DB: Blockstore + Clone + Send + Sync + 'static,
+    DB: Blockstore + Send + Sync + 'static,
 {
     let state_manager = &data.state_manager;
     let (addr, msg_string) = params;

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -210,7 +210,7 @@ pub const NO_CALLBACK: Option<fn(&Cid, &ChainMessage, &ApplyRet) -> anyhow::Resu
 
 impl<DB> StateManager<DB>
 where
-    DB: Blockstore + Send + Sync + 'static,
+    DB: Blockstore,
 {
     pub fn new(
         cs: Arc<ChainStore<DB>>,
@@ -342,7 +342,12 @@ where
 
         Ok(None)
     }
+}
 
+impl<DB> StateManager<DB>
+where
+    DB: Blockstore + Send + Sync + 'static,
+{
     /// Returns the pair of (parent state root, message receipt root). This will
     /// either be cached or will be calculated and fill the cache. Tipset
     /// state for a given tipset is guaranteed not to be computed twice.
@@ -774,7 +779,7 @@ where
         confidence: i64,
     ) -> Result<(Option<Arc<Tipset>>, Option<Receipt>), Error>
     where
-        DB: Blockstore + Clone + Send + Sync + 'static,
+        DB: Blockstore + Send + Sync + 'static,
     {
         let mut subscriber = self.cs.publisher().subscribe();
         let (sender, mut receiver) = oneshot::channel::<()>();

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -777,10 +777,7 @@ where
         self: &Arc<Self>,
         msg_cid: Cid,
         confidence: i64,
-    ) -> Result<(Option<Arc<Tipset>>, Option<Receipt>), Error>
-    where
-        DB: Blockstore + Send + Sync + 'static,
-    {
+    ) -> Result<(Option<Arc<Tipset>>, Option<Receipt>), Error> {
         let mut subscriber = self.cs.publisher().subscribe();
         let (sender, mut receiver) = oneshot::channel::<()>();
         let message = crate::chain::get_chain_message(self.blockstore(), &msg_cid)


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Came across the issue when implementing https://github.com/ChainSafe/forest/pull/3292

Changes introduced in this pull request:

- Simplify `Blockstore` type constraint in RPC APIs

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
