### PR TITLE
[WIP] Use `CidHashMap` in the ForestCAR.zst encoder

### DIFF
--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -49,6 +49,7 @@
 use super::{CacheKey, ZstdFrameCache};
 use crate::blocks::{Tipset, TipsetKeys};
 use crate::db::car::plain::write_skip_frame_header_async;
+use crate::ipld::CidHashMap;
 use crate::utils::db::car_index::{CarIndex, CarIndexBuilder, FrameOffset};
 use crate::utils::db::car_stream::{Block, CarHeader};
 use crate::utils::encoding::uvibytes::UviBytes;
@@ -280,7 +281,7 @@ impl Encoder {
         offset += header_len;
 
         // Write seekable zstd and collect a mapping of CIDs to frame_offset+data_offset.
-        let mut cid_map = ahash::HashMap::new();
+        let mut cid_map = CidHashMap::new();
         while let Some((cids, zstd_frame)) = stream.try_next().await? {
             for cid in cids {
                 cid_map.insert(cid, offset as FrameOffset);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

Modify the `cid_map` in the `.forest.car.zst` encoder to use `CidHashMap` instead of `HashMap<Cid, u64>`.

Acceptance criteria:
- [ ] Add missing methods (if any) to `CidHashMap`
- [ ] Replace `HashMap<Cid, u64>` with `CidHashMap<u64>` in `src/db/car/forest.rs`
- [ ] Measure change in peak memory use when encoding calibnet and mainnet snapshots. See `/usr/bin/time -v forest-cli snapshot compress {snapshot}.car`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3287 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
