### PR TITLE
chore: use less memory when export

### DIFF
--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -205,11 +205,12 @@ async fn do_export(
         output_path.to_str().unwrap_or_default()
     );
 
-    let pb = indicatif::ProgressBar::new_spinner()
-        .with_style(
-            indicatif::ProgressStyle::with_template("{spinner} exported {total_bytes} with {binary_bytes_per_sec} in {elapsed}")
-                .expect("indicatif template must be valid"),
-        );
+    let pb = indicatif::ProgressBar::new_spinner().with_style(
+        indicatif::ProgressStyle::with_template(
+            "{spinner} exported {total_bytes} with {binary_bytes_per_sec} in {elapsed}",
+        )
+        .expect("indicatif template must be valid"),
+    );
     pb.enable_steady_tick(std::time::Duration::from_secs_f32(0.1));
     let writer = pb.wrap_async_write(writer);
 

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -205,6 +205,14 @@ async fn do_export(
         output_path.to_str().unwrap_or_default()
     );
 
+    let pb = indicatif::ProgressBar::new_spinner()
+        .with_style(
+            indicatif::ProgressStyle::with_template("{spinner} exported {total_bytes} with {binary_bytes_per_sec} in {elapsed}")
+                .expect("indicatif template must be valid"),
+        );
+    pb.enable_steady_tick(std::time::Duration::from_secs_f32(0.1));
+    let writer = pb.wrap_async_write(writer);
+
     crate::chain::export::<Sha256>(store, &ts, depth, writer, seen, true).await?;
 
     Ok(())

--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -49,6 +49,7 @@
 use super::{CacheKey, ZstdFrameCache};
 use crate::blocks::{Tipset, TipsetKeys};
 use crate::db::car::plain::write_skip_frame_header_async;
+use crate::ipld::CidHashMap;
 use crate::utils::db::car_index::{CarIndex, CarIndexBuilder, FrameOffset};
 use crate::utils::db::car_stream::{Block, CarHeader};
 use crate::utils::encoding::uvibytes::UviBytes;
@@ -280,7 +281,7 @@ impl Encoder {
         offset += header_len;
 
         // Write seekable zstd and collect a mapping of CIDs to frame_offset+data_offset.
-        let mut cid_map = ahash::HashMap::new();
+        let mut cid_map = CidHashMap::new();
         while let Some((cids, zstd_frame)) = stream.try_next().await? {
             for cid in cids {
                 cid_map.insert(cid, offset as FrameOffset);

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -3,7 +3,11 @@
 
 use crate::utils::cid::{CidVariant, BLAKE2B256_SIZE};
 use ahash::{HashMap, HashMapExt};
-use cid::Cid;
+use cid::{
+    multihash::{Code, MultihashDigest},
+    Cid,
+};
+use fvm_ipld_encoding::DAG_CBOR;
 
 // The size of a CID is 96 bytes. A CID contains:
 //   - a version
@@ -78,6 +82,43 @@ impl<V> CidHashMap<V> {
     /// Returns the number of elements in the map.
     pub fn len(&self) -> usize {
         self.v1_dagcbor_blake2b_hash_map.len() + self.fallback_hash_map.len()
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = (Cid, V)> + ExactSizeIterator {
+        let blakes = self
+            .v1_dagcbor_blake2b_hash_map
+            .into_iter()
+            .map(|(hash, v)| {
+                let cid = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&hash));
+                (cid, v)
+            });
+        let other = self.fallback_hash_map.into_iter();
+        ExactChain(blakes.chain(other))
+    }
+}
+
+// `Chain` does not implement ExactSizeIterator because the combined size may
+// exceed usize. We don't have to worry about that.
+struct ExactChain<A, B>(std::iter::Chain<A, B>);
+
+impl<A, B> std::iter::Iterator for ExactChain<A, B>
+where
+    A: Iterator,
+    B: Iterator<Item = A::Item>,
+{
+    type Item = A::Item;
+    fn next(&mut self) -> Option<A::Item> {
+        self.0.next()
+    }
+}
+
+impl<A, B> std::iter::ExactSizeIterator for ExactChain<A, B>
+where
+    A: ExactSizeIterator,
+    B: Iterator<Item = A::Item> + ExactSizeIterator,
+{
+    fn len(&self) -> usize {
+        self.0.size_hint().0
     }
 }
 

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -89,7 +89,12 @@ impl<V> CidHashMap<V> {
             .v1_dagcbor_blake2b_hash_map
             .into_iter()
             .map(|(hash, v)| {
-                let cid = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&hash));
+                let cid = Cid::new_v1(
+                    DAG_CBOR,
+                    Code::Blake2b256
+                        .wrap(&hash)
+                        .expect("wrapping [u8; 32] is infallible"),
+                );
                 (cid, v)
             });
         let other = self.fallback_hash_map.into_iter();


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Use a `CidHashMap` when compressing `.forest.car.zst` files.
- Show a progress indicator when exporting snapshots without a forest-node.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
