### PR TITLE
chore: reduce car cache from 2GiB to 1GiB

### DIFF
--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -38,8 +38,8 @@ impl Default for ZstdFrameCache {
 }
 
 impl ZstdFrameCache {
-    // 2 GiB
-    pub const DEFAULT_SIZE: usize = 2 * 1024 * 1024 * 1024;
+    // 1 GiB
+    pub const DEFAULT_SIZE: usize = 1 * 1024 * 1024 * 1024;
 
     pub fn new(max_size: usize) -> Self {
         ZstdFrameCache {

--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -39,7 +39,7 @@ impl Default for ZstdFrameCache {
 
 impl ZstdFrameCache {
     // 1 GiB
-    pub const DEFAULT_SIZE: usize = 1 * 1024 * 1024 * 1024;
+    pub const DEFAULT_SIZE: usize = 1024 * 1024 * 1024;
 
     pub fn new(max_size: usize) -> Self {
         ZstdFrameCache {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Reduce cache of z-frames from 2GiB to 1GiB.

Benchmarks in #3288 showed that there's little benefit to using a large cache. Going from 2GiB to 1GiB should have no impact on performance but will lessen the memory strain.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
