### PR TITLE
Revert paralell manycar get

### DIFF
--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -83,8 +83,9 @@ impl TryFrom<Vec<PathBuf>> for ManyCar<MemoryDB> {
 
 impl<WriterT: Blockstore> Blockstore for ManyCar<WriterT> {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
-        // FIXME: Query each file in parallel. Tracking issue:
-        //        https://github.com/ChainSafe/forest/issues/3222
+        // Theoretically it should be easily parallelizable with `rayon`.
+        // In practice, there is a massive performance loss when providing
+        // more than a single reader.
         for reader in self.read_only.iter() {
             if let Some(val) = reader.get(k)? {
                 return Ok(Some(val));


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- revert parallelization of get introduced in https://github.com/ChainSafe/forest/pull/3293. It turns out, it ends up being significantly less performant than a single-threaded version (at least when using two, three snapshots that have similar entries). We may look into it more in the future, for now let's remove the performance degradation.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
