### PR TITLE
fix: allow streaming of CAR.zst files with multiple frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
 ### Fixed
 
+- [#3319](https://github.com/ChainSafe/forest/pull/3319): Fix bug triggered by
+  re-encoding ForestCAR.zst files.
+
 ## Forest v0.12.1 "Carp++"
 
 ### Fixed

--- a/src/utils/db/car_stream.rs
+++ b/src/utils/db/car_stream.rs
@@ -90,13 +90,15 @@ impl<ReaderT: AsyncSeek + AsyncBufRead + Unpin> CarStream<ReaderT> {
         } else {
             reader.seek(SeekFrom::Start(start_position)).await?;
             let mut zstd = ZstdDecoder::new(reader);
+            zstd.multiple_members(true);
             if let Some(header) = read_header(&mut zstd).await {
                 let mut reader = zstd.into_inner();
 
                 reset_bufread(&mut reader).await?;
 
                 reader.seek(SeekFrom::Start(start_position)).await?;
-                let zstd = ZstdDecoder::new(reader);
+                let mut zstd = ZstdDecoder::new(reader);
+                zstd.multiple_members(true);
                 let mut framed_reader = FramedRead::new(Either::Right(zstd), UviBytes::default());
                 let _ = framed_reader.next().await;
                 Ok(CarStream {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- multiple frames are disallowed by default but we need them for the ForestCAR.zst format.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
