### PR TITLE
Migrate settings to db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 
 ### Breaking
 
+- [#3231](https://github.com/ChainSafe/forest/issues/3231) Moved some Forest
+  internal settings from files to the database.
+
 ### Added
 
 ### Changed

--- a/src/blocks/persistence.rs
+++ b/src/blocks/persistence.rs
@@ -29,7 +29,7 @@ mod tests {
     fn tipset_keys_round_trip() -> Result<()> {
         let path = Path::new("src/blocks/tests/calibnet/HEAD");
         let obj1: FileBacked<TipsetKeys> =
-            FileBacked::load_from_file_or_create(path.into(), Default::default, None)?;
+            FileBacked::load_from_file_or_create(path.into(), Default::default)?;
         let serialized = obj1.inner().serialize()?;
         let deserialized = TipsetKeys::deserialize(&serialized)?;
 

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 use crate::blocks::{BlockHeader, Tipset, TipsetKeys, TxMeta};
 use crate::interpreter::BlockMessages;
@@ -13,10 +13,7 @@ use crate::shim::{
     address::Address, econ::TokenAmount, executor::Receipt, message::Message,
     state_tree::StateTree, version::NetworkVersion,
 };
-use crate::utils::db::{
-    file_backed_obj::{ChainMeta, FileBacked},
-    BlockstoreExt, CborStoreExt,
-};
+use crate::utils::db::{BlockstoreExt, CborStoreExt};
 use ahash::{HashMap, HashMapExt, HashSet};
 use anyhow::Result;
 use cid::Cid;
@@ -34,6 +31,8 @@ use super::{
     Error,
 };
 use crate::chain::Scale;
+use crate::db::setting_keys::{ESTIMATED_RECORDS_KEY, HEAD_KEY};
+use crate::db::{SettingsStore, SettingsStoreExt};
 
 // A cap on the size of the future_sink
 const SINK_CAP: usize = 200;
@@ -59,6 +58,9 @@ pub struct ChainStore<DB> {
     /// key-value `datastore`.
     pub db: Arc<DB>,
 
+    /// Settings store
+    settings: Arc<dyn SettingsStore + Sync + Send>,
+
     /// Used as a cache for tipset `lookbacks`.
     pub chain_index: Arc<ChainIndex<Arc<DB>>>,
 
@@ -67,14 +69,8 @@ pub struct ChainStore<DB> {
 
     genesis_block_header: BlockHeader,
 
-    /// File backed heaviest tipset keys
-    file_backed_heaviest_tipset_keys: Mutex<FileBacked<TipsetKeys>>,
-
     /// validated blocks
     validated_blocks: Mutex<HashSet<Cid>>,
-
-    /// File backed chain metadata
-    file_backed_chain_meta: Arc<Mutex<FileBacked<ChainMeta>>>,
 }
 
 impl<DB> BitswapStoreRead for ChainStore<DB>
@@ -107,57 +103,49 @@ where
 {
     pub fn new(
         db: Arc<DB>,
+        settings: Arc<dyn SettingsStore + Sync + Send>,
         chain_config: Arc<ChainConfig>,
         genesis_block_header: BlockHeader,
-        chain_data_root: &Path,
     ) -> Result<Self> {
         let (publisher, _) = broadcast::channel(SINK_CAP);
         let chain_index = Arc::new(ChainIndex::new(Arc::clone(&db)));
-        let file_backed_heaviest_tipset_keys = Mutex::new({
-            let mut head_store = FileBacked::load_from_file_or_create(
-                chain_data_root.join("HEAD"),
-                || TipsetKeys::new(vec![*genesis_block_header.cid()]),
-                None,
-            )?;
-            let is_valid = chain_index.load_tipset(head_store.inner()).is_ok();
-            if !is_valid {
-                // If the stored HEAD is invalid, reset it to the genesis tipset.
-                head_store.set_inner(TipsetKeys::new(vec![*genesis_block_header.cid()]))?;
+
+        match settings.read_obj::<TipsetKeys>(HEAD_KEY)? {
+            None => {
+                let tipset_keys = TipsetKeys::new(vec![*genesis_block_header.cid()]);
+                settings.write_obj(HEAD_KEY, &tipset_keys)?;
             }
-            head_store
-        });
+            Some(tipset_keys) => {
+                let is_valid = chain_index.load_tipset(&tipset_keys).is_ok();
+                if !is_valid {
+                    // If the stored HEAD is invalid, reset it to the genesis tipset.
+                    settings.write_obj(
+                        HEAD_KEY,
+                        &TipsetKeys::new(vec![*genesis_block_header.cid()]),
+                    )?;
+                }
+            }
+        }
+
         let validated_blocks = Mutex::new(HashSet::default());
-        let file_backed_chain_meta = Arc::new(Mutex::new(FileBacked::load_from_file_or_create(
-            chain_data_root.join("meta.yaml"),
-            ChainMeta::default,
-            None,
-        )?));
 
         let cs = Self {
             publisher,
             chain_index,
             tipset_tracker: TipsetTracker::new(Arc::clone(&db), chain_config),
             db,
+            settings,
             genesis_block_header,
-            file_backed_heaviest_tipset_keys,
             validated_blocks,
-            file_backed_chain_meta,
         };
 
         Ok(cs)
     }
 
-    /// Gets chain metadata
-    pub fn file_backed_chain_meta(&self) -> &Arc<Mutex<FileBacked<ChainMeta>>> {
-        &self.file_backed_chain_meta
-    }
-
     /// Sets heaviest tipset within `ChainStore` and store its tipset keys in
-    /// `{crate::chain_store}/HEAD`
+    /// the settings store under the [`crate::db::setting_keys::HEAD_KEY`] key.
     pub fn set_heaviest_tipset(&self, ts: Arc<Tipset>) -> Result<(), Error> {
-        self.file_backed_heaviest_tipset_keys
-            .lock()
-            .set_inner(ts.key().clone())?;
+        self.settings.write_obj(HEAD_KEY, ts.key())?;
         if self.publisher.send(HeadChange::Apply(ts)).is_err() {
             debug!("did not publish head change, no active receivers");
         }
@@ -168,6 +156,11 @@ where
     /// headers.
     pub fn add_to_tipset_tracker(&self, header: &BlockHeader) {
         self.tipset_tracker.add(header);
+    }
+
+    pub fn set_estimated_records(&self, records: u64) -> anyhow::Result<()> {
+        self.settings.write_obj(ESTIMATED_RECORDS_KEY, &records)?;
+        Ok(())
     }
 
     /// Writes tipset block headers to data store and updates heaviest tipset
@@ -200,8 +193,14 @@ where
 
     /// Returns the currently tracked heaviest tipset.
     pub fn heaviest_tipset(&self) -> Arc<Tipset> {
-        self.tipset_from_keys(self.file_backed_heaviest_tipset_keys.lock().inner())
-            .expect("Failed to load heaviest tipset")
+        self.tipset_from_keys(
+            &self
+                .settings
+                .read_obj::<TipsetKeys>(HEAD_KEY)
+                .expect("failed to load heaviest tipset")
+                .expect("failed to load heaviest tipset"),
+        )
+        .expect("failed to load heaviest tipset")
     }
 
     /// Returns a reference to the publisher of head changes.
@@ -596,7 +595,6 @@ mod tests {
         Cid,
     };
     use fvm_ipld_encoding::DAG_CBOR;
-    use tempfile::TempDir;
 
     use super::*;
 
@@ -614,9 +612,7 @@ mod tests {
             .miner_address(Address::new_id(0))
             .build()
             .unwrap();
-        let chain_data_root = TempDir::new().unwrap();
-        let cs =
-            ChainStore::new(db, chain_config, gen_block.clone(), chain_data_root.path()).unwrap();
+        let cs = ChainStore::new(db.clone(), db, chain_config, gen_block.clone()).unwrap();
 
         assert_eq!(cs.genesis(), &gen_block);
     }
@@ -630,8 +626,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let chain_data_root = TempDir::new().unwrap();
-        let cs = ChainStore::new(db, chain_config, gen_block, chain_data_root.path()).unwrap();
+        let cs = ChainStore::new(db.clone(), db, chain_config, gen_block).unwrap();
 
         let cid = Cid::new_v1(DAG_CBOR, Blake2b256.digest(&[1, 2, 3]));
         assert!(!cs.is_block_validated(&cid));

--- a/src/db/memory.rs
+++ b/src/db/memory.rs
@@ -19,29 +19,19 @@ pub struct MemoryDB {
 }
 
 impl SettingsStore for MemoryDB {
-    fn read_bin<K>(&self, key: K) -> anyhow::Result<Option<Vec<u8>>>
-    where
-        K: AsRef<str>,
-    {
-        Ok(self.settings_db.read().get(key.as_ref()).cloned())
+    fn read_bin(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self.settings_db.read().get(key).cloned())
     }
 
-    fn write_bin<K, V>(&self, key: K, value: V) -> anyhow::Result<()>
-    where
-        K: AsRef<str>,
-        V: AsRef<[u8]>,
-    {
+    fn write_bin(&self, key: &str, value: &[u8]) -> anyhow::Result<()> {
         self.settings_db
             .write()
-            .insert(key.as_ref().to_owned(), value.as_ref().to_vec());
+            .insert(key.to_owned(), value.to_vec());
         Ok(())
     }
 
-    fn exists<K>(&self, key: K) -> anyhow::Result<bool>
-    where
-        K: AsRef<str>,
-    {
-        Ok(self.settings_db.read().contains_key(key.as_ref()))
+    fn exists(&self, key: &str) -> anyhow::Result<bool> {
+        Ok(self.settings_db.read().contains_key(key))
     }
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -5,50 +5,55 @@ mod memory;
 mod metrics;
 pub mod parity_db;
 pub mod parity_db_config;
+
 pub use memory::MemoryDB;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 pub mod car;
 
 pub mod rolling;
+
+pub mod setting_keys {
+    /// Key used to store the heaviest tipset in the settings store.
+    pub const HEAD_KEY: &str = "head";
+    /// Estimated number of IPLD records in the database.
+    pub const ESTIMATED_RECORDS_KEY: &str = "estimated_reachable_records";
+}
 
 /// Interface used to store and retrieve settings from the database.
 /// To store IPLD blocks, use the `BlockStore` trait.
 pub trait SettingsStore {
     /// Reads binary field from the Settings store. This should be used for
-    /// non-serializable data. For serializable data, use [`SettingsStore::read_obj`].
-    fn read_bin<K>(&self, key: K) -> anyhow::Result<Option<Vec<u8>>>
-    where
-        K: AsRef<str>;
+    /// non-serializable data. For serializable data, use [`SettingsStoreExt::read_obj`].
+    fn read_bin(&self, key: &str) -> anyhow::Result<Option<Vec<u8>>>;
 
     /// Writes binary field to the Settings store. This should be used for
-    /// non-serializable data. For serializable data, use [`SettingsStore::write_obj`].
-    fn write_bin<K, V>(&self, key: K, value: V) -> anyhow::Result<()>
-    where
-        K: AsRef<str>,
-        V: AsRef<[u8]>;
+    /// non-serializable data. For serializable data, use [`SettingsStoreExt::write_obj`].
+    fn write_bin(&self, key: &str, value: &[u8]) -> anyhow::Result<()>;
 
-    fn read_obj<K, T>(&self, key: K) -> anyhow::Result<Option<T>>
-    where
-        K: AsRef<str>,
-        T: serde::de::DeserializeOwned,
-    {
+    /// Returns `Ok(true)` if key exists in store
+    fn exists(&self, key: &str) -> anyhow::Result<bool>;
+}
+
+/// Extension trait for the [`SettingsStore`] trait. It is implemented for all types that implement
+/// [`SettingsStore`].
+/// It provides methods for writing and reading any serializable object from the store.
+pub trait SettingsStoreExt {
+    fn read_obj<V: DeserializeOwned>(&self, key: &str) -> anyhow::Result<Option<V>>;
+    fn write_obj<V: Serialize>(&self, key: &str, value: &V) -> anyhow::Result<()>;
+}
+
+impl<T: ?Sized + SettingsStore> SettingsStoreExt for T {
+    fn read_obj<V: DeserializeOwned>(&self, key: &str) -> anyhow::Result<Option<V>> {
         match self.read_bin(key)? {
             Some(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
             None => Ok(None),
         }
     }
 
-    fn write_obj<K, T>(&self, key: K, value: &T) -> anyhow::Result<()>
-    where
-        K: AsRef<str>,
-        T: serde::Serialize,
-    {
-        self.write_bin(key, serde_json::to_vec(value)?)
+    fn write_obj<V: Serialize>(&self, key: &str, value: &V) -> anyhow::Result<()> {
+        self.write_bin(key, &serde_json::to_vec(value)?)
     }
-
-    /// Returns `Ok(true)` if key exists in store
-    fn exists<K>(&self, key: K) -> anyhow::Result<bool>
-    where
-        K: AsRef<str>;
 }
 
 /// Traits for collecting DB stats

--- a/src/db/tests/subtests/mod.rs
+++ b/src/db/tests/subtests/mod.rs
@@ -58,7 +58,9 @@ pub fn does_not_exist<DB>(db: &DB)
 where
     DB: SettingsStore,
 {
-    let key = "0";
-    let res = db.exists(key).unwrap();
-    assert!(!res);
+    let key = "Azathoth";
+
+    assert!(!db.exists(key).unwrap());
+    assert!(db.read_obj::<i32>(key).unwrap().is_none());
+    assert!(db.require_obj::<i32>(key).is_err());
 }

--- a/src/db/tests/subtests/mod.rs
+++ b/src/db/tests/subtests/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::db::SettingsStore;
+use crate::db::{SettingsStore, SettingsStoreExt};
 
 pub fn write_bin<DB>(db: &DB)
 where
@@ -9,7 +9,7 @@ where
 {
     let key = "1";
     let value = [1];
-    db.write_bin(key, value).unwrap();
+    db.write_bin(key, &value).unwrap();
 }
 
 pub fn read_bin<DB>(db: &DB)
@@ -18,7 +18,7 @@ where
 {
     let key = "0";
     let value = [1];
-    db.write_bin(key, value).unwrap();
+    db.write_bin(key, &value).unwrap();
     let res = db.read_bin(key).unwrap().unwrap();
     assert_eq!(value.as_ref(), res.as_slice());
 }
@@ -31,7 +31,15 @@ where
     let value = 42;
     db.write_obj(key, &value).unwrap();
     let res: i32 = db.read_obj(key).unwrap().unwrap();
+    assert_eq!(value, res);
 
+    // ensure that we are able to overwrite the value.
+    // this is to ensure we don't enable settings such as
+    // `preimage` for the settings column which would
+    // assume that the value is immutable.
+    let value = 1337;
+    db.write_obj(key, &value).unwrap();
+    let res: i32 = db.read_obj(key).unwrap().unwrap();
     assert_eq!(value, res);
 }
 
@@ -41,7 +49,7 @@ where
 {
     let key = "0";
     let value = [1];
-    db.write_bin(key, value).unwrap();
+    db.write_bin(key, &value).unwrap();
     let res = db.exists(key).unwrap();
     assert!(res);
 }

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -114,9 +114,7 @@ where
         stopwatch.elapsed().as_secs()
     );
     if let Some(n_records) = n_records {
-        let mut meta = sm.chain_store().file_backed_chain_meta().lock();
-        meta.inner_mut().estimated_reachable_records = n_records;
-        meta.sync()?;
+        sm.chain_store().set_estimated_records(n_records as u64)?;
     }
 
     let ts = sm.chain_store().tipset_from_keys(&TipsetKeys::new(cids))?;

--- a/src/libp2p/chain_exchange/provider.rs
+++ b/src/libp2p/chain_exchange/provider.rs
@@ -155,7 +155,6 @@ mod tests {
     use crate::networks::ChainConfig;
     use crate::shim::address::Address;
     use fvm_ipld_car::load_car;
-    use tempfile::TempDir;
     use tokio::io::BufReader;
     use tokio_util::compat::TokioAsyncReadCompatExt;
 
@@ -181,15 +180,8 @@ mod tests {
             .build()
             .unwrap();
 
-        let chain_store_root = TempDir::new().unwrap();
         let response = make_chain_exchange_response(
-            &ChainStore::new(
-                db,
-                Arc::new(ChainConfig::default()),
-                gen_block,
-                chain_store_root.path(),
-            )
-            .unwrap(),
+            &ChainStore::new(db.clone(), db, Arc::new(ChainConfig::default()), gen_block).unwrap(),
             &ChainExchangeRequest {
                 start: cids,
                 request_len: 2,

--- a/src/message_pool/config.rs
+++ b/src/message_pool/config.rs
@@ -43,7 +43,7 @@ impl Default for MpoolConfig {
 impl MpoolConfig {
     /// Saves message pool `config` to the database, to easily reload.
     pub fn save_config<DB: SettingsStore>(&self, store: &DB) -> Result<(), anyhow::Error> {
-        store.write_bin(MPOOL_CONFIG_KEY, fvm_ipld_encoding::to_vec(&self)?)
+        store.write_bin(MPOOL_CONFIG_KEY, &fvm_ipld_encoding::to_vec(&self)?)
     }
 
     /// Returns the low limit capacity of messages to allocate.

--- a/src/rpc/sync_api.rs
+++ b/src/rpc/sync_api.rs
@@ -70,7 +70,6 @@ mod tests {
     use crate::state_manager::StateManager;
     use fvm_ipld_encoding::from_slice;
     use serde_json::from_str;
-    use tempfile::TempDir;
     use tokio::{sync::RwLock, task::JoinSet};
 
     use super::*;
@@ -97,15 +96,8 @@ mod tests {
             .build()
             .unwrap();
 
-        let chain_data_root = TempDir::new().unwrap();
         let cs_arc = Arc::new(
-            ChainStore::new(
-                db,
-                chain_config.clone(),
-                genesis_header.clone(),
-                chain_data_root.path(),
-            )
-            .unwrap(),
+            ChainStore::new(db.clone(), db, chain_config.clone(), genesis_header.clone()).unwrap(),
         );
 
         let state_manager = Arc::new(StateManager::new(cs_arc.clone(), chain_config).unwrap());


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- moved most of the file-backed entries to the database. There is one left, `DbIndex`, but having the DB govern itself doesn't seem right.
- This is a breaking change. We could have a 'migration' in theory. Happy to discuss if we want it.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3231

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
