### PR TITLE
ban tempfile default c-tor

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -19,3 +19,7 @@ use parking_lot::RwLock instead to silently ignore panics."""
 path = "std::sync::Mutex"
 reason = """the standard library synchronization primitives are poisoned when aquiring threads panic.
 use parking_lot::Mutex instead to silently ignore panics."""
+
+[[disallowed-methods]]
+path = "tempfile::NamedTempFile::new"
+reason = """ The temporary files created by this method are not persistable if the temporary directory lives on a different filesystem than the target directory. While it is valid in other contexts (if not persisting files), it was misused many times and so we are banning it. Consider using `tempfile::NamedTempFile::new_in` or `tempfile::NamedTempFile::Builder"""

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -22,4 +22,4 @@ use parking_lot::Mutex instead to silently ignore panics."""
 
 [[disallowed-methods]]
 path = "tempfile::NamedTempFile::new"
-reason = """ The temporary files created by this method are not persistable if the temporary directory lives on a different filesystem than the target directory. While it is valid in other contexts (if not persisting files), it was misused many times and so we are banning it. Consider using `tempfile::NamedTempFile::new_in` or `tempfile::NamedTempFile::Builder"""
+reason = """The temporary files created by this method are not persistable if the temporary directory lives on a different filesystem than the target directory. While it is valid in other contexts (if not persisting files), it was misused many times and so we are banning it. Consider using `tempfile::NamedTempFile::new_in` or `tempfile::NamedTempFile::Builder"""

--- a/src/state_migration/tests/mod.rs
+++ b/src/state_migration/tests/mod.rs
@@ -11,7 +11,7 @@ use anyhow::*;
 use cid::Cid;
 use fvm_ipld_encoding::CborStore;
 use pretty_assertions::assert_eq;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{str::FromStr, sync::Arc};
 use tokio::io::AsyncWriteExt;
 
@@ -72,9 +72,10 @@ async fn test_state_migration(
     expected_new_state: Cid,
 ) -> Result<()> {
     // Car files are cached under data folder for Go test to pick up without network access
-    let car_path = format!("./src/state_migration/tests/data/{old_state}.car");
+    let car_path = PathBuf::from(format!("./src/state_migration/tests/data/{old_state}.car"));
     if !Path::new(&car_path).is_file() {
-        let tmp: tempfile::TempPath = tempfile::NamedTempFile::new()?.into_temp_path();
+        let tmp: tempfile::TempPath =
+            tempfile::NamedTempFile::new_in(car_path.parent().unwrap())?.into_temp_path();
         {
             let mut reader = crate::utils::net::reader(&format!(
                 "https://forest-continuous-integration.fra1.cdn.digitaloceanspaces.com/state_migration/state/{old_state}.car"

--- a/src/state_migration/tests/mod.rs
+++ b/src/state_migration/tests/mod.rs
@@ -73,7 +73,7 @@ async fn test_state_migration(
 ) -> Result<()> {
     // Car files are cached under data folder for Go test to pick up without network access
     let car_path = PathBuf::from(format!("./src/state_migration/tests/data/{old_state}.car"));
-    if !Path::new(&car_path).is_file() {
+    if !car_path.is_file() {
         let tmp: tempfile::TempPath =
             tempfile::NamedTempFile::new_in(car_path.parent().unwrap())?.into_temp_path();
         {

--- a/src/state_migration/tests/mod.rs
+++ b/src/state_migration/tests/mod.rs
@@ -11,7 +11,7 @@ use anyhow::*;
 use cid::Cid;
 use fvm_ipld_encoding::CborStore;
 use pretty_assertions::assert_eq;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::{str::FromStr, sync::Arc};
 use tokio::io::AsyncWriteExt;
 

--- a/tests/car_tests.rs
+++ b/tests/car_tests.rs
@@ -14,18 +14,28 @@ use futures::StreamExt;
 use fvm_ipld_car::{CarHeader, CarReader};
 use fvm_ipld_encoding::DAG_CBOR;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
-use tempfile::NamedTempFile;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
 use crate::common::cli;
 
 #[tokio::test]
 async fn forest_cli_car_concat() -> Result<()> {
-    let a = NamedTempFile::new()?;
+    let a = tempfile::Builder::new()
+        .prefix("forest-cli-car-concat-a")
+        .suffix(".car")
+        .tempfile()?;
     new_car(1024, a.path()).await?;
-    let b = NamedTempFile::new()?;
+
+    let b = tempfile::Builder::new()
+        .prefix("forest-cli-car-concat-b")
+        .suffix(".car")
+        .tempfile()?;
     new_car(2048, b.path()).await?;
-    let output = NamedTempFile::new()?;
+
+    let output = tempfile::Builder::new()
+        .prefix("forest-cli-car-concat-output")
+        .suffix(".car")
+        .tempfile()?;
 
     cli()?
         .arg("car")
@@ -44,7 +54,10 @@ async fn forest_cli_car_concat() -> Result<()> {
 
 #[tokio::test]
 async fn forest_cli_car_concat_same_file() -> Result<()> {
-    let output = NamedTempFile::new()?;
+    let output = tempfile::Builder::new()
+        .prefix("forest-cli-car-concat-same-file")
+        .suffix(".car")
+        .tempfile()?;
 
     cli()?
         .arg("car")
@@ -63,7 +76,10 @@ async fn forest_cli_car_concat_same_file() -> Result<()> {
 
 #[tokio::test]
 async fn forest_cli_car_concat_same_file_3_times() -> Result<()> {
-    let output = NamedTempFile::new()?;
+    let output = tempfile::Builder::new()
+        .prefix("forest-cli-car-concat-same-file-3-times")
+        .suffix(".car")
+        .tempfile()?;
 
     cli()?
         .arg("car")


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- banned the `NamedTempFile::new` method. While it is valid in contexts where we don't persist the data, it is difficult to enforce the usage in contexts where we actually need it. The issue surfaced a few times already (https://github.com/ChainSafe/forest/pull/2893#issuecomment-1576755240, https://github.com/ChainSafe/forest/pull/2693) and wasn't caught by the CI as the runners have a single fs.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

https://docs.rs/tempfile/latest/tempfile/struct.TempPath.html#method.persist
>  Note: Temporary files cannot be persisted across filesystems. Also neither the file contents nor the containing directory are synchronized, so the update may not yet have reached the disk when persist returns.

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
