### PR TITLE
feat: add --depth flag to snapshot export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 - [#3316](https://github.com/ChainSafe/forest/pull/3316): Add
   `forest-tool benchmark` commands.
-- [#3330](https://github.com/ChainSafe/forest/pull/3330): Add `--diff` flag to
+- [#3330](https://github.com/ChainSafe/forest/pull/3330): Add `--depth` flag to
   `forest-cli snapshot export`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 - [#3316](https://github.com/ChainSafe/forest/pull/3316): Add
   `forest-tool benchmark` commands.
+- [#3330](https://github.com/ChainSafe/forest/pull/3330): Add `--diff` flag to
+  `forest-cli snapshot export`.
 
 ### Changed
 

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -144,9 +144,8 @@ impl SnapshotCommands {
                 let finality = config.chain.policy.chain_finality.min(epoch);
                 if params.recent_roots < finality {
                     bail!(
-                        "For {}, depth has to be at least {}.",
-                        config.chain.network,
-                        finality
+                        "For {}, depth has to be at least {finality}.",
+                        config.chain.network
                     );
                 }
 

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -141,6 +141,14 @@ impl SnapshotCommands {
                     dry_run,
                 };
 
+                let finality = config.chain
+                    .policy
+                    .chain_finality
+                    .min(epoch);
+                if params.recent_roots < finality {
+                    bail!("For {}, depth has to be at least {}.", config.chain.network, finality);
+                }
+
                 let handle = tokio::spawn({
                     let tmp_file = temp_path.to_owned();
                     let output_path = output_path.clone();

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -46,6 +46,9 @@ pub enum SnapshotCommands {
         /// Tipset to start the export from, default is the chain head
         #[arg(short, long)]
         tipset: Option<i64>,
+        /// How many state-roots to include. Lower limit is 900 for `calibnet` and `mainnet`.
+        #[arg(short, long)]
+        depth: Option<crate::chain::ChainEpochDelta>,
     },
 
     /// Fetches the most recent snapshot from a trusted, pre-defined location.
@@ -102,6 +105,7 @@ impl SnapshotCommands {
                 skip_checksum,
                 dry_run,
                 tipset,
+                depth,
             } => {
                 let chain_head = match chain_head(&config.client.rpc_token).await {
                     Ok(head) => head.0,
@@ -130,7 +134,7 @@ impl SnapshotCommands {
 
                 let params = ChainExportParams {
                     epoch,
-                    recent_roots: config.chain.recent_state_roots,
+                    recent_roots: depth.unwrap_or(config.chain.recent_state_roots),
                     output_path: temp_path.to_path_buf(),
                     tipset_keys: TipsetKeysJson(chain_head.key().clone()),
                     skip_checksum,

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -141,12 +141,13 @@ impl SnapshotCommands {
                     dry_run,
                 };
 
-                let finality = config.chain
-                    .policy
-                    .chain_finality
-                    .min(epoch);
+                let finality = config.chain.policy.chain_finality.min(epoch);
                 if params.recent_roots < finality {
-                    bail!("For {}, depth has to be at least {}.", config.chain.network, finality);
+                    bail!(
+                        "For {}, depth has to be at least {}.",
+                        config.chain.network,
+                        finality
+                    );
                 }
 
                 let handle = tokio::spawn({


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- A depth of 2000 is the default but other depths are useful. This PR adds a flag to using a custom depth when exporting.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
