### PR TITLE
feat: use multiple threads when exporting snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
 
 ### Changed
 
+- [#3331](https://github.com/ChainSafe/forest/pull/3331): Use multiple cores
+  when exporting snapshots.
+
 ### Removed
 
 ### Fixed

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -6,21 +6,24 @@ use crate::blocks::Tipset;
 use crate::db::car::forest;
 use crate::ipld::{stream_chain, CidHashSet};
 use crate::utils::io::{AsyncWriterWithChecksum, Checksum};
+use crate::utils::stream::par_buffer;
 use anyhow::{Context, Result};
 use digest::Digest;
 use fvm_ipld_blockstore::Blockstore;
+use std::sync::Arc;
 use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 
 pub use self::{store::*, weight::*};
 
 pub async fn export<D: Digest>(
-    db: impl Blockstore,
+    db: impl Blockstore + Send + Sync + 'static,
     tipset: &Tipset,
     lookup_depth: ChainEpochDelta,
     writer: impl AsyncWrite + Unpin,
     seen: CidHashSet,
     skip_checksum: bool,
 ) -> Result<Option<digest::Output<D>>, Error> {
+    let db = Arc::new(db);
     let stateroot_lookup_limit = tipset.epoch() - lookup_depth;
     let roots = tipset.key().cids().to_vec();
 
@@ -29,8 +32,15 @@ pub async fn export<D: Digest>(
 
     // Stream stateroots in range stateroot_lookup_limit..=tipset.epoch(). Also
     // stream all block headers until genesis.
-    let blocks =
-        stream_chain(&db, tipset.clone().chain(&db), stateroot_lookup_limit).with_seen(seen);
+    let blocks = par_buffer(
+        1024,
+        stream_chain(
+            Arc::clone(&db),
+            tipset.clone().chain(Arc::clone(&db)),
+            stateroot_lookup_limit,
+        )
+        .with_seen(seen),
+    );
 
     // Encode Ipld key-value pairs in zstd frames
     let frames = forest::Encoder::compress_stream(8000usize.next_power_of_two(), 3, blocks);

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -33,6 +33,9 @@ pub async fn export<D: Digest>(
     // Stream stateroots in range stateroot_lookup_limit..=tipset.epoch(). Also
     // stream all block headers until genesis.
     let blocks = par_buffer(
+        // Queue 1k blocks. This is enuogh to saturate the compressor and blocks
+        // are small enough that keeping 1k in memory isn't a problem. Average
+        // block size is between 1kb and 2kb.
         1024,
         stream_chain(
             Arc::clone(&db),

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -98,10 +98,10 @@ impl ArchiveCommands {
                 diff,
             } => {
                 let store = ManyCar::try_from(snapshot_files)?;
-
+                let heaviest_tipset = store.heaviest_tipset()?;
                 do_export(
-                    &store,
-                    store.heaviest_tipset()?,
+                    store,
+                    heaviest_tipset,
                     output_path,
                     epoch,
                     depth,
@@ -142,7 +142,7 @@ fn build_output_path(
 }
 
 async fn do_export(
-    store: impl Blockstore,
+    store: impl Blockstore + Send + Sync + 'static,
     root: Tipset,
     output_path: PathBuf,
     epoch_option: Option<ChainEpoch>,

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -393,9 +393,10 @@ mod tests {
     async fn export() {
         let output_path = TempDir::new().unwrap();
         let store = AnyCar::try_from(calibnet::DEFAULT_GENESIS).unwrap();
+        let heaviest_tipset = store.heaviest_tipset().unwrap();
         do_export(
-            &store,
-            store.heaviest_tipset().unwrap(),
+            store,
+            heaviest_tipset,
             output_path.path().into(),
             Some(0),
             1,

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -99,15 +99,7 @@ impl ArchiveCommands {
             } => {
                 let store = ManyCar::try_from(snapshot_files)?;
                 let heaviest_tipset = store.heaviest_tipset()?;
-                do_export(
-                    store,
-                    heaviest_tipset,
-                    output_path,
-                    epoch,
-                    depth,
-                    diff,
-                )
-                .await
+                do_export(store, heaviest_tipset, output_path, epoch, depth, diff).await
             }
             Self::Checkpoints {
                 snapshot_files: snapshot,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,7 @@ pub mod monitoring;
 pub mod net;
 pub mod proofs_api;
 pub mod version;
+pub mod stream;
 
 use futures::{
     future::{pending, FusedFuture},

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,8 +10,8 @@ pub mod misc;
 pub mod monitoring;
 pub mod net;
 pub mod proofs_api;
-pub mod version;
 pub mod stream;
+pub mod version;
 
 use futures::{
     future::{pending, FusedFuture},

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -1,3 +1,5 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
 use futures::{Stream, StreamExt};
 
 /// Decouple stream generation and stream consumption into separate threads,

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -1,0 +1,7 @@
+use futures::{Stream, StreamExt};
+
+pub fn par_buffer<V: Send + Sync + 'static>(cap: usize, stream: impl Stream<Item = V> + Send + Sync + 'static) -> impl Stream<Item = V> {
+    let (send, recv) = flume::bounded(cap);
+    tokio::task::spawn(stream.map(Ok).forward(send.into_sink()));
+    recv.into_stream()
+}

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -11,7 +11,10 @@ use futures::{Stream, StreamExt};
 /// and will make use of multiple cores when both the stream and the stream
 /// consumer are CPU-bound. Because a new thread is spawned, the stream has to
 /// be [`Sync`], [`Send`] and `'static`.
-pub fn par_buffer<V: Send + Sync + 'static>(cap: usize, stream: impl Stream<Item = V> + Send + Sync + 'static) -> impl Stream<Item = V> {
+pub fn par_buffer<V: Send + Sync + 'static>(
+    cap: usize,
+    stream: impl Stream<Item = V> + Send + Sync + 'static,
+) -> impl Stream<Item = V> {
     let (send, recv) = flume::bounded(cap);
     tokio::task::spawn(stream.map(Ok).forward(send.into_sink()));
     recv.into_stream()

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -1,5 +1,14 @@
 use futures::{Stream, StreamExt};
 
+/// Decouple stream generation and stream consumption into separate threads,
+/// keeping not-yet-consumed elements in a bounded queue. This is similar to
+/// [`stream::buffered`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html#method.buffered)
+/// and
+/// [`sink::buffer`](https://docs.rs/futures/latest/futures/sink/trait.SinkExt.html#method.buffer).
+/// The key difference is that [`par_buffer`] is parallel rather than concurrent
+/// and will make use of multiple cores when both the stream and the stream
+/// consumer are CPU-bound. Because a new thread is spawned, the stream has to
+/// be [`Sync`], [`Send`] and `'static`.
 pub fn par_buffer<V: Send + Sync + 'static>(cap: usize, stream: impl Stream<Item = V> + Send + Sync + 'static) -> impl Stream<Item = V> {
     let (send, recv) = flume::bounded(cap);
     tokio::task::spawn(stream.map(Ok).forward(send.into_sink()));


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Exporting a snapshot involves two CPU-bound tasks: Walking the graph, and encoding the ForestCAR.zst file. This PR moves each task to a separate thread, nearly doubling the throughput.

Benchmark (three runs each):
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `export calibnet (par-buffer)` | 27.646 ± 0.295 | 27.324 | 27.904 | 1.00 |
| `export calibnet (baseline)` | 48.516 ± 0.458 | 47.999 | 48.873 | 1.75 |


## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
