### PR TITLE
feat: lotus_json for json interop handling

### DIFF
--- a/.config/forest.dic
+++ b/.config/forest.dic
@@ -25,6 +25,7 @@ crypto
 daemon
 daemonize
 DB/S
+destructuring
 DNS
 Enum
 EOF
@@ -62,13 +63,14 @@ RPC
 SECP
 SECP256k1
 seekable
-skippable
 serializable
 serializer/SM
+skippable
 statediff
 stateful
 stderr
 stdout
+struct/SM
 synchronizer
 syscall/S
 TCP
@@ -79,8 +81,9 @@ TOML
 trie
 TTY
 uncompress
-URL
+unrepresentable
 untrusted
+URL
 validator/S
 varint
 verifier

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead 0.4.3",
  "aes 0.7.5",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "86b8f9420f797f2d9e935edf629310eb938a0d839f984e25327f3c7eed22300c"
 dependencies = [
  "memchr",
 ]
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -271,7 +271,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "memchr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "zstd",
  "zstd-safe",
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
  "event-listener",
 ]
@@ -337,7 +337,7 @@ checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
 ]
 
 [[package]]
@@ -378,7 +378,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
 ]
 
 [[package]]
@@ -413,7 +413,7 @@ dependencies = [
  "memchr",
  "mime",
  "percent-encoding",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "rustversion",
  "serde",
  "serde_json",
@@ -454,7 +454,7 @@ dependencies = [
  "futures-core",
  "getrandom 0.2.10",
  "instant",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "rand 0.8.5",
  "tokio",
 ]
@@ -799,7 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata 0.3.4",
+ "regex-automata 0.3.6",
  "serde",
 ]
 
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f1226cd9da55587234753d1245dd5b132343ea240f26b6a9003d68706141ba"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
 dependencies = [
  "jobserver",
  "libc",
@@ -1006,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1514,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
  "cipher 0.3.0",
 ]
@@ -1666,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
 dependencies = [
  "serde",
 ]
@@ -2072,7 +2072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if 1.0.0",
- "rustix 0.38.4",
+ "rustix 0.38.7",
  "windows-sys 0.48.0",
 ]
 
@@ -2557,6 +2557,7 @@ dependencies = [
  "data-encoding-macro",
  "derive-quickcheck-arbitrary",
  "derive_builder",
+ "derive_more",
  "dialoguer",
  "digest 0.10.7",
  "directories",
@@ -2622,7 +2623,7 @@ dependencies = [
  "parity-db",
  "parking_lot",
  "pbr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "positioned-io",
  "pretty_assertions",
  "prometheus",
@@ -2818,7 +2819,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "waker-fn",
 ]
 
@@ -2886,7 +2887,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "pin-utils",
  "slab",
 ]
@@ -3397,6 +3398,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"
@@ -3470,7 +3474,7 @@ checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes 1.4.0",
  "http",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
 ]
 
 [[package]]
@@ -3513,7 +3517,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "socket2 0.4.9",
  "tokio",
  "tower-service",
@@ -3530,7 +3534,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
  "tokio-rustls",
 ]
@@ -3542,7 +3546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "tokio-io-timeout",
 ]
@@ -3645,6 +3649,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -3732,7 +3737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.4",
+ "rustix 0.38.7",
  "windows-sys 0.48.0",
 ]
 
@@ -4516,9 +4521,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67827e6ea8ee8a7c4a72227ef4fc08957040acffdb5f122733b24fa12daff41b"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "matrixmultiply"
@@ -5317,18 +5322,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5343,9 +5348,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -5405,7 +5410,7 @@ dependencies = [
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "windows-sys 0.48.0",
 ]
 
@@ -5417,7 +5422,7 @@ checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.4.1",
+ "universal-hash 0.4.0",
 ]
 
 [[package]]
@@ -5440,7 +5445,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.4.1",
+ "universal-hash 0.4.0",
 ]
 
 [[package]]
@@ -5976,13 +5981,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.4",
+ "regex-automata 0.3.6",
  "regex-syntax 0.7.4",
 ]
 
@@ -5997,9 +6002,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6055,8 +6060,8 @@ dependencies = [
  "mime",
  "once_cell",
  "percent-encoding",
- "pin-project-lite 0.2.10",
- "rustls 0.21.5",
+ "pin-project-lite 0.2.12",
+ "rustls 0.21.6",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -6197,9 +6202,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "172891ebdceb05aa0005f533a6cbfca599ddd7d966f6f5d4d9b2e70478e70399"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -6222,13 +6227,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.2",
+ "rustls-webpki 0.101.3",
  "sct",
 ]
 
@@ -6253,9 +6258,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
 dependencies = [
  "ring",
  "untrusted",
@@ -6364,9 +6369,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -6391,9 +6396,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6500,25 +6505,26 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e47d95bc83ed33b2ecf84f4187ad1ab9685d18ff28db000c99deac8ce180e3"
+checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
 dependencies = [
  "base64 0.21.2",
  "chrono",
  "hex",
  "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.24",
+ "time 0.3.25",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3cee93715c2e266b9338b7544da68a9f24e227722ba482bd1c024367c77c65"
+checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
@@ -6590,9 +6596,9 @@ dependencies = [
 
 [[package]]
 name = "sha2-asm"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
+checksum = "f27ba7066011e3fb30d808b51affff34f0a66d3a03a58edd787c6e420e40e44e"
 dependencies = [
  "cc",
 ]
@@ -6693,7 +6699,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.24",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -7014,9 +7020,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -7027,9 +7033,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -7106,14 +7112,14 @@ checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "rustix 0.38.7",
  "windows-sys 0.48.0",
 ]
 
@@ -7210,9 +7216,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
  "deranged",
  "itoa",
@@ -7263,20 +7269,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "2d3ce25f50619af8b0aec2eb23deebe84249e19e2ddd393a6e16e3300a6dadfd"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes 1.4.0",
  "libc",
  "mio",
  "num_cpus",
  "parking_lot",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -7288,7 +7293,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
 ]
 
@@ -7309,7 +7314,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
 ]
 
@@ -7320,7 +7325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
 ]
 
@@ -7359,7 +7364,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
 ]
 
@@ -7373,7 +7378,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "tracing",
 ]
@@ -7459,7 +7464,7 @@ dependencies = [
  "futures-util",
  "indexmap 1.9.3",
  "pin-project",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "rand 0.8.5",
  "slab",
  "tokio",
@@ -7489,7 +7494,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -7501,7 +7506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.24",
+ "time 0.3.25",
  "tracing-subscriber",
 ]
 
@@ -7745,9 +7750,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array",
  "subtle",
@@ -8492,9 +8497,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
+checksum = "acaaa1190073b2b101e15083c38ee8ec891b5e05cbee516521e94ec008f61e64"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ daemonize-me = "2.0"
 data-encoding = "2.3"
 data-encoding-macro = "0.1"
 derive_builder = "0.12"
+derive_more = "0.99.17"
 dialoguer = "0.10.2"
 digest = "0.10.5"
 directories = "5"
@@ -72,7 +73,7 @@ fvm_shared2 = { package = "fvm_shared", version = "~2.5" }
 fvm_shared3 = { package = "fvm_shared", version = "~3.4", features = ["testing", "proofs"] }
 gethostname = "0.4"
 git-version = "0.3"
-hex = "0.4"
+hex = { version = "0.4", features = ["serde"] }
 http = "0.2.8"
 human-repr = "1.0"
 humantime = "2.1.0"

--- a/src/beacon/beacon_entries.rs
+++ b/src/beacon/beacon_entries.rs
@@ -28,6 +28,11 @@ impl BeaconEntry {
     pub fn data(&self) -> &[u8] {
         &self.data
     }
+
+    pub fn into_parts(self) -> (u64, Vec<u8>) {
+        let Self { round, data } = self;
+        (round, data)
+    }
 }
 
 pub mod json {

--- a/src/blocks/election_proof.rs
+++ b/src/blocks/election_proof.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::json::vrf::VRFProof;
+use crate::blocks::VRFProof;
 use crate::shim::clock::BLOCKS_PER_EPOCH;
 use crate::utils::encoding::blake2b_256;
 use lazy_static::lazy_static;

--- a/src/blocks/gossip_block.rs
+++ b/src/blocks/gossip_block.rs
@@ -8,7 +8,7 @@ use crate::blocks::BlockHeader;
 
 /// Block message used as serialized `gossipsub` messages for blocks topic.
 #[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
-#[derive(Clone, Debug, PartialEq, Serialize_tuple, Deserialize_tuple)]
+#[derive(Clone, Debug, PartialEq, Serialize_tuple, Deserialize_tuple, Default)]
 pub struct GossipBlock {
     pub header: BlockHeader,
     pub bls_messages: Vec<Cid>,

--- a/src/blocks/header/lotus_json.rs
+++ b/src/blocks/header/lotus_json.rs
@@ -1,0 +1,162 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+use crate::lotus_json::*;
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+
+use super::BlockHeader;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct BlockHeaderLotusJson {
+    miner: AddressLotusJson,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ticket: Option<TicketLotusJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    election_proof: Option<ElectionProofLotusJson>,
+    beacon_entries: VecLotusJson<BeaconEntryLotusJson>,
+    win_po_st_proof: VecLotusJson<PoStProofLotusJson>,
+    parents: TipsetKeysLotusJson,
+    parent_weight: BigIntLotusJson,
+    height: i64,
+    parent_state_root: CidLotusJson,
+    parent_message_receipts: CidLotusJson,
+    messages: CidLotusJson,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b_l_s_aggregate: Option<SignatureLotusJson>,
+    timestamp: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    block_sig: Option<SignatureLotusJson>,
+    fork_signaling: u64,
+    parent_base_fee: TokenAmountLotusJson,
+}
+
+impl HasLotusJson for BlockHeader {
+    type LotusJson = BlockHeaderLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        use serde_json::json;
+
+        vec![(
+            json!({
+                "BeaconEntries": null,
+                "Miner": "f00",
+                "Parents": null,
+                "ParentWeight": "0",
+                "Height": 0,
+                "ParentStateRoot": {
+                    "/": "baeaaaaa"
+                },
+                "ParentMessageReceipts": {
+                    "/": "baeaaaaa"
+                },
+                "Messages": {
+                    "/": "baeaaaaa"
+                },
+                "WinPoStProof": null,
+                "Timestamp": 0,
+                "ForkSignaling": 0,
+                "ParentBaseFee": "0",
+            }),
+            BlockHeader::default(),
+        )]
+    }
+}
+
+#[test]
+fn snapshots() {
+    assert_all_snapshots::<BlockHeader>()
+}
+
+#[cfg(test)]
+quickcheck::quickcheck! {
+    fn quickcheck(val: BlockHeader) -> () {
+        assert_unchanged_via_json(val)
+    }
+}
+
+impl From<BlockHeader> for BlockHeaderLotusJson {
+    fn from(value: BlockHeader) -> Self {
+        let BlockHeader {
+            parents,
+            weight,
+            epoch,
+            beacon_entries,
+            winning_post_proof,
+            miner_address,
+            messages,
+            message_receipts,
+            state_root,
+            fork_signal,
+            signature,
+            election_proof,
+            timestamp,
+            ticket,
+            bls_aggregate,
+            parent_base_fee,
+            cached_cid: _ignore_cache0,
+            is_validated: _ignore_cache1,
+        } = value;
+        Self {
+            miner: miner_address.into(),
+            ticket: ticket.map(Into::into),
+            election_proof: election_proof.map(Into::into),
+            beacon_entries: beacon_entries.into(),
+            win_po_st_proof: winning_post_proof.into(),
+            parents: parents.into(),
+            parent_weight: weight.into(),
+            height: epoch,
+            parent_state_root: state_root.into(),
+            parent_message_receipts: message_receipts.into(),
+            messages: messages.into(),
+            b_l_s_aggregate: bls_aggregate.map(Into::into),
+            timestamp,
+            block_sig: signature.map(Into::into),
+            fork_signaling: fork_signal,
+            parent_base_fee: parent_base_fee.into(),
+        }
+    }
+}
+
+impl From<BlockHeaderLotusJson> for BlockHeader {
+    fn from(value: BlockHeaderLotusJson) -> Self {
+        let BlockHeaderLotusJson {
+            miner,
+            ticket,
+            election_proof,
+            beacon_entries,
+            win_po_st_proof,
+            parents,
+            parent_weight,
+            height,
+            parent_state_root,
+            parent_message_receipts,
+            messages,
+            b_l_s_aggregate: bls_aggregate,
+            timestamp,
+            block_sig,
+            fork_signaling,
+            parent_base_fee,
+        } = value;
+        Self {
+            parents: parents.into(),
+            weight: parent_weight.into(),
+            epoch: height,
+            beacon_entries: beacon_entries.into(),
+            winning_post_proof: win_po_st_proof.into(),
+            miner_address: miner.into(),
+            messages: messages.into(),
+            message_receipts: parent_message_receipts.into(),
+            state_root: parent_state_root.into(),
+            fork_signal: fork_signaling,
+            signature: block_sig.map(Into::into),
+            election_proof: election_proof.map(Into::into),
+            timestamp,
+            ticket: ticket.map(Into::into),
+            bls_aggregate: bls_aggregate.map(Into::into),
+            parent_base_fee: parent_base_fee.into(),
+            cached_cid: OnceCell::new(),
+            is_validated: OnceCell::new(),
+        }
+    }
+}

--- a/src/blocks/header/mod.rs
+++ b/src/blocks/header/mod.rs
@@ -20,6 +20,10 @@ use once_cell::sync::OnceCell;
 
 mod encoding;
 pub mod json;
+#[cfg(not(doc))]
+mod lotus_json;
+#[cfg(doc)]
+pub mod lotus_json;
 #[cfg(test)]
 mod tests;
 

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -9,6 +9,7 @@ pub mod header;
 pub mod persistence;
 pub mod ticket;
 pub mod tipset;
+mod vrf_proof;
 
 pub use block::*;
 pub use election_proof::ElectionProof;
@@ -17,6 +18,7 @@ pub use gossip_block::GossipBlock;
 pub use header::BlockHeader;
 pub use ticket::Ticket;
 pub use tipset::*;
+pub use vrf_proof::VRFProof;
 
 #[cfg(test)]
 mod tests {

--- a/src/blocks/ticket.rs
+++ b/src/blocks/ticket.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::json::vrf::VRFProof;
+use crate::blocks::VRFProof;
 use serde_tuple::{self, Deserialize_tuple, Serialize_tuple};
 
 /// A Ticket is a marker of a tick of the blockchain's clock.  It is the source

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -562,7 +562,7 @@ mod property_tests {
 
 #[cfg(test)]
 mod test {
-    use crate::json::vrf::VRFProof;
+    use crate::blocks::VRFProof;
     use crate::shim::address::Address;
     use cid::{
         multihash::{Code::Identity, MultihashDigest},

--- a/src/blocks/vrf_proof.rs
+++ b/src/blocks/vrf_proof.rs
@@ -5,6 +5,7 @@ use crate::utils::encoding::{blake2b_256, serde_byte_array};
 use serde::{Deserialize, Serialize};
 
 /// The output from running a VRF proof.
+#[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Default, Serialize, Deserialize)]
 pub struct VRFProof(#[serde(with = "serde_byte_array")] pub Vec<u8>);
 

--- a/src/blocks/vrf_proof.rs
+++ b/src/blocks/vrf_proof.rs
@@ -1,0 +1,26 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::utils::encoding::{blake2b_256, serde_byte_array};
+use serde::{Deserialize, Serialize};
+
+/// The output from running a VRF proof.
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Default, Serialize, Deserialize)]
+pub struct VRFProof(#[serde(with = "serde_byte_array")] pub Vec<u8>);
+
+impl VRFProof {
+    /// Creates a `VRFProof` from a raw vector.
+    pub fn new(output: Vec<u8>) -> Self {
+        Self(output)
+    }
+
+    /// Returns reference to underlying proof bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Compute the `BLAKE2b256` digest of the proof.
+    pub fn digest(&self) -> [u8; 32] {
+        blake2b_256(&self.0)
+    }
+}

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1608,8 +1608,8 @@ fn validate_tipset_against_cache<C: Consensus>(
 
 #[cfg(test)]
 mod test {
+    use crate::blocks::VRFProof;
     use crate::blocks::{BlockHeader, ElectionProof, Ticket, Tipset};
-    use crate::json::vrf::VRFProof;
     use crate::shim::address::Address;
     use cid::Cid;
     use num_bigint::BigInt;

--- a/src/json/vrf.rs
+++ b/src/json/vrf.rs
@@ -1,30 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::utils::encoding::{blake2b_256, serde_byte_array};
-use serde::{Deserialize, Serialize};
-
-/// The output from running a VRF proof.
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Default, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct VRFProof(#[serde(with = "serde_byte_array")] pub Vec<u8>);
-
-impl VRFProof {
-    /// Creates a `VRFProof` from a raw vector.
-    pub fn new(output: Vec<u8>) -> Self {
-        Self(output)
-    }
-
-    /// Returns reference to underlying proof bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
-    /// Compute the `BLAKE2b256` digest of the proof.
-    pub fn digest(&self) -> [u8; 32] {
-        blake2b_256(&self.0)
-    }
-}
+use crate::blocks::VRFProof;
 
 pub mod json {
     use std::borrow::Cow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod json;
 mod key_management;
 mod libp2p;
 mod libp2p_bitswap;
+mod lotus_json;
 mod message;
 mod message_pool;
 mod metrics;

--- a/src/lotus_json/address.rs
+++ b/src/lotus_json/address.rs
@@ -1,0 +1,17 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+
+use crate::shim::address::Address;
+
+#[derive(Serialize, Deserialize, From, Into)]
+pub struct AddressLotusJson(#[serde(with = "stringify")] Address);
+
+impl HasLotusJson for Address {
+    type LotusJson = AddressLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(json!("f00"), Address::default())]
+    }
+}

--- a/src/lotus_json/beacon_entry.rs
+++ b/src/lotus_json/beacon_entry.rs
@@ -1,0 +1,38 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::beacon::BeaconEntry;
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct BeaconEntryLotusJson {
+    round: u64,
+    data: VecU8LotusJson,
+}
+
+impl HasLotusJson for BeaconEntry {
+    type LotusJson = BeaconEntryLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(json!({"Round": 0, "Data": ""}), BeaconEntry::default())]
+    }
+}
+
+impl From<BeaconEntry> for BeaconEntryLotusJson {
+    fn from(value: BeaconEntry) -> Self {
+        let (round, data) = value.into_parts();
+        Self {
+            round,
+            data: data.into(),
+        }
+    }
+}
+
+impl From<BeaconEntryLotusJson> for BeaconEntry {
+    fn from(value: BeaconEntryLotusJson) -> Self {
+        let BeaconEntryLotusJson { round, data } = value;
+        Self::new(round, data.into())
+    }
+}

--- a/src/lotus_json/big_int.rs
+++ b/src/lotus_json/big_int.rs
@@ -1,0 +1,17 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+
+use num::BigInt;
+
+#[derive(Serialize, Deserialize, From, Into)]
+pub struct BigIntLotusJson(#[serde(with = "stringify")] BigInt);
+
+impl HasLotusJson for BigInt {
+    type LotusJson = BigIntLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(json!("1"), BigInt::from(1))]
+    }
+}

--- a/src/lotus_json/cid.rs
+++ b/src/lotus_json/cid.rs
@@ -1,0 +1,32 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+
+pub type CidLotusJson = CidLotusJsonGeneric<64>;
+
+#[derive(Serialize, Deserialize, From, Into)]
+pub struct CidLotusJsonGeneric<const S: usize> {
+    #[serde(rename = "/", with = "stringify")]
+    slash: ::cid::CidGeneric<S>,
+}
+
+impl<const S: usize> HasLotusJson for ::cid::CidGeneric<S> {
+    type LotusJson = CidLotusJsonGeneric<S>;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        unimplemented!("only Cid<64> is tested, below")
+    }
+}
+
+#[test]
+fn snapshots() {
+    assert_one_snapshot(json!({"/": "baeaaaaa"}), ::cid::Cid::default());
+}
+
+#[cfg(test)]
+quickcheck! {
+    fn quickcheck(val: ::cid::Cid) -> () {
+        assert_unchanged_via_json(val)
+    }
+}

--- a/src/lotus_json/election_proof.rs
+++ b/src/lotus_json/election_proof.rs
@@ -1,0 +1,53 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::blocks::ElectionProof;
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ElectionProofLotusJson {
+    v_r_f_proof: VRFProofLotusJson,
+    win_count: i64,
+}
+
+impl HasLotusJson for ElectionProof {
+    type LotusJson = ElectionProofLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!({
+                "WinCount": 0,
+                "VRFProof": ""
+            }),
+            ElectionProof::default(),
+        )]
+    }
+}
+
+impl From<ElectionProofLotusJson> for ElectionProof {
+    fn from(value: ElectionProofLotusJson) -> Self {
+        let ElectionProofLotusJson {
+            v_r_f_proof: vrfproof,
+            win_count,
+        } = value;
+        Self {
+            win_count,
+            vrfproof: vrfproof.into(),
+        }
+    }
+}
+
+impl From<ElectionProof> for ElectionProofLotusJson {
+    fn from(value: ElectionProof) -> Self {
+        let ElectionProof {
+            win_count,
+            vrfproof,
+        } = value;
+        Self {
+            v_r_f_proof: vrfproof.into(),
+            win_count,
+        }
+    }
+}

--- a/src/lotus_json/gossip_block.rs
+++ b/src/lotus_json/gossip_block.rs
@@ -1,0 +1,92 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+
+use crate::blocks::GossipBlock;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GossipBlockLotusJson {
+    pub header: <crate::blocks::BlockHeader as HasLotusJson>::LotusJson,
+    pub bls_messages: VecLotusJson<CidLotusJson>,
+    pub secpk_messages: VecLotusJson<CidLotusJson>,
+}
+
+#[test]
+fn snapshots() {
+    assert_all_snapshots::<GossipBlock>()
+}
+
+#[cfg(test)]
+quickcheck! {
+    fn quickcheck(val: GossipBlock) -> () {
+        assert_unchanged_via_json(val)
+    }
+}
+
+impl HasLotusJson for GossipBlock {
+    type LotusJson = GossipBlockLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        use serde_json::json;
+
+        vec![(
+            json!({
+                "Header": {
+                    "BeaconEntries": null,
+                    "Miner": "f00",
+                    "Parents": null,
+                    "ParentWeight": "0",
+                    "Height": 0,
+                    "ParentStateRoot": {
+                        "/": "baeaaaaa"
+                    },
+                    "ParentMessageReceipts": {
+                        "/": "baeaaaaa"
+                    },
+                    "Messages": {
+                        "/": "baeaaaaa"
+                    },
+                    "WinPoStProof": null,
+                    "Timestamp": 0,
+                    "ForkSignaling": 0,
+                    "ParentBaseFee": "0",
+                },
+                "BlsMessages": null,
+                "SecpkMessages": null
+            }),
+            GossipBlock::default(),
+        )]
+    }
+}
+
+impl From<GossipBlockLotusJson> for GossipBlock {
+    fn from(value: GossipBlockLotusJson) -> Self {
+        let GossipBlockLotusJson {
+            header,
+            bls_messages,
+            secpk_messages,
+        } = value;
+        Self {
+            header: header.into(),
+            bls_messages: bls_messages.into(),
+            secpk_messages: secpk_messages.into(),
+        }
+    }
+}
+
+impl From<GossipBlock> for GossipBlockLotusJson {
+    fn from(value: GossipBlock) -> Self {
+        let GossipBlock {
+            header,
+            bls_messages,
+            secpk_messages,
+        } = value;
+        Self {
+            header: header.into(),
+            bls_messages: bls_messages.into(),
+            secpk_messages: secpk_messages.into(),
+        }
+    }
+}

--- a/src/lotus_json/message.rs
+++ b/src/lotus_json/message.rs
@@ -1,0 +1,107 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+
+use crate::shim::message::Message;
+
+// TODO(aatifsyed): derive
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MessageLotusJson {
+    version: u64,
+    to: AddressLotusJson,
+    from: AddressLotusJson,
+    nonce: u64,
+    value: TokenAmountLotusJson,
+    gas_limit: u64,
+    gas_fee_cap: TokenAmountLotusJson,
+    gas_premium: TokenAmountLotusJson,
+    method: u64,
+    params: Option<RawBytesLotusJson>,
+    #[serde(rename = "CID", skip_serializing_if = "Option::is_none")]
+    cid: Option<CidLotusJson>,
+}
+
+impl HasLotusJson for Message {
+    type LotusJson = MessageLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!({
+                "From": "f00",
+                "GasFeeCap": "0",
+                "GasLimit": 0, // BUG?(aatifsyed)
+                "GasPremium": "0",
+                "Method": 0,
+                "Nonce": 0,
+                "Params": "", // BUG?(aatifsyed)
+                "To": "f00",
+                "Value": "0",
+                "Version": 0
+            }),
+            Message::default(),
+        )]
+    }
+}
+
+// TODO(aatifsyed): derive
+impl From<MessageLotusJson> for Message {
+    fn from(value: MessageLotusJson) -> Self {
+        let MessageLotusJson {
+            version,
+            to,
+            from,
+            nonce,
+            value,
+            gas_limit,
+            gas_fee_cap,
+            gas_premium,
+            method,
+            params,
+            cid: _ignored, // TODO(aatifsyed): is this an error?
+        } = value;
+        Self {
+            version,
+            from: from.into(),
+            to: to.into(),
+            sequence: nonce,
+            value: value.into(),
+            method_num: method,
+            params: params.map(Into::into).unwrap_or_default(),
+            gas_limit,
+            gas_fee_cap: gas_fee_cap.into(),
+            gas_premium: gas_premium.into(),
+        }
+    }
+}
+
+impl From<Message> for MessageLotusJson {
+    fn from(value: Message) -> Self {
+        let Message {
+            version,
+            from,
+            to,
+            sequence,
+            value,
+            method_num,
+            params,
+            gas_limit,
+            gas_fee_cap,
+            gas_premium,
+        } = value;
+        Self {
+            version,
+            to: to.into(),
+            from: from.into(),
+            nonce: sequence,
+            value: value.into(),
+            gas_limit,
+            gas_fee_cap: gas_fee_cap.into(),
+            gas_premium: gas_premium.into(),
+            method: method_num,
+            params: Some(params.into()),
+            cid: None, // TODO(aatifsyed): is this an error?
+        }
+    }
+}

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -114,7 +114,13 @@ use {pretty_assertions::assert_eq, quickcheck::quickcheck};
 pub trait HasLotusJson: Sized + Into<Self::LotusJson> {
     /// The struct representing JSON. You should `#[derive(Deserialize, Serialize)]` on it.
     type LotusJson: Into<Self> + Serialize + DeserializeOwned;
-    /// You MUST add snapshot tests
+    /// To ensure code quality, conversion to/from lotus JSON MUST be tested.
+    /// Provide snapshots of the JSON, and the domain type it should serialize to.
+    ///
+    /// Serialization and de-serialization of the domain type should match the snapshot.
+    ///
+    /// If using [`decl_and_test`], this test is automatically run for you, but if the test
+    /// is out-of-module, you must call [`assert_all_snapshots`] manually.
     fn snapshots() -> Vec<(serde_json::Value, Self)>;
 }
 
@@ -178,7 +184,7 @@ mod vec; // can't make snapshots of generic type
 pub use self::raw_bytes::RawBytesLotusJson;
 mod raw_bytes; // fvm_ipld_encoding::RawBytes: !quickcheck::Arbitrary
 
-#[cfg(test)]
+#[cfg(any(test, doc))]
 pub fn assert_all_snapshots<T>()
 where
     T: HasLotusJson + PartialEq + std::fmt::Debug + Clone,

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -1,0 +1,294 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! In the Filecoin ecosystem, there are TWO different ways to present a domain object:
+//! - CBOR (defined in [`fvm_ipld_encoding`]).
+//!   This is the wire format.
+//! - JSON (see [`serde_json`]).
+//!   This is used in e.g RPC code, or in lotus printouts
+//!
+//! We care about compatibility with lotus/the Filecoin ecosystem for both.
+//! This module defines traits and types for handling both.
+//!
+//! # Terminology and background
+//! - A "domain object" is the _concept_ of an object.
+//!   E.g `"a CID with version = 1, codec = 0, and a multihash which is all zero"`
+//!   (This happens to be the default CID).
+//! - The "in memory" representation is how (rust) lays that out in memory.
+//!   See the definition of [`struct Cid { .. }`](`::cid::Cid`).
+//! - The "lotus JSON" is how [lotus](https://github.com/filecoin-project/lotus),
+//!   the reference Filecoin implementation, displays that object in JSON.
+//!   ```json
+//!   { "/": "baeaaaaa" }
+//!   ```
+//! - The "lotus CBOR" is how lotus represents that object on the wire.
+//!   ```rust
+//!   let in_memory = ::cid::Cid::default();
+//!   let cbor = fvm_ipld_encoding::to_vec(&in_memory).unwrap();
+//!   assert_eq!(
+//!       cbor,
+//!       0b_11011000_00101010_01000101_00000000_00000001_00000000_00000000_00000000_u64.to_be_bytes(),
+//!   );
+//!   ```
+//!
+//! In rust, the most common serialization framework is [`serde`].
+//! It has ONE (de)serialization model for each struct - the serialization code _cannot_ know
+//! if it's writing JSON or CBOR.
+//!
+//! The cleanest way handle the distinction would be a serde-compatible trait:
+//! ```rust
+//! # use serde::Serializer;
+//! pub trait LotusSerialize {
+//!     fn serialize_cbor<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//!     where
+//!         S: Serializer;
+//!
+//!     fn serialize_json<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//!     where
+//!         S: Serializer;
+//! }
+//! pub trait LotusDeserialize<'de> { /* ... */ }
+//! ```
+//!
+//! However, that would require writing and maintaining a custom derive macro - can we lean on
+//! [`macro@serde::Serialize`] and [`macro@serde::Deserialize`] instead?
+//!
+//! # Lotus JSON in Forest
+//! - Have a struct which represents a domain object: e.g [`GossipBlock`](crate::blocks::GossipBlock).
+//! - Implement [`serde::Serialize`] on that object, normally using [`serde_tuple::Serialize_tuple`].
+//!   This corresponds to the CBOR representation.
+//! - Implement [`HasLotusJson`] on the domain object.
+//!   This attaches a separate JSON type, which should implement (`#[derive(...)]`) [`serde::Serialize`] and [`serde::Deserialize`] AND conversions to and from the domain object
+//!   E.g [`GossipBlockLotusJson`]
+//!
+//! ## Implementation notes
+//! ### Illegal states are unrepresentable
+//! Consider [Address](crate::shim::address::Address) - it is represented as a simple string in JSON,
+//! so there are two possible definitions of `AddressLotusJson`:
+//! ```rust
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Serialize, Deserialize)] enum Address {}
+//! # mod stringify {
+//! #     pub fn serialize<T, S: serde::Serializer>(_: &T, _: S) -> Result<S::Ok, S::Error> { unimplemented!() }
+//! #     pub fn deserialize<'de, T, D: serde::Deserializer<'de>>(_: D) -> Result<T, D::Error> { unimplemented!() }
+//! # }
+//! #[derive(Serialize, Deserialize)]
+//! pub struct AddressLotusJson(#[serde(with = "stringify")] Address);
+//! ```
+//! ```rust
+//! # use serde::{Deserialize, Serialize};
+//! #[derive(Serialize, Deserialize)]
+//! pub struct AddressLotusJson(String);
+//! ```
+//! However, with the second implementation, `impl From<AddressLotusJson> for Address` would involve unwrapping
+//! a call to [std::primitive::str::parse], which is unacceptable - malformed JSON could cause a crash!
+//!
+//! ### Location
+//! Prefer implementing in this module, as [`decl_and_test`] will handle `quickcheck`-ing and snapshot testing.
+//!
+//! If you require access to private fields, consider:
+//! - implementing an exhaustive helper method, e.g [`crate::beacon::BeaconEntry::into_parts`].
+//! - moving implementation to the module where the struct is defined, e.g [`crate::blocks::header::lotus_json::BlockHeaderLotusJson`].
+//!   If you do this, you MUST manually add snapshot and `quickcheck` tests.
+//!
+//! ### Compound structs
+//! - Each field of a struct should be transformed into its `LotusJson` equivalent.
+//! - Each [From] implementation should use only [From]/[Into] calls for each field
+//! - Use destructuring to ensure exhaustiveness
+//!
+//! # API hazards
+//! - Avoid using `#[serde(with = ...)]` except for leaf types
+//! - There is a hazard if the same type can be de/serialized in multiple ways.
+//!
+//! # Future work
+//! - use [`proptest`](https://docs.rs/proptest/) to test the parser pipeline
+//! - use a derive macro for simple compound structs
+
+use derive_more::{From, Into};
+use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::json;
+use std::{fmt::Display, str::FromStr};
+#[cfg(test)]
+use {pretty_assertions::assert_eq, quickcheck::quickcheck};
+
+pub trait HasLotusJson: Sized + Into<Self::LotusJson> {
+    /// The struct representing JSON. You should `#[derive(Deserialize, Serialize)]` on it.
+    type LotusJson: Into<Self> + Serialize + DeserializeOwned;
+    /// You MUST add snapshot tests
+    fn snapshots() -> Vec<(serde_json::Value, Self)>;
+}
+
+macro_rules! decl_and_test {
+    ($($mod_name:ident -> $lotus_json_ty:ident for $domain_ty:ty),* $(,)?) => {
+        $(
+            #[allow(unused)]
+            pub use self::$mod_name::$lotus_json_ty; // convenience for other structs
+            mod $mod_name;
+        )*
+        #[test]
+        fn all_snapshots() {
+            $(
+                print!("test snapshots for {}...", std::any::type_name::<$domain_ty>());
+                std::io::Write::flush(&mut std::io::stdout()).unwrap();
+                // ^ make sure the above line is flushed in case the test fails
+                assert_all_snapshots::<$domain_ty>();
+                println!("ok.");
+            )*
+        }
+        #[test]
+        fn all_quickchecks() {
+            $(
+                print!("quickcheck for {}...", std::any::type_name::<$domain_ty>());
+                std::io::Write::flush(&mut std::io::stdout()).unwrap();
+                // ^ make sure the above line is flushed in case the test fails
+                ::quickcheck::quickcheck(assert_unchanged_via_json::<$domain_ty> as fn(_));
+                println!("ok.");
+            )*
+        }
+    }
+}
+#[cfg(doc)]
+pub(crate) use decl_and_test;
+
+decl_and_test!(
+    address -> AddressLotusJson for crate::shim::address::Address,
+    beacon_entry -> BeaconEntryLotusJson for crate::beacon::BeaconEntry,
+    big_int -> BigIntLotusJson for num::BigInt,
+    gossip_block -> GossipBlockLotusJson for crate::blocks::GossipBlock,
+    election_proof -> ElectionProofLotusJson for crate::blocks::ElectionProof,
+    message -> MessageLotusJson for crate::shim::message::Message,
+    po_st_proof -> PoStProofLotusJson for crate::shim::sector::PoStProof,
+    registered_po_st_proof -> RegisteredPoStProofLotusJson for crate::shim::sector::RegisteredPoStProof,
+    signature -> SignatureLotusJson for crate::shim::crypto::Signature,
+    signature_type -> SignatureTypeLotusJson for crate::shim::crypto::SignatureType,
+    signed_message -> SignedMessageLotusJson for  crate::message::SignedMessage,
+    ticket -> TicketLotusJson for crate::blocks::Ticket,
+    tipset_keys ->  TipsetKeysLotusJson for crate::blocks::TipsetKeys,
+    token_amount -> TokenAmountLotusJson for crate::shim::econ::TokenAmount,
+    vec_u8 -> VecU8LotusJson for Vec<u8>,
+    vrf_proof -> VRFProofLotusJson for crate::blocks::VRFProof,
+);
+
+pub use self::cid::CidLotusJson;
+mod cid; // can't make snapshots of generic type
+
+pub use self::vec::VecLotusJson;
+mod vec; // can't make snapshots of generic type
+
+pub use self::raw_bytes::RawBytesLotusJson;
+mod raw_bytes; // fvm_ipld_encoding::RawBytes: !quickcheck::Arbitrary
+
+#[cfg(test)]
+pub fn assert_all_snapshots<T>()
+where
+    T: HasLotusJson + PartialEq + std::fmt::Debug + Clone,
+{
+    let snapshots = T::snapshots();
+    assert!(!snapshots.is_empty());
+    for (lotus_json, val) in snapshots {
+        assert_one_snapshot(lotus_json, val);
+    }
+}
+
+#[cfg(test)]
+pub fn assert_one_snapshot<T>(lotus_json: serde_json::Value, val: T)
+where
+    T: HasLotusJson + PartialEq + std::fmt::Debug + Clone,
+{
+    // T -> T::LotusJson -> lotus_json
+    let serialized = serde_json::to_value(Into::<T::LotusJson>::into(val.clone())).unwrap();
+    assert_eq!(
+        serialized.to_string(),
+        lotus_json.to_string(),
+        "snapshot failed for {}",
+        std::any::type_name::<T>()
+    );
+
+    // lotus_json -> T::LotusJson -> T
+    let deserialized = match serde_json::from_value::<T::LotusJson>(lotus_json.clone()) {
+        Ok(lotus_json) => Into::<T>::into(lotus_json),
+        Err(e) => panic!(
+            "couldn't deserialize a {} from {}: {e}",
+            std::any::type_name::<T::LotusJson>(),
+            lotus_json
+        ),
+    };
+    assert_eq!(deserialized, val);
+}
+
+#[cfg(test)]
+pub fn assert_unchanged_via_json<T>(val: T)
+where
+    T: HasLotusJson + Clone + Into<T::LotusJson> + PartialEq + std::fmt::Debug,
+    T::LotusJson: Into<T> + Serialize + serde::de::DeserializeOwned,
+{
+    // T -> T::LotusJson -> lotus_json -> T::LotusJson -> T
+
+    // T -> T::LotusJson
+    let temp = Into::<T::LotusJson>::into(val.clone());
+    // T::LotusJson -> lotus_json
+    let temp = serde_json::to_value(temp).unwrap();
+    // lotus_json -> T::LotusJson
+    let temp = serde_json::from_value::<T::LotusJson>(temp).unwrap();
+    // T::LotusJson -> T
+    let temp = Into::<T>::into(temp);
+
+    assert_eq!(val, temp);
+}
+
+/// Usage: `#[serde(with = "stringify")]`
+pub mod stringify {
+    use super::*;
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Display,
+        S: Serializer,
+    {
+        serializer.collect_str(value)
+    }
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: FromStr,
+        T::Err: Display,
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Usage: `#[serde(with = "base64_standard")]`
+pub mod base64_standard {
+    use super::*;
+
+    use base64::engine::{general_purpose::STANDARD, Engine as _};
+
+    pub fn serialize<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        STANDARD.encode(value).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        STANDARD
+            .decode(String::deserialize(deserializer)?)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// MUST NOT be used in any `LotusJson` structs.
+#[cfg(test)]
+pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: HasLotusJson,
+{
+    T::LotusJson::deserialize(deserializer).map(Into::into)
+}

--- a/src/lotus_json/po_st_proof.rs
+++ b/src/lotus_json/po_st_proof.rs
@@ -1,0 +1,59 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::shim::sector::PoStProof;
+use fvm_shared3::sector::PoStProof as PoStProofV3;
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct PoStProofLotusJson {
+    po_st_proof: RegisteredPoStProofLotusJson,
+    proof_bytes: VecU8LotusJson,
+}
+
+impl HasLotusJson for PoStProof {
+    type LotusJson = PoStProofLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!({
+                "PoStProof": 0,
+                "ProofBytes": "aGVsbG8gd29ybGQh"
+            }),
+            PoStProof::new(
+                crate::shim::sector::RegisteredPoStProof::from(
+                    crate::shim::sector::RegisteredPoStProofV3::StackedDRGWinning2KiBV1,
+                ),
+                Vec::from_iter(*b"hello world!"),
+            ),
+        )]
+    }
+}
+
+impl From<PoStProof> for PoStProofLotusJson {
+    fn from(value: PoStProof) -> Self {
+        let PoStProofV3 {
+            post_proof,
+            proof_bytes,
+        } = value.into();
+        Self {
+            po_st_proof: crate::shim::sector::RegisteredPoStProof::from(post_proof).into(),
+            proof_bytes: proof_bytes.into(),
+        }
+    }
+}
+
+impl From<PoStProofLotusJson> for PoStProof {
+    fn from(value: PoStProofLotusJson) -> Self {
+        let PoStProofLotusJson {
+            po_st_proof,
+            proof_bytes,
+        } = value;
+        Self::from(PoStProofV3 {
+            post_proof: crate::shim::sector::RegisteredPoStProof::from(po_st_proof).into(),
+            proof_bytes: proof_bytes.into(),
+        })
+    }
+}

--- a/src/lotus_json/raw_bytes.rs
+++ b/src/lotus_json/raw_bytes.rs
@@ -1,0 +1,44 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+use fvm_ipld_encoding::RawBytes;
+
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RawBytesLotusJson(#[serde(with = "base64_standard")] Vec<u8>);
+
+#[test]
+fn snapshots() {
+    assert_all_snapshots::<fvm_ipld_encoding::RawBytes>();
+}
+
+#[cfg(test)]
+quickcheck! {
+    fn quickcheck(val: Vec<u8>) -> () {
+        assert_unchanged_via_json(RawBytes::new(val))
+    }
+}
+
+impl HasLotusJson for RawBytes {
+    type LotusJson = RawBytesLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!("aGVsbG8gd29ybGQh"),
+            RawBytes::new(Vec::from_iter(*b"hello world!")),
+        )]
+    }
+}
+
+impl From<RawBytes> for RawBytesLotusJson {
+    fn from(value: RawBytes) -> Self {
+        RawBytesLotusJson(Vec::from(value))
+    }
+}
+
+impl From<RawBytesLotusJson> for RawBytes {
+    fn from(RawBytesLotusJson(value): RawBytesLotusJson) -> Self {
+        Self::from(value)
+    }
+}

--- a/src/lotus_json/registered_po_st_proof.rs
+++ b/src/lotus_json/registered_po_st_proof.rs
@@ -1,0 +1,33 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::shim::sector::RegisteredPoStProof;
+use fvm_shared3::sector::RegisteredPoStProof as RegisteredPoStProofV3;
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+pub struct RegisteredPoStProofLotusJson(i64);
+
+impl HasLotusJson for RegisteredPoStProof {
+    type LotusJson = RegisteredPoStProofLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!(0),
+            RegisteredPoStProof::from(RegisteredPoStProofV3::StackedDRGWinning2KiBV1),
+        )]
+    }
+}
+
+impl From<RegisteredPoStProof> for RegisteredPoStProofLotusJson {
+    fn from(value: RegisteredPoStProof) -> Self {
+        Self(i64::from(RegisteredPoStProofV3::from(value)))
+    }
+}
+
+impl From<RegisteredPoStProofLotusJson> for RegisteredPoStProof {
+    fn from(value: RegisteredPoStProofLotusJson) -> Self {
+        Self::from(RegisteredPoStProofV3::from(value.0))
+    }
+}

--- a/src/lotus_json/signature.rs
+++ b/src/lotus_json/signature.rs
@@ -1,0 +1,46 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+use crate::shim::crypto::Signature;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SignatureLotusJson {
+    r#type: SignatureTypeLotusJson,
+    data: VecU8LotusJson,
+}
+
+impl HasLotusJson for Signature {
+    type LotusJson = SignatureLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!({"Type": 2, "Data": "aGVsbG8gd29ybGQh"}),
+            Signature {
+                sig_type: crate::shim::crypto::SignatureType::Bls,
+                bytes: Vec::from_iter(*b"hello world!"),
+            },
+        )]
+    }
+}
+
+impl From<SignatureLotusJson> for Signature {
+    fn from(value: SignatureLotusJson) -> Self {
+        let SignatureLotusJson { r#type, data } = value;
+        Self {
+            sig_type: r#type.into(),
+            bytes: data.into(),
+        }
+    }
+}
+
+impl From<Signature> for SignatureLotusJson {
+    fn from(value: Signature) -> Self {
+        let Signature { sig_type, bytes } = value;
+        Self {
+            r#type: sig_type.into(),
+            data: bytes.into(),
+        }
+    }
+}

--- a/src/lotus_json/signature_type.rs
+++ b/src/lotus_json/signature_type.rs
@@ -1,0 +1,17 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+use crate::shim::crypto::SignatureType;
+
+#[derive(Deserialize, Serialize, From, Into)]
+// serialization happens to be the same here
+pub struct SignatureTypeLotusJson(SignatureType);
+
+impl HasLotusJson for SignatureType {
+    type LotusJson = SignatureTypeLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(json!(2), SignatureType::Bls)]
+    }
+}

--- a/src/lotus_json/signed_message.rs
+++ b/src/lotus_json/signed_message.rs
@@ -1,0 +1,71 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::message::SignedMessage;
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SignedMessageLotusJson {
+    message: MessageLotusJson,
+    signature: SignatureLotusJson,
+    #[serde(rename = "CID", skip_serializing_if = "Option::is_none")]
+    cid: Option<CidLotusJson>,
+}
+
+impl HasLotusJson for SignedMessage {
+    type LotusJson = SignedMessageLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!({
+                "Message": {
+                    "From": "f00",
+                    "GasFeeCap": "0",
+                    "GasLimit": 0,
+                    "GasPremium": "0",
+                    "Method": 0,
+                    "Nonce": 0,
+                    "Params": "",
+                    "To": "f00",
+                    "Value": "0",
+                    "Version": 0
+                },
+                "Signature": {"Type": 2, "Data": "aGVsbG8gd29ybGQh"}
+            }),
+            SignedMessage {
+                message: crate::shim::message::Message::default(),
+                signature: crate::shim::crypto::Signature {
+                    sig_type: crate::shim::crypto::SignatureType::Bls,
+                    bytes: Vec::from_iter(*b"hello world!"),
+                },
+            },
+        )]
+    }
+}
+
+impl From<SignedMessage> for SignedMessageLotusJson {
+    fn from(value: SignedMessage) -> Self {
+        let SignedMessage { message, signature } = value;
+        Self {
+            message: message.into(),
+            signature: signature.into(),
+            cid: None, // BUG?(aatifsyed)
+        }
+    }
+}
+
+impl From<SignedMessageLotusJson> for SignedMessage {
+    fn from(value: SignedMessageLotusJson) -> Self {
+        let SignedMessageLotusJson {
+            message,
+            signature,
+            cid: _ignored, // BUG?(aatifsyed)
+        } = value;
+        Self {
+            message: message.into(),
+            signature: signature.into(),
+        }
+    }
+}

--- a/src/lotus_json/ticket.rs
+++ b/src/lotus_json/ticket.rs
@@ -1,0 +1,45 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::blocks::Ticket;
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct TicketLotusJson {
+    v_r_f_proof: VRFProofLotusJson,
+}
+
+impl HasLotusJson for Ticket {
+    type LotusJson = TicketLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!({"VRFProof": "aGVsbG8gd29ybGQh"}),
+            Ticket {
+                vrfproof: crate::blocks::VRFProof(Vec::from_iter(*b"hello world!")),
+            },
+        )]
+    }
+}
+
+impl From<Ticket> for TicketLotusJson {
+    fn from(value: Ticket) -> Self {
+        let Ticket { vrfproof } = value;
+        Self {
+            v_r_f_proof: vrfproof.into(),
+        }
+    }
+}
+
+impl From<TicketLotusJson> for Ticket {
+    fn from(value: TicketLotusJson) -> Self {
+        let TicketLotusJson {
+            v_r_f_proof: vrfproof,
+        } = value;
+        Self {
+            vrfproof: vrfproof.into(),
+        }
+    }
+}

--- a/src/lotus_json/tipset_keys.rs
+++ b/src/lotus_json/tipset_keys.rs
@@ -1,0 +1,36 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::blocks::TipsetKeys;
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+pub struct TipsetKeysLotusJson(VecLotusJson<CidLotusJson>);
+
+impl HasLotusJson for TipsetKeys {
+    type LotusJson = TipsetKeysLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!([{"/": "baeaaaaa"}]),
+            TipsetKeys {
+                cids: vec![::cid::Cid::default()],
+            },
+        )]
+    }
+}
+
+impl From<TipsetKeys> for TipsetKeysLotusJson {
+    fn from(value: TipsetKeys) -> Self {
+        let TipsetKeys { cids } = value;
+        Self(cids.into())
+    }
+}
+
+impl From<TipsetKeysLotusJson> for TipsetKeys {
+    fn from(value: TipsetKeysLotusJson) -> Self {
+        let TipsetKeysLotusJson(cids) = value;
+        Self { cids: cids.into() }
+    }
+}

--- a/src/lotus_json/token_amount.rs
+++ b/src/lotus_json/token_amount.rs
@@ -1,0 +1,34 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+
+use crate::shim::econ::TokenAmount;
+
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)] // name the field for clarity
+pub struct TokenAmountLotusJson {
+    attos: BigIntLotusJson,
+}
+
+impl HasLotusJson for TokenAmount {
+    type LotusJson = TokenAmountLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(json!("1"), TokenAmount::from_atto(1))]
+    }
+}
+
+impl From<TokenAmount> for TokenAmountLotusJson {
+    fn from(value: TokenAmount) -> Self {
+        Self {
+            attos: value.atto().clone().into(),
+        }
+    }
+}
+
+impl From<TokenAmountLotusJson> for TokenAmount {
+    fn from(value: TokenAmountLotusJson) -> Self {
+        Self::from_atto(value.attos)
+    }
+}

--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -1,0 +1,79 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+
+pub struct VecLotusJson<T>(Vec<T>);
+
+impl<T> HasLotusJson for Vec<T>
+where
+    T: HasLotusJson,
+{
+    type LotusJson = VecLotusJson<T::LotusJson>;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        unimplemented!("only Vec<Cid> is tested, below")
+    }
+}
+
+#[test]
+fn shapshots() {
+    assert_one_snapshot(json!([{"/": "baeaaaaa"}]), vec![::cid::Cid::default()]);
+}
+
+#[cfg(test)]
+quickcheck! {
+    fn quickcheck(val: Vec<::cid::Cid>) -> () {
+        assert_unchanged_via_json(val)
+    }
+}
+
+impl<T> Serialize for VecLotusJson<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.0.is_empty() {
+            true => serializer.serialize_none(),
+            false => self.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for VecLotusJson<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<Vec<T>>::deserialize(deserializer)
+            .map(Option::unwrap_or_default)
+            .map(Self)
+    }
+}
+
+// VecLotusJson<T::LotusJson> -> Vec<T>
+impl<T> From<VecLotusJson<T::LotusJson>> for Vec<T>
+where
+    T: HasLotusJson,
+    T::LotusJson: Into<T>,
+{
+    fn from(value: VecLotusJson<T::LotusJson>) -> Self {
+        value.0.into_iter().map(Into::into).collect()
+    }
+}
+
+// Vec<T> -> VecLotusJson<T::LotusJson>
+impl<T> From<Vec<T>> for VecLotusJson<T::LotusJson>
+where
+    T: HasLotusJson + Into<T::LotusJson>,
+{
+    fn from(value: Vec<T>) -> Self {
+        Self(value.into_iter().map(Into::into).collect())
+    }
+}

--- a/src/lotus_json/vec_u8.rs
+++ b/src/lotus_json/vec_u8.rs
@@ -1,0 +1,16 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+
+#[derive(Serialize, Deserialize, From, Into)]
+#[serde(transparent)]
+pub struct VecU8LotusJson(#[serde(with = "base64_standard")] Vec<u8>);
+
+impl HasLotusJson for Vec<u8> {
+    type LotusJson = VecU8LotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(json!("aGVsbG8gd29ybGQh"), Vec::from_iter(*b"hello world!"))]
+    }
+}

--- a/src/lotus_json/vrf_proof.rs
+++ b/src/lotus_json/vrf_proof.rs
@@ -1,0 +1,32 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::blocks::VRFProof;
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+pub struct VRFProofLotusJson(VecU8LotusJson);
+
+impl HasLotusJson for VRFProof {
+    type LotusJson = VRFProofLotusJson;
+
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!("aGVsbG8gd29ybGQh"),
+            VRFProof(Vec::from_iter(*b"hello world!")),
+        )]
+    }
+}
+
+impl From<VRFProofLotusJson> for VRFProof {
+    fn from(VRFProofLotusJson(value): VRFProofLotusJson) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<VRFProof> for VRFProofLotusJson {
+    fn from(VRFProof(value): VRFProof) -> Self {
+        Self(value.into())
+    }
+}

--- a/src/message_pool/msgpool/test_provider.rs
+++ b/src/message_pool/msgpool/test_provider.rs
@@ -5,10 +5,10 @@
 
 use std::{convert::TryFrom, sync::Arc};
 
+use crate::blocks::VRFProof;
 use crate::blocks::{BlockHeader, ElectionProof, Ticket, Tipset, TipsetKeys};
 use crate::chain::HeadChange;
 use crate::ipld::CidHashMap;
-use crate::json::vrf::VRFProof;
 use crate::message::{ChainMessage, Message as MessageTrait, SignedMessage};
 use crate::shim::{address::Address, econ::TokenAmount, message::Message, state_tree::ActorState};
 use ahash::HashMap;

--- a/src/shim/sector.rs
+++ b/src/shim/sector.rs
@@ -117,8 +117,25 @@ impl From<SectorInfo> for SectorInfoV2 {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    derive_more::From,
+    derive_more::Into,
+)]
 pub struct RegisteredPoStProof(RegisteredPoStProofV3);
+
+#[cfg(test)]
+impl quickcheck::Arbitrary for RegisteredPoStProof {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        // RegisteredPoStProofV3: ::arbitrary::Arbitrary
+        // RegisteredPoStProofV3: !::quickcheck::Arbitrary
+        Self(RegisteredPoStProofV3::from(i64::arbitrary(g)))
+    }
+}
 
 impl Deref for RegisteredPoStProof {
     type Target = RegisteredPoStProofV3;
@@ -132,12 +149,6 @@ impl TryFrom<RegisteredPoStProof> for filecoin_proofs_api::RegisteredPoStProof {
 
     fn try_from(value: RegisteredPoStProof) -> Result<Self, Self::Error> {
         value.0.try_into().map_err(|e: String| anyhow::anyhow!(e))
-    }
-}
-
-impl From<RegisteredPoStProofV3> for RegisteredPoStProof {
-    fn from(value: RegisteredPoStProofV3) -> Self {
-        RegisteredPoStProof(value)
     }
 }
 
@@ -213,7 +224,15 @@ impl From<SectorSize> for SectorSizeV3 {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    derive_more::From,
+    derive_more::Into,
+)]
 #[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
 pub struct PoStProof(PoStProofV3);
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::blocks::Ticket;
-use crate::json::vrf::VRFProof;
+use crate::blocks::VRFProof;
 use crate::message::SignedMessage;
 use crate::shim::{
     address::Address,


### PR DESCRIPTION
See here for background: https://github.com/ChainSafe/forest/blob/8d038ca64cbe31ce1e947713bac3d57da396431f/src/lotus_json/mod.rs

The way forest currently handles the distinction between CBOR and JSON is to have a single struct represent
- the domain object
- the in memory representation
- the lotus cbor via `#[derive(Serialize, Deserialize)]`

This is largely the right decision - the [Serialize] and [Deserialize]
implementations of crates we depend on model the lotus cbor only.

However, the way we handle json is inconsistent:
- [Typically we create a `json` module for the domain object, for use with `serde(with = ...)`](https://github.com/ChainSafe/forest/blob/77d6b2b128d73900b0162e3f573ff8d63e6324b3/src/json/token_amount.rs)
- [Sometimes we create a `FooJson` wrapper struct to wrap the deserialization](https://github.com/ChainSafe/forest/blob/77d6b2b128d73900b0162e3f573ff8d63e6324b3/src/json/message_receipt.rs#L17)
- [Sometimes we create a `JsonHelper` struct for serde](https://github.com/ChainSafe/forest/blob/77d6b2b128d73900b0162e3f573ff8d63e6324b3/src/json/signature.rs#L20-L25)
- Sometimes we create [different](https://github.com/ChainSafe/forest/blob/77d6b2b128d73900b0162e3f573ff8d63e6324b3/src/blocks/header/json.rs#L37-L66) [structs](https://github.com/ChainSafe/forest/blob/77d6b2b128d73900b0162e3f573ff8d63e6324b3/src/blocks/header/json.rs#L95-L124) for each serialization direction,
  where one typically wraps a reference.
- Typically we create additional [vec](https://github.com/ChainSafe/forest/blob/77d6b2b128d73900b0162e3f573ff8d63e6324b3/src/json/cid.rs#L45-L78) and [opt](https://github.com/ChainSafe/forest/blob/77d6b2b128d73900b0162e3f573ff8d63e6324b3/src/json/cid.rs#L80-L99) modules for domain objects which may be wrapped as `Vec<T>` and `Option<T>`

This PR introduces a `HasLotusJson` trait, which defines the one way to handle this.
It is so far only used in the `serialization-vectors` tests - adding new types for RPC calls etc is future work