### PR TITLE
ci: disable two invalid assertions

### DIFF
--- a/scripts/tests/forest_cli_check.sh
+++ b/scripts/tests/forest_cli_check.sh
@@ -49,12 +49,14 @@ pushd "$(mktemp --directory)"
     BASE_EPOCH=$(forest_query_epoch base_snapshot.forest.car.zst)
     assert_eq "$BASE_EPOCH" $((EPOCH-1100))
 
-    BASE_STATE_ROOTS=$(forest_query_state_roots base_snapshot.forest.car.zst)
-    assert_eq "$BASE_STATE_ROOTS" 900
+    # This assertion is not true in the presence of null tipsets
+    #BASE_STATE_ROOTS=$(forest_query_state_roots base_snapshot.forest.car.zst)
+    #assert_eq "$BASE_STATE_ROOTS" 900
 
     "$FOREST_CLI_PATH" archive export --diff "$BASE_EPOCH" -o diff_snapshot.forest.car.zst exported_snapshot.car.zst
-    DIFF_STATE_ROOTS=$(forest_query_state_roots diff_snapshot.forest.car.zst)
-    assert_eq "$DIFF_STATE_ROOTS" 1100
+    # This assertion is not true in the presence of null tipsets
+    #DIFF_STATE_ROOTS=$(forest_query_state_roots diff_snapshot.forest.car.zst)
+    #assert_eq "$DIFF_STATE_ROOTS" 1100
 
     : Validate the union of a snapshot and a diff
     "$FOREST_CLI_PATH" snapshot validate --check-network calibnet base_snapshot.forest.car.zst diff_snapshot.forest.car.zst


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Two assertions didn't take null tipsets into account. Disable them until they can be replaced with better checks.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
