### PR TITLE
feat: add flag for limiting the diff depth of snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   `forest-tool benchmark` commands.
 - [#3330](https://github.com/ChainSafe/forest/pull/3330): Add `--depth` flag to
   `forest-cli snapshot export`.
+- [#3348](https://github.com/ChainSafe/forest/pull/3348): Add `--diff-depth`
+  flag to `forest-cli archive export`.
 
 ### Changed
 


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:

- Add `--diff-depth` flag to `forest-cli archive export`. All values reachable in the diff depth will not be included in diff snapshots.
- Fix type of `diff` from `ChainEpochDelta` to `ChainEpoch`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
