### PR TITLE
feat: impl Blockstore::has for ForestCar and AnyCar

### DIFF
--- a/src/db/car/any.rs
+++ b/src/db/car/any.rs
@@ -108,6 +108,14 @@ impl<ReaderT> Blockstore for AnyCar<ReaderT>
 where
     ReaderT: ReadAt,
 {
+    fn has(&self, k: &Cid) -> anyhow::Result<bool> {
+        match self {
+            AnyCar::Forest(forest) => forest.has(k),
+            AnyCar::Plain(plain) => plain.has(k),
+            AnyCar::Memory(mem) => mem.has(k),
+        }
+    }
+
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         match self {
             AnyCar::Forest(forest) => forest.get(k),

--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -165,6 +165,11 @@ where
     ReaderT: ReadAt,
 {
     #[tracing::instrument(level = "trace", skip(self))]
+    fn has(&self, k: &Cid) -> anyhow::Result<bool> {
+        Ok(self.write_cache.read().contains_key(k) || !self.indexed.lookup(*k)?.is_empty())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         // Return immediately if the value is cached.
         if let Some(value) = self.write_cache.read().get(k) {

--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -70,6 +70,14 @@ impl ZstdFrameCache {
         }
     }
 
+    /// Return a flag that indicated whether the value associated with `cid` is found. Unlike `get`,
+    /// this function does not update the LRU list.
+    pub fn has(&mut self, offset: FrameOffset, key: CacheKey, cid: Cid) -> Option<bool> {
+        self.lru
+            .peek(&(offset, key))
+            .map(|index| index.contains_key(&cid))
+    }
+
     /// Return a clone of the value associated with `cid`. If a value is found,
     /// the cache entry is moved to the top of the queue.
     pub fn get(&mut self, offset: FrameOffset, key: CacheKey, cid: Cid) -> Option<Option<Vec<u8>>> {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

`Blockstore::has` implementation can be more efficient than the default impl (`Blockstore::get().is_some()`) by leveraging the index
 
Changes introduced in this pull request:

- impl Blockstore::has for ForestCar and AnyCar

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
