### PR TITLE
fix: crate doc build failure on docs.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,8 +29,10 @@ const PROTO_DIR: &str = "proto";
 const CARGO_OUT_DIR: &str = "proto";
 
 // Using a local path instead of `OUT_DIR` to reuse the cache as much as possible
-static ACTOR_BUNDLE_CACHE_DIR: Lazy<PathBuf> =
-    Lazy::new(|| Path::new("target/actor_bundles/").to_owned());
+static ACTOR_BUNDLE_CACHE_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    let target_dir = PathBuf::from(env::var("CARGO_TARGET_DIR").unwrap_or("target".into()));
+    target_dir.join("actor_bundles")
+});
 
 pub fn global_http_client() -> reqwest::Client {
     static CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to fix the doc build failure https://docs.rs/crate/forest-filecoin/0.12.1/builds/876092

```
[INFO] running `Command { std: "docker" "create" "-v" "/home/cratesfyi/workspace/builds/forest-filecoin-0.12.1/target:/opt/rustwide/target:rw,Z" "-v" "/home/cratesfyi/workspace/builds/forest-filecoin-0.12.1/source:/opt/rustwide/workdir:ro,Z" "-v" "/home/cratesfyi/workspace/cargo-home:/opt/rustwide/cargo-home:ro,Z" "-v" "/home/cratesfyi/workspace/rustup-home:/opt/rustwide/rustup-home:ro,Z" "-e" "SOURCE_DIR=/opt/rustwide/workdir" "-e" "CARGO_TARGET_DIR=/opt/rustwide/target" "-e" "DOCS_RS=1" "-e" "CARGO_HOME=/opt/rustwide/cargo-home" "-e" "RUSTUP_HOME=/opt/rustwide/rustup-home" "-w" "/opt/rustwide/workdir" "-m" "3221225472" "--cpus" "3" "--user" "1001:1001" "--network" "none" "ghcr.io/rust-lang/crates-build-env/linux@sha256:5c16f4e6c37141f9fef0bc86f7a492d732943053e42aab8461035881e3f53823" "/opt/rustwide/cargo-home/bin/cargo" "+nightly" "rustdoc" "--lib" "-Zrustdoc-map" "-Z" "unstable-options" "--config" "build.rustdocflags=[\"-Z\", \"unstable-options\", \"--emit=invocation-specific\", \"--resource-suffix\", \"-20230801-1.73.0-nightly-d12c6e947\", \"--static-root-path\", \"/-/rustdoc.static/\", \"--cap-lints\", \"warn\", \"--disable-per-crate-search\", \"--extern-html-root-takes-precedence\"]" "--offline" "-Zunstable-options" "--config=doc.extern-map.registries.crates-io=\"https://docs.rs/{pkg_name}/{version}/x86_64-unknown-linux-gnu\"" "-Zrustdoc-scrape-examples" "-j3" "--target" "x86_64-unknown-linux-gnu", kill_on_drop: false }`
...
[INFO] [stderr]   Error: Failed to get bafy2bzacedbedgynklc4dgpyxippkxmba2mgtw7ecntoneclsvvl4klqwuyyy.car from https://forest-continuous-integration.fra1.cdn.digitaloceanspaces.com/builtin-actors/calibnet/Shark.car
[INFO] [stderr] 
[INFO] [stderr]   Caused by:
[INFO] [stderr]       Read-only file system (os error 30)
```

build target dir is specified by `CARGO_TARGET_DIR` env var in the script, with read-write access.

Changes introduced in this pull request:

- Respect `CARGO_TARGET_DIR` env var when getting `target` dir
- Generate a dummy bundle for docs.rs build

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
