### PR TITLE
feat: better cargo-audit practice

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,19 +6,19 @@
 # - tracking issues with the "security" label
 # - reasons why they're ignored
 ignore = [
-    # Waiting on libp2p to update ed25519-dalek 1.x -> 2.x
-    # https://github.com/ChainSafe/forest/issues/3371
-    "RUSTSEC-2022-0093",
-    # TODO: ???
-    # https://github.com/ChainSafe/forest/issues/3372
-    "RUSTSEC-2020-0071",
-    # Waiting on fvm2 to update unmaintained deps
-    # https://github.com/ChainSafe/forest/issues/3373
-    "RUSTSEC-2020-0168",
-    "RUSTSEC-2022-0061",
-    # TODO: Take renamed crate
-    # https://github.com/ChainSafe/forest/issues/3374
-    "RUSTSEC-2023-0037",
+  # Waiting on libp2p to update ed25519-dalek 1.x -> 2.x
+  # https://github.com/ChainSafe/forest/issues/3371
+  "RUSTSEC-2022-0093",
+  # TODO: ???
+  # https://github.com/ChainSafe/forest/issues/3372
+  "RUSTSEC-2020-0071",
+  # Waiting on fvm2 to update unmaintained deps
+  # https://github.com/ChainSafe/forest/issues/3373
+  "RUSTSEC-2020-0168",
+  "RUSTSEC-2022-0061",
+  # TODO: Take renamed crate
+  # https://github.com/ChainSafe/forest/issues/3374
+  "RUSTSEC-2023-0037",
 ]
 
 [output]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,26 @@
+# Keys and default values are documented here:
+# https://github.com/rustsec/rustsec/blob/f70e5bc4252ab7f7801d127aeee4a7486e4c07e5/cargo-audit/audit.toml.example
+
+[advisories]
+# These should all have either:
+# - tracking issues with the "security" label
+# - reasons why they're ignored
+ignore = [
+    # Waiting on libp2p to update ed25519-dalek 1.x -> 2.x
+    # https://github.com/ChainSafe/forest/issues/3371
+    "RUSTSEC-2022-0093",
+    # TODO: ???
+    # https://github.com/ChainSafe/forest/issues/3372
+    "RUSTSEC-2020-0071",
+    # Waiting on fvm2 to update unmaintained deps
+    # https://github.com/ChainSafe/forest/issues/3373
+    "RUSTSEC-2020-0168",
+    "RUSTSEC-2022-0061",
+    # TODO: Take renamed crate
+    # https://github.com/ChainSafe/forest/issues/3374
+    "RUSTSEC-2023-0037",
+]
+
+[output]
+deny = ["unmaintained"]
+quiet = false

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,13 +9,17 @@ ignore = [
   # Waiting on libp2p to update ed25519-dalek 1.x -> 2.x
   # https://github.com/ChainSafe/forest/issues/3371
   "RUSTSEC-2022-0093",
+
   # TODO: ???
   # https://github.com/ChainSafe/forest/issues/3372
   "RUSTSEC-2020-0071",
-  # Waiting on fvm2 to update unmaintained deps
-  # https://github.com/ChainSafe/forest/issues/3373
-  "RUSTSEC-2020-0168",
-  "RUSTSEC-2022-0061",
+
+  # Unmaintained crates that fvm2 requires, and will not change for
+  # compatability/consensus reasons - see
+  # https://github.com/filecoin-project/ref-fvm/issues/1843
+  "RUSTSEC-2020-0168", # mach is unmaintained
+  "RUSTSEC-2022-0061", # parity-wasm is deprecated
+
   # TODO: Take renamed crate
   # https://github.com/ChainSafe/forest/issues/3374
   "RUSTSEC-2023-0037",

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean:
 lint-all: lint audit spellcheck
 
 audit:
-	cargo audit --ignore RUSTSEC-2020-0071
+	cargo audit || (echo "See .config/audit.toml"; false)
 
 spellcheck:
 	cargo spellcheck --code 1 || (echo "See .config/spellcheck.md for tips"; false)


### PR DESCRIPTION
Prompted by `cargo audit` beginning to fail in pipelines due to RUSTSEC-2022-0093