### PR TITLE
`CidVariant` refactor

### DIFF
--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -1,18 +1,22 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use anyhow::Context;
 use async_compression::futures::bufread::ZstdDecoder;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 
 pub async fn load_actor_bundles(db: &impl Blockstore) -> anyhow::Result<Vec<Cid>> {
-    pub const ACTOR_BUNDLES_CAR_ZST: &[u8] = include_bytes!("../../assets/actor_bundles.car.zst");
+    const ERROR_MESSAGE: &str = "Actor bundles assets are not properly downloaded, make sure git-lfs is installed and run `git lfs pull` again. See <https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md>";
+    const ACTOR_BUNDLES_CAR_ZST: &[u8] = include_bytes!("../../assets/actor_bundles.car.zst");
+    assert!(ACTOR_BUNDLES_CAR_ZST.len() > 1024 * 1024, "{ERROR_MESSAGE}");
 
-    Ok(fvm_ipld_car::load_car(
+    fvm_ipld_car::load_car(
         db,
         ZstdDecoder::new(futures::io::BufReader::new(ACTOR_BUNDLES_CAR_ZST)),
     )
-    .await?)
+    .await
+    .context(ERROR_MESSAGE)
 }
 
 #[cfg(test)]

--- a/src/ipld/frozen_cids.rs
+++ b/src/ipld/frozen_cids.rs
@@ -6,7 +6,7 @@ use cid::Cid;
 use serde::{Deserialize, Serialize};
 
 /// A wrapper around `Box<[CidVariant]>` with a [`Cid`]-friendly API:
-/// - Uses [`CidVariant`] over [`Cid`] to save memory on common CIDs - see docs for that type for more
+/// - Uses [`SmallCid`] over [`Cid`] to save memory on common CIDs - see docs for that type for more
 /// - Uses `Box<[...]>`, over `Vec<...>` avoiding vector overallocation
 ///
 /// There will be MANY small collections of [`FrozenCids`] over the codebase, so these space savings matter

--- a/src/ipld/frozen_cids.rs
+++ b/src/ipld/frozen_cids.rs
@@ -5,7 +5,7 @@ use crate::utils::cid::SmallCid;
 use cid::Cid;
 use serde::{Deserialize, Serialize};
 
-/// A wrapper around `Box<[CidVariant]>` with a [`Cid`]-friendly API:
+/// A wrapper around `Box<[SmallCid]>` with a [`Cid`]-friendly API:
 /// - Uses [`SmallCid`] over [`Cid`] to save memory on common CIDs - see docs for that type for more
 /// - Uses `Box<[...]>`, over `Vec<...>` avoiding vector overallocation
 ///

--- a/src/ipld/frozen_cids.rs
+++ b/src/ipld/frozen_cids.rs
@@ -64,11 +64,7 @@ impl From<FrozenCids> for Vec<Cid> {
 
 impl From<&FrozenCids> for Vec<Cid> {
     fn from(frozen_cids: &FrozenCids) -> Self {
-        let mut cids = Vec::with_capacity(frozen_cids.0.len());
-        for cid in frozen_cids.into_iter() {
-            cids.push(cid);
-        }
-        cids
+        Vec::from_iter(frozen_cids.into_iter())
     }
 }
 

--- a/src/utils/cid/mod.rs
+++ b/src/utils/cid/mod.rs
@@ -53,7 +53,7 @@ impl SmallCid {
             SmallCidInner::V1DagCborBlake2b(digest) => Cid::new_v1(
                 DAG_CBOR,
                 multihash::Multihash::wrap(Blake2b256.into(), digest)
-                    .expect("failed to convert Blake2b digest to V1 DAG-CBOR Blake2b CID"),
+                    .expect("failed to convert Blake2b digest to Multihash for creation of V1 DAG-CBOR Blake2b CID"),
             ),
         }
     }
@@ -114,7 +114,7 @@ impl From<&SmallCid> for Cid {
             SmallCid(SmallCidInner::V1DagCborBlake2b(digest)) => Cid::new_v1(
                 DAG_CBOR,
                 multihash::Multihash::wrap(Blake2b256.into(), digest)
-                    .expect("failed to convert Blake2b digest to V1 DAG-CBOR Blake2b CID"),
+                    .expect("failed to convert Blake2b digest to Multihash for creation of V1 DAG-CBOR Blake2b CID"),
             ),
         }
     }

--- a/src/utils/cid/mod.rs
+++ b/src/utils/cid/mod.rs
@@ -31,20 +31,37 @@ impl CidCborExt for Cid {}
 
 pub const BLAKE2B256_SIZE: usize = 32;
 
-/// `CidVariant` is an enumeration of known CID types that are used in the Filecoin blockchain. CIDs
+/// `SmallCid` encapsulates an enumeration of known CID types that are used in the Filecoin blockchain. CIDs
 /// contain a significant amount of static data (such as version, codec, hash identifier, hash
 /// length). This static data represented by a single tag in the `enum`.
 ///
 /// Nearly all Filecoin CIDs are `V1`,`DagCbor` encoded, and hashed with `Blake2b256` (which has a hash
-/// length of 256 bits). Naively representing such a CID requires 96 bytes but `CidVariant` does it in
-/// only 40 bytes. If other types of CID become popular, they can be added to the `CidVariant`
+/// length of 256 bits). Naively representing such a CID requires 96 bytes but `SmallCid` does it in
+/// only 40 bytes. If other types of CID become popular, they can be added to the `SmallCid`
 /// structure.
 ///
 /// The `Generic` variant is used for CIDs that do not fit into the other variants.
 /// These variants are used for optimizing storage of CIDs in the `FrozenCids` structure.
 #[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum CidVariant {
+pub struct SmallCid(SmallCidInner);
+
+impl SmallCid {
+    pub fn cid(&self) -> Cid {
+        match &self.0 {
+            SmallCidInner::Generic(cid) => **cid,
+            SmallCidInner::V1DagCborBlake2b(digest) => Cid::new_v1(
+                DAG_CBOR,
+                multihash::Multihash::wrap(Blake2b256.into(), digest)
+                    .expect("failed to convert Blake2b digest to V1 DAG-CBOR Blake2b CID"),
+            ),
+        }
+    }
+}
+
+#[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum SmallCidInner {
     Generic(Box<Cid>),
     V1DagCborBlake2b(
         #[cfg_attr(test, arbitrary(gen(|g: &mut quickcheck::Gen| std::array::from_fn(|_ix| Arbitrary::arbitrary(g)))))]
@@ -52,16 +69,16 @@ pub enum CidVariant {
     ),
 }
 
-impl Serialize for CidVariant {
+impl Serialize for SmallCid {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        Cid::from(self).serialize(serializer)
+        self.cid().serialize(serializer)
     }
 }
 
-impl<'de> Deserialize<'de> for CidVariant {
+impl<'de> Deserialize<'de> for SmallCid {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -70,31 +87,31 @@ impl<'de> Deserialize<'de> for CidVariant {
     }
 }
 
-impl From<Cid> for CidVariant {
+impl From<Cid> for SmallCid {
     fn from(cid: Cid) -> Self {
         if cid.version() == Version::V1 && cid.codec() == DAG_CBOR {
             if let Ok(small_hash) = cid.hash().resize() {
                 let (code, bytes, size) = small_hash.into_inner();
                 if code == u64::from(Code::Blake2b256) && size as usize == BLAKE2B256_SIZE {
-                    return CidVariant::V1DagCborBlake2b(bytes);
+                    return SmallCid(SmallCidInner::V1DagCborBlake2b(bytes));
                 }
             }
         }
-        CidVariant::Generic(Box::new(cid))
+        SmallCid(SmallCidInner::Generic(Box::new(cid)))
     }
 }
 
-impl From<CidVariant> for Cid {
-    fn from(variant: CidVariant) -> Self {
+impl From<SmallCid> for Cid {
+    fn from(variant: SmallCid) -> Self {
         Cid::from(&variant)
     }
 }
 
-impl From<&CidVariant> for Cid {
-    fn from(variant: &CidVariant) -> Self {
+impl From<&SmallCid> for Cid {
+    fn from(variant: &SmallCid) -> Self {
         match variant {
-            CidVariant::Generic(cid) => **cid,
-            CidVariant::V1DagCborBlake2b(digest) => Cid::new_v1(
+            SmallCid(SmallCidInner::Generic(cid)) => **cid,
+            SmallCid(SmallCidInner::V1DagCborBlake2b(digest)) => Cid::new_v1(
                 DAG_CBOR,
                 multihash::Multihash::wrap(Blake2b256.into(), digest)
                     .expect("failed to convert Blake2b digest to V1 DAG-CBOR Blake2b CID"),
@@ -105,7 +122,7 @@ impl From<&CidVariant> for Cid {
 
 #[cfg(test)]
 mod tests {
-    use super::CidVariant;
+    use super::SmallCid;
     use super::*;
     use crate::db::MemoryDB;
     use crate::utils::db::CborStoreExt;
@@ -155,18 +172,18 @@ mod tests {
         .unwrap();
         assert!(matches!(
             cid.try_into().unwrap(),
-            CidVariant::V1DagCborBlake2b(_)
+            SmallCid(SmallCidInner::V1DagCborBlake2b(_))
         ));
     }
 
     // If this test fails, the default encoding is no longer v1+dagcbor+blake2b. Add the new default
-    // CID type to `CidVariant`.
+    // CID type to `SmallCid`.
     #[test]
     fn default_is_v1_dagcbor() {
         let cid = MemoryDB::default().put_cbor_default(&()).unwrap();
         assert!(matches!(
             cid.try_into().unwrap(),
-            CidVariant::V1DagCborBlake2b(_)
+            SmallCid(SmallCidInner::V1DagCborBlake2b(_))
         ));
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Renamed `CidVariant` to `SmallCid` and modified type structure to hide enum details from users.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3367 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
