### PR TITLE
fix: make it a compile time error when the actor bundle size is invalid

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -77,12 +77,6 @@ jobs:
   cargo-publish-dry-run:
     runs-on: ubuntu-latest
     steps:
-      # To help investigate transient test failures
-      - run: lscpu
-      # find the nearest S3 space for storing cache files
-      - name: Show IP
-        run: curl ifconfig.me
-        continue-on-error: true
       - name: Checkout Sources
         uses: actions/checkout@v3
       - run: ./assets/ci_download.sh

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -75,7 +75,6 @@ jobs:
           if-no-files-found: error
 
   cargo-publish-dry-run:
-    name: cargo publish --dry-run
     runs-on: ubuntu-latest
     steps:
       # To help investigate transient test failures

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -74,6 +74,28 @@ jobs:
             ~/.cargo/bin/forest*
           if-no-files-found: error
 
+  cargo-publish-dry-run:
+    name: cargo publish --dry-run
+    runs-on: ubuntu-latest
+    steps:
+      # To help investigate transient test failures
+      - run: lscpu
+      # find the nearest S3 space for storing cache files
+      - name: Show IP
+        run: curl ifconfig.me
+        continue-on-error: true
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+      - run: ./assets/ci_download.sh
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        continue-on-error: true
+      - name: Install Apt Dependencies
+        run: |
+          sudo make install-deps
+      - run: cargo publish --dry-run --allow-dirty # assets are not pulled by git-lfs thus the repo is dirty.
+
   # cli-specific tests
   forest-cli-check:
     needs:

--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -5,11 +5,15 @@ use anyhow::Context;
 use async_compression::futures::bufread::ZstdDecoder;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
+use static_assertions::const_assert_eq;
 
 pub async fn load_actor_bundles(db: &impl Blockstore) -> anyhow::Result<Vec<Cid>> {
     const ERROR_MESSAGE: &str = "Actor bundles assets are not properly downloaded, make sure git-lfs is installed and run `git lfs pull` again. See <https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md>";
+
     const ACTOR_BUNDLES_CAR_ZST: &[u8] = include_bytes!("../../assets/actor_bundles.car.zst");
-    assert!(ACTOR_BUNDLES_CAR_ZST.len() > 1024 * 1024, "{ERROR_MESSAGE}");
+    // Check bundle size at compile time, see `ERROR_MESSAGE` for details.
+    // Note: make sure the bundle size is updated with the bundle file.
+    const_assert_eq!(ACTOR_BUNDLES_CAR_ZST.len(), 2438387);
 
     fvm_ipld_car::load_car(
         db,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Make it a compile time error when the actor bundle size is invalid
- Add a `cargo publish --dry-run` CI job to capture errors like assets are invalid, assets are not properly included, and temporary crate patch, etc. that blocks cargo publishing.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
