### PR TITLE
Add prompt to overwrite existing file during `archive export` and `--force` flag to suppress prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
   `forest-cli snapshot export`.
 - [#3348](https://github.com/ChainSafe/forest/pull/3348): Add `--diff-depth`
   flag to `forest-cli archive export`.
+- [#3322](https://github.com/ChainSafe/forest/issues/3322): Added prompt to
+  `forest-cli archive export` to overwrite file if the file specified with
+  `--output-path` already exists and a `--force` flag to suppress the prompt.
 
 ### Changed
 

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -39,6 +39,7 @@ use crate::shim::clock::{ChainEpoch, EPOCHS_IN_DAY, EPOCH_DURATION_SECONDS};
 use anyhow::{bail, Context as _};
 use chrono::NaiveDateTime;
 use clap::Subcommand;
+use dialoguer::{theme::ColorfulTheme, Confirm};
 use futures::TryStreamExt;
 use fvm_ipld_blockstore::Blockstore;
 use indicatif::ProgressIterator;
@@ -78,6 +79,9 @@ pub enum ArchiveCommands {
         /// state-roots are included if this flag is not set.
         #[arg(short, long)]
         diff_depth: Option<ChainEpochDelta>,
+        /// Overwrite output file without prompting.
+        #[arg(long, default_value_t = false)]
+        force: bool,
     },
     /// Print block headers at 30 day interval for a snapshot file
     Checkpoints {
@@ -101,6 +105,7 @@ impl ArchiveCommands {
                 depth,
                 diff,
                 diff_depth,
+                force,
             } => {
                 let store = ManyCar::try_from(snapshot_files)?;
                 let heaviest_tipset = store.heaviest_tipset()?;
@@ -112,6 +117,7 @@ impl ArchiveCommands {
                     depth,
                     diff,
                     diff_depth,
+                    force,
                 )
                 .await
             }
@@ -147,6 +153,7 @@ fn build_output_path(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn do_export(
     store: impl Blockstore + Send + Sync + 'static,
     root: Tipset,
@@ -155,6 +162,7 @@ async fn do_export(
     depth: ChainEpochDelta,
     diff: Option<ChainEpoch>,
     diff_depth: Option<ChainEpochDelta>,
+    force: bool,
 ) -> anyhow::Result<()> {
     let ts = Arc::new(root);
 
@@ -206,6 +214,21 @@ async fn do_export(
 
     let output_path =
         build_output_path(network.to_string(), genesis.timestamp(), epoch, output_path);
+
+    if output_path.exists() && !force {
+        let have_permission = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!(
+                "{} will be overwritten. Continue?",
+                output_path.to_string_lossy()
+            ))
+            .default(false)
+            .interact()
+            // e.g not a tty (or some other error), so haven't got permission.
+            .unwrap_or(false);
+        if !have_permission {
+            return Ok(());
+        }
+    }
 
     let writer = tokio::fs::File::create(&output_path)
         .await
@@ -427,6 +450,7 @@ mod tests {
             1,
             None,
             None,
+            false,
         )
         .await
         .unwrap();

--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -215,7 +215,7 @@ async fn do_export(
     let output_path =
         build_output_path(network.to_string(), genesis.timestamp(), epoch, output_path);
 
-    if output_path.exists() && !force {
+    if !force && output_path.exists() {
         let have_permission = Confirm::with_theme(&ColorfulTheme::default())
             .with_prompt(format!(
                 "{} will be overwritten. Continue?",

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -240,7 +240,7 @@ impl SnapshotCommands {
                     false => output.clone(),
                 };
 
-                if destination.exists() && !force {
+                if !force && destination.exists() {
                     let have_permission = Confirm::with_theme(&ColorfulTheme::default())
                         .with_prompt(format!(
                             "{} will be overwritten. Continue?",


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `forest-cli archive export` doesn't currently warn before overwriting the `output-path`. Added prompt if the output path already exists and a `--force` flag to suppress the prompt.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes associated task in #3322 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
