### PR TITLE
Use consistent output path flags for `archive export`, `snapshot export`, and `snapshot compress`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,7 +18,7 @@ ignore = [
 
   # https://github.com/ChainSafe/forest/issues/3410
   "RUSTSEC-2023-0052", # No fixed upgrade is available!
-  "RUSTSEC-2023-0053" # TODO: Upgrade to >=0.100.2, <0.101.0 OR >=0.101.4
+  "RUSTSEC-2023-0053", # TODO: Upgrade to >=0.100.2, <0.101.0 OR >=0.101.4
 ]
 
 [output]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,6 +15,10 @@ ignore = [
   # https://github.com/filecoin-project/ref-fvm/issues/1843
   "RUSTSEC-2020-0168", # mach is unmaintained
   "RUSTSEC-2022-0061", # parity-wasm is deprecated
+
+  # https://github.com/ChainSafe/forest/issues/3410
+  "RUSTSEC-2023-0052", # No fixed upgrade is available!
+  "RUSTSEC-2023-0053" # TODO: Upgrade to >=0.100.2, <0.101.0 OR >=0.101.4
 ]
 
 [output]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@
   walking performance.
 - [#3178](https://github.com/ChainSafe/forest/issues/3178): Removed inaccurate
   progress log ETA; now only the elapsed time is displayed.
+- [#3322](https://github.com/ChainSafe/forest/issues/3322): The
+  `snapshot export` and `snapshot compress` subcommands for `forest-cli` are now
+  both consistent with `forest-cli archive export` in supporting a short-form
+  output path flag `-o` and a long-form output path flag `--output-path`. The
+  flag `--output` for the `snapshot compress` subcommand was replaced by
+  `--output-path`.
 
 ### Removed
 

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -25,7 +25,7 @@ pub enum SnapshotCommands {
     /// Export a snapshot of the chain to `<output_path>`
     Export {
         /// `./forest_snapshot_{chain}_{year}-{month}-{day}_height_{epoch}.car.zst`.
-        #[arg(short, default_value = ".", verbatim_doc_comment)]
+        #[arg(short, long, default_value = ".", verbatim_doc_comment)]
         output_path: PathBuf,
         /// Skip creating the checksum file.
         #[arg(long)]
@@ -72,7 +72,7 @@ pub enum SnapshotCommands {
         /// Will reuse the source name (with new extension) if pointed to a
         /// directory.
         #[arg(short, long, default_value = ".")]
-        output: PathBuf,
+        output_path: PathBuf,
         #[arg(long, default_value_t = 3)]
         compression_level: u16,
         /// End zstd frames after they exceed this length
@@ -184,16 +184,16 @@ impl SnapshotCommands {
             }
             Self::Compress {
                 source,
-                output,
+                output_path,
                 compression_level,
                 frame_size,
                 force,
             } => {
                 // If input is 'snapshot.car.zst' and output is '.', set the
                 // destination to './snapshot.forest.car.zst'.
-                let destination = match output.is_dir() {
+                let destination = match output_path.is_dir() {
                     true => {
-                        let mut destination = output;
+                        let mut destination = output_path;
                         destination.push(source.clone());
                         while let Some(ext) = destination.extension() {
                             if !(ext == "zst" || ext == "car" || ext == "forest") {
@@ -203,7 +203,7 @@ impl SnapshotCommands {
                         }
                         destination.with_extension("forest.car.zst")
                     }
-                    false => output.clone(),
+                    false => output_path.clone(),
                 };
 
                 if !force && destination.exists() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The `snapshot export` and `snapshot compress` subcommands for `forest-cli` are now both consistent with `forest-cli archive export` in supporting a short-form output path flag `-o` and a long-form output path flag `--output-path`. The flag `--output` for the `snapshot compress` subcommand was replaced by `--output-path`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3322 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
