### PR TITLE
feat: automatically migrate database folder, ensuring eternal backwards compatibility

### DIFF
--- a/.config/forest.dic
+++ b/.config/forest.dic
@@ -59,8 +59,10 @@ mutex
 overallocation
 P2P
 parsable
+ParityDb
 pointer/SM
 PoSt
+PoC
 RPC
 SECP
 SECP256k1

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -210,6 +210,25 @@ jobs:
       - name: Snapshot export check
         run: ./scripts/tests/calibnet_export_check.sh
 
+  db-migration-checks:
+    needs:
+      - build-ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: forest-${{ runner.os }}
+          path: ~/.cargo/bin
+      # Permissions are lost during artifact-upload
+      # https://github.com/actions/upload-artifact#permission-loss
+      - name: Set permissions
+        run: |
+          chmod +x ~/.cargo/bin/forest*
+      - name: Database migration checks
+        run: ./scripts/tests/calibnet_db_migration.sh
+
   local-devnet-check:
     if: false
     name: Devnet checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "deprecate-until"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec2e2a2d0c79afd023be50309ecf010f20bf4a2761f15e264f4ac9516aff58b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +2709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,7 +2745,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forest-filecoin"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "anes",
@@ -2822,6 +2840,7 @@ dependencies = [
  "memmap2 0.7.1",
  "memory-stats",
  "mimalloc",
+ "multimap",
  "nom",
  "nonempty",
  "nonzero_ext",
@@ -2834,6 +2853,7 @@ dependencies = [
  "once_cell",
  "parity-db",
  "parking_lot",
+ "pathfinding",
  "pbr",
  "pin-project-lite",
  "positioned-io",
@@ -3981,6 +4001,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924df4f0e24e2e7f9cdd90babb0b96f93b20f3ecfa949ea9e6613756b8c8e1bf"
 
 [[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5067,6 +5096,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70db9248a93dc36a36d9a47898caa007a32755c7ad140ec64eeeb50d5a730631"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "multistream-select"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5584,6 +5622,21 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pathfinding"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c246434cbaa32c6430ea09b0a7dd28c0f954143f7866cf551e42f2390d8a65ae"
+dependencies = [
+ "deprecate-until",
+ "fixedbitset",
+ "indexmap 2.0.0",
+ "integer-sqrt",
+ "num-traits",
+ "rustc-hash",
+ "thiserror",
+]
 
 [[package]]
 name = "pbr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forest-filecoin"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 repository = "https://github.com/ChainSafe/forest"
 edition = "2021"
@@ -113,6 +113,7 @@ lru = "0.11"
 memmap2 = "0.7"
 memory-stats = "1.1"
 mimalloc = { version = "0.1.34", optional = true, default-features = false }
+multimap = "0.9.0"
 nom = "7.1.3"
 nonempty = "0.8.0"
 nonzero_ext = "0.3.0"
@@ -125,6 +126,7 @@ num_cpus = "1.14"
 once_cell = "1.15"
 parity-db = { version = "0.4.6", default-features = false }
 parking_lot = "0.12"
+pathfinding = "4.3.1"
 pbr = "1.1"
 pin-project-lite = "0.2"
 positioned-io = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -292,21 +292,6 @@ background:
 The command will block until the detached Forest process has started its RPC
 server, allowing you to chain some RPC command immediately after.
 
-### Database
-
-By default, Forest will create a database of its current version or try to
-migrate to it. This can be overridden with the `FOREST_DB_DEV_MODE`
-environmental variable.
-
-| Value                          | Description                                                                                                                                      |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `current` or (unset)           | Forest will either create a new database with the current version or attempt a migration if possible. On failure, it will create a new database. |
-| `latest`                       | Forest will use the latest versioned database. No migration will be performed.                                                                   |
-| other values (e.g., `cthulhu`) | Forest will use the provided database (if it exists, otherwise it will create one under this name)                                               |
-
-The databases can be found, by default, under `<DATA_DIR>/<chain>/`, e.g.,
-`$HOME/.local/share/forest/calibnet`.
-
 ### Forest snapshot links
 
 - [calibration network](https://forest.chainsafe.io/calibnet/snapshot-latest)

--- a/README.md
+++ b/README.md
@@ -292,6 +292,21 @@ background:
 The command will block until the detached Forest process has started its RPC
 server, allowing you to chain some RPC command immediately after.
 
+### Database
+
+By default, Forest will create a database of its current version or try to
+migrate to it. This can be overridden with the `FOREST_DB_DEV_MODE`
+environmental variable.
+
+| Value                          | Description                                                                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `current` or (unset)           | Forest will either create a new database with the current version or attempt a migration if possible. On failure, it will create a new database. |
+| `latest`                       | Forest will use the latest versioned database. No migration will be performed.                                                                   |
+| other values (e.g., `cthulhu`) | Forest will use the provided database (if it exists, otherwise it will create one under this name)                                               |
+
+The databases can be found, by default, under `<DATA_DIR>/<chain>/`, e.g.,
+`$HOME/.local/share/forest/calibnet`.
+
 ### Forest snapshot links
 
 - [calibration network](https://forest.chainsafe.io/calibnet/snapshot-latest)

--- a/documentation/src/environment_variables.md
+++ b/documentation/src/environment_variables.md
@@ -4,7 +4,23 @@ Besides CLI options and the configuration values in the configuration file,
 there are some environment variables that control the behaviour of a `forest`
 process.
 
-| Environment variable       | Value     | Default | Description                                              |
-| -------------------------- | --------- | ------- | -------------------------------------------------------- |
-| FOREST_KEYSTORE_PHRASE_ENV | any text  | empty   | The passphrase for the encrypted keystore                |
-| FOREST_CAR_LOADER_FILE_IO  | 1 or true | false   | Load CAR files with `RandomAccessFile` instead of `Mmap` |
+| Environment variable       | Value                            | Default | Description                                              |
+| -------------------------- | -------------------------------- | ------- | -------------------------------------------------------- |
+| FOREST_KEYSTORE_PHRASE_ENV | any text                         | empty   | The passphrase for the encrypted keystore                |
+| FOREST_CAR_LOADER_FILE_IO  | 1 or true                        | false   | Load CAR files with `RandomAccessFile` instead of `Mmap` |
+| FOREST_DB_DEV_MODE         | [see here](#-forest_db_dev_mode) | current | The database to use in development mode                  |
+
+### FOREST_DB_DEV_MODE
+
+By default, Forest will create a database of its current version or try to
+migrate to it. This can be overridden with the `FOREST_DB_DEV_MODE`
+environmental variable.
+
+| Value                          | Description                                                                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `current` or (unset)           | Forest will either create a new database with the current version or attempt a migration if possible. On failure, it will create a new database. |
+| `latest`                       | Forest will use the latest versioned database. No migration will be performed.                                                                   |
+| other values (e.g., `cthulhu`) | Forest will use the provided database (if it exists, otherwise it will create one under this name)                                               |
+
+The databases can be found, by default, under `<DATA_DIR>/<chain>/`, e.g.,
+`$HOME/.local/share/forest/calibnet`.

--- a/scripts/tests/calibnet_db_migration.sh
+++ b/scripts/tests/calibnet_db_migration.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euxo pipefail
+
+# This script tests the migration(s) from Forest 0.12.1 to the current version.
+# As simple as it is, it will detect regressions in the migration process and breaking changes.
+
+source "$(dirname "$0")/harness.sh"
+
+DATA_DIR="${TMP_DIR}/data_dir"
+mkdir -p "${DATA_DIR}"
+
+chmod -R 777 "${DATA_DIR}"
+
+# Run Forest 0.12.1 with mounted db so that we can re-use it later.
+docker run --init --rm --name forest-0.12.1 \
+  --volume "${DATA_DIR}":/home/forest/.local/share/forest \
+  ghcr.io/chainsafe/forest:v0.12.1 \
+  --chain calibnet \
+  --encrypt-keystore false \
+  --auto-download-snapshot --halt-after-import
+
+# Assert the database is looking as expected.
+if [ ! -d "${DATA_DIR}/calibnet/paritydb" ]; then
+  echo "Database directory not found"
+  exit 1
+fi
+
+# If can't access due to permissions, try changing ownership to the current user.
+# This is needed for GHA which runs under a particular user.
+if [ ! -w "${DATA_DIR}/calibnet/paritydb" ]; then
+  sudo chown -R "$(id -u):$(id -g)" "${DATA_DIR}/"
+fi
+
+# Note that for Forest 0.12.1, a seamless migration is not really possible given that there is no notion of versioning.
+# We **know** here that Forest was at 0.12.1 so we manually change the directory name to reflect that. This should not be required in the future.
+mv "${DATA_DIR}/calibnet/paritydb" "${DATA_DIR}/calibnet/0.12.1"
+
+CONFIG_FILE="${TMP_DIR}/config.toml"
+
+# Create config file to point to the old database
+echo "[client]" > "${CONFIG_FILE}"
+echo "data_dir = \"${TMP_DIR}/data_dir\"" >> "${CONFIG_FILE}"
+echo 'encrypt_keystore = false' >> "${CONFIG_FILE}"
+
+# Run the current Forest with the old database. This should trigger a migration (or several ones).
+forest --chain calibnet --encrypt-keystore false --log-dir "$LOG_DIRECTORY" --detach --save-token ./admin_token --track-peak-rss --config "${CONFIG_FILE}"
+
+ADMIN_TOKEN=$(cat admin_token)
+FULLNODE_API_INFO="$ADMIN_TOKEN:/ip4/127.0.0.1/tcp/2345/http"
+
+export ADMIN_TOKEN
+export FULLNODE_API_INFO
+
+forest_wait_for_sync
+forest_check_db_stats
+
+# Assert there is no "0.12.1" directory in the database directory. This and a successful sync indicate that the database was successfully migrated.
+if [ -d "${DATA_DIR}/calibnet/0.12.1" ]; then
+  echo "Database directory not migrated"
+  exit 1
+fi
+
+# Get current Forest version
+CURRENT_VERSION=$(forest --version | sed -E 's/.* (.*)\+.*/\1/')
+
+# Assert there is a database directory for the current version
+ls -d "${DATA_DIR}"/calibnet/"${CURRENT_VERSION}"/
+
+echo "Migration test successful, artifacts are in ${TMP_DIR}"

--- a/src/cli/subcommands/state_cmd.rs
+++ b/src/cli/subcommands/state_cmd.rs
@@ -64,7 +64,8 @@ impl StateCommands {
                     .client
                     .data_dir
                     .join(config.chain.network.to_string());
-                let blockstore = Arc::new(open_proxy_db(db_root(&chain_path), Default::default())?);
+                let blockstore =
+                    Arc::new(open_proxy_db(db_root(&chain_path)?, Default::default())?);
 
                 if let Err(err) = print_state_diff(&blockstore, &pre, &post, depth) {
                     eprintln!("Failed to print state diff: {err}");

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -172,8 +172,16 @@ pub(super) async fn start(
     let keystore = Arc::new(RwLock::new(keystore));
 
     let chain_data_path = chain_path(&config);
+
+    // Try to migrate the database if needed. In case the migration fails, we fallback to creating a new database
+    // to avoid breaking the node.
+    let db_migration = crate::db::migration::DbMigration::new(chain_data_path.clone());
+    if let Err(e) = db_migration.migrate() {
+        warn!("Failed to migrate database: {e}");
+    }
+
     let db = Arc::new(ManyCar::new(Arc::new(open_proxy_db(
-        db_root(&chain_data_path),
+        db_root(&chain_data_path)?,
         config.db_config().clone(),
     )?)));
 
@@ -196,7 +204,7 @@ pub(super) async fn start(
             "Prometheus server started at {}",
             config.client.metrics_address
         );
-        let db_directory = crate::db::db_engine::db_root(&chain_path(&config));
+        let db_directory = crate::db::db_engine::db_root(&chain_path(&config))?;
         let db = db.writer().clone();
         services.spawn(async {
             crate::metrics::init_prometheus(prometheus_listener, db_directory, db)

--- a/src/db/db_mode.rs
+++ b/src/db/db_mode.rs
@@ -1,0 +1,174 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use semver::Version;
+
+use crate::utils::version::FOREST_VERSION;
+
+/// Environment variable used to set the development mode
+/// It is used for development purposes. Possible values:
+/// - `current`: use the database matching the current binary version. May result in migrations.
+/// - `latest`: use the latest database version.
+/// - other values: use the database matching the provided name.
+pub(super) const FOREST_DB_DEV_MODE: &str = "FOREST_DB_DEV_MODE";
+
+/// Lists all versioned databases in the chain data directory.
+/// Versioned databases are directories with a `SemVer` version as their name. The rest is discarded.
+fn list_versioned_databases(chain_data_path: &Path) -> anyhow::Result<Vec<Version>> {
+    let versions = fs::read_dir(chain_data_path)?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let path = entry.path();
+            let version = Version::parse(path.file_name()?.to_str()?);
+            match version {
+                Ok(version) => Some(version),
+                // Ignore any directories that are not valid semver versions. Those might be
+                // development databases.
+                Err(_) => None,
+            }
+        })
+        .collect();
+
+    Ok(versions)
+}
+
+/// Returns the latest versioned database in the chain data directory (if such one exists).
+pub(super) fn get_latest_versioned_database(
+    chain_data_path: &Path,
+) -> anyhow::Result<Option<Version>> {
+    let versions = list_versioned_databases(chain_data_path)?;
+    Ok(versions.iter().max().cloned())
+}
+
+/// Chooses the correct database directory to use based on the `[FOREST_DB_DEV_MODE]`
+/// environment variable (or the lack of it).
+pub fn choose_db(chain_data_path: &Path) -> anyhow::Result<PathBuf> {
+    let db = match DbMode::read() {
+        DbMode::Current => chain_data_path.join(FOREST_VERSION.to_string()),
+        DbMode::Latest => {
+            let versions = list_versioned_databases(chain_data_path)?;
+
+            if versions.is_empty() {
+                chain_data_path.join(FOREST_VERSION.to_string())
+            } else {
+                let latest = versions
+                    .iter()
+                    .max()
+                    .ok_or_else(|| anyhow::anyhow!("Failed to find latest versioned database"))?; // This should never happen
+                chain_data_path.join(latest.to_string())
+            }
+        }
+        DbMode::Custom(custom) => chain_data_path.join(custom),
+    };
+
+    Ok(db)
+}
+
+/// Represents different modes of access to the database
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum DbMode {
+    /// Using the database matching the binary version. This is the default, and is the only mode
+    /// in which migrations are run.
+    Current,
+    /// Using the latest versioned database if exists
+    Latest,
+    /// Using a custom database
+    Custom(String),
+}
+
+impl DbMode {
+    /// Returns the database mode based on the environment variable
+    pub fn read() -> Self {
+        match std::env::var(FOREST_DB_DEV_MODE)
+            .map(|s| s.to_lowercase())
+            .as_deref()
+        {
+            Ok("latest") => Self::Latest,
+            Ok("current") | Err(_) => Self::Current,
+            Ok(val) => Self::Custom(val.to_owned()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_db_mode() {
+        env::set_var(FOREST_DB_DEV_MODE, "latest");
+        assert_eq!(DbMode::read(), DbMode::Latest);
+
+        env::set_var(FOREST_DB_DEV_MODE, "current");
+        assert_eq!(DbMode::read(), DbMode::Current);
+
+        env::set_var(FOREST_DB_DEV_MODE, "cthulhu");
+        assert_eq!(DbMode::read(), DbMode::Custom("cthulhu".to_owned()));
+
+        env::remove_var(FOREST_DB_DEV_MODE);
+        assert_eq!(DbMode::read(), DbMode::Current);
+    }
+
+    #[test]
+    fn test_list_versioned_databases() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path();
+
+        for dir in &["0.1.0", "0.2.0", "0.3.0", "Elder God", "my0.4.0"] {
+            std::fs::create_dir(path.join(dir)).unwrap();
+        }
+
+        let versions = list_versioned_databases(path)
+            .unwrap()
+            .iter()
+            .sorted()
+            .cloned()
+            .collect_vec();
+        assert_eq!(
+            versions,
+            vec![
+                Version::parse("0.1.0").unwrap(),
+                Version::parse("0.2.0").unwrap(),
+                Version::parse("0.3.0").unwrap()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_choose_db() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path();
+
+        for dir in &["0.1.0", "0.2.0", "0.3.0", "Elder God", "my0.4.0"] {
+            std::fs::create_dir(path.join(dir)).unwrap();
+        }
+
+        let cases = [
+            ("latest", path.join("0.3.0")),
+            ("current", path.join(FOREST_VERSION.to_string())),
+            ("cthulhu", path.join("cthulhu")),
+        ];
+
+        for (mode, expected) in &cases {
+            env::set_var(FOREST_DB_DEV_MODE, mode);
+            let db = choose_db(path).unwrap();
+            assert_eq!(db, *expected);
+        }
+
+        env::remove_var(FOREST_DB_DEV_MODE);
+        let db = choose_db(path).unwrap();
+        assert_eq!(db, path.join(FOREST_VERSION.to_string()));
+    }
+}

--- a/src/db/migration/db_migration.rs
+++ b/src/db/migration/db_migration.rs
@@ -1,0 +1,137 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::path::PathBuf;
+
+use tracing::info;
+
+use crate::{
+    db::{
+        db_mode::{get_latest_versioned_database, DbMode},
+        migration::migration_map::create_migration_chain,
+    },
+    utils::version::FOREST_VERSION,
+};
+
+/// Governs the database migration process. This is the entry point for the migration process.
+pub struct DbMigration {
+    /// Root of the chain data directory. This is where all the databases are stored.
+    chain_data_path: PathBuf,
+}
+
+impl DbMigration {
+    pub fn new(chain_data_path: PathBuf) -> Self {
+        Self { chain_data_path }
+    }
+
+    /// Verifies if a migration is needed for the current Forest process.
+    /// Note that migration can possibly happen only if the DB is in `current` mode.
+    pub fn is_migration_required(&self) -> anyhow::Result<bool> {
+        // No chain data means that this is a fresh instance. No migration required.
+        if !self.chain_data_path.exists() {
+            return Ok(false);
+        }
+
+        // migration is required only if the DB is in `current` mode and the current db version is
+        // smaller than the current binary version
+        if let DbMode::Current = DbMode::read() {
+            let current_db = get_latest_versioned_database(&self.chain_data_path)?
+                .unwrap_or_else(|| FOREST_VERSION.clone());
+            Ok(current_db < *FOREST_VERSION)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Performs a database migration if required. Note that this may take a long time to complete
+    /// and may need a lot of disk space (at least twice the size of the current database).
+    /// On a successful migration, the current database will be removed and the new database will
+    /// be used.
+    /// This method is tested via integration tests.
+    pub fn migrate(&self) -> anyhow::Result<()> {
+        if !self.is_migration_required()? {
+            info!("No database migration required");
+            return Ok(());
+        }
+
+        let latest_db_version = get_latest_versioned_database(&self.chain_data_path)?
+            .unwrap_or_else(|| FOREST_VERSION.clone());
+
+        info!(
+            "Migrating database from version {} to {}",
+            latest_db_version, *FOREST_VERSION
+        );
+
+        let target_db_version = &FOREST_VERSION;
+
+        let migrations = create_migration_chain(&latest_db_version, target_db_version)?;
+
+        for migration in migrations {
+            migration.migrate(&self.chain_data_path)?;
+        }
+
+        info!(
+            "Migration to version {} complete",
+            target_db_version.to_string()
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::db_mode::FOREST_DB_DEV_MODE;
+
+    use super::*;
+
+    #[test]
+    fn test_migration_not_required_no_chain_path() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db_migration = DbMigration::new(temp_dir.path().join("azathoth"));
+        assert!(!db_migration.is_migration_required()?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_migration_not_required_no_databases() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db_migration = DbMigration::new(temp_dir.path().to_owned());
+        assert!(!db_migration.is_migration_required()?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_migration_not_required_under_non_current_mode() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let db_dir = temp_dir.path().join("0.1.0");
+        std::fs::create_dir(&db_dir)?;
+        let db_migration = DbMigration::new(temp_dir.path().to_owned());
+
+        std::env::set_var(FOREST_DB_DEV_MODE, "latest");
+        assert!(!db_migration.is_migration_required()?);
+
+        std::fs::remove_dir(db_dir)?;
+        std::fs::create_dir(temp_dir.path().join("cthulhu"))?;
+
+        std::env::set_var(FOREST_DB_DEV_MODE, "cthulhu");
+        assert!(!db_migration.is_migration_required()?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_migration_required_current_mode() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let db_dir = temp_dir.path().join("0.1.0");
+        std::fs::create_dir(db_dir)?;
+        let db_migration = DbMigration::new(temp_dir.path().to_owned());
+
+        std::env::set_var(FOREST_DB_DEV_MODE, "current");
+        assert!(db_migration.is_migration_required()?);
+        std::env::remove_var(FOREST_DB_DEV_MODE);
+        assert!(db_migration.is_migration_required()?);
+        Ok(())
+    }
+}

--- a/src/db/migration/migration_map.rs
+++ b/src/db/migration/migration_map.rs
@@ -1,0 +1,424 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::bail;
+use itertools::Itertools;
+use multimap::MultiMap;
+use once_cell::sync::Lazy;
+use semver::Version;
+use tracing::info;
+
+use super::v0_12_1::Migration0_12_1_0_13_0;
+
+/// Migration trait. It is expected that the [`MigrationOperation::migrate`] method will pick up the relevant database
+/// existing under `chain_data_path` and create a new migration database in the same directory.
+pub(super) trait MigrationOperation {
+    /// Performs pre-migration checks. This is the place to check if the database is in a valid
+    /// state and if the migration can be performed. Note that some of the higher-level checks
+    /// (like checking if the database exists) are performed by the [`Migration`].
+    fn pre_checks(&self, chain_data_path: &Path) -> anyhow::Result<()>;
+    /// Performs the actual migration. All the logic should be implemented here.
+    /// Ideally, the migration should use as little of the Forest codebase as possible to avoid
+    /// potential issues with the migration code itself and having to update it in the future.
+    /// Returns the path to the migrated database (which is not yet validated)
+    fn migrate(&self, chain_data_path: &Path) -> anyhow::Result<PathBuf>;
+    /// Performs post-migration checks. This is the place to check if the migration database is
+    /// ready to be used by Forest and renamed into a versioned database.
+    fn post_checks(&self, chain_data_path: &Path) -> anyhow::Result<()>;
+}
+
+/// Migrations map. The key is the starting version and the value is the tuple of the target version
+/// and the [`MigrationOperation`] implementation.
+///
+/// In the future we might want to drop legacy migrations (e.g., to clean-up the database
+/// dependency that may get several breaking changes).
+// If need be, we should introduce "jump" migrations here, e.g. 0.12.0 -> 0.12.2, 0.12.2 -> 0.12.3, etc.
+// This would allow us to skip migrations in case of bugs or just for performance reasons.
+type Migrator = Arc<dyn MigrationOperation + Send + Sync>;
+type MigrationsMap = MultiMap<Version, (Version, Migrator)>;
+pub(super) static MIGRATIONS: Lazy<MigrationsMap> = Lazy::new(|| {
+    MigrationsMap::from_iter(
+        [(
+            Version::new(0, 12, 1),
+            (
+                Version::new(0, 13, 0),
+                Arc::new(Migration0_12_1_0_13_0) as _,
+            ),
+        )]
+        .iter()
+        .cloned(),
+    )
+});
+
+pub struct Migration {
+    from: Version,
+    to: Version,
+    migrator: Migrator,
+}
+
+impl Migration {
+    pub fn migrate(&self, chain_data_path: &Path) -> anyhow::Result<()> {
+        info!(
+            "Migrating database from version {} to {}",
+            self.from, self.to
+        );
+
+        self.pre_checks(chain_data_path)?;
+        let migrated_db = self.migrator.migrate(chain_data_path)?;
+        self.post_checks(chain_data_path)?;
+
+        let new_db = chain_data_path.join(format!("{}", self.to));
+        std::fs::rename(migrated_db, new_db)?;
+
+        let old_db = chain_data_path.join(format!("{}", self.from));
+        std::fs::remove_dir_all(old_db)?;
+
+        info!("Database migration complete");
+        Ok(())
+    }
+
+    fn pre_checks(&self, chain_data_path: &Path) -> anyhow::Result<()> {
+        let source_db = chain_data_path.join(self.from.to_string());
+        if !source_db.exists() {
+            bail!(
+                "source database {source_db} does not exist",
+                source_db = source_db.display()
+            );
+        }
+
+        let target_db = chain_data_path.join(self.to.to_string());
+        if target_db.exists() {
+            bail!(
+                "target database {target_db} already exists",
+                target_db = target_db.display()
+            );
+        }
+
+        self.migrator.pre_checks(chain_data_path)
+    }
+
+    fn post_checks(&self, chain_data_path: &Path) -> anyhow::Result<()> {
+        self.migrator.post_checks(chain_data_path)
+    }
+}
+
+/// Creates a migration chain from `start` to `goal`. The chain is chosen to be the shortest
+/// possible. If there are multiple shortest paths, any of them is chosen. This method will use
+/// the pre-defined migrations map.
+pub(super) fn create_migration_chain(
+    start: &Version,
+    goal: &Version,
+) -> anyhow::Result<Vec<Migration>> {
+    create_migration_chain_from_migrations(start, goal, &MIGRATIONS)
+}
+
+/// Same as [`create_migration_chain`], but uses any provided migrations map.
+fn create_migration_chain_from_migrations(
+    start: &Version,
+    goal: &Version,
+    migrations_map: &MigrationsMap,
+) -> anyhow::Result<Vec<Migration>> {
+    let result = pathfinding::directed::bfs::bfs(
+        start,
+        |from| {
+            if let Some(migrations) = migrations_map.get_vec(from) {
+                migrations.iter().map(|(to, _)| to.clone()).collect()
+            } else {
+                vec![]
+            }
+        },
+        |to| to == goal,
+    )
+    .ok_or_else(|| anyhow::anyhow!("No migration path found from version {start} to {goal}"))?
+    .iter()
+    .tuple_windows()
+    .map(|(from, to)| {
+        let migrator = migrations_map
+            .get_vec(from)
+            .expect("Migration must exist")
+            .iter()
+            .find(|(version, _)| version == to)
+            .expect("Migration must exist")
+            .1
+            .clone();
+
+        Migration {
+            from: from.clone(),
+            to: to.clone(),
+            migrator,
+        }
+    })
+    .collect_vec();
+
+    if result.is_empty() {
+        bail!(
+            "No migration path found from version {start} to {goal}",
+            start = start,
+            goal = goal
+        );
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::utils::version::FOREST_VERSION;
+
+    #[test]
+    fn test_possible_to_migrate_to_current_version() {
+        // This test ensures that it is possible to migrate from the oldest supported version to the current
+        // version.
+        let earliest_version = MIGRATIONS
+            .iter_all()
+            .map(|(from, _)| from)
+            .min()
+            .expect("At least one migration must exist");
+        let current_version = &FOREST_VERSION;
+
+        let migrations = create_migration_chain(earliest_version, current_version).unwrap();
+        assert!(!migrations.is_empty());
+    }
+
+    #[test]
+    fn test_ensure_migration_possible_from_anywhere_to_latest() {
+        // This test ensures that it is possible to find migration chain from any version to the
+        // current version.
+        let current_version = &FOREST_VERSION;
+
+        for (from, _) in MIGRATIONS.iter_all() {
+            let migrations = create_migration_chain(from, current_version).unwrap();
+            assert!(!migrations.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_ensure_migration_not_possible_if_higher_than_latest() {
+        // This test ensures that it is not possible to migrate from a version higher than the
+        // current version.
+        let current_version = &FOREST_VERSION;
+
+        let higher_version = Version::new(
+            current_version.major,
+            current_version.minor,
+            current_version.patch + 1,
+        );
+        let migrations = create_migration_chain(&higher_version, current_version);
+        assert!(migrations.is_err());
+    }
+
+    #[test]
+    fn test_migration_down_not_possible() {
+        // This test ensures that it is not possible to migrate down from the latest version.
+        // This is not a strict requirement and we may want to allow this in the future.
+        let current_version = &FOREST_VERSION;
+
+        for (from, _) in MIGRATIONS.iter_all() {
+            let migrations = create_migration_chain(current_version, from);
+            assert!(migrations.is_err());
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct EmptyMigration;
+
+    impl MigrationOperation for EmptyMigration {
+        fn pre_checks(&self, _chain_data_path: &Path) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn migrate(&self, _chain_data_path: &Path) -> anyhow::Result<PathBuf> {
+            Ok("".into())
+        }
+
+        fn post_checks(&self, _chain_data_path: &Path) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_migration_should_use_shortest_path() -> anyhow::Result<()> {
+        let migrations = MigrationsMap::from_iter(
+            [
+                (
+                    Version::new(0, 1, 0),
+                    (Version::new(0, 2, 0), Arc::new(EmptyMigration) as _),
+                ),
+                (
+                    Version::new(0, 2, 0),
+                    (Version::new(0, 3, 0), Arc::new(EmptyMigration) as _),
+                ),
+                (
+                    Version::new(0, 1, 0),
+                    (Version::new(0, 3, 0), Arc::new(EmptyMigration) as _),
+                ),
+            ]
+            .iter()
+            .cloned(),
+        );
+
+        let migrations = create_migration_chain_from_migrations(
+            &Version::new(0, 1, 0),
+            &Version::new(0, 3, 0),
+            &migrations,
+        )?;
+
+        // The shortest path is 0.1.0 to 0.3.0 (without going through 0.2.0)
+        assert_eq!(1, migrations.len());
+        assert_eq!(Version::new(0, 1, 0), migrations[0].from);
+        assert_eq!(Version::new(0, 3, 0), migrations[0].to);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_migration_complex_path() -> anyhow::Result<()> {
+        let migrations = MigrationsMap::from_iter(
+            [
+                (
+                    Version::new(0, 1, 0),
+                    (Version::new(0, 2, 0), Arc::new(EmptyMigration) as _),
+                ),
+                (
+                    Version::new(0, 2, 0),
+                    (Version::new(0, 3, 0), Arc::new(EmptyMigration) as _),
+                ),
+                (
+                    Version::new(0, 1, 0),
+                    (Version::new(0, 3, 0), Arc::new(EmptyMigration) as _),
+                ),
+                (
+                    Version::new(0, 3, 0),
+                    (Version::new(0, 3, 1), Arc::new(EmptyMigration) as _),
+                ),
+            ]
+            .iter()
+            .cloned(),
+        );
+
+        let migrations = create_migration_chain_from_migrations(
+            &Version::new(0, 1, 0),
+            &Version::new(0, 3, 1),
+            &migrations,
+        )?;
+
+        // The shortest path is 0.1.0 -> 0.3.0 -> 0.3.1
+        assert_eq!(2, migrations.len());
+        assert_eq!(Version::new(0, 1, 0), migrations[0].from);
+        assert_eq!(Version::new(0, 3, 0), migrations[0].to);
+        assert_eq!(Version::new(0, 3, 0), migrations[1].from);
+        assert_eq!(Version::new(0, 3, 1), migrations[1].to);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_same_distance_paths_should_yield_any() -> anyhow::Result<()> {
+        let migrations = MigrationsMap::from_iter(
+            [
+                (
+                    Version::new(0, 1, 0),
+                    (Version::new(0, 2, 0), Arc::new(EmptyMigration) as _),
+                ),
+                (
+                    Version::new(0, 2, 0),
+                    (Version::new(0, 4, 0), Arc::new(EmptyMigration) as _),
+                ),
+                (
+                    Version::new(0, 1, 0),
+                    (Version::new(0, 3, 0), Arc::new(EmptyMigration) as _),
+                ),
+                (
+                    Version::new(0, 3, 0),
+                    (Version::new(0, 4, 0), Arc::new(EmptyMigration) as _),
+                ),
+            ]
+            .iter()
+            .cloned(),
+        );
+
+        let migrations = create_migration_chain_from_migrations(
+            &Version::new(0, 1, 0),
+            &Version::new(0, 4, 0),
+            &migrations,
+        )?;
+
+        // there are two possible shortest paths:
+        // 0.1.0 -> 0.2.0 -> 0.4.0
+        // 0.1.0 -> 0.3.0 -> 0.4.0
+        // Both of them are correct and should be accepted.
+        assert_eq!(2, migrations.len());
+        if migrations[0].to == Version::new(0, 2, 0) {
+            assert_eq!(Version::new(0, 1, 0), migrations[0].from);
+            assert_eq!(Version::new(0, 2, 0), migrations[0].to);
+            assert_eq!(Version::new(0, 2, 0), migrations[1].from);
+            assert_eq!(Version::new(0, 4, 0), migrations[1].to);
+        } else {
+            assert_eq!(Version::new(0, 1, 0), migrations[0].from);
+            assert_eq!(Version::new(0, 3, 0), migrations[0].to);
+            assert_eq!(Version::new(0, 3, 0), migrations[1].from);
+            assert_eq!(Version::new(0, 4, 0), migrations[1].to);
+        }
+
+        Ok(())
+    }
+
+    struct SimpleMigration0_1_0_0_2_0;
+
+    impl MigrationOperation for SimpleMigration0_1_0_0_2_0 {
+        fn pre_checks(&self, chain_data_path: &Path) -> anyhow::Result<()> {
+            let path = chain_data_path.join("0.1.0");
+            if !path.exists() {
+                anyhow::bail!("0.1.0 does not exist");
+            }
+            Ok(())
+        }
+
+        fn migrate(&self, chain_data_path: &Path) -> anyhow::Result<PathBuf> {
+            fs::create_dir(chain_data_path.join("migration_0_1_0_0_2_0"))?;
+            Ok(chain_data_path.join("migration_0_1_0_0_2_0"))
+        }
+
+        fn post_checks(&self, chain_data_path: &Path) -> anyhow::Result<()> {
+            let path = chain_data_path.join("migration_0_1_0_0_2_0");
+            if !path.exists() {
+                anyhow::bail!("migration_0_1_0_0_2_0 does not exist");
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_migration_map_migration() -> anyhow::Result<()> {
+        let migration = Migration {
+            from: Version::new(0, 1, 0),
+            to: Version::new(0, 2, 0),
+            migrator: Arc::new(SimpleMigration0_1_0_0_2_0),
+        };
+
+        let temp_dir = TempDir::new()?;
+
+        assert!(migration.pre_checks(temp_dir.path()).is_err());
+        fs::create_dir(temp_dir.path().join("0.1.0"))?;
+        assert!(migration.pre_checks(temp_dir.path()).is_ok());
+
+        migration.migrate(temp_dir.path())?;
+        assert!(temp_dir.path().join("0.2.0").exists());
+
+        assert!(migration.post_checks(temp_dir.path()).is_err());
+        fs::create_dir(temp_dir.path().join("migration_0_1_0_0_2_0"))?;
+        assert!(migration.post_checks(temp_dir.path()).is_ok());
+
+        Ok(())
+    }
+}

--- a/src/db/migration/mod.rs
+++ b/src/db/migration/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+mod db_migration;
+mod migration_map;
+mod v0_12_1;
+
+pub use db_migration::DbMigration;

--- a/src/db/migration/v0_12_1.rs
+++ b/src/db/migration/v0_12_1.rs
@@ -1,0 +1,286 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Migration logic from version 0.12.1
+//! This is more of an exercise and a PoC than a real migration, the reason being that the
+//! database directories before the Forest version 0.12.1 were not yet versioned and so we can only guess the version
+//! of their underlying databases.
+//! All in all, it gives us a good idea of how to do a migration and solves potential caveats
+//! coming from the rolling database and ParityDb.
+
+use fs_extra::dir::CopyOptions;
+use std::path::{Path, PathBuf};
+use tracing::info;
+
+use super::migration_map::MigrationOperation;
+
+#[derive(Default)]
+pub(super) struct Migration0_12_1_0_13_0;
+
+/// Temporary database path for the migration.
+const MIGRATION_DB_0_12_1_0_13_0: &str = "migration_0_12_1_to_0_13_0";
+
+/// Migrates the database from version 0.12.1 to 0.13.0
+/// This migration is needed because the `Settings` column in the `ParityDb` table changed to
+/// binary-tree indexed and the data from `HEAD` and `meta.yaml` files was moved to the `Settings` column.
+impl MigrationOperation for Migration0_12_1_0_13_0 {
+    fn pre_checks(&self, _chain_data_path: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate(&self, chain_data_path: &Path) -> anyhow::Result<PathBuf> {
+        let source_db = chain_data_path.join("0.12.1");
+
+        let temp_db_path = chain_data_path.join(MIGRATION_DB_0_12_1_0_13_0);
+        if temp_db_path.exists() {
+            info!(
+                "removing old temporary database {temp_db_path}",
+                temp_db_path = temp_db_path.display()
+            );
+            std::fs::remove_dir_all(&temp_db_path)?;
+        }
+
+        // copy the old database to a new directory
+        info!(
+            "copying old database from {source_db} to {temp_db_path}",
+            source_db = source_db.display(),
+            temp_db_path = temp_db_path.display()
+        );
+        fs_extra::copy_items(
+            &[source_db.as_path()],
+            temp_db_path.clone(),
+            &CopyOptions::default().copy_inside(true),
+        )?;
+
+        // there are two YAML files that are supposed to be in the `Settings` column now.
+        // We need to add them manually to the database.
+        let head_file_path = chain_data_path.join("HEAD");
+        let head = std::fs::read(&head_file_path)?;
+
+        // The HEAD type was kept in binary format, so we need to convert it to JSON.
+        let head: Vec<cid::Cid> = fvm_ipld_encoding::from_slice(&head)?;
+        let head = serde_json::to_vec(&head)?;
+
+        // Estimated records were kept in a YAML file...
+        let estimated_records_path = chain_data_path.join("meta.yaml");
+        let estimated_records = std::fs::read_to_string(&estimated_records_path)?;
+        let estimated_records = estimated_records
+            .split_once(':')
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "meta.yaml file is not in the expected format, expected `key: value`"
+                )
+            })
+            .map(|(_, value)| value.trim())?
+            .parse::<u64>()?;
+        let estimated_records = serde_json::to_vec(&estimated_records)?;
+
+        // because of the rolling db, we have to do the migration for each sub-database...
+        for sub_db in temp_db_path
+            .read_dir()?
+            .filter_map(|entry| Some(entry.ok()?.path()))
+            .filter(|entry| entry.is_dir())
+        {
+            let db = paritydb_0_12_1::ParityDb::open(&sub_db)?;
+
+            // The `Settings` column is now binary-tree indexed, there is only one entry in this version
+            // that needs to be migrated.
+            // It is very unlikely this entry was changed, but we treat it as the first migration proof of
+            // concept.
+            let mpool_config = db
+                .db
+                .get(paritydb_0_12_1::DbColumn::Settings as u8, b"/mpool/config")?;
+
+            drop(db);
+
+            let mut db_config = paritydb_0_12_1::ParityDb::to_options(sub_db.clone());
+            let settings_column_config_new = parity_db::ColumnOptions {
+                preimage: false,
+                btree_index: true,
+                compression: parity_db::CompressionType::Lz4,
+                ..Default::default()
+            };
+            parity_db::Db::reset_column(
+                &mut db_config,
+                paritydb_0_12_1::DbColumn::Settings as u8,
+                Some(settings_column_config_new),
+            )?;
+
+            let db = paritydb_0_13_0::ParityDb::open(&sub_db)?;
+
+            let tx = [(
+                paritydb_0_13_0::DbColumn::Settings as u8,
+                b"/mpool/config",
+                mpool_config,
+            )];
+            db.db.commit(tx)?;
+
+            let tx = [(
+                paritydb_0_13_0::DbColumn::Settings as u8,
+                b"head",
+                Some(head.clone()),
+            )];
+            db.db.commit(tx)?;
+
+            let tx = [(
+                paritydb_0_13_0::DbColumn::Settings as u8,
+                b"estimated_reachable_records",
+                Some(estimated_records.clone()),
+            )];
+            db.db.commit(tx)?;
+        }
+
+        std::fs::remove_file(head_file_path)?;
+        std::fs::remove_file(estimated_records_path)?;
+
+        Ok(temp_db_path)
+    }
+
+    fn post_checks(&self, chain_data_path: &Path) -> anyhow::Result<()> {
+        if !chain_data_path.join(MIGRATION_DB_0_12_1_0_13_0).exists() {
+            anyhow::bail!(
+                "migration database {} does not exist",
+                chain_data_path.join(MIGRATION_DB_0_12_1_0_13_0).display()
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Database settings from Forest `v0.12.1`
+mod paritydb_0_12_1 {
+    use parity_db::{CompressionType, Db, Options};
+    use std::path::PathBuf;
+    use strum::{Display, EnumIter, IntoEnumIterator};
+
+    #[derive(Copy, Clone, Debug, PartialEq, EnumIter, Display)]
+    #[repr(u8)]
+    pub(super) enum DbColumn {
+        GraphDagCborBlake2b256,
+        GraphFull,
+        Settings,
+    }
+
+    impl DbColumn {
+        fn create_column_options(compression: CompressionType) -> Vec<parity_db::ColumnOptions> {
+            DbColumn::iter()
+                .map(|col| {
+                    match col {
+                        DbColumn::GraphDagCborBlake2b256 | DbColumn::Settings => {
+                            parity_db::ColumnOptions {
+                                preimage: true,
+                                compression,
+                                ..Default::default()
+                            }
+                        }
+                        DbColumn::GraphFull => parity_db::ColumnOptions {
+                            preimage: true,
+                            // This is needed for key retrieval.
+                            btree_index: true,
+                            compression,
+                            ..Default::default()
+                        },
+                    }
+                })
+                .collect()
+        }
+    }
+
+    pub(super) struct ParityDb {
+        pub db: parity_db::Db,
+    }
+
+    impl ParityDb {
+        pub(super) fn to_options(path: PathBuf) -> Options {
+            Options {
+                path,
+                sync_wal: true,
+                sync_data: true,
+                stats: false,
+                salt: None,
+                columns: DbColumn::create_column_options(CompressionType::Lz4),
+                compression_threshold: [(0, 128)].into_iter().collect(),
+            }
+        }
+
+        pub(super) fn open(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
+            let opts = Self::to_options(path.into());
+            Ok(Self {
+                db: Db::open_or_create(&opts)?,
+            })
+        }
+    }
+}
+
+/// Database settings from Forest `v0.13.0`
+mod paritydb_0_13_0 {
+
+    use parity_db::{CompressionType, Db, Options};
+    use std::path::PathBuf;
+    use strum::{Display, EnumIter, IntoEnumIterator};
+
+    #[derive(Copy, Clone, Debug, PartialEq, EnumIter, Display)]
+    #[repr(u8)]
+    pub(super) enum DbColumn {
+        GraphDagCborBlake2b256,
+        GraphFull,
+        Settings,
+    }
+
+    impl DbColumn {
+        fn create_column_options(compression: CompressionType) -> Vec<parity_db::ColumnOptions> {
+            DbColumn::iter()
+                .map(|col| {
+                    match col {
+                        DbColumn::GraphDagCborBlake2b256 => parity_db::ColumnOptions {
+                            preimage: true,
+                            compression,
+                            ..Default::default()
+                        },
+                        DbColumn::GraphFull => parity_db::ColumnOptions {
+                            preimage: true,
+                            // This is needed for key retrieval.
+                            btree_index: true,
+                            compression,
+                            ..Default::default()
+                        },
+                        DbColumn::Settings => parity_db::ColumnOptions {
+                            // explicitly disable preimage for settings column
+                            // othewise we are not able to overwrite entries
+                            preimage: false,
+                            // This is needed for key retrieval.
+                            btree_index: true,
+                            compression,
+                            ..Default::default()
+                        },
+                    }
+                })
+                .collect()
+        }
+    }
+
+    pub(super) struct ParityDb {
+        pub db: parity_db::Db,
+    }
+
+    impl ParityDb {
+        pub(super) fn to_options(path: PathBuf) -> Options {
+            Options {
+                path,
+                sync_wal: true,
+                sync_data: true,
+                stats: false,
+                salt: None,
+                columns: DbColumn::create_column_options(CompressionType::Lz4),
+                compression_threshold: [(0, 128)].into_iter().collect(),
+            }
+        }
+
+        pub(super) fn open(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
+            let opts = Self::to_options(path.into());
+            Ok(Self {
+                db: Db::open_or_create(&opts)?,
+            })
+        }
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -10,13 +10,15 @@ pub use memory::MemoryDB;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 pub mod car;
+mod db_mode;
+pub mod migration;
 
 pub mod rolling;
 
 pub mod setting_keys {
-    /// Key used to store the heaviest tipset in the settings store.
+    /// Key used to store the heaviest tipset in the settings store. This is expected to be a [`crate::blocks::TipsetKeys`]
     pub const HEAD_KEY: &str = "head";
-    /// Estimated number of IPLD records in the database.
+    /// Estimated number of IPLD records in the database. This is expected to be a `usize`
     pub const ESTIMATED_RECORDS_KEY: &str = "estimated_reachable_records";
     /// Key used to store the memory pool configuration in the settings store.
     pub const MPOOL_CONFIG_KEY: &str = "/mpool/config";
@@ -88,12 +90,14 @@ pub mod db_engine {
 
     use crate::db::rolling::*;
 
+    use super::db_mode::choose_db;
+
     pub type Db = crate::db::parity_db::ParityDb;
     pub type DbConfig = crate::db::parity_db_config::ParityDbConfig;
-    const DIR_NAME: &str = "paritydb";
 
-    pub fn db_root(chain_data_root: &Path) -> PathBuf {
-        chain_data_root.join(DIR_NAME)
+    /// Returns the path to the database directory to be used by the daemon.
+    pub fn db_root(chain_data_root: &Path) -> anyhow::Result<PathBuf> {
+        choose_db(chain_data_root)
     }
 
     pub(in crate::db) fn open_db(path: &Path, config: &DbConfig) -> anyhow::Result<Db> {

--- a/src/tool/subcommands/db_cmd.rs
+++ b/src/tool/subcommands/db_cmd.rs
@@ -42,7 +42,7 @@ impl DBCommands {
 
                 let config = read_config(config, chain)?;
 
-                let dir = db_root(&chain_path(&config));
+                let dir = db_root(&chain_path(&config))?;
                 println!("Database path: {}", dir.display());
                 let size = fs_extra::dir::get_size(dir).unwrap_or_default();
                 println!("Database size: {}", size.human_count_bytes());

--- a/src/utils/version/mod.rs
+++ b/src/utils/version/mod.rs
@@ -12,3 +12,6 @@ pub const GIT_HASH: &str =
 /// E.g., `0.8.0+git.e69baf3e4`
 pub static FOREST_VERSION_STRING: Lazy<String> =
     Lazy::new(|| format!("{}+git.{}", env!("CARGO_PKG_VERSION"), GIT_HASH));
+
+pub static FOREST_VERSION: Lazy<semver::Version> =
+    Lazy::new(|| semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Invalid version"));

--- a/tests/db_migration_tests.rs
+++ b/tests/db_migration_tests.rs
@@ -1,0 +1,42 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+pub mod common;
+
+use crate::common::{create_tmp_config, daemon, CommonArgs, CommonEnv};
+use anyhow::Result;
+
+#[test]
+fn failing_migration_should_not_fail_daemon() -> Result<()> {
+    let (config_file, data_dir) = create_tmp_config()?;
+
+    // Create an invalid, versioned database in the data directory.
+    // This will trigger a migration, which should fail. Forest should be able to recover from
+    // this.
+    // In the end, we should have two databases in the data directory:
+    // - The invalid database which should not be deleted,
+    // - The new, fresh database which should be used by the daemon.
+
+    let bad_db_path = data_dir.path().join("calibnet").join("0.12.1");
+    std::fs::create_dir_all(&bad_db_path)?;
+    daemon()?
+        .common_env()
+        .common_args()
+        .arg("--config")
+        .arg(config_file)
+        .arg("--encrypt-keystore")
+        .arg("false")
+        .assert()
+        .success();
+
+    assert!(bad_db_path.exists());
+
+    let forest_version = std::env::var("CARGO_PKG_VERSION").unwrap();
+    assert!(data_dir
+        .path()
+        .join("calibnet")
+        .join(forest_version)
+        .exists());
+
+    Ok(())
+}

--- a/tests/db_mode_tests.rs
+++ b/tests/db_mode_tests.rs
@@ -1,0 +1,85 @@
+// Copyright 2019-2023 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+pub mod common;
+
+use crate::common::{create_tmp_config, daemon, CommonArgs, CommonEnv};
+use anyhow::Result;
+
+#[test]
+fn current_mode_should_create_current_version_if_no_migrations() -> Result<()> {
+    let (config_file, data_dir) = create_tmp_config()?;
+
+    daemon()?
+        .common_env()
+        // In its absence, the default will be "current" anyway, but let's make it explicit.
+        .env("FOREST_DB_DEV_MODE", "current")
+        .common_args()
+        .arg("--config")
+        .arg(config_file)
+        .arg("--encrypt-keystore")
+        .arg("false")
+        .assert()
+        .success();
+
+    let forest_version = std::env::var("CARGO_PKG_VERSION").unwrap();
+    assert!(data_dir
+        .path()
+        .join("calibnet")
+        .join(forest_version)
+        .exists());
+
+    Ok(())
+}
+
+#[test]
+fn development_mode_should_create_named_db() -> Result<()> {
+    let (config_file, data_dir) = create_tmp_config()?;
+
+    daemon()?
+        .common_env()
+        .env("FOREST_DB_DEV_MODE", "azathoth")
+        .common_args()
+        .arg("--config")
+        .arg(&config_file)
+        .arg("--encrypt-keystore")
+        .arg("false")
+        .assert()
+        .success();
+
+    assert!(data_dir.path().join("calibnet").join("azathoth").exists());
+
+    // write something to the created directory to ensure it's not deleted on a re-run
+    std::fs::write(
+        data_dir
+            .path()
+            .join("calibnet")
+            .join("azathoth")
+            .join("chant"),
+        "Rlyeh wgah nagl fhtagn",
+    )?;
+
+    daemon()?
+        .common_env()
+        .env("FOREST_DB_DEV_MODE", "azathoth")
+        .common_args()
+        .arg("--config")
+        .arg(config_file)
+        .arg("--encrypt-keystore")
+        .arg("false")
+        .assert()
+        .success();
+
+    assert_eq!(
+        std::fs::read_to_string(
+            data_dir
+                .path()
+                .join("calibnet")
+                .join("azathoth")
+                .join("chant")
+        )?,
+        "Rlyeh wgah nagl fhtagn"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Introduced a database migration framework: this should ensure we no longer have to manually re-create Forest databases going forward.
- More post-migration checks would be great to implement - I can either do this here or in a follow-up PR,
- the integration test should ensure we catch breaking changes early and we always have a migration at hand (and that the person that breaks it has the golden opportunity to implement the migration!)
- implemented a PoC migration from `0.12.1`. This migration won't be performed outside of tests (unless someone manually changes the `paritydb` directory to `0.12.1`)
- adhered (mostly) to the [agreed design](https://github.com/ChainSafe/forest/blob/main/documentation/src/developer_documentation/database_migrations.md)
- Introduced a DB mode environmental variable, more explained in the Rust documentation and README.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3203

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
