### PR TITLE
fix: relax diff snapshot tests to allow null tipsets

### DIFF
--- a/scripts/tests/forest_cli_check.sh
+++ b/scripts/tests/forest_cli_check.sh
@@ -44,7 +44,7 @@ pushd "$(mktemp --directory)"
 
     : verify that diff exports contain the expected number of state roots
     EPOCH=$(forest_query_epoch exported_snapshot.car.zst)
-    "$FOREST_CLI_PATH" archive export --epoch $((EPOCH-500)) --output-path base_snapshot.forest.car.zst exported_snapshot.car.zst
+    "$FOREST_CLI_PATH" archive export --epoch $((EPOCH-500)) --depth 900 --output-path base_snapshot.forest.car.zst exported_snapshot.car.zst
 
     BASE_EPOCH=$(forest_query_epoch base_snapshot.forest.car.zst)
     # This assertion is not true in the presence of null tipsets

--- a/scripts/tests/forest_cli_check.sh
+++ b/scripts/tests/forest_cli_check.sh
@@ -44,10 +44,11 @@ pushd "$(mktemp --directory)"
 
     : verify that diff exports contain the expected number of state roots
     EPOCH=$(forest_query_epoch exported_snapshot.car.zst)
-    "$FOREST_CLI_PATH" archive export --epoch $((EPOCH-1100)) --depth 900 --output-path base_snapshot.forest.car.zst exported_snapshot.car.zst
+    "$FOREST_CLI_PATH" archive export --epoch $((EPOCH-500)) --output-path base_snapshot.forest.car.zst exported_snapshot.car.zst
 
     BASE_EPOCH=$(forest_query_epoch base_snapshot.forest.car.zst)
-    assert_eq "$BASE_EPOCH" $((EPOCH-1100))
+    # This assertion is not true in the presence of null tipsets
+    #assert_eq "$BASE_EPOCH" $((EPOCH-500))
 
     # This assertion is not true in the presence of null tipsets
     #BASE_STATE_ROOTS=$(forest_query_state_roots base_snapshot.forest.car.zst)

--- a/scripts/tests/forest_cli_check.sh
+++ b/scripts/tests/forest_cli_check.sh
@@ -60,7 +60,7 @@ pushd "$(mktemp --directory)"
     #assert_eq "$DIFF_STATE_ROOTS" 1100
 
     : Validate the union of a snapshot and a diff
-    "$FOREST_TOOL_PATH" snapshot validate --check-network calibnet base_snapshot.forest.car.zst diff_snapshot.forest.car.zst
+    "$FOREST_TOOL_PATH" snapshot validate --check-network calibnet --check-stateroots $((900+500)) base_snapshot.forest.car.zst diff_snapshot.forest.car.zst
 rm -- *
 popd
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The presence of null tipsets means that it's difficult to specify exact tests when splitting and merging snapshots. This PR relaxes the epoch limits for the diff-snapshot tests and should make the tests succeed even when there are lots of null tipsets.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
