### PR TITLE
feat: add `fn forest::Encoder::compress_stream_default` to reduce duplicate code

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -47,7 +47,7 @@ pub async fn export<D: Digest>(
     );
 
     // Encode Ipld key-value pairs in zstd frames
-    let frames = forest::Encoder::compress_stream(8000usize.next_power_of_two(), 3, blocks);
+    let frames = forest::Encoder::compress_stream_default(blocks);
 
     // Write zstd frames and include a skippable index
     forest::Encoder::write(&mut writer, roots, frames).await?;

--- a/src/cli/subcommands/car_cmd.rs
+++ b/src/cli/subcommands/car_cmd.rs
@@ -41,9 +41,7 @@ impl CarCommands {
                     .cloned()
                     .collect::<Vec<_>>();
 
-                let frames = crate::db::car::forest::Encoder::compress_stream(
-                    8000_usize.next_power_of_two(),
-                    zstd::DEFAULT_COMPRESSION_LEVEL as _,
+                let frames = crate::db::car::forest::Encoder::compress_stream_default(
                     dedup_block_stream(merge_car_streams(car_streams)).map_err(anyhow::Error::from),
                 );
                 let mut writer = tokio::io::BufWriter::new(tokio::fs::File::create(&output).await?);
@@ -96,9 +94,7 @@ mod tests {
     impl Blocks {
         async fn into_forest_car_zst_bytes(self) -> Vec<u8> {
             let roots = vec![self.0[0].cid];
-            let frames = crate::db::car::forest::Encoder::compress_stream(
-                8000_usize.next_power_of_two(),
-                zstd::DEFAULT_COMPRESSION_LEVEL as _,
+            let frames = crate::db::car::forest::Encoder::compress_stream_default(
                 self.into_stream().map_err(anyhow::Error::from),
             );
             let mut writer = vec![];

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -4,6 +4,7 @@
 use super::*;
 use crate::cli::subcommands::{cli_error_and_die, handle_rpc_err};
 use crate::cli_shared::snapshot::{self, TrustedVendor};
+use crate::db::car::forest::DEFAULT_FOREST_CAR_FRAME_SIZE;
 use crate::rpc_api::chain_api::ChainExportParams;
 use crate::rpc_client::chain_ops::*;
 use crate::utils::bail_moved_cmd;
@@ -76,7 +77,7 @@ pub enum SnapshotCommands {
         #[arg(long, default_value_t = 3)]
         compression_level: u16,
         /// End zstd frames after they exceed this length
-        #[arg(long, default_value_t = 8000usize.next_power_of_two())]
+        #[arg(long, default_value_t = DEFAULT_FOREST_CAR_FRAME_SIZE)]
         frame_size: usize,
         /// Overwrite output file without prompting.
         #[arg(long, default_value_t = false)]

--- a/src/tool/subcommands/benchmark_cmd.rs
+++ b/src/tool/subcommands/benchmark_cmd.rs
@@ -5,6 +5,7 @@ use crate::chain::{
     index::{ChainIndex, ResolveNullTipset},
     ChainEpochDelta,
 };
+use crate::db::car::forest::DEFAULT_FOREST_CAR_FRAME_SIZE;
 use crate::db::car::ManyCar;
 use crate::ipld::{stream_chain, stream_graph};
 use crate::shim::clock::ChainEpoch;
@@ -50,7 +51,7 @@ pub enum BenchmarkCommands {
         #[arg(long, default_value_t = 3)]
         compression_level: u16,
         /// End zstd frames after they exceed this length
-        #[arg(long, default_value_t = 8000usize.next_power_of_two())]
+        #[arg(long, default_value_t = DEFAULT_FOREST_CAR_FRAME_SIZE)]
         frame_size: usize,
     },
     /// Exporting a `.forest.car.zst` file from HEAD
@@ -61,7 +62,7 @@ pub enum BenchmarkCommands {
         #[arg(long, default_value_t = 3)]
         compression_level: u16,
         /// End zstd frames after they exceed this length
-        #[arg(long, default_value_t = 8000usize.next_power_of_two())]
+        #[arg(long, default_value_t = DEFAULT_FOREST_CAR_FRAME_SIZE)]
         frame_size: usize,
         /// Latest epoch that has to be exported for this snapshot, the upper bound. This value
         /// cannot be greater than the latest epoch available in the input snapshot.


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to remove the duplicate hard-coded frame size and compression level parameters from `fn forest::Encoder::compress_stream`

Changes introduced in this pull request:

- Add const DEFAULT_FOREST_CAR_FRAME_SIZE
- Add const DEFAULT_FOREST_CAR_COMPRESSION_LEVEL
- Add `fn compress_stream_default` that defaults `zstd_frame_size_tripwire` and `zstd_compression_level` to `DEFAULT_FOREST_CAR_FRAME_SIZE` and `DEFAULT_FOREST_CAR_COMPRESSION_LEVEL` respectively

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
