### PR TITLE
fix: include all blocks when calculating diff sets

### DIFF
--- a/src/cli/subcommands/archive_cmd.rs
+++ b/src/cli/subcommands/archive_cmd.rs
@@ -37,7 +37,6 @@ use crate::ipld::{stream_graph, CidHashSet};
 use crate::networks::{calibnet, mainnet, ChainConfig, NetworkChain};
 use crate::shim::clock::{ChainEpoch, EPOCHS_IN_DAY, EPOCH_DURATION_SECONDS};
 use crate::utils::bail_moved_cmd;
-use crate::utils::db::car_stream::CarStream;
 use anyhow::{bail, Context as _};
 use chrono::NaiveDateTime;
 use clap::Subcommand;
@@ -77,10 +76,6 @@ pub enum ArchiveCommands {
         /// state-roots are included if this flag is not set.
         #[arg(short, long)]
         diff_depth: Option<ChainEpochDelta>,
-        /// Do not include any values present in this file. Supported formats:
-        /// `.car`, `.car.zst`, `.forest.car.zst`.
-        #[arg(long)]
-        diff_file: Option<PathBuf>,
         /// Overwrite output file without prompting.
         #[arg(long, default_value_t = false)]
         force: bool,
@@ -104,7 +99,6 @@ impl ArchiveCommands {
                 depth,
                 diff,
                 diff_depth,
-                diff_file,
                 force,
             } => {
                 let store = ManyCar::try_from(snapshot_files)?;
@@ -117,7 +111,6 @@ impl ArchiveCommands {
                     depth,
                     diff,
                     diff_depth,
-                    diff_file,
                     force,
                 )
                 .await
@@ -163,7 +156,6 @@ async fn do_export(
     depth: ChainEpochDelta,
     diff: Option<ChainEpoch>,
     diff_depth: Option<ChainEpochDelta>,
-    diff_file: Option<PathBuf>,
     force: bool,
 ) -> anyhow::Result<()> {
     let ts = Arc::new(root);
@@ -195,7 +187,7 @@ async fn do_export(
         .tipset_by_height(epoch, ts, ResolveNullTipset::TakeOlder)
         .context("unable to get a tipset at given height")?;
 
-    let mut seen = if let Some(diff) = diff {
+    let seen = if let Some(diff) = diff {
         let diff_ts: Arc<Tipset> = index
             .tipset_by_height(diff, ts.clone(), ResolveNullTipset::TakeOlder)
             .context("diff epoch must be smaller than target epoch")?;
@@ -207,16 +199,6 @@ async fn do_export(
     } else {
         CidHashSet::default()
     };
-
-    if let Some(diff_file) = diff_file {
-        let mut stream = CarStream::new(tokio::io::BufReader::new(
-            tokio::fs::File::open(diff_file).await?,
-        ))
-        .await?;
-        while let Some(block) = stream.try_next().await? {
-            seen.insert(block.cid);
-        }
-    }
 
     let output_path =
         build_output_path(network.to_string(), genesis.timestamp(), epoch, output_path);
@@ -327,7 +309,6 @@ mod tests {
             output_path.path().into(),
             Some(0),
             1,
-            None,
             None,
             None,
             false,

--- a/src/ipld/util.rs
+++ b/src/ipld/util.rs
@@ -323,13 +323,14 @@ pub fn stream_chain<DB: Blockstore, T: Iterator<Item = Tipset> + Unpin>(
 pub fn stream_graph<DB: Blockstore, T: Iterator<Item = Tipset> + Unpin>(
     db: DB,
     tipset_iter: T,
+    stateroot_limit: ChainEpoch,
 ) -> ChainStream<DB, T> {
     ChainStream {
         tipset_iter,
         db,
         dfs: VecDeque::new(),
         seen: CidHashSet::default(),
-        stateroot_limit: 0,
+        stateroot_limit,
         fail_on_dead_links: false,
     }
 }

--- a/src/tool/subcommands/benchmark_cmd.rs
+++ b/src/tool/subcommands/benchmark_cmd.rs
@@ -154,7 +154,7 @@ async fn benchmark_graph_traversal(input: Vec<PathBuf>) -> Result<()> {
 
     let mut sink = indicatif_sink("traversed");
 
-    let mut s = stream_graph(&store, heaviest.chain(&store));
+    let mut s = stream_graph(&store, heaviest.chain(&store), 0);
     while let Some(block) = s.try_next().await? {
         sink.write_all(&block.data).await?
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- all blocks going back to genesis should be included when calculating diff sets
- this fix reduces the file size of diff files

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
