### PR TITLE
feat: add `--consume-snapshot` to `forest` daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
 - [#3322](https://github.com/ChainSafe/forest/issues/3322): Added prompt to
   `forest-cli archive export` to overwrite file if the file specified with
   `--output-path` already exists and a `--force` flag to suppress the prompt.
+- [#3439](https://github.com/ChainSafe/forest/pull/3439): Add
+  `--consume-snapshot` option to `forest` command.
 
 ### Changed
 

--- a/documentation/src/configuration.md
+++ b/documentation/src/configuration.md
@@ -21,6 +21,7 @@ use of the following flags:
 | --kademlia           | Boolean      | Determines whether Kademilia is allowed                                                             |
 | --mdns               | Boolean      | Determines whether MDNS is allowed                                                                  |
 | --import-snapshot    | OS File Path | Path to snapshot CAR file                                                                           |
+| --consume-snapshot   | OS File Path | Path to snapshot CAR file (delete after importing)                                                  |
 | --import-chain       | OS File Path | Path to chain CAR file                                                                              |
 | --skip-load          | Boolean      | Skips loading CAR File and uses header to index chain                                               |
 | --req-window         | Integer      | Sets the number of tipsets requested over chain exchange                                            |

--- a/src/cli_shared/cli/client.rs
+++ b/src/cli_shared/cli/client.rs
@@ -46,7 +46,7 @@ pub struct Client {
     /// If this is true, then we do not validate the imported snapshot.
     /// Otherwise, we validate and compute the states.
     pub snapshot: bool,
-    /// If this is true, delete the snapshot at snapshot_path if it's a local file.
+    /// If this is true, delete the snapshot at `snapshot_path` if it's a local file.
     pub consume_snapshot: bool,
     pub snapshot_height: Option<i64>,
     pub snapshot_head: Option<i64>,

--- a/src/cli_shared/cli/client.rs
+++ b/src/cli_shared/cli/client.rs
@@ -46,6 +46,8 @@ pub struct Client {
     /// If this is true, then we do not validate the imported snapshot.
     /// Otherwise, we validate and compute the states.
     pub snapshot: bool,
+    /// If this is true, delete the snapshot at snapshot_path if it's a local file.
+    pub consume_snapshot: bool,
     pub snapshot_height: Option<i64>,
     pub snapshot_head: Option<i64>,
     pub snapshot_path: Option<PathBuf>,
@@ -83,6 +85,7 @@ impl Default for Client {
             rpc_token: None,
             snapshot_path: None,
             snapshot: false,
+            consume_snapshot: false,
             snapshot_height: None,
             snapshot_head: None,
             skip_load: false,

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -77,6 +77,9 @@ pub struct CliOpts {
     /// Import a snapshot from a local CAR file or URL
     #[arg(long)]
     pub import_snapshot: Option<String>,
+    /// Import a snapshot from a local CAR file and delete it, or from a URL
+    #[arg(long)]
+    pub consume_snapshot: Option<String>,
     /// Halt with exit code 0 after successfully importing a snapshot
     #[arg(long)]
     pub halt_after_import: bool,
@@ -188,11 +191,20 @@ impl CliOpts {
         }
         if self.import_snapshot.is_some() && self.import_chain.is_some() {
             anyhow::bail!("Can't set import_snapshot and import_chain at the same time!")
+        } else if self.import_snapshot.is_some() && self.consume_snapshot.is_some() {
+            anyhow::bail!("Can't set import_snapshot and consume_snapshot at the same time!")
+        } else if self.consume_snapshot.is_some() && self.import_chain.is_some() {
+            anyhow::bail!("Can't set consume_snapshot and import_chain at the same time!")
         }
 
         if let Some(snapshot_path) = &self.import_snapshot {
             cfg.client.snapshot_path = Some(snapshot_path.into());
             cfg.client.snapshot = true;
+        }
+        if let Some(snapshot_path) = &self.consume_snapshot {
+            cfg.client.snapshot_path = Some(snapshot_path.into());
+            cfg.client.snapshot = true;
+            cfg.client.consume_snapshot = true;
         }
         if let Some(snapshot_path) = &self.import_chain {
             cfg.client.snapshot_path = Some(snapshot_path.into());

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -406,8 +406,6 @@ pub(super) async fn start(
     // Import chain if needed
     if !opts.skip_load.unwrap_or_default() {
         if let Some(path) = &config.client.snapshot_path {
-            // TODO: respect `--consume-snapshot` CLI option once it's implemented.
-            // See <https://github.com/ChainSafe/forest/issues/3334>.
             let (car_db_path, ts) = import_chain_as_forest_car(
                 path,
                 &forest_car_db_dir,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -408,8 +408,12 @@ pub(super) async fn start(
         if let Some(path) = &config.client.snapshot_path {
             // TODO: respect `--consume-snapshot` CLI option once it's implemented.
             // See <https://github.com/ChainSafe/forest/issues/3334>.
-            let (car_db_path, ts) =
-                import_chain_as_forest_car(path, &forest_car_db_dir, false).await?;
+            let (car_db_path, ts) = import_chain_as_forest_car(
+                path,
+                &forest_car_db_dir,
+                config.client.consume_snapshot,
+            )
+            .await?;
             db.read_only_files(std::iter::once(car_db_path.clone()))?;
             debug!("Loaded car DB at {}", car_db_path.display());
             state_manager


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to implement below feature decribed in https://github.com/ChainSafe/forest/issues/3334

> Add flag --consume-snapshot. It should do the same as --import-snapshot, but it'll move or delete the snapshot.

Changes introduced in this pull request:

- add `--consume-snapshot` to `forest` daemon

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3334

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
