### PR TITLE
chore: remove futures-io feature from async_compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d495b6dc0184693324491a5ac05f559acc97bf937ab31d7a1c33dd0016be6d2b"
 dependencies = [
  "futures-core",
- "futures-io",
  "memchr",
  "pin-project-lite",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ ahash = "0.8"
 anes = "0.1.6"
 anyhow = "1.0"
 argon2 = "0.5"
-async-compression = { version = "0.4", features = ["futures-io", "tokio", "zstd"] }
+async-compression = { version = "0.4", features = ["tokio", "zstd"] }
 async-fs = "1"
 async-recursion = "1.0"
 async-trait = "0.1"

--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::Context;
-use async_compression::futures::bufread::ZstdDecoder;
+use async_compression::tokio::bufread::ZstdDecoder;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
+use tokio_util::compat::TokioAsyncReadCompatExt;
 
 pub async fn load_actor_bundles(db: &impl Blockstore) -> anyhow::Result<Vec<Cid>> {
     const ERROR_MESSAGE: &str = "Actor bundles assets are not properly downloaded, make sure git-lfs is installed and run `git lfs pull` again. See <https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md>";
@@ -13,7 +14,7 @@ pub async fn load_actor_bundles(db: &impl Blockstore) -> anyhow::Result<Vec<Cid>
 
     fvm_ipld_car::load_car(
         db,
-        ZstdDecoder::new(futures::io::BufReader::new(ACTOR_BUNDLES_CAR_ZST)),
+        ZstdDecoder::new(tokio::io::BufReader::new(ACTOR_BUNDLES_CAR_ZST)).compat(),
     )
     .await
     .context(ERROR_MESSAGE)


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- remove `futures-io` as we're moving towards tokio.

A follow-up PR will get rid of the external CAR reader/writer entirely.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3084

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
