### PR TITLE
Replace `generate_hash_maps` method with `Arbitrary` implementation

### DIFF
--- a/.config/forest.dic
+++ b/.config/forest.dic
@@ -11,6 +11,7 @@ blockchain/M
 blockstore/SM
 BLS
 callee
+canonicalization
 CAR/SM
 CARv1/SM
 CARv2/SM

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "derive-quickcheck-arbitrary"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35c2490d52708fdc25efd66239f38c13911dcaeb34fff9d1c5319ecd7dc4546"
+checksum = "697d85c38ac8f4dad3129d38d0d40060a98fd2557bfaf0bc8c071ecfce884ce5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -158,18 +158,7 @@ mod tests {
         V: Arbitrary,
     {
         fn arbitrary(g: &mut Gen) -> Self {
-            let cid_vector = Vec::<(Cid, u64)>::arbitrary(g);
-            let mut cid_hash_map = CidHashMap::new();
-            for item in cid_vector.iter() {
-                cid_hash_map.insert(item.0, V::arbitrary(g));
-                // Quickcheck does not reliably generate the DAG_CBOR/Blake2b variant of V1 CIDs; need to ensure we have enough samples of this variant in the map for testing, so generate this variant from the values in the key-value pairs.
-                let cid_v1 = Cid::new_v1(
-                    DAG_CBOR,
-                    multihash::Code::Blake2b256.digest(&item.1.to_be_bytes()),
-                );
-                cid_hash_map.insert(cid_v1, V::arbitrary(g));
-            }
-            cid_hash_map
+            Self(HashMap::arbitrary(g))
         }
     }
 

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -188,7 +188,7 @@ mod tests {
 
     #[quickcheck]
     fn remove_key(mut cid_hash_map: CidHashMap<u64>, cid: Cid, insert: bool) {
-        let mut hash_map = HashMap::from(cid_hash_map.clone().into_iter().collect());
+        let mut hash_map = HashMap::from_iter(cid_hash_map.clone());
         // Quickcheck rarely generates a key that is already present in the maps, so insert it with 50% probability to test `remove` with an equal distribution of results.
         if insert {
             cid_hash_map.insert(cid, 0);

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -154,7 +154,9 @@ mod tests {
     use quickcheck_macros::quickcheck;
 
     impl<V> Arbitrary for CidHashMap<V>
-    where V: Clone + Arbitrary, {
+    where
+        V: Clone + Arbitrary,
+    {
         fn arbitrary(g: &mut Gen) -> Self {
             let cid_vector = Vec::<(Cid, u64)>::arbitrary(g);
             let mut cid_hash_map = CidHashMap::new();

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -153,18 +153,19 @@ mod tests {
     use quickcheck::Gen;
     use quickcheck_macros::quickcheck;
 
-    impl Arbitrary for CidHashMap<u64> {
+    impl<V> Arbitrary for CidHashMap<V>
+    where V: Clone + Arbitrary, {
         fn arbitrary(g: &mut Gen) -> Self {
             let cid_vector = Vec::<(Cid, u64)>::arbitrary(g);
             let mut cid_hash_map = CidHashMap::new();
             for item in cid_vector.iter() {
-                cid_hash_map.insert(item.0, item.1);
+                cid_hash_map.insert(item.0, V::arbitrary(g));
                 // Quickcheck does not reliably generate the DAG_CBOR/Blake2b variant of V1 CIDs; need to ensure we have enough samples of this variant in the map for testing, so generate this variant from the values in the key-value pairs.
                 let cid_v1 = Cid::new_v1(
                     DAG_CBOR,
                     multihash::Code::Blake2b256.digest(&item.1.to_be_bytes()),
                 );
-                cid_hash_map.insert(cid_v1, item.1);
+                cid_hash_map.insert(cid_v1, V::arbitrary(g));
             }
             cid_hash_map
         }

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -147,8 +147,6 @@ impl<V> CidHashMap<V> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cid::multihash::{self, MultihashDigest};
-    use fvm_ipld_encoding::DAG_CBOR;
     use quickcheck::Arbitrary;
     use quickcheck::Gen;
     use quickcheck_macros::quickcheck;

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -149,29 +149,29 @@ mod tests {
     use super::*;
     use cid::multihash::{self, MultihashDigest};
     use fvm_ipld_encoding::DAG_CBOR;
+    use quickcheck::Arbitrary;
+    use quickcheck::Gen;
     use quickcheck_macros::quickcheck;
 
-    fn generate_hash_maps(cid_vector: Vec<(Cid, u64)>) -> (CidHashMap<u64>, HashMap<Cid, u64>) {
-        let mut cid_hash_map = CidHashMap::new();
-        let mut hash_map = HashMap::new();
-        for item in cid_vector.iter() {
-            cid_hash_map.insert(item.0, item.1);
-            hash_map.insert(item.0, item.1);
-
-            // Quickcheck does not reliably generate the DAG_CBOR/Blake2b variant of V1 CIDs; need to ensure we have enough samples of this variant in the map for testing, so generate this variant from the values in the key-value pairs.
-            let cid_v1 = Cid::new_v1(
-                DAG_CBOR,
-                multihash::Code::Blake2b256.digest(&item.1.to_be_bytes()),
-            );
-            cid_hash_map.insert(cid_v1, item.1);
-            hash_map.insert(cid_v1, item.1);
+    impl Arbitrary for CidHashMap<u64> {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let cid_vector = Vec::<(Cid, u64)>::arbitrary(g);
+            let mut cid_hash_map = CidHashMap::new();
+            for item in cid_vector.iter() {
+                cid_hash_map.insert(item.0, item.1);
+                // Quickcheck does not reliably generate the DAG_CBOR/Blake2b variant of V1 CIDs; need to ensure we have enough samples of this variant in the map for testing, so generate this variant from the values in the key-value pairs.
+                let cid_v1 = Cid::new_v1(
+                    DAG_CBOR,
+                    multihash::Code::Blake2b256.digest(&item.1.to_be_bytes()),
+                );
+                cid_hash_map.insert(cid_v1, item.1);
+            }
+            cid_hash_map
         }
-        (cid_hash_map, hash_map)
     }
 
     #[quickcheck]
-    fn insert_new_key_is_none(cid_vector: Vec<(Cid, u64)>, cid: Cid, payload: u64) {
-        let (mut cid_hash_map, _) = generate_hash_maps(cid_vector);
+    fn insert_new_key_is_none(mut cid_hash_map: CidHashMap<u64>, cid: Cid, payload: u64) {
         // Quickcheck occasionally generates a key that is already present in the map, so remove it if it is present.
         if cid_hash_map.contains_key(cid) {
             cid_hash_map.remove(cid);
@@ -180,15 +180,14 @@ mod tests {
     }
 
     #[quickcheck]
-    fn insert_existing_key_is_some(cid_vector: Vec<(Cid, u64)>, cid: Cid, payload: u64) {
-        let (mut cid_hash_map, _) = generate_hash_maps(cid_vector);
+    fn insert_existing_key_is_some(mut cid_hash_map: CidHashMap<u64>, cid: Cid, payload: u64) {
         cid_hash_map.insert(cid, payload);
         assert!(cid_hash_map.insert(cid, payload).is_some());
     }
 
     #[quickcheck]
-    fn contains_key(cid_vector: Vec<(Cid, u64)>, cid: Cid, insert: bool) {
-        let (mut cid_hash_map, mut hash_map) = generate_hash_maps(cid_vector);
+    fn contains_key(mut cid_hash_map: CidHashMap<u64>, cid: Cid, insert: bool) {
+        let mut hash_map = HashMap::from(cid_hash_map.clone().into_iter().collect());
         // Quickcheck rarely generates a key that is already present in the maps, so insert it with 50% probability to test `contains_key` with an equal distribution of results.
         if insert {
             cid_hash_map.insert(cid, 0);
@@ -198,8 +197,8 @@ mod tests {
     }
 
     #[quickcheck]
-    fn remove_key(cid_vector: Vec<(Cid, u64)>, cid: Cid, insert: bool) {
-        let (mut cid_hash_map, mut hash_map) = generate_hash_maps(cid_vector);
+    fn remove_key(mut cid_hash_map: CidHashMap<u64>, cid: Cid, insert: bool) {
+        let mut hash_map = HashMap::from(cid_hash_map.clone().into_iter().collect());
         // Quickcheck rarely generates a key that is already present in the maps, so insert it with 50% probability to test `remove` with an equal distribution of results.
         if insert {
             cid_hash_map.insert(cid, 0);
@@ -209,8 +208,8 @@ mod tests {
     }
 
     #[quickcheck]
-    fn get_value_at_key(cid_vector: Vec<(Cid, u64)>, cid: Cid, insert: bool) {
-        let (mut cid_hash_map, mut hash_map) = generate_hash_maps(cid_vector);
+    fn get_value_at_key(mut cid_hash_map: CidHashMap<u64>, cid: Cid, insert: bool) {
+        let mut hash_map = HashMap::from(cid_hash_map.clone().into_iter().collect());
         // Quickcheck rarely generates a key that is already present in the maps, so insert it with 50% probability to test `get` with an equal distribution of results.
         if insert {
             cid_hash_map.insert(cid, 0);
@@ -220,14 +219,14 @@ mod tests {
     }
 
     #[quickcheck]
-    fn len(cid_vector: Vec<(Cid, u64)>) {
-        let (cid_hash_map, hash_map) = generate_hash_maps(cid_vector);
+    fn len(cid_hash_map: CidHashMap<u64>) {
+        let hash_map = HashMap::from(cid_hash_map.clone().into_iter().collect());
         assert_eq!(cid_hash_map.len(), hash_map.len());
     }
 
     #[quickcheck]
-    fn check_entry(cid_vector: Vec<(Cid, u64)>, cid: Cid, insert: bool) {
-        let (mut cid_hash_map, mut hash_map) = generate_hash_maps(cid_vector);
+    fn check_entry(mut cid_hash_map: CidHashMap<u64>, cid: Cid, insert: bool) {
+        let mut hash_map = HashMap::from(cid_hash_map.clone().into_iter().collect());
         // Insert key half of the time to ensure equal probability of entry being occupied or vacant; occasionally the key will already be present when quickcheck generates the maps, so we also remove the key with 50% probability.
         if insert {
             cid_hash_map.insert(cid, 0);
@@ -247,8 +246,8 @@ mod tests {
     }
 
     #[quickcheck]
-    fn keys(cid_vector: Vec<(Cid, u64)>) {
-        let (cid_hash_map, hash_map) = generate_hash_maps(cid_vector);
+    fn keys(cid_hash_map: CidHashMap<u64>) {
+        let hash_map = HashMap::from(cid_hash_map.clone().into_iter().collect());
         // Hash maps are not required to be ordered, but it is important for vectors, so sort the vectors of keys before comparing.
         let mut cid_hash_map = cid_hash_map.keys().collect::<Vec<Cid>>();
         cid_hash_map.sort();
@@ -258,8 +257,7 @@ mod tests {
     }
 
     #[quickcheck]
-    fn cidhashmap_to_hashmap_to_cidhashmap(cid_vector: Vec<(Cid, u64)>) {
-        let (cid_hash_map, _) = generate_hash_maps(cid_vector);
+    fn cidhashmap_to_hashmap_to_cidhashmap(cid_hash_map: CidHashMap<u64>) {
         let hash_map: HashMap<Cid, u64> = cid_hash_map.clone().into_iter().collect();
         let cid_hash_map_2: CidHashMap<u64> = hash_map.into_iter().collect();
         assert_eq!(cid_hash_map, cid_hash_map_2);

--- a/src/ipld/cid_hashmap.rs
+++ b/src/ipld/cid_hashmap.rs
@@ -155,7 +155,7 @@ mod tests {
 
     impl<V> Arbitrary for CidHashMap<V>
     where
-        V: Clone + Arbitrary,
+        V: Arbitrary,
     {
         fn arbitrary(g: &mut Gen) -> Self {
             let cid_vector = Vec::<(Cid, u64)>::arbitrary(g);

--- a/src/utils/cid/mod.rs
+++ b/src/utils/cid/mod.rs
@@ -58,18 +58,20 @@ impl SmallCid {
             ),
         }
     }
+}
 
+impl SmallCidInner {
     /// [`SmallCidInner::Other`] should not contain a CID which could be represented by more specialized variants.
     fn canonical_small(cid: Cid) -> SmallCidInner {
         if cid.version() == Version::V1 && cid.codec() == DAG_CBOR {
             if let Ok(small_hash) = cid.hash().resize() {
                 let (code, bytes, size) = small_hash.into_inner();
                 if code == u64::from(Code::Blake2b256) && size as usize == BLAKE2B256_SIZE {
-                    return SmallCid(SmallCidInner::V1DagCborBlake2b(bytes));
+                    return SmallCidInner::V1DagCborBlake2b(bytes);
                 }
             }
         }
-        SmallCid(SmallCidInner::Other(Box::new(cid)))
+        SmallCidInner::Other(Box::new(cid))
     }
 }
 
@@ -106,7 +108,7 @@ impl<'de> Deserialize<'de> for SmallCid {
 
 impl From<Cid> for SmallCid {
     fn from(cid: Cid) -> Self {
-        SmallCid::canonical_small(cid)
+        SmallCid(SmallCidInner::canonical_small(cid))
     }
 }
 
@@ -139,7 +141,7 @@ mod tests {
 
     impl Arbitrary for SmallCid {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            SmallCid(SmallCidInner::canonical(Cid::arbitrary(g)))
+            SmallCid(SmallCidInner::canonical_small(Cid::arbitrary(g)))
         }
     }
 

--- a/src/utils/cid/mod.rs
+++ b/src/utils/cid/mod.rs
@@ -108,7 +108,7 @@ impl<'de> Deserialize<'de> for SmallCid {
 
 impl From<Cid> for SmallCid {
     fn from(cid: Cid) -> Self {
-        SmallCid(SmallCidInner::canonical_small(cid))
+        SmallCid(SmallCidInner::canonical(cid))
     }
 }
 
@@ -141,7 +141,7 @@ mod tests {
 
     impl Arbitrary for SmallCid {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            SmallCid(SmallCidInner::canonical_small(Cid::arbitrary(g)))
+            SmallCid(SmallCidInner::canonical(Cid::arbitrary(g)))
         }
     }
 

--- a/src/utils/cid/mod.rs
+++ b/src/utils/cid/mod.rs
@@ -62,7 +62,7 @@ impl SmallCid {
 
 impl SmallCidInner {
     /// [`SmallCidInner::Other`] should not contain a CID which could be represented by more specialized variants.
-    fn canonical_small(cid: Cid) -> SmallCidInner {
+    fn canonical(cid: Cid) -> SmallCidInner {
         if cid.version() == Version::V1 && cid.codec() == DAG_CBOR {
             if let Ok(small_hash) = cid.hash().resize() {
                 let (code, bytes, size) = small_hash.into_inner();

--- a/src/utils/cid/mod.rs
+++ b/src/utils/cid/mod.rs
@@ -75,9 +75,9 @@ impl SmallCidInner {
     }
 }
 
-/// No guarantees are made about canonicalisation with this struct
-/// That is, you may have a [`Self::Other`] variant which could be representated as a [`Self::V1DagCborBlake2b`]
-/// (typically as a result of calling [`Arbitrary::arbitrary`]
+/// No guarantees are made about canonicalization with this struct
+/// That is, you may have a [`Self::Other`] variant which could be represented as a [`Self::V1DagCborBlake2b`]
+/// (typically as a result of calling `quickcheck::Arbitrary::arbitrary`)
 #[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum SmallCidInner {

--- a/src/utils/cid/mod.rs
+++ b/src/utils/cid/mod.rs
@@ -58,7 +58,7 @@ impl SmallCid {
     }
 
     // We always want to represent a CID with the minimal size of `SmallCidInner` if possible, so we can convert the `SmallCid` to its minimal form by checking if the `SmallCidInner` is already in minimal form and converting if necessary.
-    /// [`SmallCid::Other`] should not contain a CID which could be represented by more specialised variants.
+    /// [`SmallCidInner::Other`] should not contain a CID which could be represented by more specialized variants.
     fn canonical_small(cid: Cid) -> SmallCid {
         if cid.version() == Version::V1 && cid.codec() == DAG_CBOR {
             if let Ok(small_hash) = cid.hash().resize() {

--- a/src/utils/cid/mod.rs
+++ b/src/utils/cid/mod.rs
@@ -58,7 +58,8 @@ impl SmallCid {
     }
 
     // We always want to represent a CID with the minimal size of `SmallCidInner` if possible, so we can convert the `SmallCid` to its minimal form by checking if the `SmallCidInner` is already in minimal form and converting if necessary.
-    pub fn minimal_cid(small_cid: SmallCid) -> SmallCid {
+    /// [`SmallCid::Other`] should not contain a CID which could be represented by more specialised variants.
+    fn canonical_small(cid: Cid) -> SmallCid {
         if small_cid.cid().version() == Version::V1 && small_cid.cid().codec() == DAG_CBOR {
             if let Ok(small_hash) = small_cid.cid().hash().resize() {
                 let (code, bytes, size) = small_hash.into_inner();


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Added an `Arbitrary` implementation for `CidHashMap` and replaced `generate_hash_maps` function with the `Arbitrary` impl.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3413 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
