### PR TITLE
chore: rename `Block` to `CarBlock`

### DIFF
--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -427,7 +427,7 @@ mod tests {
         zstd_frame_size_tripwire: usize,
         zstd_compression_level: u16,
         roots: Vec<Cid>,
-        block: Vec<Block>,
+        block: Vec<CarBlock>,
     ) -> Vec<u8> {
         block_on(async {
             let frame_stream = Encoder::compress_stream(
@@ -444,7 +444,7 @@ mod tests {
     }
 
     #[quickcheck]
-    fn forest_car_create_basic(head: Block, mut tail: Vec<Block>, roots: Vec<Cid>) {
+    fn forest_car_create_basic(head: CarBlock, mut tail: Vec<CarBlock>, roots: Vec<Cid>) {
         tail.push(head);
         let forest_car =
             ForestCar::new(mk_encoded_car(1024 * 4, 3, roots.clone(), tail.clone())).unwrap();
@@ -456,8 +456,8 @@ mod tests {
 
     #[quickcheck]
     fn forest_car_create_options(
-        head: Block,
-        mut tail: Vec<Block>,
+        head: CarBlock,
+        mut tail: Vec<CarBlock>,
         roots: Vec<Cid>,
         frame_size: usize,
         mut compression_level: u16,

--- a/src/tool/subcommands/benchmark_cmd.rs
+++ b/src/tool/subcommands/benchmark_cmd.rs
@@ -9,7 +9,7 @@ use crate::db::car::forest::DEFAULT_FOREST_CAR_FRAME_SIZE;
 use crate::db::car::ManyCar;
 use crate::ipld::{stream_chain, stream_graph, unordered_stream_graph};
 use crate::shim::clock::ChainEpoch;
-use crate::utils::db::car_stream::{Block, CarStream};
+use crate::utils::db::car_stream::{CarBlock, CarStream};
 use crate::utils::encoding::extract_cids;
 use crate::utils::stream::par_buffer;
 use anyhow::{Context as _, Result};
@@ -146,7 +146,7 @@ async fn benchmark_car_streaming_inspect(input: Vec<PathBuf>) -> Result<()> {
             .try_flatten(),
     );
     while let Some(block) = s.try_next().await? {
-        let block: Block = block;
+        let block: CarBlock = block;
         if block.cid.codec() == DAG_CBOR {
             let cid_vec: Vec<Cid> = extract_cids(&block.data)?;
             let _ = cid_vec.iter().unique().count();

--- a/src/utils/db/car_stream.rs
+++ b/src/utils/db/car_stream.rs
@@ -27,12 +27,12 @@ pub struct CarHeader {
 }
 
 #[derive(Debug, Clone)]
-pub struct Block {
+pub struct CarBlock {
     pub cid: Cid,
     pub data: Vec<u8>,
 }
 
-impl Block {
+impl CarBlock {
     // Write a varint frame containing the cid and the data
     pub fn write(&self, mut writer: &mut impl std::io::Write) -> io::Result<()> {
         let frame_length = self.cid.encoded_len() + self.data.len();
@@ -44,14 +44,14 @@ impl Block {
         Ok(())
     }
 
-    pub fn from_bytes(bytes: impl Into<Bytes>) -> Option<Block> {
+    pub fn from_bytes(bytes: impl Into<Bytes>) -> Option<CarBlock> {
         let bytes: Bytes = bytes.into();
         let mut cursor = Cursor::new(bytes);
         let cid = Cid::read_bytes(&mut cursor).ok()?;
         let data_offset = cursor.position();
         let mut bytes = cursor.into_inner();
         bytes.advance(data_offset as usize);
-        Some(Block {
+        Some(CarBlock {
             cid,
             data: bytes.to_vec(),
         })
@@ -117,7 +117,7 @@ impl<ReaderT: AsyncSeek + AsyncBufRead + Unpin> CarStream<ReaderT> {
 }
 
 impl<ReaderT: AsyncBufRead> Stream for CarStream<ReaderT> {
-    type Item = io::Result<Block>;
+    type Item = io::Result<CarBlock>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
@@ -130,7 +130,7 @@ impl<ReaderT: AsyncBufRead> Stream for CarStream<ReaderT> {
                 let data_offset = cursor.position();
                 let mut bytes = cursor.into_inner();
                 bytes.advance(data_offset as usize);
-                Ok(Block {
+                Ok(CarBlock {
                     cid,
                     data: bytes.to_vec(),
                 })
@@ -145,7 +145,7 @@ async fn read_header<ReaderT: AsyncRead + Unpin>(reader: &mut ReaderT) -> Option
     if header.version != 1 {
         return None;
     }
-    let first_block = Block::from_bytes(framed_reader.next().await?.ok()?)?;
+    let first_block = CarBlock::from_bytes(framed_reader.next().await?.ok()?)?;
     if !first_block.valid() {
         return None;
     }
@@ -171,8 +171,8 @@ mod tests {
     use quickcheck::{Arbitrary, Gen};
     // use quickcheck_macros::quickcheck;
 
-    impl Arbitrary for Block {
-        fn arbitrary(g: &mut Gen) -> Block {
+    impl Arbitrary for CarBlock {
+        fn arbitrary(g: &mut Gen) -> CarBlock {
             let data = Vec::<u8>::arbitrary(g);
             let encoding = g
                 .choose(&[
@@ -183,7 +183,7 @@ mod tests {
                 .unwrap();
             let code = g.choose(&[Code::Blake2b256, Code::Sha2_256]).unwrap();
             let cid = Cid::new_v1(*encoding, code.digest(&data));
-            Block { cid, data }
+            CarBlock { cid, data }
         }
     }
 }

--- a/src/utils/db/car_util.rs
+++ b/src/utils/db/car_util.rs
@@ -38,7 +38,7 @@ mod tests {
     use quickcheck_macros::quickcheck;
 
     #[derive(Debug, Clone)]
-    struct Blocks(Vec<Block>);
+    struct Blocks(Vec<CarBlock>);
 
     impl From<&Blocks> for HashSet<Cid> {
         fn from(blocks: &Blocks) -> Self {
@@ -61,12 +61,12 @@ mod tests {
             writer
         }
 
-        fn into_stream(self) -> impl Stream<Item = std::io::Result<Block>> {
+        fn into_stream(self) -> impl Stream<Item = std::io::Result<CarBlock>> {
             futures::stream::iter(self.0).map(Ok)
         }
 
         /// Implicit clone is performed inside to simplify caller code
-        fn to_stream(&self) -> impl Stream<Item = std::io::Result<Block>> {
+        fn to_stream(&self) -> impl Stream<Item = std::io::Result<CarBlock>> {
             self.clone().into_stream()
         }
     }
@@ -80,7 +80,7 @@ mod tests {
                 // use small len here to increase the chance of duplication
                 let data = [u8::arbitrary(g), u8::arbitrary(g)];
                 let cid = Cid::new_v1(DAG_CBOR, multihash::Code::Blake2b256.digest(&data));
-                let block = Block {
+                let block = CarBlock {
                     cid,
                     data: data.to_vec(),
                 };

--- a/src/utils/db/car_util.rs
+++ b/src/utils/db/car_util.rs
@@ -5,11 +5,11 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use tokio::io::{AsyncBufRead, AsyncSeek};
 
 use crate::ipld::CidHashSet;
-use crate::utils::db::car_stream::{Block, CarStream};
+use crate::utils::db::car_stream::{CarBlock, CarStream};
 
 pub fn merge_car_streams<R>(
     car_streams: Vec<CarStream<R>>,
-) -> impl Stream<Item = std::io::Result<Block>>
+) -> impl Stream<Item = std::io::Result<CarBlock>>
 where
     R: AsyncSeek + AsyncBufRead + Unpin,
 {
@@ -17,10 +17,10 @@ where
 }
 
 pub fn dedup_block_stream(
-    stream: impl Stream<Item = std::io::Result<Block>>,
-) -> impl Stream<Item = std::io::Result<Block>> {
+    stream: impl Stream<Item = std::io::Result<CarBlock>>,
+) -> impl Stream<Item = std::io::Result<CarBlock>> {
     let mut seen = CidHashSet::default();
-    stream.try_filter(move |Block { cid, data: _ }| futures::future::ready(seen.insert(*cid)))
+    stream.try_filter(move |CarBlock { cid, data: _ }| futures::future::ready(seen.insert(*cid)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:

- Rename `Block` to `CarBlock` to avoid name clashes with filecoin blocks.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Part of #3490

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
