### PR TITLE
chore: remove unused RPCState field

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -317,7 +317,6 @@ pub(super) async fn start(
     let mpool = Arc::new(mpool);
 
     // Initialize ChainMuxer
-    let chain_muxer_tipset_sink = tipset_sink.clone();
     let chain_muxer = ChainMuxer::new(
         Arc::clone(&state_manager),
         peer_manager,
@@ -325,7 +324,7 @@ pub(super) async fn start(
         network_send.clone(),
         network_rx,
         Arc::new(Tipset::from(genesis_header)),
-        chain_muxer_tipset_sink,
+        tipset_sink,
         tipset_stream,
         config.sync.clone(),
     )?;
@@ -367,7 +366,6 @@ pub(super) async fn start(
                     // TODO: the RPCState can fetch this itself from the StateManager
                     beacon,
                     chain_store: rpc_chain_store,
-                    new_mined_block_tx: tipset_sink,
                     gc_event_tx,
                 }),
                 rpc_listen,

--- a/src/rpc/sync_api.rs
+++ b/src/rpc/sync_api.rs
@@ -130,7 +130,6 @@ mod tests {
             )
             .unwrap()
         };
-        let (new_mined_block_tx, _) = flume::bounded(5);
         let start_time = chrono::Utc::now();
         let (gc_event_tx, _) = flume::unbounded();
 
@@ -145,7 +144,6 @@ mod tests {
             start_time,
             chain_store: cs_for_chain.clone(),
             beacon,
-            new_mined_block_tx,
             gc_event_tx,
         });
         (state, network_rx)

--- a/src/rpc_api/data_types.rs
+++ b/src/rpc_api/data_types.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use crate::beacon::BeaconSchedule;
-use crate::blocks::{Tipset, TipsetKeys};
+use crate::blocks::TipsetKeys;
 use crate::chain::ChainStore;
 use crate::chain_sync::{BadBlockCache, SyncState};
 use crate::ipld::json::IpldJson;
@@ -41,7 +41,6 @@ where
     pub network_send: flume::Sender<NetworkMessage>,
     pub network_name: String,
     pub start_time: chrono::DateTime<Utc>,
-    pub new_mined_block_tx: flume::Sender<Arc<Tipset>>,
     pub beacon: Arc<BeaconSchedule>,
     pub gc_event_tx: flume::Sender<flume::Sender<anyhow::Result<()>>>,
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Remove the unused `new_mined_block_tx` field in `RPCState`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
