### PR TITLE
fix: Lazy<Vec<String>> should just be &[&str]

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,7 +5,6 @@ use crate::key_management::KeyInfo;
 use crate::shim::crypto::SignatureType;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, errors::Result as JWTResult, DecodingKey, EncodingKey, Header};
-use once_cell::sync::Lazy;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -13,21 +12,13 @@ use thiserror::Error;
 /// constant string that is used to identify the JWT secret key in `KeyStore`
 pub const JWT_IDENTIFIER: &str = "auth-jwt-private";
 /// Admin permissions
-pub static ADMIN: Lazy<Vec<String>> = Lazy::new(|| {
-    vec![
-        "read".to_string(),
-        "write".to_string(),
-        "sign".to_string(),
-        "admin".to_string(),
-    ]
-});
+pub static ADMIN: &[&str] = &["read", "write", "sign", "admin"];
 /// Signing permissions
-pub static SIGN: Lazy<Vec<String>> =
-    Lazy::new(|| vec!["read".to_string(), "write".to_string(), "sign".to_string()]);
+pub static SIGN: &[&str] = &["read", "write", "sign"];
 /// Writing permissions
-pub static WRITE: Lazy<Vec<String>> = Lazy::new(|| vec!["read".to_string(), "write".to_string()]);
+pub static WRITE: &[&str] = &["read", "write"];
 /// Reading permissions
-pub static READ: Lazy<Vec<String>> = Lazy::new(|| vec!["read".to_string()]);
+pub static READ: &[&str] = &["read"];
 
 /// Error enumeration for Authentication
 #[derive(Debug, Error, Serialize, Deserialize)]

--- a/src/cli/subcommands/auth_cmd.rs
+++ b/src/cli/subcommands/auth_cmd.rs
@@ -27,13 +27,16 @@ pub enum AuthCommands {
 }
 
 fn process_perms(perm: String) -> Result<Vec<String>, JsonRpcError> {
-    match perm.as_str() {
-        "admin" => Ok(ADMIN.to_owned()),
-        "sign" => Ok(SIGN.to_owned()),
-        "write" => Ok(WRITE.to_owned()),
-        "read" => Ok(READ.to_owned()),
-        _ => Err(JsonRpcError::INVALID_PARAMS),
+    Ok(match perm.as_str() {
+        "admin" => ADMIN,
+        "sign" => SIGN,
+        "write" => WRITE,
+        "read" => READ,
+        _ => return Err(JsonRpcError::INVALID_PARAMS),
     }
+    .iter()
+    .map(ToString::to_string)
+    .collect())
 }
 
 impl AuthCommands {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -531,7 +531,11 @@ async fn set_snapshot_path_if_needed(
 fn handle_admin_token(opts: &CliOpts, config: &Config, keystore: &KeyStore) -> anyhow::Result<()> {
     let ki = keystore.get(JWT_IDENTIFIER)?;
     let token_exp = config.client.token_exp;
-    let token = create_token(ADMIN.to_owned(), ki.private_key(), token_exp)?;
+    let token = create_token(
+        ADMIN.iter().map(ToString::to_string).collect(),
+        ki.private_key(),
+        token_exp,
+    )?;
     info!("Admin token: {token}");
     if let Some(path) = opts.save_token.as_ref() {
         std::fs::write(path, token)?;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-  Change `Lazy<Vec<String>>` to `&[&str]`

This PR does not update RPC-related struct fields to take `&str` though, which might require some workarounds to work with  `json_rpc` framework

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3499

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
