### PR TITLE
refactor: use bigint directly rather than from the fvm

### DIFF
--- a/src/shim/bigint.rs
+++ b/src/shim/bigint.rs
@@ -3,22 +3,16 @@
 
 use std::ops::{Deref, DerefMut};
 
+use fvm_shared3::bigint::bigint_ser;
 pub use fvm_shared3::bigint::bigint_ser::{BigIntDe, BigIntSer};
-use fvm_shared3::bigint::{bigint_ser, BigInt as BigInt_v3};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct BigInt(#[serde(with = "bigint_ser")] BigInt_v3);
-
-impl BigInt {
-    pub fn inner(&self) -> &BigInt_v3 {
-        &self.0
-    }
-}
+pub struct BigInt(#[serde(with = "bigint_ser")] num_bigint::BigInt);
 
 impl Deref for BigInt {
-    type Target = BigInt_v3;
+    type Target = num_bigint::BigInt;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -30,8 +24,8 @@ impl DerefMut for BigInt {
     }
 }
 
-impl From<BigInt_v3> for BigInt {
-    fn from(other: BigInt_v3) -> Self {
+impl From<num_bigint::BigInt> for BigInt {
+    fn from(other: num_bigint::BigInt) -> Self {
         BigInt(other)
     }
 }

--- a/src/state_migration/nv17/datacap.rs
+++ b/src/state_migration/nv17/datacap.rs
@@ -17,6 +17,7 @@ use fil_actors_shared::fvm_ipld_hamt::BytesKey;
 use fvm_ipld_blockstore::Blockstore;
 use num_traits::Zero;
 use once_cell::sync::Lazy;
+use std::ops::Deref;
 
 use super::util::hamt_addr_key_to_key;
 
@@ -50,7 +51,7 @@ impl<BS: Blockstore> PostMigrator<BS> for DataCapPostMigrator {
 
         verified_clients.for_each(|addr_key, value| {
             let key = hamt_addr_key_to_key(addr_key)?;
-            let token_amount = value.inner() * DATA_CAP_GRANULARITY;
+            let token_amount = value.deref() * DATA_CAP_GRANULARITY;
             token_supply = &token_supply + &token_amount;
             balances_map.set(key.clone(), token_amount.into())?;
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `BigInt` isn't an FVM concept. We should use the type directly from the `num-bigint` crate.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
