### PR TITLE
ci: send db-migration output to stdout rather than a file

### DIFF
--- a/scripts/tests/calibnet_db_migration.sh
+++ b/scripts/tests/calibnet_db_migration.sh
@@ -46,7 +46,7 @@ echo "data_dir = \"${TMP_DIR}/data_dir\"" >> "${CONFIG_FILE}"
 echo 'encrypt_keystore = false' >> "${CONFIG_FILE}"
 
 # Run the current Forest with the old database. This should trigger a migration (or several ones).
-forest --chain calibnet --log-dir "$LOG_DIRECTORY" --halt-after-import --save-token ./admin_token --track-peak-rss --config "${CONFIG_FILE}"
+forest --chain calibnet --log-dir "$LOG_DIRECTORY" --halt-after-import --track-peak-rss --config "${CONFIG_FILE}"
 
 # Sync to HEAD. This might reveal migrations errors not caught above.
 forest --chain calibnet --log-dir "$LOG_DIRECTORY" --detach --save-token ./admin_token --track-peak-rss --config "${CONFIG_FILE}"

--- a/scripts/tests/calibnet_db_migration.sh
+++ b/scripts/tests/calibnet_db_migration.sh
@@ -46,7 +46,10 @@ echo "data_dir = \"${TMP_DIR}/data_dir\"" >> "${CONFIG_FILE}"
 echo 'encrypt_keystore = false' >> "${CONFIG_FILE}"
 
 # Run the current Forest with the old database. This should trigger a migration (or several ones).
-forest --chain calibnet --encrypt-keystore false --log-dir "$LOG_DIRECTORY" --detach --save-token ./admin_token --track-peak-rss --config "${CONFIG_FILE}"
+forest --chain calibnet --log-dir "$LOG_DIRECTORY" --halt-after-import --save-token ./admin_token --track-peak-rss --config "${CONFIG_FILE}"
+
+# Sync to HEAD. This might reveal migrations errors not caught above.
+forest --chain calibnet --log-dir "$LOG_DIRECTORY" --detach --save-token ./admin_token --track-peak-rss --config "${CONFIG_FILE}"
 
 ADMIN_TOKEN=$(cat admin_token)
 FULLNODE_API_INFO="$ADMIN_TOKEN:/ip4/127.0.0.1/tcp/2345/http"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Show DB migration results in the github-worker output. This makes it a bit easier to see when something goes wrong.
- The sync output is still hidden. You must re-run the code locally to see the errors if something goes wrong during sync.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
