### PR TITLE
refactor: manifest

### DIFF
--- a/src/shim/machine/manifest.rs
+++ b/src/shim/machine/manifest.rs
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
-#![allow(deprecated, dead_code)]
 
 use std::collections::BTreeMap;
 
-use ahash::HashMap;
-use anyhow::{anyhow, ensure, Context as _};
+use anyhow::{ensure, Context as _};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore as _;
@@ -94,132 +92,6 @@ impl BuiltinActorManifest {
     }
     pub fn builtin_actors(&self) -> impl ExactSizeIterator<Item = (BuiltinActor, Cid)> + '_ {
         self.builtin2cid.iter().map(|(k, v)| (*k, *v)) // std::iter::Copied doesn't play well with the tuple here
-    }
-}
-
-// For details on actor name and version, see <https://github.com/filecoin-project/go-state-types/blob/1e6cf0d47cdda75383ef036fc2725d1cf51dbde8/manifest/manifest.go#L36>
-
-macro_rules! name {
-    ($($ident:ident = $lit:literal),* $(,)?) => {
-        $(
-            #[allow(unused)] // included for completeness
-            pub const $ident: &str = $lit;
-        )*
-    }
-}
-name!(
-    ACCOUNT_ACTOR_NAME = "account",
-    CRON_ACTOR_NAME = "cron",
-    INIT_ACTOR_NAME = "init",
-    MARKET_ACTOR_NAME = "storagemarket",
-    MINER_ACTOR_NAME = "storageminer",
-    MULTISIG_ACTOR_NAME = "multisig",
-    PAYCH_ACTOR_NAME = "paymentchannel",
-    POWER_ACTOR_NAME = "storagepower",
-    REWARD_ACTOR_NAME = "reward",
-    SYSTEM_ACTOR_NAME = "system",
-    VERIFREG_ACTOR_NAME = "verifiedregistry",
-    // actor version >= 9
-    DATACAP_ACTOR_NAME = "datacap",
-    // actor version >= 10
-    EVM_ACTOR_NAME = "evm",
-    EAM_ACTOR_NAME = "eam",
-    PLACEHOLDER_ACTOR_NAME = "placeholder",
-    ETH_ACCOUNT_ACTOR_NAME = "ethaccount",
-);
-
-/// Manifest is serialized as a tuple of version and manifest actors CID
-type ManifestCbor = (u32, Cid);
-
-/// Manifest data is serialized as a vector of name-to-actor-CID pair
-type ManifestActorsCbor = Vec<(String, Cid)>;
-
-/// A mapping of builtin actor CIDs to their respective types.
-#[deprecated]
-pub struct Manifest {
-    by_name: HashMap<String, Cid>,
-
-    actors_cid: Cid,
-
-    init_code: Cid,
-    system_code: Cid,
-}
-
-impl Manifest {
-    /// Load a manifest from the block store with manifest CID.
-    pub fn load<B: Blockstore>(bs: &B, manifest_cid: &Cid) -> anyhow::Result<Self> {
-        let (version, actors_cid): ManifestCbor = bs.get_cbor(manifest_cid)?.ok_or_else(|| {
-            anyhow::anyhow!("Failed to retrieve manifest with manifest cid {manifest_cid}")
-        })?;
-
-        Self::load_with_actors(bs, &actors_cid, version)
-    }
-
-    /// Load a manifest from the block store with actors CID and version.
-    /// Note that only version 1 is supported.
-    pub fn load_with_actors<B: Blockstore>(
-        bs: &B,
-        actors_cid: &Cid,
-        version: u32,
-    ) -> anyhow::Result<Self> {
-        if version != 1 {
-            anyhow::bail!("unsupported manifest version {version}");
-        }
-
-        let actors: ManifestActorsCbor = bs.get_cbor(actors_cid)?.ok_or_else(|| {
-            anyhow::anyhow!("Failed to retrieve manifest actors with actors cid {actors_cid}")
-        })?;
-
-        Self::new(actors, *actors_cid)
-    }
-
-    /// Construct a new manifest from actor name/CID tuples.
-    fn new(iter: impl IntoIterator<Item = (String, Cid)>, actors_cid: Cid) -> anyhow::Result<Self> {
-        let by_name = HashMap::from_iter(iter);
-
-        let init_code = *by_name
-            .get(INIT_ACTOR_NAME)
-            .context("manifest missing init actor")?;
-
-        let system_code = *by_name
-            .get(SYSTEM_ACTOR_NAME)
-            .context("manifest missing system actor")?;
-
-        Ok(Self {
-            by_name,
-            actors_cid,
-            init_code,
-            system_code,
-        })
-    }
-
-    pub fn actors_cid(&self) -> Cid {
-        self.actors_cid
-    }
-
-    /// Returns the code CID for a builtin actor, given the actor's name.
-    pub fn code_by_name(&self, name: &str) -> anyhow::Result<&Cid> {
-        self.by_name
-            .get(name)
-            .ok_or_else(|| anyhow!("Failed to retrieve actor code by name {name}"))
-    }
-
-    pub fn actors_count(&self) -> usize {
-        self.by_name.len()
-    }
-
-    pub fn builtin_actors(&self) -> impl Iterator<Item = (&String, &Cid)> {
-        self.by_name.iter()
-    }
-
-    /// Returns the code CID for the init actor.
-    pub fn init_code(&self) -> &Cid {
-        &self.init_code
-    }
-
-    /// Returns the code CID for the system actor.
-    pub fn system_code(&self) -> &Cid {
-        &self.system_code
     }
 }
 

--- a/src/shim/machine/manifest.rs
+++ b/src/shim/machine/manifest.rs
@@ -10,7 +10,7 @@ use ahash::HashMap;
 use anyhow::{anyhow, ensure, Context as _};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
+use fvm_ipld_encoding::CborStore as _;
 use itertools::Itertools as _;
 
 /// This should be the latest enumeration of all builtin actors

--- a/src/shim/machine/mod.rs
+++ b/src/shim/machine/mod.rs
@@ -4,8 +4,8 @@
 use fvm2::machine::MultiEngine as MultiEngine_v2;
 use fvm3::engine::MultiEngine as MultiEngine_v3;
 use fvm4::engine::MultiEngine as MultiEngine_v4;
+pub use manifest::{BuiltinActor, BuiltinActorManifest};
 mod manifest;
-pub use manifest::*;
 
 pub struct MultiEngine {
     pub v2: MultiEngine_v2,

--- a/src/state_migration/common/macros/system.rs
+++ b/src/state_migration/common/macros/system.rs
@@ -21,12 +21,12 @@ macro_rules! impl_system {
 
             use cid::Cid;
             use fvm_ipld_blockstore::Blockstore;
-            use $crate::shim::machine::Manifest2;
+            use $crate::shim::machine::BuiltinActorManifest;
             use $crate::state_migration::common::*;
             use $crate::utils::db::CborStoreExt;
 
             pub(super) fn system_migrator<BS: Blockstore>(
-                new_manifest: &Manifest2,
+                new_manifest: &BuiltinActorManifest,
             ) -> Arc<dyn ActorMigration<BS> + Send + Sync> {
                 Arc::new(SystemMigrator {
                     new_builtin_actors_cid: new_manifest.source_cid(),

--- a/src/state_migration/common/macros/system.rs
+++ b/src/state_migration/common/macros/system.rs
@@ -21,16 +21,16 @@ macro_rules! impl_system {
 
             use cid::Cid;
             use fvm_ipld_blockstore::Blockstore;
-            use $crate::shim::machine::Manifest;
+            use $crate::shim::machine::Manifest2;
             use $crate::state_migration::common::*;
             use $crate::utils::db::CborStoreExt;
 
             pub(super) fn system_migrator<BS: Blockstore>(
-                new_manifest: &Manifest,
+                new_manifest: &Manifest2,
             ) -> Arc<dyn ActorMigration<BS> + Send + Sync> {
                 Arc::new(SystemMigrator {
-                    new_builtin_actors_cid: new_manifest.actors_cid(),
-                    new_code_cid: *new_manifest.system_code(),
+                    new_builtin_actors_cid: new_manifest.source_cid(),
+                    new_code_cid: new_manifest.get_system(),
                 })
             }
 

--- a/src/state_migration/common/macros/verifier.rs
+++ b/src/state_migration/common/macros/verifier.rs
@@ -11,7 +11,7 @@ macro_rules! impl_verifier {
             use $crate::cid_collections::CidHashMap;
             use fvm_ipld_blockstore::Blockstore;
             use fvm_ipld_encoding::CborStore;
-            use $crate::shim::{address::Address, machine::Manifest2, state_tree::StateTree};
+            use $crate::shim::{address::Address, machine::BuiltinActorManifest, state_tree::StateTree};
             use $crate::state_migration::common::{verifier::ActorMigrationVerifier, Migrator};
 
             use super::*;
@@ -34,7 +34,7 @@ macro_rules! impl_verifier {
                         .get_cbor::<SystemStateOld>(&system_actor.state)?
                         .ok_or_else(|| anyhow::anyhow!("system actor state not found"))?;
                     let manifest =
-                        Manifest2::load_from_v1_actor_list(&store, &system_actor_state.builtin_actors)?;
+                        BuiltinActorManifest::load_v1_actor_list(&store, &system_actor_state.builtin_actors)?;
                     let manifest_actors_count = manifest.builtin_actors().len();
                     if manifest_actors_count == migrations.len() {
                         tracing::debug!("Migration spec is correct.");

--- a/src/state_migration/common/macros/verifier.rs
+++ b/src/state_migration/common/macros/verifier.rs
@@ -11,7 +11,7 @@ macro_rules! impl_verifier {
             use $crate::cid_collections::CidHashMap;
             use fvm_ipld_blockstore::Blockstore;
             use fvm_ipld_encoding::CborStore;
-            use $crate::shim::{address::Address, machine::Manifest, state_tree::StateTree};
+            use $crate::shim::{address::Address, machine::Manifest2, state_tree::StateTree};
             use $crate::state_migration::common::{verifier::ActorMigrationVerifier, Migrator};
 
             use super::*;
@@ -34,8 +34,8 @@ macro_rules! impl_verifier {
                         .get_cbor::<SystemStateOld>(&system_actor.state)?
                         .ok_or_else(|| anyhow::anyhow!("system actor state not found"))?;
                     let manifest =
-                        Manifest::load_with_actors(&store, &system_actor_state.builtin_actors, 1)?;
-                    let manifest_actors_count = manifest.actors_count();
+                        Manifest2::load_from_v1_actor_list(&store, &system_actor_state.builtin_actors)?;
+                    let manifest_actors_count = manifest.builtin_actors().len();
                     if manifest_actors_count == migrations.len() {
                         tracing::debug!("Migration spec is correct.");
                     } else {

--- a/src/state_migration/nv17/migration.rs
+++ b/src/state_migration/nv17/migration.rs
@@ -35,11 +35,11 @@ impl<BS: Blockstore + Send + Sync> StateMigration<BS> {
     ) -> anyhow::Result<()> {
         let system_actor = actors_in
             .get_actor(&Address::new_id(0))?
-            .context("system actor not found")?;
+            .ok_or_else(|| anyhow!("system actor not found"))?;
 
         let system_actor_state: SystemStateOld = store
             .get_cbor(&system_actor.state)?
-            .context("system actor state not found")?;
+            .ok_or_else(|| anyhow!("system actor state not found"))?;
         let current_manifest_data = system_actor_state.builtin_actors;
 
         let current_manifest =
@@ -86,7 +86,7 @@ impl<BS: Blockstore + Send + Sync> StateMigration<BS> {
             system::system_migrator(new_manifest),
         );
 
-        let miner_v8_actor_code = current_manifest.get(BuiltinActor::Miner)?; // TODO(aatifsyed): can Miner is a v8 actor - can we guarantee it's always there?
+        let miner_v8_actor_code = current_manifest.get(BuiltinActor::Miner)?;
         let miner_v9_actor_code = new_manifest.get(BuiltinActor::Miner)?;
 
         self.add_migrator(

--- a/src/state_migration/nv17/migration.rs
+++ b/src/state_migration/nv17/migration.rs
@@ -4,11 +4,10 @@
 use std::sync::Arc;
 
 use crate::networks::{ChainConfig, Height};
-use crate::shim::machine::*;
 use crate::shim::{
     address::Address,
     clock::ChainEpoch,
-    machine::Manifest,
+    machine::{Builtin, Manifest2},
     state_tree::{StateTree, StateTreeVersion},
 };
 use anyhow::{anyhow, Context};
@@ -30,20 +29,20 @@ impl<BS: Blockstore + Send + Sync> StateMigration<BS> {
         &mut self,
         store: &Arc<BS>,
         actors_in: &mut StateTree<BS>,
-        new_manifest: &Manifest,
+        new_manifest: &Manifest2,
         prior_epoch: ChainEpoch,
         chain_config: &ChainConfig,
     ) -> anyhow::Result<()> {
         let system_actor = actors_in
             .get_actor(&Address::new_id(0))?
-            .ok_or_else(|| anyhow!("system actor not found"))?;
+            .context("system actor not found")?;
 
         let system_actor_state: SystemStateOld = store
             .get_cbor(&system_actor.state)?
-            .ok_or_else(|| anyhow!("system actor state not found"))?;
+            .context("system actor state not found")?;
         let current_manifest_data = system_actor_state.builtin_actors;
 
-        let current_manifest = Manifest::load_with_actors(&store, &current_manifest_data, 1)?;
+        let current_manifest = Manifest2::load_from_v1_actor_list(store, &current_manifest_data)?;
 
         let verifreg_actor_v8 = actors_in
             .get_actor(&fil_actors_shared::v8::VERIFIED_REGISTRY_ACTOR_ADDR.into())?
@@ -69,27 +68,30 @@ impl<BS: Blockstore + Send + Sync> StateMigration<BS> {
             get_pending_verified_deals_and_total_size(&store, &market_state_v8)?;
 
         for (name, code) in current_manifest.builtin_actors() {
-            if name == MARKET_ACTOR_NAME || name == VERIFREG_ACTOR_NAME {
-                self.add_migrator(*code, Arc::new(DeferredMigrator))
-            } else {
-                let new_code = new_manifest.code_by_name(name)?;
-                self.add_migrator(*code, nil_migrator(*new_code));
+            match name {
+                Builtin::Market | Builtin::VerifiedRegistry => {
+                    self.add_migrator(code, Arc::new(DeferredMigrator))
+                }
+                _ => {
+                    let new_code = new_manifest.get(name)?;
+                    self.add_migrator(code, nil_migrator(new_code))
+                }
             }
         }
 
         // https://github.com/filecoin-project/go-state-types/blob/1e6cf0d47cdda75383ef036fc2725d1cf51dbde8/builtin/v9/migration/top.go#L178
         self.add_migrator(
-            *current_manifest.system_code(),
+            current_manifest.get_system(),
             system::system_migrator(new_manifest),
         );
 
-        let miner_v8_actor_code = current_manifest.code_by_name(MINER_ACTOR_NAME)?;
-        let miner_v9_actor_code = new_manifest.code_by_name(MINER_ACTOR_NAME)?;
+        let miner_v8_actor_code = current_manifest.get(Builtin::Miner)?; // TODO(aatifsyed): can Miner is a v8 actor - can we guarantee it's always there?
+        let miner_v9_actor_code = new_manifest.get(Builtin::Miner)?;
 
         self.add_migrator(
-            *miner_v8_actor_code,
+            miner_v8_actor_code,
             miner::miner_migrator(
-                *miner_v9_actor_code,
+                miner_v9_actor_code,
                 store,
                 market_state_v8.proposals,
                 chain_config,
@@ -100,8 +102,8 @@ impl<BS: Blockstore + Send + Sync> StateMigration<BS> {
         let verifreg_state_v8: fil_actor_verifreg_state::v8::State = store
             .get_cbor(&verifreg_state_v8_cid)?
             .context("Failed to load verifreg state v8")?;
-        let verifreg_code = *new_manifest.code_by_name(VERIFREG_ACTOR_NAME)?;
-        let market_code = *new_manifest.code_by_name(MARKET_ACTOR_NAME)?;
+        let verifreg_code = new_manifest.get(Builtin::VerifiedRegistry)?;
+        let market_code = new_manifest.get(Builtin::Market)?;
 
         self.add_post_migrator(Arc::new(VerifregMarketPostMigrator {
             prior_epoch,
@@ -119,7 +121,7 @@ impl<BS: Blockstore + Send + Sync> StateMigration<BS> {
         // by setting up an empty actor to migrate from with a migrator,
         // while forest uses a post migrator to simplify the logic.
         self.add_post_migrator(Arc::new(datacap::DataCapPostMigrator {
-            new_code_cid: *new_manifest.code_by_name(DATACAP_ACTOR_NAME)?,
+            new_code_cid: new_manifest.get(Builtin::DataCap)?,
             verifreg_state: store
                 .get_cbor(&verifreg_state_v8_cid)?
                 .context("Failed to load verifreg state v8")?,
@@ -155,7 +157,7 @@ where
         )
     })?;
 
-    let new_manifest = Manifest::load(&blockstore, new_manifest_cid)?;
+    let new_manifest = Manifest2::load_from_manifest(blockstore, new_manifest_cid)?;
 
     let mut actors_in = StateTree::new_from_root(blockstore.clone(), state)?;
 

--- a/src/state_migration/nv17/migration.rs
+++ b/src/state_migration/nv17/migration.rs
@@ -10,10 +10,10 @@ use crate::shim::{
     machine::{BuiltinActor, BuiltinActorManifest},
     state_tree::{StateTree, StateTreeVersion},
 };
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context as _};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
+use fvm_ipld_encoding::CborStore as _;
 
 use super::super::common::{
     migrators::{nil_migrator, DeferredMigrator},
@@ -68,14 +68,14 @@ impl<BS: Blockstore + Send + Sync> StateMigration<BS> {
         let (pending_verified_deals, pending_verified_deal_size) =
             get_pending_verified_deals_and_total_size(&store, &market_state_v8)?;
 
-        for (name, code) in current_manifest.builtin_actors() {
-            match name {
+        for (actor, cid) in current_manifest.builtin_actors() {
+            match actor {
                 BuiltinActor::Market | BuiltinActor::VerifiedRegistry => {
-                    self.add_migrator(code, Arc::new(DeferredMigrator))
+                    self.add_migrator(cid, Arc::new(DeferredMigrator))
                 }
                 _ => {
-                    let new_code = new_manifest.get(name)?;
-                    self.add_migrator(code, nil_migrator(new_code))
+                    let new_code = new_manifest.get(actor)?;
+                    self.add_migrator(cid, nil_migrator(new_code))
                 }
             }
         }

--- a/src/state_migration/nv18/eam.rs
+++ b/src/state_migration/nv18/eam.rs
@@ -3,7 +3,7 @@
 
 use crate::shim::{
     address::Address,
-    machine::{Manifest, EAM_ACTOR_NAME},
+    machine::{Builtin, Manifest2},
     state_tree::{ActorState, StateTree},
 };
 use fvm_ipld_blockstore::Blockstore;
@@ -25,9 +25,9 @@ impl<BS: Blockstore> PostMigrator<BS> for EamPostMigrator {
             .get_cbor(&sys_actor.state)?
             .ok_or_else(|| anyhow::anyhow!("Couldn't get statev10"))?;
 
-        let manifest = Manifest::load_with_actors(&store, &sys_state.builtin_actors, 1)?;
+        let manifest = Manifest2::load_from_v1_actor_list(store, &sys_state.builtin_actors)?;
 
-        let eam_actor = ActorState::new_empty(*manifest.code_by_name(EAM_ACTOR_NAME)?, None);
+        let eam_actor = ActorState::new_empty(manifest.get(Builtin::EAM)?, None);
         actors_out.set_actor(&Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR, eam_actor)?;
         Ok(())
     }

--- a/src/state_migration/nv18/eam.rs
+++ b/src/state_migration/nv18/eam.rs
@@ -3,7 +3,7 @@
 
 use crate::shim::{
     address::Address,
-    machine::{Builtin, Manifest2},
+    machine::{BuiltinActor, BuiltinActorManifest},
     state_tree::{ActorState, StateTree},
 };
 use fvm_ipld_blockstore::Blockstore;
@@ -25,9 +25,9 @@ impl<BS: Blockstore> PostMigrator<BS> for EamPostMigrator {
             .get_cbor(&sys_actor.state)?
             .ok_or_else(|| anyhow::anyhow!("Couldn't get statev10"))?;
 
-        let manifest = Manifest2::load_from_v1_actor_list(store, &sys_state.builtin_actors)?;
+        let manifest = BuiltinActorManifest::load_v1_actor_list(store, &sys_state.builtin_actors)?;
 
-        let eam_actor = ActorState::new_empty(manifest.get(Builtin::EAM)?, None);
+        let eam_actor = ActorState::new_empty(manifest.get(BuiltinActor::EAM)?, None);
         actors_out.set_actor(&Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR, eam_actor)?;
         Ok(())
     }

--- a/src/state_migration/nv18/eth_account.rs
+++ b/src/state_migration/nv18/eth_account.rs
@@ -3,7 +3,7 @@
 
 use crate::shim::{
     address::Address,
-    machine::{Manifest, ETH_ACCOUNT_ACTOR_NAME},
+    machine::{Builtin, Manifest2},
     state_tree::{ActorState, StateTree},
 };
 use anyhow::anyhow;
@@ -41,10 +41,10 @@ impl<BS: Blockstore> PostMigrator<BS> for EthAccountPostMigrator {
             .ok_or_else(|| anyhow!("failed to get system actor state"))?;
 
         let new_manifest =
-            Manifest::load_with_actors(&store, &system_actor_state.builtin_actors, 1)?;
+            Manifest2::load_from_v1_actor_list(store, &system_actor_state.builtin_actors)?;
 
         let eth_account_actor = ActorState::new(
-            *new_manifest.code_by_name(ETH_ACCOUNT_ACTOR_NAME)?,
+            new_manifest.get(Builtin::EthAccount)?,
             fil_actors_shared::v10::runtime::EMPTY_ARR_CID,
             Default::default(),
             0,

--- a/src/state_migration/nv18/eth_account.rs
+++ b/src/state_migration/nv18/eth_account.rs
@@ -3,7 +3,7 @@
 
 use crate::shim::{
     address::Address,
-    machine::{Builtin, Manifest2},
+    machine::{BuiltinActor, BuiltinActorManifest},
     state_tree::{ActorState, StateTree},
 };
 use anyhow::anyhow;
@@ -41,10 +41,10 @@ impl<BS: Blockstore> PostMigrator<BS> for EthAccountPostMigrator {
             .ok_or_else(|| anyhow!("failed to get system actor state"))?;
 
         let new_manifest =
-            Manifest2::load_from_v1_actor_list(store, &system_actor_state.builtin_actors)?;
+            BuiltinActorManifest::load_v1_actor_list(store, &system_actor_state.builtin_actors)?;
 
         let eth_account_actor = ActorState::new(
-            new_manifest.get(Builtin::EthAccount)?,
+            new_manifest.get(BuiltinActor::EthAccount)?,
             fil_actors_shared::v10::runtime::EMPTY_ARR_CID,
             Default::default(),
             0,

--- a/src/state_migration/nv18/migration.rs
+++ b/src/state_migration/nv18/migration.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use crate::networks::{ChainConfig, Height};
-use crate::shim::machine::Manifest2;
+use crate::shim::machine::BuiltinActorManifest;
 use crate::shim::{
     address::Address,
     clock::ChainEpoch,
@@ -36,9 +36,9 @@ impl<BS: Blockstore> StateMigration<BS> {
             .get_cbor::<SystemStateOld>(&system_actor.state)?
             .ok_or_else(|| anyhow!("system actor state not found"))?;
         let current_manifest =
-            Manifest2::load_from_v1_actor_list(&store, &system_actor_state.builtin_actors)?;
+            BuiltinActorManifest::load_v1_actor_list(&store, &system_actor_state.builtin_actors)?;
 
-        let new_manifest = Manifest2::load_from_manifest(&store, new_manifest)?;
+        let new_manifest = BuiltinActorManifest::load_manifest(&store, new_manifest)?;
 
         for (name, code) in current_manifest.builtin_actors() {
             let new_code = new_manifest.get(name)?;

--- a/src/state_migration/nv18/migration.rs
+++ b/src/state_migration/nv18/migration.rs
@@ -13,7 +13,7 @@ use crate::shim::{
 use anyhow::anyhow;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
+use fvm_ipld_encoding::CborStore as _;
 
 use super::{
     eam::EamPostMigrator, eth_account::EthAccountPostMigrator, init, system, verifier::Verifier,
@@ -40,9 +40,9 @@ impl<BS: Blockstore> StateMigration<BS> {
 
         let new_manifest = BuiltinActorManifest::load_manifest(&store, new_manifest)?;
 
-        for (name, code) in current_manifest.builtin_actors() {
-            let new_code = new_manifest.get(name)?;
-            self.add_migrator(code, nil_migrator(new_code));
+        for (actor, cid) in current_manifest.builtin_actors() {
+            let new_cid = new_manifest.get(actor)?;
+            self.add_migrator(cid, nil_migrator(new_cid));
         }
 
         self.add_migrator(

--- a/src/state_migration/nv19/migration.rs
+++ b/src/state_migration/nv19/migration.rs
@@ -13,7 +13,7 @@ use crate::shim::{
 use anyhow::anyhow;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
+use fvm_ipld_encoding::CborStore as _;
 
 use super::{miner, power, system, verifier::Verifier, SystemStateOld};
 use crate::state_migration::common::{migrators::nil_migrator, StateMigration};
@@ -39,9 +39,9 @@ impl<BS: Blockstore> StateMigration<BS> {
 
         let new_manifest = BuiltinActorManifest::load_manifest(store, new_manifest)?;
 
-        for (name, code) in current_manifest.builtin_actors() {
-            let new_code = new_manifest.get(name)?;
-            self.add_migrator(code, nil_migrator(new_code));
+        for (actor, cid) in current_manifest.builtin_actors() {
+            let new_cid = new_manifest.get(actor)?;
+            self.add_migrator(cid, nil_migrator(new_cid));
         }
 
         self.add_migrator(

--- a/src/state_migration/nv19/migration.rs
+++ b/src/state_migration/nv19/migration.rs
@@ -7,7 +7,7 @@ use crate::networks::{ChainConfig, Height};
 use crate::shim::{
     address::Address,
     clock::ChainEpoch,
-    machine::{Builtin, Manifest2},
+    machine::{BuiltinActor, BuiltinActorManifest},
     state_tree::{StateTree, StateTreeVersion},
 };
 use anyhow::anyhow;
@@ -35,9 +35,9 @@ impl<BS: Blockstore> StateMigration<BS> {
             .ok_or_else(|| anyhow!("system actor state not found"))?;
 
         let current_manifest =
-            Manifest2::load_from_v1_actor_list(store, &system_actor_state.builtin_actors)?;
+            BuiltinActorManifest::load_v1_actor_list(store, &system_actor_state.builtin_actors)?;
 
-        let new_manifest = Manifest2::load_from_manifest(store, new_manifest)?;
+        let new_manifest = BuiltinActorManifest::load_manifest(store, new_manifest)?;
 
         for (name, code) in current_manifest.builtin_actors() {
             let new_code = new_manifest.get(name)?;
@@ -45,13 +45,13 @@ impl<BS: Blockstore> StateMigration<BS> {
         }
 
         self.add_migrator(
-            current_manifest.get(Builtin::Miner)?,
-            miner::miner_migrator(new_manifest.get(Builtin::Miner)?),
+            current_manifest.get(BuiltinActor::Miner)?,
+            miner::miner_migrator(new_manifest.get(BuiltinActor::Miner)?),
         );
 
         self.add_migrator(
-            current_manifest.get(Builtin::Power)?,
-            power::power_migrator(new_manifest.get(Builtin::Power)?),
+            current_manifest.get(BuiltinActor::Power)?,
+            power::power_migrator(new_manifest.get(BuiltinActor::Power)?),
         );
 
         self.add_migrator(


### PR DESCRIPTION
#3076

# Changes
- Use `fil_actor_states`' list of actors and their names rather than defining our own
- Don't have a stringy API for getting builtin actors
- Better names for everything