### PR TITLE
refactor: anyhow usage

### DIFF
--- a/src/beacon/drand.rs
+++ b/src/beacon/drand.rs
@@ -7,7 +7,7 @@ use crate::shim::clock::ChainEpoch;
 use crate::shim::version::NetworkVersion;
 use crate::utils::net::global_http_client;
 use ahash::HashMap;
-use anyhow::Context;
+use anyhow::Context as _;
 use async_trait::async_trait;
 use bls_signatures::{PublicKey, Serialize, Signature};
 use byteorder::{BigEndian, WriteBytesExt};

--- a/src/blocks/persistence.rs
+++ b/src/blocks/persistence.rs
@@ -21,12 +21,12 @@ mod tests {
     use std::path::Path;
 
     use crate::utils::db::file_backed_obj::FileBacked;
-    use anyhow::*;
+    use anyhow::ensure;
 
     use super::*;
 
     #[test]
-    fn tipset_keys_round_trip() -> Result<()> {
+    fn tipset_keys_round_trip() -> anyhow::Result<()> {
         let path = Path::new("src/blocks/tests/calibnet/HEAD");
         let obj1: FileBacked<TipsetKeys> =
             FileBacked::load_from_file_or_create(path.into(), Default::default)?;

--- a/src/blocks/persistence.rs
+++ b/src/blocks/persistence.rs
@@ -21,20 +21,17 @@ mod tests {
     use std::path::Path;
 
     use crate::utils::db::file_backed_obj::FileBacked;
-    use anyhow::ensure;
 
     use super::*;
 
     #[test]
-    fn tipset_keys_round_trip() -> anyhow::Result<()> {
+    fn tipset_keys_round_trip() {
         let path = Path::new("src/blocks/tests/calibnet/HEAD");
         let obj1: FileBacked<TipsetKeys> =
-            FileBacked::load_from_file_or_create(path.into(), Default::default)?;
-        let serialized = obj1.inner().serialize()?;
-        let deserialized = TipsetKeys::deserialize(&serialized)?;
+            FileBacked::load_from_file_or_create(path.into(), Default::default).unwrap();
+        let serialized = obj1.inner().serialize().unwrap();
+        let deserialized = TipsetKeys::deserialize(&serialized).unwrap();
 
-        ensure!(obj1.inner() == &deserialized);
-
-        Ok(())
+        assert_eq!(obj1.inner(), &deserialized);
     }
 }

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -316,7 +316,7 @@ impl Tipset {
                     if known_block_cid == &tipset.min_ticket_block().cid().to_string() {
                         return store
                             .get_cbor(&genesis_cid)?
-                            .ok_or_else(|| anyhow::anyhow!("Genesis block missing from database"));
+                            .context("Genesis block missing from database");
                     }
                 }
             }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -8,7 +8,7 @@ use crate::db::car::forest;
 use crate::ipld::stream_chain;
 use crate::utils::io::{AsyncWriterWithChecksum, Checksum};
 use crate::utils::stream::par_buffer;
-use anyhow::{Context, Result};
+use anyhow::Context as _;
 use digest::Digest;
 use fvm_ipld_blockstore::Blockstore;
 use std::sync::Arc;
@@ -23,7 +23,7 @@ pub async fn export<D: Digest>(
     writer: impl AsyncWrite + Unpin,
     seen: CidHashSet,
     skip_checksum: bool,
-) -> Result<Option<digest::Output<D>>, Error> {
+) -> anyhow::Result<Option<digest::Output<D>>, Error> {
     let db = Arc::new(db);
     let stateroot_lookup_limit = tipset.epoch() - lookup_depth;
     let roots = tipset.key().cids.clone().into_iter().collect();

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -17,7 +17,6 @@ use crate::shim::{
 };
 use crate::utils::db::{BlockstoreExt, CborStoreExt};
 use ahash::{HashMap, HashMapExt, HashSet};
-use anyhow::Result;
 use cid::Cid;
 use fil_actors_shared::fvm_ipld_amt::Amtv0 as Amt;
 use fvm_ipld_blockstore::Blockstore;
@@ -107,7 +106,7 @@ where
         settings: Arc<dyn SettingsStore + Sync + Send>,
         chain_config: Arc<ChainConfig>,
         genesis_block_header: BlockHeader,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         let (publisher, _) = broadcast::channel(SINK_CAP);
         let chain_index = Arc::new(ChainIndex::new(Arc::clone(&db)));
 

--- a/src/chain_sync/network_context.rs
+++ b/src/chain_sync/network_context.rs
@@ -20,7 +20,7 @@ use crate::libp2p::{
     rpc::RequestResponseError,
     NetworkMessage, PeerId, PeerManager, BITSWAP_TIMEOUT,
 };
-use anyhow::Context;
+use anyhow::Context as _;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;

--- a/src/cli/subcommands/config_cmd.rs
+++ b/src/cli/subcommands/config_cmd.rs
@@ -3,7 +3,7 @@
 
 use std::io::Write;
 
-use anyhow::Context;
+use anyhow::Context as _;
 use clap::Subcommand;
 
 use crate::cli::subcommands::Config;

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -8,7 +8,7 @@ use crate::db::car::forest::DEFAULT_FOREST_CAR_FRAME_SIZE;
 use crate::rpc_api::chain_api::ChainExportParams;
 use crate::rpc_client::{chain_ops::*, state_network_name};
 use crate::utils::bail_moved_cmd;
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Context as _};
 use chrono::Utc;
 use clap::Subcommand;
 use human_repr::HumanCount;
@@ -75,7 +75,7 @@ pub enum SnapshotCommands {
 }
 
 impl SnapshotCommands {
-    pub async fn run(self, config: Config) -> Result<()> {
+    pub async fn run(self, config: Config) -> anyhow::Result<()> {
         match self {
             Self::Export {
                 output_path,
@@ -182,7 +182,7 @@ impl SnapshotCommands {
 
 /// Prints hex-encoded representation of SHA-256 checksum and saves it to a file
 /// with the same name but with a `.sha256sum` extension.
-async fn save_checksum(source: &Path, encoded_hash: String) -> Result<()> {
+async fn save_checksum(source: &Path, encoded_hash: String) -> anyhow::Result<()> {
     let checksum_file_content = format!(
         "{encoded_hash} {}\n",
         source

--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::utils::db::{car_stream::CarHeader, car_util::load_car};
-use anyhow::Context;
+use anyhow::Context as _;
 use fvm_ipld_blockstore::Blockstore;
 
 pub async fn load_actor_bundles(db: &impl Blockstore) -> anyhow::Result<CarHeader> {

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -7,7 +7,7 @@ use crate::db::car::forest::FOREST_CAR_FILE_EXTENSION;
 use crate::db::car::{ForestCar, ManyCar};
 use crate::utils::db::car_stream::CarStream;
 use crate::utils::io::EitherMmapOrRandomAccessFile;
-use anyhow::Context;
+use anyhow::Context as _;
 use futures::TryStreamExt;
 use std::ffi::OsStr;
 use std::fs;

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -9,7 +9,7 @@ use crate::cli_shared::{
 use crate::daemon::ipc_shmem_conf;
 use crate::utils::io::ProgressBar;
 use crate::utils::version::FOREST_VERSION_STRING;
-use anyhow::Context;
+use anyhow::Context as _;
 use clap::Parser;
 use daemonize_me::{Daemon, Group, User};
 use raw_sync_2::{

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -35,7 +35,7 @@ use crate::utils::{
     monitoring::MemStatsTracker, proofs_api::paramfetch::ensure_params_downloaded,
     version::FOREST_VERSION_STRING,
 };
-use anyhow::{bail, Context};
+use anyhow::{bail, Context as _};
 use bundle::load_actor_bundles;
 use dialoguer::console::Term;
 use dialoguer::theme::ColorfulTheme;

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -13,7 +13,7 @@ use crate::db::{MemoryDB, SettingsStore};
 use crate::libp2p_bitswap::BitswapStoreReadWrite;
 use crate::utils::io::EitherMmapOrRandomAccessFile;
 use crate::{blocks::Tipset, libp2p_bitswap::BitswapStoreRead};
-use anyhow::Context;
+use anyhow::Context as _;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use parking_lot::{Mutex, RwLock};

--- a/src/db/db_mode.rs
+++ b/src/db/db_mode.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use anyhow::Context as _;
 use semver::Version;
 
 use crate::utils::version::FOREST_VERSION;
@@ -59,7 +60,7 @@ pub fn choose_db(chain_data_path: &Path) -> anyhow::Result<PathBuf> {
                 let latest = versions
                     .iter()
                     .max()
-                    .ok_or_else(|| anyhow::anyhow!("Failed to find latest versioned database"))?; // This should never happen
+                    .context("Failed to find latest versioned database")?; // This should never happen
                 chain_data_path.join(latest.to_string())
             }
         }

--- a/src/db/memory.rs
+++ b/src/db/memory.rs
@@ -3,7 +3,6 @@
 
 use crate::libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
 use ahash::HashMap;
-use anyhow::Result;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use itertools::Itertools;
@@ -39,11 +38,11 @@ impl SettingsStore for MemoryDB {
 }
 
 impl Blockstore for MemoryDB {
-    fn get(&self, k: &Cid) -> Result<Option<Vec<u8>>> {
+    fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         Ok(self.blockchain_db.read().get(&k.to_bytes()).cloned())
     }
 
-    fn put_keyed(&self, k: &Cid, block: &[u8]) -> Result<()> {
+    fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
         self.blockchain_db
             .write()
             .insert(k.to_bytes(), block.to_vec());
@@ -52,11 +51,11 @@ impl Blockstore for MemoryDB {
 }
 
 impl BitswapStoreRead for MemoryDB {
-    fn contains(&self, cid: &Cid) -> Result<bool> {
+    fn contains(&self, cid: &Cid) -> anyhow::Result<bool> {
         Ok(self.blockchain_db.read().contains_key(&cid.to_bytes()))
     }
 
-    fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
+    fn get(&self, cid: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         Blockstore::get(self, cid)
     }
 }
@@ -64,7 +63,7 @@ impl BitswapStoreRead for MemoryDB {
 impl BitswapStoreReadWrite for MemoryDB {
     type Params = libipld::DefaultParams;
 
-    fn insert(&self, block: &libipld::Block<Self::Params>) -> Result<()> {
+    fn insert(&self, block: &libipld::Block<Self::Params>) -> anyhow::Result<()> {
         self.put_keyed(block.cid(), block.data())
     }
 }

--- a/src/db/migration/db_migration.rs
+++ b/src/db/migration/db_migration.rs
@@ -86,52 +86,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_migration_not_required_no_chain_path() -> anyhow::Result<()> {
-        let temp_dir = tempfile::tempdir()?;
+    fn test_migration_not_required_no_chain_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let db_migration = DbMigration::new(temp_dir.path().join("azathoth"));
-        assert!(!db_migration.is_migration_required()?);
-        Ok(())
+        assert!(!db_migration.is_migration_required().unwrap());
     }
 
     #[test]
-    fn test_migration_not_required_no_databases() -> anyhow::Result<()> {
-        let temp_dir = tempfile::tempdir()?;
+    fn test_migration_not_required_no_databases() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let db_migration = DbMigration::new(temp_dir.path().to_owned());
-        assert!(!db_migration.is_migration_required()?);
-        Ok(())
+        assert!(!db_migration.is_migration_required().unwrap());
     }
 
     #[test]
-    fn test_migration_not_required_under_non_current_mode() -> anyhow::Result<()> {
-        let temp_dir = tempfile::tempdir()?;
+    fn test_migration_not_required_under_non_current_mode() {
+        let temp_dir = tempfile::tempdir().unwrap();
 
         let db_dir = temp_dir.path().join("0.1.0");
-        std::fs::create_dir(&db_dir)?;
+        std::fs::create_dir(&db_dir).unwrap();
         let db_migration = DbMigration::new(temp_dir.path().to_owned());
 
         std::env::set_var(FOREST_DB_DEV_MODE, "latest");
-        assert!(!db_migration.is_migration_required()?);
+        assert!(!db_migration.is_migration_required().unwrap());
 
-        std::fs::remove_dir(db_dir)?;
-        std::fs::create_dir(temp_dir.path().join("cthulhu"))?;
+        std::fs::remove_dir(db_dir).unwrap();
+        std::fs::create_dir(temp_dir.path().join("cthulhu")).unwrap();
 
         std::env::set_var(FOREST_DB_DEV_MODE, "cthulhu");
-        assert!(!db_migration.is_migration_required()?);
-        Ok(())
+        assert!(!db_migration.is_migration_required().unwrap());
     }
 
     #[test]
-    fn test_migration_required_current_mode() -> anyhow::Result<()> {
-        let temp_dir = tempfile::tempdir()?;
+    fn test_migration_required_current_mode() {
+        let temp_dir = tempfile::tempdir().unwrap();
 
         let db_dir = temp_dir.path().join("0.1.0");
-        std::fs::create_dir(db_dir)?;
+        std::fs::create_dir(db_dir).unwrap();
         let db_migration = DbMigration::new(temp_dir.path().to_owned());
 
         std::env::set_var(FOREST_DB_DEV_MODE, "current");
-        assert!(db_migration.is_migration_required()?);
+        assert!(db_migration.is_migration_required().unwrap());
         std::env::remove_var(FOREST_DB_DEV_MODE);
-        assert!(db_migration.is_migration_required()?);
-        Ok(())
+        assert!(db_migration.is_migration_required().unwrap());
     }
 }

--- a/src/db/migration/migration_map.rs
+++ b/src/db/migration/migration_map.rs
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    fn test_migration_should_use_shortest_path() -> anyhow::Result<()> {
+    fn test_migration_should_use_shortest_path() {
         let migrations = MigrationsMap::from_iter(
             [
                 (
@@ -286,18 +286,17 @@ mod tests {
             &Version::new(0, 1, 0),
             &Version::new(0, 3, 0),
             &migrations,
-        )?;
+        )
+        .unwrap();
 
         // The shortest path is 0.1.0 to 0.3.0 (without going through 0.2.0)
         assert_eq!(1, migrations.len());
         assert_eq!(Version::new(0, 1, 0), migrations[0].from);
         assert_eq!(Version::new(0, 3, 0), migrations[0].to);
-
-        Ok(())
     }
 
     #[test]
-    fn test_migration_complex_path() -> anyhow::Result<()> {
+    fn test_migration_complex_path() {
         let migrations = MigrationsMap::from_iter(
             [
                 (
@@ -325,7 +324,8 @@ mod tests {
             &Version::new(0, 1, 0),
             &Version::new(0, 3, 1),
             &migrations,
-        )?;
+        )
+        .unwrap();
 
         // The shortest path is 0.1.0 -> 0.3.0 -> 0.3.1
         assert_eq!(2, migrations.len());
@@ -333,12 +333,10 @@ mod tests {
         assert_eq!(Version::new(0, 3, 0), migrations[0].to);
         assert_eq!(Version::new(0, 3, 0), migrations[1].from);
         assert_eq!(Version::new(0, 3, 1), migrations[1].to);
-
-        Ok(())
     }
 
     #[test]
-    fn test_same_distance_paths_should_yield_any() -> anyhow::Result<()> {
+    fn test_same_distance_paths_should_yield_any() {
         let migrations = MigrationsMap::from_iter(
             [
                 (
@@ -366,7 +364,8 @@ mod tests {
             &Version::new(0, 1, 0),
             &Version::new(0, 4, 0),
             &migrations,
-        )?;
+        )
+        .unwrap();
 
         // there are two possible shortest paths:
         // 0.1.0 -> 0.2.0 -> 0.4.0
@@ -384,8 +383,6 @@ mod tests {
             assert_eq!(Version::new(0, 3, 0), migrations[1].from);
             assert_eq!(Version::new(0, 4, 0), migrations[1].to);
         }
-
-        Ok(())
     }
 
     struct SimpleMigration0_1_0_0_2_0;
@@ -400,7 +397,7 @@ mod tests {
         }
 
         fn migrate(&self, chain_data_path: &Path) -> anyhow::Result<PathBuf> {
-            fs::create_dir(chain_data_path.join("migration_0_1_0_0_2_0"))?;
+            fs::create_dir(chain_data_path.join("migration_0_1_0_0_2_0")).unwrap();
             Ok(chain_data_path.join("migration_0_1_0_0_2_0"))
         }
 
@@ -414,26 +411,24 @@ mod tests {
     }
 
     #[test]
-    fn test_migration_map_migration() -> anyhow::Result<()> {
+    fn test_migration_map_migration() {
         let migration = Migration {
             from: Version::new(0, 1, 0),
             to: Version::new(0, 2, 0),
             migrator: Arc::new(SimpleMigration0_1_0_0_2_0),
         };
 
-        let temp_dir = TempDir::new()?;
+        let temp_dir = TempDir::new().unwrap();
 
         assert!(migration.pre_checks(temp_dir.path()).is_err());
-        fs::create_dir(temp_dir.path().join("0.1.0"))?;
+        fs::create_dir(temp_dir.path().join("0.1.0")).unwrap();
         assert!(migration.pre_checks(temp_dir.path()).is_ok());
 
-        migration.migrate(temp_dir.path())?;
+        migration.migrate(temp_dir.path()).unwrap();
         assert!(temp_dir.path().join("0.2.0").exists());
 
         assert!(migration.post_checks(temp_dir.path()).is_err());
-        fs::create_dir(temp_dir.path().join("migration_0_1_0_0_2_0"))?;
+        fs::create_dir(temp_dir.path().join("migration_0_1_0_0_2_0")).unwrap();
         assert!(migration.post_checks(temp_dir.path()).is_ok());
-
-        Ok(())
     }
 }

--- a/src/db/migration/migration_map.rs
+++ b/src/db/migration/migration_map.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use anyhow::bail;
+use anyhow::Context as _;
 use itertools::Itertools;
 use multimap::MultiMap;
 use once_cell::sync::Lazy;
@@ -148,7 +149,7 @@ fn create_migration_chain_from_migrations(
         },
         |to| to == goal,
     )
-    .ok_or_else(|| anyhow::anyhow!("No migration path found from version {start} to {goal}"))?
+    .with_context(|| format!("No migration path found from version {start} to {goal}"))?
     .iter()
     .tuple_windows()
     .map(|(from, to)| {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -9,7 +9,7 @@ pub mod rolling;
 pub use memory::MemoryDB;
 mod db_mode;
 pub mod migration;
-
+use anyhow::Context as _;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::sync::Arc;
@@ -84,7 +84,7 @@ impl<T: ?Sized + SettingsStore> SettingsStoreExt for T {
 
     fn require_obj<V: DeserializeOwned>(&self, key: &str) -> anyhow::Result<V> {
         self.read_bin(key)?
-            .ok_or_else(|| anyhow::anyhow!("Key {key} not found"))
+            .with_context(|| format!("Key {key} not found"))
             .and_then(|bytes| serde_json::from_slice(&bytes).map_err(Into::into))
     }
 }

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -8,7 +8,7 @@ use super::SettingsStore;
 use crate::db::{parity_db_config::ParityDbConfig, DBStatistics};
 use crate::libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
 
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context as _};
 use cid::multihash::Code::Blake2b256;
 
 use cid::Cid;

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -266,7 +266,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn write_read_different_columns_test() -> anyhow::Result<()> {
+    fn write_read_different_columns_test() {
         let db = TempParityDB::new();
         let data = [
             b"h'nglui mglw'nafh".to_vec(),
@@ -286,12 +286,13 @@ mod test {
         ];
 
         for (_, cid, data) in cases {
-            db.put_keyed(&cid, data)?;
+            db.put_keyed(&cid, data).unwrap();
         }
 
         for (column, cid, data) in cases {
             let actual = db
-                .read_from_column(cid.to_bytes(), column)?
+                .read_from_column(cid.to_bytes(), column)
+                .unwrap()
                 .expect("data not found");
             assert_eq!(data, actual.as_bytes());
 
@@ -301,23 +302,24 @@ mod test {
                 DbColumn::GraphFull => DbColumn::GraphDagCborBlake2b256,
                 DbColumn::Settings => panic!("invalid column for IPLD data"),
             };
-            let actual = db.read_from_column(cid.to_bytes(), other_column)?;
+            let actual = db.read_from_column(cid.to_bytes(), other_column).unwrap();
             assert!(actual.is_none());
 
             // Blockstore API usage should be transparent
-            let actual =
-                fvm_ipld_blockstore::Blockstore::get(db.as_ref(), &cid)?.expect("data not found");
+            let actual = fvm_ipld_blockstore::Blockstore::get(db.as_ref(), &cid)
+                .unwrap()
+                .expect("data not found");
             assert_eq!(data, actual.as_slice());
         }
 
         // Check non-IPLD column as well
-        db.write_to_column(b"dagon", b"bloop", DbColumn::Settings)?;
+        db.write_to_column(b"dagon", b"bloop", DbColumn::Settings)
+            .unwrap();
         let actual = db
-            .read_from_column(b"dagon", DbColumn::Settings)?
+            .read_from_column(b"dagon", DbColumn::Settings)
+            .unwrap()
             .expect("data not found");
         assert_eq!(b"bloop", actual.as_bytes());
-
-        Ok(())
     }
 
     #[test]

--- a/src/db/rolling/gc.rs
+++ b/src/db/rolling/gc.rs
@@ -67,19 +67,19 @@
 //! 2023-03-16T22:27:38.793717Z  INFO crate::db::rolling::impls: Deleted database under /root/.local/share/forest/mainnet/paritydb/14d0f80992374fb8b20e3b1bd70d5d7b, size: 139.01GB
 //! ```
 
-use std::{
-    sync::atomic::{self, AtomicU64, AtomicUsize},
-    time::Duration,
-};
-
 use crate::blocks::Tipset;
 use crate::db::setting_keys::ESTIMATED_RECORDS_KEY;
 use crate::db::SettingsStoreExt;
 use crate::ipld::util::*;
 use crate::utils::db::{BlockstoreBufferedWriteExt, DB_KEY_BYTES};
+use anyhow::Context as _;
 use chrono::Utc;
 use fvm_ipld_blockstore::Blockstore;
 use human_repr::HumanCount;
+use std::{
+    sync::atomic::{self, AtomicU64, AtomicUsize},
+    time::Duration,
+};
 use tokio::sync::Mutex;
 
 use super::*;
@@ -239,7 +239,7 @@ where
                 async move {
                     let block = db
                         .get(&cid)?
-                        .ok_or_else(|| anyhow::anyhow!("Cid {cid} not found in blockstore"))?;
+                        .with_context(|| format!("Cid {cid} not found in blockstore"))?;
 
                     let pair = (cid, block.clone());
                     if db.writer().has(&cid)? {

--- a/src/db/rolling/impls.rs
+++ b/src/db/rolling/impls.rs
@@ -273,7 +273,7 @@ fn delete_db(db_path: &Path) {
 mod tests {
     use std::{thread::sleep, time::Duration};
 
-    use anyhow::*;
+    use anyhow::ensure;
     use cid::{multihash::MultihashDigest, Cid};
     use fvm_ipld_blockstore::Blockstore;
     use pretty_assertions::assert_eq;
@@ -285,7 +285,7 @@ mod tests {
     use crate::libp2p_bitswap::BitswapStoreRead;
 
     #[quickcheck]
-    fn ensure_settings_are_transferred(keys: Vec<String>) -> Result<()> {
+    fn ensure_settings_are_transferred(keys: Vec<String>) -> anyhow::Result<()> {
         let db_root = TempDir::new()?;
         let rolling_db = RollingDB::load_or_create(db_root.path().into(), Default::default())?;
         // Write settings
@@ -307,7 +307,7 @@ mod tests {
     }
 
     #[test]
-    fn rolling_db_behaviour_tests() -> Result<()> {
+    fn rolling_db_behaviour_tests() -> anyhow::Result<()> {
         let db_root = TempDir::new()?;
         let rolling_db = RollingDB::load_or_create(db_root.path().into(), Default::default())?;
         println!("Generating random blocks");

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -4,6 +4,7 @@
 use crate::blocks::BlockHeader;
 use crate::state_manager::StateManager;
 use crate::utils::db::car_util::load_car;
+use anyhow::Context as _;
 use fvm_ipld_blockstore::Blockstore;
 use tokio::{fs::File, io::AsyncBufRead, io::BufReader};
 use tracing::{debug, info};
@@ -29,8 +30,7 @@ where
         }
         None => {
             debug!("No specified genesis in config. Using default genesis.");
-            let genesis_bytes =
-                genesis_bytes.ok_or_else(|| anyhow::anyhow!("No default genesis."))?;
+            let genesis_bytes = genesis_bytes.context("No default genesis.")?;
             process_car(genesis_bytes, db).await?
         }
     };

--- a/src/interpreter/fvm2.rs
+++ b/src/interpreter/fvm2.rs
@@ -290,44 +290,39 @@ fn cal_gas_used_from_stats(
 mod tests {
     use std::{cell::RefCell, iter::repeat};
 
-    use anyhow::ensure;
-
     use super::*;
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_read() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_read() {
         test_cal_gas_used_from_stats_inner(1, &[])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_write() {
         test_cal_gas_used_from_stats_inner(0, &[100])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_read() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_read() {
         test_cal_gas_used_from_stats_inner(10, &[])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_write() {
         test_cal_gas_used_from_stats_inner(0, &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_read_1_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_read_1_write() {
         test_cal_gas_used_from_stats_inner(1, &[100])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_read_multi_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_read_multi_write() {
         test_cal_gas_used_from_stats_inner(10, &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
     }
 
-    fn test_cal_gas_used_from_stats_inner(
-        read_count: usize,
-        write_bytes: &[usize],
-    ) -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_inner(read_count: usize, write_bytes: &[usize]) {
         let network_version = NetworkVersion::V8;
         let stats = BSStats {
             r: read_count,
@@ -335,7 +330,8 @@ mod tests {
             br: 0, // Not used in current logic
             bw: write_bytes.iter().sum(),
         };
-        let result = cal_gas_used_from_stats(RefCell::new(stats).borrow(), network_version)?;
+        let result =
+            cal_gas_used_from_stats(RefCell::new(stats).borrow(), network_version).unwrap();
 
         // Simulates logic in old GasBlockStore
         let price_list = price_list_by_network_version(network_version);
@@ -348,12 +344,12 @@ mod tests {
         });
         for &bytes in write_bytes {
             tracker
-                .apply_charge(price_list.on_block_link(bytes).into())?
+                .apply_charge(price_list.on_block_link(bytes).into())
+                .unwrap()
                 .stop();
         }
         let expected = tracker.gas_used();
 
-        ensure!(result == expected.into());
-        Ok(())
+        assert_eq!(result, expected.into());
     }
 }

--- a/src/interpreter/fvm3.rs
+++ b/src/interpreter/fvm3.rs
@@ -312,44 +312,39 @@ fn cal_gas_used_from_stats(
 mod tests {
     use std::{cell::RefCell, iter::repeat};
 
-    use anyhow::ensure;
-
     use super::*;
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_read() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_read() {
         test_cal_gas_used_from_stats_inner(1, &[])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_write() {
         test_cal_gas_used_from_stats_inner(0, &[100])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_read() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_read() {
         test_cal_gas_used_from_stats_inner(10, &[])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_write() {
         test_cal_gas_used_from_stats_inner(0, &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_read_1_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_read_1_write() {
         test_cal_gas_used_from_stats_inner(1, &[100])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_read_multi_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_read_multi_write() {
         test_cal_gas_used_from_stats_inner(10, &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
     }
 
-    fn test_cal_gas_used_from_stats_inner(
-        read_count: usize,
-        write_bytes: &[usize],
-    ) -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_inner(read_count: usize, write_bytes: &[usize]) {
         let network_version = NetworkVersion::V18;
         let stats = BSStats {
             r: read_count,
@@ -357,7 +352,8 @@ mod tests {
             br: 0, // Not used in current logic
             bw: write_bytes.iter().sum(),
         };
-        let result = cal_gas_used_from_stats(RefCell::new(stats).borrow(), network_version)?;
+        let result =
+            cal_gas_used_from_stats(RefCell::new(stats).borrow(), network_version).unwrap();
 
         // Simulates logic in old GasBlockStore
         let price_list = price_list_by_network_version(network_version);
@@ -370,12 +366,12 @@ mod tests {
         });
         for &bytes in write_bytes {
             tracker
-                .apply_charge(price_list.on_block_link(bytes).into())?
+                .apply_charge(price_list.on_block_link(bytes).into())
+                .unwrap()
                 .stop()
         }
         let expected = tracker.gas_used();
 
-        ensure!(result == expected);
-        Ok(())
+        assert_eq!(result, expected);
     }
 }

--- a/src/interpreter/fvm4.rs
+++ b/src/interpreter/fvm4.rs
@@ -312,44 +312,39 @@ fn cal_gas_used_from_stats(
 mod tests {
     use std::{cell::RefCell, iter::repeat};
 
-    use anyhow::ensure;
-
     use super::*;
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_read() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_read() {
         test_cal_gas_used_from_stats_inner(1, &[])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_write() {
         test_cal_gas_used_from_stats_inner(0, &[100])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_read() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_read() {
         test_cal_gas_used_from_stats_inner(10, &[])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_write() {
         test_cal_gas_used_from_stats_inner(0, &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_1_read_1_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_1_read_1_write() {
         test_cal_gas_used_from_stats_inner(1, &[100])
     }
 
     #[test]
-    fn test_cal_gas_used_from_stats_multi_read_multi_write() -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_multi_read_multi_write() {
         test_cal_gas_used_from_stats_inner(10, &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
     }
 
-    fn test_cal_gas_used_from_stats_inner(
-        read_count: usize,
-        write_bytes: &[usize],
-    ) -> anyhow::Result<()> {
+    fn test_cal_gas_used_from_stats_inner(read_count: usize, write_bytes: &[usize]) {
         let network_version = NetworkVersion::V18;
         let stats = BSStats {
             r: read_count,
@@ -357,7 +352,8 @@ mod tests {
             br: 0, // Not used in current logic
             bw: write_bytes.iter().sum(),
         };
-        let result = cal_gas_used_from_stats(RefCell::new(stats).borrow(), network_version)?;
+        let result =
+            cal_gas_used_from_stats(RefCell::new(stats).borrow(), network_version).unwrap();
 
         // Simulates logic in old GasBlockStore
         let price_list = price_list_by_network_version(network_version);
@@ -370,12 +366,12 @@ mod tests {
         });
         for &bytes in write_bytes {
             tracker
-                .apply_charge(price_list.on_block_link(bytes).into())?
+                .apply_charge(price_list.on_block_link(bytes).into())
+                .unwrap()
                 .stop()
         }
         let expected = tracker.gas_used();
 
-        ensure!(result == expected);
-        Ok(())
+        assert_eq!(result, expected);
     }
 }

--- a/src/ipld/util.rs
+++ b/src/ipld/util.rs
@@ -20,7 +20,7 @@ use crate::{
     blocks::{BlockHeader, Tipset},
     utils::encoding::from_slice_with_fallback,
 };
-use anyhow::Context as AnyhowContext;
+use anyhow::Context as _;
 use cid::Cid;
 use futures::Stream;
 use fvm_ipld_blockstore::Blockstore;

--- a/src/key_management/keystore.rs
+++ b/src/key_management/keystore.rs
@@ -436,7 +436,7 @@ fn map_err_to_anyhow<T: Display>(e: T) -> anyhow::Error {
 
 #[cfg(test)]
 mod test {
-    use anyhow::*;
+    use anyhow::ensure;
     use base64::{prelude::BASE64_STANDARD, Engine};
 
     use super::*;
@@ -458,7 +458,7 @@ mod test {
     }
 
     #[test]
-    fn test_encrypt_message() -> Result<()> {
+    fn test_encrypt_message() -> anyhow::Result<()> {
         let (_, private_key) = EncryptedKeyStore::derive_key(PASSPHRASE, None)?;
         let message = "foo is coming";
         let ciphertext = EncryptedKeyStore::encrypt(&private_key, message.as_bytes())?;
@@ -471,7 +471,7 @@ mod test {
     }
 
     #[test]
-    fn test_decrypt_message() -> Result<()> {
+    fn test_decrypt_message() -> anyhow::Result<()> {
         let (_, private_key) = EncryptedKeyStore::derive_key(PASSPHRASE, None)?;
         let message = "foo is coming";
         let ciphertext = EncryptedKeyStore::encrypt(&private_key, message.as_bytes())?;
@@ -481,7 +481,7 @@ mod test {
     }
 
     #[test]
-    fn test_read_old_encrypted_keystore() -> Result<()> {
+    fn test_read_old_encrypted_keystore() -> anyhow::Result<()> {
         let dir: PathBuf = "src/key_management/tests/keystore_encrypted_old".into();
         ensure!(dir.exists());
         let ks = KeyStore::new(KeyStoreConfig::Encrypted(dir, PASSPHRASE.to_string()))?;
@@ -490,7 +490,7 @@ mod test {
     }
 
     #[test]
-    fn test_read_write_encrypted_keystore() -> Result<()> {
+    fn test_read_write_encrypted_keystore() -> anyhow::Result<()> {
         let keystore_location = tempfile::tempdir()?.into_path();
         let ks = KeyStore::new(KeyStoreConfig::Encrypted(
             keystore_location.clone(),
@@ -509,7 +509,7 @@ mod test {
     }
 
     #[test]
-    fn test_read_write_keystore() -> Result<()> {
+    fn test_read_write_keystore() -> anyhow::Result<()> {
         let keystore_location = tempfile::tempdir()?.into_path();
         let mut ks = KeyStore::new(KeyStoreConfig::Persistent(keystore_location.clone()))?;
 

--- a/src/key_management/wallet.rs
+++ b/src/key_management/wallet.rs
@@ -331,7 +331,7 @@ mod tests {
     }
 
     #[test]
-    fn import_export() -> anyhow::Result<()> {
+    fn import_export() {
         let key_vec = construct_priv_keys();
         let key = key_vec[0].clone();
         let keystore = KeyStore::new(KeyStoreConfig::Memory).unwrap();
@@ -357,7 +357,6 @@ mod tests {
         // make sure that error is thrown when attempted to re-import a duplicate
         // key_info
         assert!(matches!(duplicate_error, Error::KeyExists));
-        Ok(())
     }
 
     #[test]

--- a/src/libp2p/keypair.rs
+++ b/src/libp2p/keypair.rs
@@ -72,59 +72,57 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn test_get_or_create_keypair() -> anyhow::Result<()> {
-        let dir = tempdir()?;
+    fn test_get_or_create_keypair() {
+        let dir = tempdir().unwrap();
         let path_to_file = dir.path().join(KEYPAIR_FILE);
 
         // Test that a keypair is generated and saved to disk
-        let keypair = get_or_create_keypair(dir.path())?;
+        let keypair = get_or_create_keypair(dir.path()).unwrap();
         assert!(path_to_file.exists());
 
         // Test that the same keypair is returned if it already exists
-        let keypair2 = get_or_create_keypair(dir.path())?;
+        let keypair2 = get_or_create_keypair(dir.path()).unwrap();
         assert_eq!(keypair.public(), keypair2.public());
         assert_eq!(
-            keypair.clone().try_into_ed25519()?.to_bytes(),
-            keypair2.try_into_ed25519()?.to_bytes()
+            keypair.clone().try_into_ed25519().unwrap().to_bytes(),
+            keypair2.try_into_ed25519().unwrap().to_bytes()
         );
 
         // Test that a new keypair is generated if the file is deleted
-        remove_file(&path_to_file)?;
-        let keypair3 = get_or_create_keypair(dir.path())?;
+        remove_file(&path_to_file).unwrap();
+        let keypair3 = get_or_create_keypair(dir.path()).unwrap();
         assert_ne!(keypair.public(), keypair3.public());
         assert_ne!(
-            keypair.try_into_ed25519()?.to_bytes(),
-            keypair3.try_into_ed25519()?.to_bytes()
+            keypair.try_into_ed25519().unwrap().to_bytes(),
+            keypair3.try_into_ed25519().unwrap().to_bytes()
         );
-
-        Ok(())
     }
 
     #[test]
-    fn test_backup_keypair() -> anyhow::Result<()> {
-        let dir = tempdir()?;
+    fn test_backup_keypair() {
+        let dir = tempdir().unwrap();
         let path_to_file = dir.path().join(KEYPAIR_FILE);
 
         // Test that a keypair is generated and saved to disk
-        let keypair = create_and_save_keypair(dir.path())?;
+        let keypair = create_and_save_keypair(dir.path()).unwrap();
         assert!(path_to_file.exists());
 
         // corrupt the existing keypair file
         fs::write(
             &path_to_file,
             b"Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn",
-        )?;
+        )
+        .unwrap();
 
         // Test that a new keypair is generated if the file is corrupted
         // and the old file is backed up
-        let keypair2 = get_or_create_keypair(dir.path())?;
+        let keypair2 = get_or_create_keypair(dir.path()).unwrap();
         assert_ne!(keypair.public(), keypair2.public());
         assert_ne!(
-            keypair.try_into_ed25519()?.to_bytes(),
-            keypair2.try_into_ed25519()?.to_bytes()
+            keypair.try_into_ed25519().unwrap().to_bytes(),
+            keypair2.try_into_ed25519().unwrap().to_bytes()
         );
         assert!(path_to_file.exists());
         assert!(dir.path().join(format!("{}.bak", KEYPAIR_FILE)).exists());
-        Ok(())
     }
 }

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -13,7 +13,7 @@ use crate::message::SignedMessage;
 use crate::{blocks::GossipBlock, rpc_api::net_api::NetInfoResult};
 use crate::{chain::ChainStore, utils::encoding::from_slice_with_fallback};
 use ahash::{HashMap, HashSet};
-use anyhow::Context;
+use anyhow::Context as _;
 use cid::Cid;
 use flume::Sender;
 use futures::stream::StreamExt;

--- a/src/libp2p_bitswap/tests/go_compat.rs
+++ b/src/libp2p_bitswap/tests/go_compat.rs
@@ -8,7 +8,7 @@ mod tests {
     use crate::libp2p_bitswap::{
         BitswapBehaviour, BitswapBehaviourEvent, BitswapMessage, BitswapRequest, BitswapResponse,
     };
-    use anyhow::{Context, Result};
+    use anyhow::Context as _;
     use libipld::{
         multihash::{self, MultihashDigest},
         Cid,
@@ -30,7 +30,7 @@ mod tests {
         bitswap_go_compat_test_impl().await.unwrap()
     }
 
-    async fn bitswap_go_compat_test_impl() -> Result<()> {
+    async fn bitswap_go_compat_test_impl() -> anyhow::Result<()> {
         let id_keys = identity::Keypair::generate_ed25519();
         let peer_id = PeerId::from(id_keys.public());
         let transport = tcp::tokio::Transport::default()
@@ -141,7 +141,7 @@ mod tests {
         Ok(())
     }
 
-    fn prepare_go_bitswap() -> Result<()> {
+    fn prepare_go_bitswap() -> anyhow::Result<()> {
         const ERROR_CONTEXT: &str = "Fail to compile `go-bitswap` test app, make sure you have `Go1.20.x` compiler installed and available in $PATH. For details refer to instructions at <https://go.dev/doc/install>";
         Command::new("go")
             .args(["mod", "vendor"])
@@ -157,7 +157,7 @@ mod tests {
         cancellation_rx: flume::Receiver<()>,
         addr: impl AsRef<str>,
         cid: impl AsRef<str>,
-    ) -> Result<bool> {
+    ) -> anyhow::Result<bool> {
         let mut app = Command::new("go")
             .args(["run", ".", "--addr", addr.as_ref(), "--cid", cid.as_ref()])
             .current_dir(GO_APP_DIR)

--- a/src/libp2p_bitswap/tests/request_manager.rs
+++ b/src/libp2p_bitswap/tests/request_manager.rs
@@ -7,7 +7,6 @@ mod tests {
 
     use crate::libp2p_bitswap::*;
     use ahash::HashMap;
-    use anyhow::Result;
     use futures::StreamExt;
     use libipld::{
         multihash::{self, MultihashDigest},
@@ -34,7 +33,7 @@ mod tests {
         request_manager_e2e_test_mpl().await.unwrap();
     }
 
-    async fn request_manager_e2e_test_mpl() -> Result<()> {
+    async fn request_manager_e2e_test_mpl() -> anyhow::Result<()> {
         let block_exist = new_random_block()?;
         let block_not_exist = new_random_block()?;
 
@@ -103,7 +102,7 @@ mod tests {
         Ok(())
     }
 
-    async fn create_swarm() -> Result<(Swarm<BitswapBehaviour>, PeerId, Multiaddr)> {
+    async fn create_swarm() -> anyhow::Result<(Swarm<BitswapBehaviour>, PeerId, Multiaddr)> {
         let id_keys = Keypair::generate_ed25519();
         let peer_id = PeerId::from(id_keys.public());
         let transport = tcp::tokio::Transport::default()
@@ -125,7 +124,10 @@ mod tests {
         Ok((swarm, peer_id, peer_addr))
     }
 
-    async fn run_swarm_loop(swarm: Swarm<BitswapBehaviour>, store: TestStore) -> Result<()> {
+    async fn run_swarm_loop(
+        swarm: Swarm<BitswapBehaviour>,
+        store: TestStore,
+    ) -> anyhow::Result<()> {
         let request_manager = swarm.behaviour().request_manager();
         let mut outbound_request_rx_stream = request_manager.outbound_request_rx().stream().fuse();
         let mut swarm_stream = swarm.fuse();
@@ -154,7 +156,7 @@ mod tests {
             SwarmEvent<BitswapBehaviourEvent, libp2p::swarm::THandlerErr<BitswapBehaviour>>,
         >,
         store: &impl BitswapStoreRead,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         if let Some(SwarmEvent::Behaviour(event)) = swarm_event_opt {
             let bitswap = &mut swarm.behaviour_mut();
             bitswap.handle_event(store, event)?;
@@ -163,7 +165,7 @@ mod tests {
         Ok(())
     }
 
-    fn new_random_block() -> Result<libipld::Block<libipld::DefaultParams>> {
+    fn new_random_block() -> anyhow::Result<libipld::Block<libipld::DefaultParams>> {
         // 100KB
         let mut data = vec![0; 100 * 1024];
         OsRng.fill(&mut data[..]);

--- a/src/message_pool/msgpool/msg_pool.rs
+++ b/src/message_pool/msgpool/msg_pool.rs
@@ -23,7 +23,7 @@ use crate::shim::{
 };
 use crate::state_manager::is_valid_for_sending;
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
-use anyhow::Context;
+use anyhow::Context as _;
 use cid::Cid;
 use futures::StreamExt;
 use fvm_ipld_encoding::to_vec;

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -3,7 +3,6 @@
 
 use std::{fmt::Display, str::FromStr};
 
-use anyhow::Error;
 use cid::Cid;
 use fil_actors_shared::v10::runtime::Policy;
 use libp2p::Multiaddr;
@@ -44,7 +43,7 @@ pub enum NetworkChain {
 }
 
 impl FromStr for NetworkChain {
-    type Err = Error;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {

--- a/src/rpc/chain_api.rs
+++ b/src/rpc/chain_api.rs
@@ -14,7 +14,6 @@ use crate::rpc_api::{
 };
 use crate::shim::message::Message;
 use crate::utils::io::VoidAsyncWriter;
-use anyhow::Result;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 use hex::ToHex;

--- a/src/rpc/state_api.rs
+++ b/src/rpc/state_api.rs
@@ -14,7 +14,7 @@ use crate::shim::address::Address;
 use crate::state_manager::InvocResult;
 use crate::utils::db::car_stream::{CarBlock, CarWriter};
 use ahash::{HashMap, HashMapExt};
-use anyhow::Context;
+use anyhow::Context as _;
 use fil_actor_interface::market;
 use futures::StreamExt;
 use fvm_ipld_blockstore::Blockstore;

--- a/src/rpc/state_api.rs
+++ b/src/rpc/state_api.rs
@@ -306,7 +306,7 @@ pub(in crate::rpc) async fn state_fetch_root<DB: Blockstore + Sync + Send + 'sta
 
                         let new_ipld = db
                             .get_cbor::<Ipld>(&cid)?
-                            .ok_or_else(|| anyhow::anyhow!("Request failed: {cid}"))?;
+                            .with_context(|| format!("Request failed: {cid}"))?;
                         dfs_vec.lock().push(new_ipld);
                         if let Some(car_tx) = &car_tx {
                             car_tx.send(CarBlock {

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, bail, Context as _};
 use cid::Cid;
 pub use fvm2::state_tree::{ActorState as ActorStateV2, StateTree as StateTreeV2};
 pub use fvm3::state_tree::{ActorState as ActorStateV3, StateTree as StateTreeV3};

--- a/src/state_manager/chain_rand.rs
+++ b/src/state_manager/chain_rand.rs
@@ -10,7 +10,7 @@ use crate::networks::ChainConfig;
 use crate::shim::clock::ChainEpoch;
 use crate::shim::externs::Rand;
 use crate::utils::encoding::blake2b_256;
-use anyhow::{bail, Context};
+use anyhow::{bail, Context as _};
 use blake2b_simd::Params;
 use byteorder::{BigEndian, WriteBytesExt};
 use fvm_ipld_blockstore::Blockstore;

--- a/src/state_manager/vm_circ_supply.rs
+++ b/src/state_manager/vm_circ_supply.rs
@@ -11,7 +11,7 @@ use crate::shim::{
     econ::TokenAmount,
     state_tree::{ActorState, StateTree},
 };
-use anyhow::Context;
+use anyhow::Context as _;
 use cid::Cid;
 use fil_actor_interface::{market, power, reward};
 use fvm_ipld_blockstore::Blockstore;

--- a/src/state_manager/vm_circ_supply.rs
+++ b/src/state_manager/vm_circ_supply.rs
@@ -115,7 +115,7 @@ fn get_actor_state<DB: Blockstore>(
 ) -> Result<ActorState, anyhow::Error> {
     state_tree
         .get_actor(addr)?
-        .ok_or_else(|| anyhow::anyhow!("Failed to get Actor for address {addr}"))
+        .with_context(|| format!("Failed to get Actor for address {addr}"))
 }
 
 fn get_fil_vested(genesis_info: &GenesisInfo, height: ChainEpoch) -> TokenAmount {

--- a/src/state_migration/common/macros/verifier.rs
+++ b/src/state_migration/common/macros/verifier.rs
@@ -9,10 +9,11 @@ macro_rules! impl_verifier {
     () => {
         pub(super) mod verifier {
             use $crate::cid_collections::CidHashMap;
-            use fvm_ipld_blockstore::Blockstore;
-            use fvm_ipld_encoding::CborStore;
             use $crate::shim::{address::Address, machine::BuiltinActorManifest, state_tree::StateTree};
+            use ::fvm_ipld_blockstore::Blockstore;
+            use ::fvm_ipld_encoding::CborStore as _;
             use $crate::state_migration::common::{verifier::ActorMigrationVerifier, Migrator};
+            use ::anyhow::Context as _;
 
             use super::*;
 
@@ -28,11 +29,11 @@ macro_rules! impl_verifier {
                 ) -> anyhow::Result<()> {
                     let system_actor = actors_in
                         .get_actor(&Address::SYSTEM_ACTOR)?
-                        .ok_or_else(|| anyhow::anyhow!("system actor not found"))?;
+                        .context("system actor not found")?;
 
                     let system_actor_state = store
                         .get_cbor::<SystemStateOld>(&system_actor.state)?
-                        .ok_or_else(|| anyhow::anyhow!("system actor state not found"))?;
+                        .context("system actor state not found")?;
                     let manifest =
                         BuiltinActorManifest::load_v1_actor_list(&store, &system_actor_state.builtin_actors)?;
                     let manifest_actors_count = manifest.builtin_actors().len();

--- a/src/state_migration/nv17/miner.rs
+++ b/src/state_migration/nv17/miner.rs
@@ -369,7 +369,6 @@ mod tests {
         machine::{BuiltinActor, BuiltinActorManifest},
         state_tree::{ActorState, StateRoot, StateTree, StateTreeVersion},
     };
-    use anyhow::ensure;
     use cid::multihash::{Multihash, MultihashDigest};
     use fil_actor_interface::BURNT_FUNDS_ACTOR_ADDR;
     use fil_actors_shared::fvm_ipld_hamt::BytesKey;
@@ -384,19 +383,20 @@ mod tests {
     };
 
     #[test]
-    fn test_nv17_miner_migration() -> anyhow::Result<()> {
+    fn test_nv17_miner_migration() {
         let store = Arc::new(crate::db::MemoryDB::default());
-        let (mut state_tree_old, manifest_old) = make_input_tree(&store)?;
+        let (mut state_tree_old, manifest_old) = make_input_tree(&store);
         let system_actor_old = state_tree_old
-            .get_actor(&fil_actor_interface::system::ADDRESS.into())?
+            .get_actor(&fil_actor_interface::system::ADDRESS.into())
+            .unwrap()
             .unwrap();
         let system_state_old: fil_actor_system_state::v9::State =
-            store.get_cbor(&system_actor_old.state)?.unwrap();
+            store.get_cbor(&system_actor_old.state).unwrap().unwrap();
         let manifest_data_cid_old = system_state_old.builtin_actors;
-        ensure!(manifest_data_cid_old == manifest_old.source_cid());
-        ensure!(
-            manifest_data_cid_old.to_string()
-                == "bafy2bzaceb7wfqkjc5c3ccjyhaf7zuhkvbzpvhnb35feaettztoharc7zdndc"
+        assert_eq!(manifest_data_cid_old, manifest_old.source_cid());
+        assert_eq!(
+            manifest_data_cid_old.to_string(),
+            "bafy2bzaceb7wfqkjc5c3ccjyhaf7zuhkvbzpvhnb35feaettztoharc7zdndc"
         );
 
         let base_addr_id = 10000;
@@ -405,14 +405,16 @@ mod tests {
 
         // create 3 deal proposals
         let mut market_actor_old = state_tree_old
-            .get_actor(&fil_actor_interface::market::ADDRESS.into())?
+            .get_actor(&fil_actor_interface::market::ADDRESS.into())
+            .unwrap()
             .unwrap();
         let mut market_state_old: fil_actor_market_state::v8::State =
-            store.get_cbor(&market_actor_old.state)?.unwrap();
+            store.get_cbor(&market_actor_old.state).unwrap().unwrap();
         let mut proposals = fil_actors_shared::v8::Array::<
             fil_actor_market_state::v8::DealProposal,
             _,
-        >::load(&market_state_old.proposals, &store)?;
+        >::load(&market_state_old.proposals, &store)
+        .unwrap();
         let base_deal = fil_actor_market_state::v8::DealProposal {
             piece_cid: Default::default(),
             piece_size: PaddedPieceSize(512),
@@ -428,59 +430,69 @@ mod tests {
         };
         let deal0 = {
             let mut deal = base_deal.clone();
-            deal.piece_cid = make_piece_cid("0".as_bytes())?;
-            ensure!(
-                deal.piece_cid.to_string()
-                    == "baga6ea4seaqf73hlm374q3zy3fjhq3dnnfwhtqw3yi452turwrtstvz2e75vp2i"
+            deal.piece_cid = make_piece_cid("0".as_bytes());
+            assert_eq!(
+                deal.piece_cid.to_string(),
+                "baga6ea4seaqf73hlm374q3zy3fjhq3dnnfwhtqw3yi452turwrtstvz2e75vp2i"
             );
             deal
         };
         let deal1 = {
             let mut deal = base_deal.clone();
-            deal.piece_cid = make_piece_cid("1".as_bytes())?;
-            ensure!(
-                deal.piece_cid.to_string()
-                    == "baga6ea4seaqgxbvsop7tj7hbtvvyatx7li7vor5nutvkely5jhab4uw5w6dvwsy"
+            deal.piece_cid = make_piece_cid("1".as_bytes());
+            assert_eq!(
+                deal.piece_cid.to_string(),
+                "baga6ea4seaqgxbvsop7tj7hbtvvyatx7li7vor5nutvkely5jhab4uw5w6dvwsy"
             );
             deal
         };
         let deal2 = {
             let mut deal = base_deal;
-            deal.piece_cid = make_piece_cid("2".as_bytes())?;
-            ensure!(
-                deal.piece_cid.to_string()
-                    == "baga6ea4seaqni426hitf4fxo4a7vs4mltnoqgam4a7mlnri7sdnduzto5qj2wni"
+            deal.piece_cid = make_piece_cid("2".as_bytes());
+            assert_eq!(
+                deal.piece_cid.to_string(),
+                "baga6ea4seaqni426hitf4fxo4a7vs4mltnoqgam4a7mlnri7sdnduzto5qj2wni"
             );
             deal
         };
 
         let mut pending_proposals =
-            fil_actors_shared::v8::Set::from_root(&store, &market_state_old.pending_proposals)?;
+            fil_actors_shared::v8::Set::from_root(&store, &market_state_old.pending_proposals)
+                .unwrap();
 
-        proposals.set(0, deal0)?;
-        pending_proposals.put(BytesKey(deal1.cid()?.to_bytes()))?;
-        proposals.set(1, deal1)?;
-        pending_proposals.put(BytesKey(deal2.cid()?.to_bytes()))?;
-        proposals.set(2, deal2)?;
+        proposals.set(0, deal0).unwrap();
+        pending_proposals
+            .put(BytesKey(deal1.cid().unwrap().to_bytes()))
+            .unwrap();
+        proposals.set(1, deal1).unwrap();
+        pending_proposals
+            .put(BytesKey(deal2.cid().unwrap().to_bytes()))
+            .unwrap();
+        proposals.set(2, deal2).unwrap();
 
-        market_state_old.proposals = proposals.flush()?;
-        ensure!(
-            market_state_old.proposals.to_string()
-                == "bafy2bzacecskt5brcfawiowjlv5lwnskkks2xzsmsnhkmjixndqlxuyb3abxs"
+        market_state_old.proposals = proposals.flush().unwrap();
+        assert_eq!(
+            market_state_old.proposals.to_string(),
+            "bafy2bzacecskt5brcfawiowjlv5lwnskkks2xzsmsnhkmjixndqlxuyb3abxs"
         );
-        market_state_old.pending_proposals = pending_proposals.root()?;
+        market_state_old.pending_proposals = pending_proposals.root().unwrap();
 
-        let market_state_cid_old = store.put_cbor_default(&market_state_old)?;
+        let market_state_cid_old = store.put_cbor_default(&market_state_old).unwrap();
         market_actor_old.state = market_state_cid_old;
-        state_tree_old.set_actor(
-            &fil_actor_interface::market::ADDRESS.into(),
-            market_actor_old,
-        )?;
+        state_tree_old
+            .set_actor(
+                &fil_actor_interface::market::ADDRESS.into(),
+                market_actor_old,
+            )
+            .unwrap();
 
         // base stuff to create miners
-        let miner_cid_old = manifest_old.get(BuiltinActor::Miner)?;
-        ensure!(miner_cid_old.to_string() == "bafkqaetgnfwc6obpon2g64tbm5sw22lomvza");
-        let base_miner_state = make_base_miner_state(&store, &base_addr, &base_worker_addr)?;
+        let miner_cid_old = manifest_old.get(BuiltinActor::Miner).unwrap();
+        assert_eq!(
+            miner_cid_old.to_string(),
+            "bafkqaetgnfwc6obpon2g64tbm5sw22lomvza"
+        );
+        let base_miner_state = make_base_miner_state(&store, &base_addr, &base_worker_addr);
 
         let base_precommit = fil_actor_miner_state::v8::SectorPreCommitOnChainInfo {
             pre_commit_deposit: Zero::zero(),
@@ -489,13 +501,13 @@ mod tests {
             verified_deal_weight: Zero::zero(),
             info: fil_actor_miner_state::v8::SectorPreCommitInfo {
                 seal_proof: fvm_shared2::sector::RegisteredSealProof::StackedDRG32GiBV1P1,
-                sealed_cid: make_sealed_cid("100".as_bytes())?,
+                sealed_cid: make_sealed_cid("100".as_bytes()),
                 ..Default::default()
             },
         };
-        ensure!(
-            base_precommit.info.sealed_cid.to_string()
-                == "bagboea4b5abcblkxgzugketokvsj5szdvyourcdvislw57venjeowxmfu3xljuyg"
+        assert_eq!(
+            base_precommit.info.sealed_cid.to_string(),
+            "bagboea4b5abcblkxgzugketokvsj5szdvyourcdvislw57venjeowxmfu3xljuyg"
         );
 
         // make 3 miners
@@ -504,49 +516,59 @@ mod tests {
         // miner3 has 3 precommits, with deals [0], [1,2], and []
 
         // miner1 has no precommits at all
-        let miner1_state_cid = store.put_cbor_default(&base_miner_state)?;
-        ensure!(
-            miner1_state_cid.to_string()
-                == "bafy2bzaceaqtktd7f5b2gutreh3b2czp2mkqu4ilyuu7mjcpwrk75g5nl6w6k"
+        let miner1_state_cid = store.put_cbor_default(&base_miner_state).unwrap();
+        assert_eq!(
+            miner1_state_cid.to_string(),
+            "bafy2bzaceaqtktd7f5b2gutreh3b2czp2mkqu4ilyuu7mjcpwrk75g5nl6w6k"
         );
 
         let miner1 = ActorState::new(miner_cid_old, miner1_state_cid, Zero::zero(), 0, None);
         let addr1 = Address::new_id(base_addr_id + 1);
-        state_tree_old.set_actor(&addr1, miner1)?;
+        state_tree_old.set_actor(&addr1, miner1).unwrap();
 
         // miner2 has precommits, but they have no deals
         let mut precommits2 = fil_actors_shared::v8::make_map_with_root::<
             _,
             fil_actor_miner_state::v8::SectorPreCommitOnChainInfo,
-        >(&base_miner_state.pre_committed_sectors, &store)?;
-        precommits2.set(sector_key(0)?, base_precommit.clone())?;
-        precommits2.set(sector_key(1)?, base_precommit.clone())?;
-        precommits2.set(sector_key(2)?, base_precommit.clone())?;
-        precommits2.set(sector_key(3)?, base_precommit.clone())?;
+        >(&base_miner_state.pre_committed_sectors, &store)
+        .unwrap();
+        precommits2
+            .set(sector_key(0).unwrap(), base_precommit.clone())
+            .unwrap();
+        precommits2
+            .set(sector_key(1).unwrap(), base_precommit.clone())
+            .unwrap();
+        precommits2
+            .set(sector_key(2).unwrap(), base_precommit.clone())
+            .unwrap();
+        precommits2
+            .set(sector_key(3).unwrap(), base_precommit.clone())
+            .unwrap();
 
-        let precommit2_cid = precommits2.flush()?;
-        ensure!(
-            precommit2_cid.to_string()
-                == "bafy2bzacedogkdulyeaujgdsiqzo323s5dpz44efwihxsuekkkpo4znpl3g2s"
+        let precommit2_cid = precommits2.flush().unwrap();
+        assert_eq!(
+            precommit2_cid.to_string(),
+            "bafy2bzacedogkdulyeaujgdsiqzo323s5dpz44efwihxsuekkkpo4znpl3g2s"
         );
 
         let mut miner2_state = base_miner_state.clone();
         miner2_state.pre_committed_sectors = precommit2_cid;
-        let miner2_state_cid = store.put_cbor_default(&miner2_state)?;
-        ensure!(
-            miner2_state_cid.to_string()
-                == "bafy2bzacedad6xkymehkuoij4rhg2inzqnfin3er52znw53lddn5364usp2bi"
+        let miner2_state_cid = store.put_cbor_default(&miner2_state).unwrap();
+        assert_eq!(
+            miner2_state_cid.to_string(),
+            "bafy2bzacedad6xkymehkuoij4rhg2inzqnfin3er52znw53lddn5364usp2bi"
         );
 
         let miner2 = ActorState::new(miner_cid_old, miner2_state_cid, Zero::zero(), 0, None);
         let addr2 = Address::new_id(base_addr_id + 2);
-        state_tree_old.set_actor(&addr2, miner2)?;
+        state_tree_old.set_actor(&addr2, miner2).unwrap();
 
         // miner 3 has precommits, some of which have deals
         let mut precommits3 = fil_actors_shared::v8::make_map_with_root::<
             _,
             fil_actor_miner_state::v8::SectorPreCommitOnChainInfo,
-        >(&base_miner_state.pre_committed_sectors, &store)?;
+        >(&base_miner_state.pre_committed_sectors, &store)
+        .unwrap();
         let mut precommits3dot0 = base_precommit.clone();
         precommits3dot0.info.deal_ids = vec![0];
         precommits3dot0.info.sector_number = 0;
@@ -558,99 +580,101 @@ mod tests {
         let mut precommits3dot2 = base_precommit;
         precommits3dot2.info.sector_number = 2;
 
-        precommits3.set(sector_key(0)?, precommits3dot0)?;
-        precommits3.set(sector_key(1)?, precommits3dot1)?;
-        precommits3.set(sector_key(2)?, precommits3dot2)?;
+        precommits3
+            .set(sector_key(0).unwrap(), precommits3dot0)
+            .unwrap();
+        precommits3
+            .set(sector_key(1).unwrap(), precommits3dot1)
+            .unwrap();
+        precommits3
+            .set(sector_key(2).unwrap(), precommits3dot2)
+            .unwrap();
 
-        let precommits3_cid = precommits3.flush()?;
-        ensure!(
-            precommits3_cid.to_string()
-                == "bafy2bzacecdpddgu5sxniq5iez3xapyxvi3dg7pc5oxthywuclvxyj4h2vweo"
+        let precommits3_cid = precommits3.flush().unwrap();
+        assert_eq!(
+            precommits3_cid.to_string(),
+            "bafy2bzacecdpddgu5sxniq5iez3xapyxvi3dg7pc5oxthywuclvxyj4h2vweo"
         );
 
         let mut miner3_state = base_miner_state.clone();
         miner3_state.pre_committed_sectors = precommits3_cid;
-        let miner3_state_cid = store.put_cbor_default(&miner3_state)?;
-        ensure!(
-            miner3_state_cid.to_string()
-                == "bafy2bzaceb7ojujla7jb6iaxeuk4etg2kui4gtjujwqadqkc7lkp4ugoqrh2m"
+        let miner3_state_cid = store.put_cbor_default(&miner3_state).unwrap();
+        assert_eq!(
+            miner3_state_cid.to_string(),
+            "bafy2bzaceb7ojujla7jb6iaxeuk4etg2kui4gtjujwqadqkc7lkp4ugoqrh2m"
         );
 
         let miner3 = ActorState::new(miner_cid_old, miner3_state_cid, Zero::zero(), 0, None);
         let addr3 = Address::new_id(base_addr_id + 3);
-        state_tree_old.set_actor(&addr3, miner3)?;
+        state_tree_old.set_actor(&addr3, miner3).unwrap();
 
-        let tree_root = state_tree_old.flush()?;
+        let tree_root = state_tree_old.flush().unwrap();
 
-        let (new_manifest_cid, _new_manifest) = make_test_manifest(&store, "fil/9/")?;
+        let (new_manifest_cid, _new_manifest) = make_test_manifest(&store, "fil/9/");
 
-        let mut chain_config = ChainConfig::calibnet();
-        if let Some(bundle) = &mut chain_config.height_infos[Height::Shark as usize].bundle {
-            *bundle = new_manifest_cid;
-        }
-        let new_state_cid = super::super::run_migration(&chain_config, &store, &tree_root, 200)?;
-        let actors_out_state_root: StateRoot = store.get_cbor(&new_state_cid)?.unwrap();
-        ensure!(
-            actors_out_state_root.actors.to_string()
-                == "bafy2bzacedgtk3lnnyfxnzc32etqaj3zvi7ar7nxq2jtxd2qr36ftbsjoycqu"
-        );
-        let new_state_cid2 = super::super::run_migration(&chain_config, &store, &tree_root, 200)?;
-        ensure!(new_state_cid == new_state_cid2);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_fip0029_miner_migration() -> anyhow::Result<()> {
-        let store = Arc::new(crate::db::MemoryDB::default());
-        let (mut state_tree_old, manifest_old) = make_input_tree(&store)?;
-        let addr = Address::new_id(10000);
-        let worker_addr = Address::new_id(20000);
-        let miner_cid_old = manifest_old.get(BuiltinActor::Miner)?;
-        let miner_state = make_base_miner_state(&store, &addr, &worker_addr)?;
-        let miner_state_cid = store.put_cbor_default(&miner_state)?;
-        ensure!(
-            miner_state_cid.to_string()
-                == "bafy2bzaceacitm72b4zks7ivplygpmyqa6aas2pxkv4rkiknluxiko5mn4ng6"
-        );
-        let miner_actor = ActorState::new(miner_cid_old, miner_state_cid, Zero::zero(), 0, None);
-        state_tree_old.set_actor(&addr, miner_actor)?;
-        let state_tree_old_root = state_tree_old.flush()?;
-        let (new_manifest_cid, _new_manifest) = make_test_manifest(&store, "fil/9/")?;
         let mut chain_config = ChainConfig::calibnet();
         if let Some(bundle) = &mut chain_config.height_infos[Height::Shark as usize].bundle {
             *bundle = new_manifest_cid;
         }
         let new_state_cid =
-            super::super::run_migration(&chain_config, &store, &state_tree_old_root, 200)?;
-        let actors_out_state_root: StateRoot = store.get_cbor(&new_state_cid)?.unwrap();
-        ensure!(
-            actors_out_state_root.actors.to_string()
-                == "bafy2bzacebdpnjjyspbyj7al7d6234kdhkmdygkfdkp6zyao5o3egsfmribty"
+            super::super::run_migration(&chain_config, &store, &tree_root, 200).unwrap();
+        let actors_out_state_root: StateRoot = store.get_cbor(&new_state_cid).unwrap().unwrap();
+        assert_eq!(
+            actors_out_state_root.actors.to_string(),
+            "bafy2bzacedgtk3lnnyfxnzc32etqaj3zvi7ar7nxq2jtxd2qr36ftbsjoycqu"
         );
-
-        Ok(())
+        let new_state_cid2 =
+            super::super::run_migration(&chain_config, &store, &tree_root, 200).unwrap();
+        assert_eq!(new_state_cid, new_state_cid2);
     }
 
-    fn make_input_tree<BS: Blockstore>(
-        store: &Arc<BS>,
-    ) -> anyhow::Result<(StateTree<BS>, BuiltinActorManifest)> {
-        let mut tree = StateTree::new(store.clone(), StateTreeVersion::V4)?;
+    #[test]
+    fn test_fip0029_miner_migration() {
+        let store = Arc::new(crate::db::MemoryDB::default());
+        let (mut state_tree_old, manifest_old) = make_input_tree(&store);
+        let addr = Address::new_id(10000);
+        let worker_addr = Address::new_id(20000);
+        let miner_cid_old = manifest_old.get(BuiltinActor::Miner).unwrap();
+        let miner_state = make_base_miner_state(&store, &addr, &worker_addr);
+        let miner_state_cid = store.put_cbor_default(&miner_state).unwrap();
+        assert_eq!(
+            miner_state_cid.to_string(),
+            "bafy2bzaceacitm72b4zks7ivplygpmyqa6aas2pxkv4rkiknluxiko5mn4ng6"
+        );
+        let miner_actor = ActorState::new(miner_cid_old, miner_state_cid, Zero::zero(), 0, None);
+        state_tree_old.set_actor(&addr, miner_actor).unwrap();
+        let state_tree_old_root = state_tree_old.flush().unwrap();
+        let (new_manifest_cid, _new_manifest) = make_test_manifest(&store, "fil/9/");
+        let mut chain_config = ChainConfig::calibnet();
+        if let Some(bundle) = &mut chain_config.height_infos[Height::Shark as usize].bundle {
+            *bundle = new_manifest_cid;
+        }
+        let new_state_cid =
+            super::super::run_migration(&chain_config, &store, &state_tree_old_root, 200).unwrap();
+        let actors_out_state_root: StateRoot = store.get_cbor(&new_state_cid).unwrap().unwrap();
+        assert_eq!(
+            actors_out_state_root.actors.to_string(),
+            "bafy2bzacebdpnjjyspbyj7al7d6234kdhkmdygkfdkp6zyao5o3egsfmribty"
+        );
+    }
 
-        let (_manifest_cid, manifest) = make_test_manifest(&store, "fil/8/")?;
-        let account_cid = manifest.get(BuiltinActor::Account)?;
+    fn make_input_tree<BS: Blockstore>(store: &Arc<BS>) -> (StateTree<BS>, BuiltinActorManifest) {
+        let mut tree = StateTree::new(store.clone(), StateTreeVersion::V4).unwrap();
+
+        let (_manifest_cid, manifest) = make_test_manifest(&store, "fil/8/");
+        let account_cid = manifest.get(BuiltinActor::Account).unwrap();
         // fmt.Printf("accountCid: %s\n", accountCid)
-        ensure!(account_cid.to_string() == "bafkqadlgnfwc6obpmfrwg33vnz2a");
+        assert_eq!(account_cid.to_string(), "bafkqadlgnfwc6obpmfrwg33vnz2a");
         let system_cid = manifest.get_system();
         // fmt.Printf("systemCid: %s\n", systemCid)
-        ensure!(system_cid.to_string() == "bafkqaddgnfwc6obpon4xg5dfnu");
+        assert_eq!(system_cid.to_string(), "bafkqaddgnfwc6obpon4xg5dfnu");
         let system_state = fil_actor_system_state::v9::State {
             builtin_actors: manifest.source_cid(),
         };
-        let system_state_cid = store.put_cbor_default(&system_state)?;
-        ensure!(
-            system_state_cid.to_string()
-                == "bafy2bzacebrujchvrqxwiml3aaud4ts7kgj74kkf7qewwmrsj5tvhneeamtlq"
+        let system_state_cid = store.put_cbor_default(&system_state).unwrap();
+        assert_eq!(
+            system_state_cid.to_string(),
+            "bafy2bzacebrujchvrqxwiml3aaud4ts7kgj74kkf7qewwmrsj5tvhneeamtlq"
         );
         init_actor(
             &mut tree,
@@ -658,16 +682,17 @@ mod tests {
             system_cid,
             &fil_actor_interface::system::ADDRESS.into(),
             Zero::zero(),
-        )?;
+        );
 
         let init_cid = manifest.get_init();
         // fmt.Printf("initCid: %s\n", initCid)
-        ensure!(init_cid.to_string() == "bafkqactgnfwc6obpnfxgs5a");
-        let init_state = fil_actor_init_state::v8::State::new(&store, "migrationtest".into())?;
-        let init_state_cid = store.put_cbor_default(&init_state)?;
-        ensure!(
-            init_state_cid.to_string()
-                == "bafy2bzacednf3o3eyjwkm2isixe5lezt6klncgz5axriewegbkw34r6pqszbe"
+        assert_eq!(init_cid.to_string(), "bafkqactgnfwc6obpnfxgs5a");
+        let init_state =
+            fil_actor_init_state::v8::State::new(&store, "migrationtest".into()).unwrap();
+        let init_state_cid = store.put_cbor_default(&init_state).unwrap();
+        assert_eq!(
+            init_state_cid.to_string(),
+            "bafy2bzacednf3o3eyjwkm2isixe5lezt6klncgz5axriewegbkw34r6pqszbe"
         );
         init_actor(
             &mut tree,
@@ -675,15 +700,15 @@ mod tests {
             init_cid,
             &fil_actor_interface::init::ADDRESS.into(),
             Zero::zero(),
-        )?;
+        );
 
-        let reward_cid = manifest.get(BuiltinActor::Reward)?;
-        ensure!(reward_cid.to_string() == "bafkqaddgnfwc6obpojsxoylsmq");
+        let reward_cid = manifest.get(BuiltinActor::Reward).unwrap();
+        assert_eq!(reward_cid.to_string(), "bafkqaddgnfwc6obpojsxoylsmq");
         let reward_state = fil_actor_reward_state::v8::State::new(Default::default());
-        let reward_state_cid = store.put_cbor_default(&reward_state)?;
-        ensure!(
-            reward_state_cid.to_string()
-                == "bafy2bzaceaslbmsgmgmfi6pn2osvqcfuqinauuyt67zifnefurhpk4zxd2fos"
+        let reward_state_cid = store.put_cbor_default(&reward_state).unwrap();
+        assert_eq!(
+            reward_state_cid.to_string(),
+            "bafy2bzaceaslbmsgmgmfi6pn2osvqcfuqinauuyt67zifnefurhpk4zxd2fos"
         );
         init_actor(
             &mut tree,
@@ -691,10 +716,10 @@ mod tests {
             reward_cid,
             &fil_actor_interface::reward::ADDRESS.into(),
             TokenAmount::from_whole(1_100_000_000),
-        )?;
+        );
 
-        let cron_cid = manifest.get(BuiltinActor::Cron)?;
-        ensure!(cron_cid.to_string() == "bafkqactgnfwc6obpmnzg63q");
+        let cron_cid = manifest.get(BuiltinActor::Cron).unwrap();
+        assert_eq!(cron_cid.to_string(), "bafkqactgnfwc6obpmnzg63q");
         let cron_state = fil_actor_cron_state::v8::State {
             entries: vec![
                 fil_actor_cron_state::v8::Entry {
@@ -707,10 +732,10 @@ mod tests {
                 },
             ],
         };
-        let cron_state_cid = store.put_cbor_default(&cron_state)?;
-        ensure!(
-            cron_state_cid.to_string()
-                == "bafy2bzacebs5dwwxmsjmzvoqcamx3qtl2x5qpqgpqxgnzl7scccmbvd37ulvs"
+        let cron_state_cid = store.put_cbor_default(&cron_state).unwrap();
+        assert_eq!(
+            cron_state_cid.to_string(),
+            "bafy2bzacebs5dwwxmsjmzvoqcamx3qtl2x5qpqgpqxgnzl7scccmbvd37ulvs"
         );
         init_actor(
             &mut tree,
@@ -718,15 +743,18 @@ mod tests {
             cron_cid,
             &fil_actor_interface::cron::ADDRESS.into(),
             Zero::zero(),
-        )?;
+        );
 
-        let power_cid = manifest.get(BuiltinActor::Power)?;
-        ensure!(power_cid.to_string() == "bafkqaetgnfwc6obpon2g64tbm5sxa33xmvza");
-        let power_state = fil_actor_power_state::v8::State::new(&store)?;
-        let power_state_cid = store.put_cbor_default(&power_state)?;
-        ensure!(
-            power_state_cid.to_string()
-                == "bafy2bzacebx3h3ib435qrzwb7zj7enrgepqeiyyeqpq6zwygasoag4m3mhy3w"
+        let power_cid = manifest.get(BuiltinActor::Power).unwrap();
+        assert_eq!(
+            power_cid.to_string(),
+            "bafkqaetgnfwc6obpon2g64tbm5sxa33xmvza"
+        );
+        let power_state = fil_actor_power_state::v8::State::new(&store).unwrap();
+        let power_state_cid = store.put_cbor_default(&power_state).unwrap();
+        assert_eq!(
+            power_state_cid.to_string(),
+            "bafy2bzacebx3h3ib435qrzwb7zj7enrgepqeiyyeqpq6zwygasoag4m3mhy3w"
         );
         init_actor(
             &mut tree,
@@ -734,15 +762,18 @@ mod tests {
             power_cid,
             &fil_actor_interface::power::ADDRESS.into(),
             Zero::zero(),
-        )?;
+        );
 
-        let market_cid = manifest.get(BuiltinActor::Market)?;
-        ensure!(market_cid.to_string() == "bafkqae3gnfwc6obpon2g64tbm5sw2ylsnnsxi");
-        let market_state = fil_actor_market_state::v8::State::new(&store)?;
-        let market_state_cid = store.put_cbor_default(&market_state)?;
-        ensure!(
-            market_state_cid.to_string()
-                == "bafy2bzacea5udmevoj4io3yqy7ku7aitblugdvirbirg7wstzstb5xub5empc"
+        let market_cid = manifest.get(BuiltinActor::Market).unwrap();
+        assert_eq!(
+            market_cid.to_string(),
+            "bafkqae3gnfwc6obpon2g64tbm5sw2ylsnnsxi"
+        );
+        let market_state = fil_actor_market_state::v8::State::new(&store).unwrap();
+        let market_state_cid = store.put_cbor_default(&market_state).unwrap();
+        assert_eq!(
+            market_state_cid.to_string(),
+            "bafy2bzacea5udmevoj4io3yqy7ku7aitblugdvirbirg7wstzstb5xub5empc"
         );
         init_actor(
             &mut tree,
@@ -750,17 +781,17 @@ mod tests {
             market_cid,
             &fil_actor_interface::market::ADDRESS.into(),
             Zero::zero(),
-        )?;
+        );
 
         // this will need to be replaced with the address of a multisig actor for the verified registry to be tested accurately
         let verifreg_root = Address::new_id(80);
         let account_state = fil_actor_account_state::v8::State {
             address: verifreg_root.into(),
         };
-        let account_state_cid = store.put_cbor_default(&account_state)?;
-        ensure!(
-            account_state_cid.to_string()
-                == "bafy2bzaceajm42pledpxusdh4owdrdfvv463dthqg24npeeaz4jlbgzdcgkve"
+        let account_state_cid = store.put_cbor_default(&account_state).unwrap();
+        assert_eq!(
+            account_state_cid.to_string(),
+            "bafy2bzaceajm42pledpxusdh4owdrdfvv463dthqg24npeeaz4jlbgzdcgkve"
         );
         init_actor(
             &mut tree,
@@ -768,12 +799,15 @@ mod tests {
             account_cid,
             &account_state.address.into(),
             Zero::zero(),
-        )?;
+        );
 
-        let verifreg_cid = manifest.get(BuiltinActor::VerifiedRegistry)?;
-        ensure!(verifreg_cid.to_string() == "bafkqaftgnfwc6obpozsxe2lgnfswi4tfm5uxg5dspe");
+        let verifreg_cid = manifest.get(BuiltinActor::VerifiedRegistry).unwrap();
+        assert_eq!(
+            verifreg_cid.to_string(),
+            "bafkqaftgnfwc6obpozsxe2lgnfswi4tfm5uxg5dspe"
+        );
         let mut verifreg_state =
-            fil_actor_verifreg_state::v8::State::new(&store, verifreg_root.into())?;
+            fil_actor_verifreg_state::v8::State::new(&store, verifreg_root.into()).unwrap();
         let mut verified_clients = fil_actors_shared::v8::make_empty_map::<BS, BigInt>(
             store,
             fil_actors_shared::v8::builtin::HAMT_BIT_WIDTH,
@@ -793,33 +827,37 @@ mod tests {
         // vrState.VerifiedClients = verifiedClientsCID
         // ```
         {
-            verified_clients.set(
-                BytesKey(Address::new_id(1001).to_bytes()),
-                num_bigint::BigInt::from(1).into(),
-            )?;
-            verified_clients.set(
-                BytesKey(Address::new_id(1002).to_bytes()),
-                num_bigint::BigInt::from(2).into(),
-            )?;
-            verifreg_state.verified_clients = verified_clients.flush()?;
+            verified_clients
+                .set(
+                    BytesKey(Address::new_id(1001).to_bytes()),
+                    num_bigint::BigInt::from(1).into(),
+                )
+                .unwrap();
+            verified_clients
+                .set(
+                    BytesKey(Address::new_id(1002).to_bytes()),
+                    num_bigint::BigInt::from(2).into(),
+                )
+                .unwrap();
+            verifreg_state.verified_clients = verified_clients.flush().unwrap();
         }
-        let verifreg_state_cid = store.put_cbor_default(&verifreg_state)?;
+        let verifreg_state_cid = store.put_cbor_default(&verifreg_state).unwrap();
         init_actor(
             &mut tree,
             verifreg_state_cid,
             verifreg_cid,
             &fil_actors_shared::v8::builtin::VERIFIED_REGISTRY_ACTOR_ADDR.into(),
             Zero::zero(),
-        )?;
+        );
 
         // burnt funds
         let account_state = fil_actor_account_state::v8::State {
             address: BURNT_FUNDS_ACTOR_ADDR,
         };
-        let account_state_cid = store.put_cbor_default(&account_state)?;
-        ensure!(
-            account_state_cid.to_string()
-                == "bafy2bzacedpuk5ggwoq3s2wixsyjjnexpsjstdlyntio76vs2lt2jvy3o6mau"
+        let account_state_cid = store.put_cbor_default(&account_state).unwrap();
+        assert_eq!(
+            account_state_cid.to_string(),
+            "bafy2bzacedpuk5ggwoq3s2wixsyjjnexpsjstdlyntio76vs2lt2jvy3o6mau"
         );
         init_actor(
             &mut tree,
@@ -827,11 +865,11 @@ mod tests {
             account_cid,
             &account_state.address.into(),
             Zero::zero(),
-        )?;
+        );
 
-        tree.flush()?;
+        tree.flush().unwrap();
 
-        Ok((tree, manifest))
+        (tree, manifest)
     }
 
     fn init_actor<BS: Blockstore>(
@@ -840,17 +878,12 @@ mod tests {
         code: Cid,
         addr: &Address,
         balance: TokenAmount,
-    ) -> anyhow::Result<()> {
+    ) {
         let actor = ActorState::new(code, state, balance, 0, None);
-        tree.set_actor(addr, actor)?;
-
-        Ok(())
+        tree.set_actor(addr, actor).unwrap();
     }
 
-    fn make_test_manifest<BS: Blockstore>(
-        store: &BS,
-        prefix: &str,
-    ) -> anyhow::Result<(Cid, BuiltinActorManifest)> {
+    fn make_test_manifest<BS: Blockstore>(store: &BS, prefix: &str) -> (Cid, BuiltinActorManifest) {
         let mut manifest_data = vec![];
         for name in [
             "account",
@@ -871,17 +904,19 @@ mod tests {
             manifest_data.push((name, code_cid));
         }
 
-        let manifest_cid = store.put_cbor_default(&(1, store.put_cbor_default(&manifest_data)?))?;
-        let manifest = BuiltinActorManifest::load_manifest(store, &manifest_cid)?;
+        let manifest_cid = store
+            .put_cbor_default(&(1, store.put_cbor_default(&manifest_data).unwrap()))
+            .unwrap();
+        let manifest = BuiltinActorManifest::load_manifest(store, &manifest_cid).unwrap();
 
-        Ok((manifest_cid, manifest))
+        (manifest_cid, manifest)
     }
 
     fn make_base_miner_state<BS: Blockstore>(
         store: &BS,
         base_addr: &Address,
         base_worker_addr: &Address,
-    ) -> anyhow::Result<fil_actor_miner_state::v8::State> {
+    ) -> fil_actor_miner_state::v8::State {
         let empty_miner_info = fil_actor_miner_state::v8::MinerInfo {
             owner: base_addr.into(),
             worker: base_worker_addr.into(),
@@ -896,28 +931,27 @@ mod tests {
             pending_owner_address: None,
         };
 
-        let empty_miner_info_cid = store.put_cbor_default(&empty_miner_info)?;
+        let empty_miner_info_cid = store.put_cbor_default(&empty_miner_info).unwrap();
 
-        let empty_miner_state = fil_actor_miner_state::v8::State::new(
+        fil_actor_miner_state::v8::State::new(
             &fil_actors_shared::v8::runtime::Policy::calibnet(),
             store,
             empty_miner_info_cid,
             0,
             0,
-        )?;
-
-        Ok(empty_miner_state)
+        )
+        .unwrap()
     }
 
-    fn make_piece_cid(data: &[u8]) -> anyhow::Result<Cid> {
+    fn make_piece_cid(data: &[u8]) -> Cid {
         let hash = cid::multihash::Code::Sha2_256.digest(data);
-        let hash = Multihash::wrap(SHA2_256_TRUNC254_PADDED, hash.digest())?;
-        Ok(Cid::new_v1(FIL_COMMITMENT_UNSEALED, hash))
+        let hash = Multihash::wrap(SHA2_256_TRUNC254_PADDED, hash.digest()).unwrap();
+        Cid::new_v1(FIL_COMMITMENT_UNSEALED, hash)
     }
 
-    fn make_sealed_cid(data: &[u8]) -> anyhow::Result<Cid> {
+    fn make_sealed_cid(data: &[u8]) -> Cid {
         let hash = cid::multihash::Code::Sha2_256.digest(data);
-        let hash = Multihash::wrap(POSEIDON_BLS12_381_A1_FC1, hash.digest())?;
-        Ok(Cid::new_v1(FIL_COMMITMENT_SEALED, hash))
+        let hash = Multihash::wrap(POSEIDON_BLS12_381_A1_FC1, hash.digest()).unwrap();
+        Cid::new_v1(FIL_COMMITMENT_SEALED, hash)
     }
 }

--- a/src/state_migration/nv17/miner.rs
+++ b/src/state_migration/nv17/miner.rs
@@ -93,7 +93,7 @@ where
 
         let in_state: MinerStateOld = store
             .get_cbor(&input.head)?
-            .ok_or_else(|| anyhow::anyhow!("Init actor: could not read v9 state"))?;
+            .context("Init actor: could not read v9 state")?;
         let new_pre_committed_sectors =
             self.migrate_pre_committed_sectors(&store, &in_state.pre_committed_sectors)?;
         let new_sectors =

--- a/src/state_migration/nv17/util.rs
+++ b/src/state_migration/nv17/util.rs
@@ -67,7 +67,7 @@ pub(super) fn hamt_addr_key_to_key(addr_key: &BytesKey) -> anyhow::Result<BytesK
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::*;
+    use anyhow::ensure;
     use cid::multihash::{Multihash, MultihashDigest};
     use fvm_shared2::{
         bigint::Zero,
@@ -140,7 +140,7 @@ mod tests {
     // }
     // ```
     #[test]
-    fn test_get_pending_verified_deals_and_total_size() -> Result<()> {
+    fn test_get_pending_verified_deals_and_total_size() -> anyhow::Result<()> {
         let store = crate::db::MemoryDB::default();
         let mut market_state = fil_actor_market_state::v8::State::new(&store)?;
 
@@ -206,7 +206,7 @@ mod tests {
         Ok(())
     }
 
-    fn make_piece_cid(data: &[u8]) -> Result<Cid> {
+    fn make_piece_cid(data: &[u8]) -> anyhow::Result<Cid> {
         let hash = cid::multihash::Code::Sha2_256.digest(data);
         let hash = Multihash::wrap(SHA2_256_TRUNC254_PADDED, hash.digest())?;
         Ok(Cid::new_v1(FIL_COMMITMENT_UNSEALED, hash))

--- a/src/state_migration/nv17/util.rs
+++ b/src/state_migration/nv17/util.rs
@@ -67,7 +67,6 @@ pub(super) fn hamt_addr_key_to_key(addr_key: &BytesKey) -> anyhow::Result<BytesK
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::ensure;
     use cid::multihash::{Multihash, MultihashDigest};
     use fvm_shared2::{
         bigint::Zero,
@@ -140,9 +139,9 @@ mod tests {
     // }
     // ```
     #[test]
-    fn test_get_pending_verified_deals_and_total_size() -> anyhow::Result<()> {
+    fn test_get_pending_verified_deals_and_total_size() {
         let store = crate::db::MemoryDB::default();
-        let mut market_state = fil_actor_market_state::v8::State::new(&store)?;
+        let mut market_state = fil_actor_market_state::v8::State::new(&store).unwrap();
 
         let mut pending_proposals = fil_actors_shared::v8::Set::new(&store);
         market_state.proposals = {
@@ -165,50 +164,52 @@ mod tests {
             };
             let deal0 = {
                 let mut deal = base_deal.clone();
-                deal.piece_cid = make_piece_cid("0".as_bytes())?;
+                deal.piece_cid = make_piece_cid("0".as_bytes());
                 deal
             };
             let deal1 = {
                 let mut deal = base_deal.clone();
-                deal.piece_cid = make_piece_cid("1".as_bytes())?;
+                deal.piece_cid = make_piece_cid("1".as_bytes());
                 deal
             };
             let deal2 = {
                 let mut deal = base_deal;
-                deal.piece_cid = make_piece_cid("2".as_bytes())?;
+                deal.piece_cid = make_piece_cid("2".as_bytes());
                 deal
             };
 
-            proposals.set(100, deal0)?;
-            pending_proposals.put(BytesKey(deal1.cid()?.to_bytes()))?;
-            proposals.set(101, deal1)?;
-            pending_proposals.put(BytesKey(deal2.cid()?.to_bytes()))?;
-            proposals.set(102, deal2)?;
+            proposals.set(100, deal0).unwrap();
+            pending_proposals
+                .put(BytesKey(deal1.cid().unwrap().to_bytes()))
+                .unwrap();
+            proposals.set(101, deal1).unwrap();
+            pending_proposals
+                .put(BytesKey(deal2.cid().unwrap().to_bytes()))
+                .unwrap();
+            proposals.set(102, deal2).unwrap();
 
-            proposals.flush()?
+            proposals.flush().unwrap()
         };
-        market_state.pending_proposals = pending_proposals.root()?;
-        ensure!(
-            market_state.pending_proposals.to_string()
-                == "bafy2bzaceaznfegva7wvkm3yd66r5ej7t7726pr6lwhnosxbslmmkuoymtvtw"
+        market_state.pending_proposals = pending_proposals.root().unwrap();
+        assert_eq!(
+            market_state.pending_proposals.to_string(),
+            "bafy2bzaceaznfegva7wvkm3yd66r5ej7t7726pr6lwhnosxbslmmkuoymtvtw"
         );
-        ensure!(
-            market_state.proposals.to_string()
-                == "bafy2bzaceck7at6aj7iy4s4gkndk5njvcba4yoveucxcdpfuwdeczaw3fcly2"
+        assert_eq!(
+            market_state.proposals.to_string(),
+            "bafy2bzaceck7at6aj7iy4s4gkndk5njvcba4yoveucxcdpfuwdeczaw3fcly2"
         );
 
         let (pending_verified_deals, pending_verified_deal_size) =
-            get_pending_verified_deals_and_total_size(&store, &market_state)?;
+            get_pending_verified_deals_and_total_size(&store, &market_state).unwrap();
 
-        ensure!(pending_verified_deal_size == 1024);
-        ensure!(pending_verified_deals == vec![101, 102]);
-
-        Ok(())
+        assert_eq!(pending_verified_deal_size, 1024);
+        assert_eq!(pending_verified_deals, vec![101, 102]);
     }
 
-    fn make_piece_cid(data: &[u8]) -> anyhow::Result<Cid> {
+    fn make_piece_cid(data: &[u8]) -> Cid {
         let hash = cid::multihash::Code::Sha2_256.digest(data);
-        let hash = Multihash::wrap(SHA2_256_TRUNC254_PADDED, hash.digest())?;
-        Ok(Cid::new_v1(FIL_COMMITMENT_UNSEALED, hash))
+        let hash = Multihash::wrap(SHA2_256_TRUNC254_PADDED, hash.digest()).unwrap();
+        Cid::new_v1(FIL_COMMITMENT_UNSEALED, hash)
     }
 }

--- a/src/state_migration/nv17/verifreg_market.rs
+++ b/src/state_migration/nv17/verifreg_market.rs
@@ -11,7 +11,7 @@ use crate::shim::{
 };
 use crate::utils::db::CborStoreExt;
 use ahash::HashMap;
-use anyhow::Context;
+use anyhow::Context as _;
 use cid::Cid;
 use fil_actors_shared::fvm_ipld_hamt::BytesKey;
 use fvm_ipld_blockstore::Blockstore;

--- a/src/state_migration/nv18/eam.rs
+++ b/src/state_migration/nv18/eam.rs
@@ -6,6 +6,7 @@ use crate::shim::{
     machine::{BuiltinActor, BuiltinActorManifest},
     state_tree::{ActorState, StateTree},
 };
+use anyhow::Context as _;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 
@@ -20,10 +21,10 @@ impl<BS: Blockstore> PostMigrator<BS> for EamPostMigrator {
     fn post_migrate_state(&self, store: &BS, actors_out: &mut StateTree<BS>) -> anyhow::Result<()> {
         let sys_actor = actors_out
             .get_actor(&Address::SYSTEM_ACTOR)?
-            .ok_or_else(|| anyhow::anyhow!("Couldn't get sys actor state"))?;
+            .context("Couldn't get sys actor state")?;
         let sys_state: SystemStateNew = store
             .get_cbor(&sys_actor.state)?
-            .ok_or_else(|| anyhow::anyhow!("Couldn't get statev10"))?;
+            .context("Couldn't get statev10")?;
 
         let manifest = BuiltinActorManifest::load_v1_actor_list(store, &sys_state.builtin_actors)?;
 

--- a/src/state_migration/nv18/eth_account.rs
+++ b/src/state_migration/nv18/eth_account.rs
@@ -7,6 +7,7 @@ use crate::shim::{
     state_tree::{ActorState, StateTree},
 };
 use anyhow::anyhow;
+use anyhow::Context as _;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 
@@ -21,10 +22,10 @@ impl<BS: Blockstore> PostMigrator<BS> for EthAccountPostMigrator {
     fn post_migrate_state(&self, store: &BS, actors_out: &mut StateTree<BS>) -> anyhow::Result<()> {
         let init_actor = actors_out
             .get_actor(&Address::INIT_ACTOR)?
-            .ok_or_else(|| anyhow::anyhow!("Couldn't get init actor state"))?;
+            .context("Couldn't get init actor state")?;
         let init_state: fil_actor_init_state::v10::State = store
             .get_cbor(&init_actor.state)?
-            .ok_or_else(|| anyhow::anyhow!("Couldn't get statev10"))?;
+            .context("Couldn't get statev10")?;
 
         let eth_zero_addr =
             Address::new_delegated(Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR.id()?, &[0; 20])?;

--- a/src/state_migration/nv18/init.rs
+++ b/src/state_migration/nv18/init.rs
@@ -6,15 +6,15 @@
 
 use std::sync::Arc;
 
+use crate::state_migration::common::{
+    ActorMigration, ActorMigrationInput, ActorMigrationOutput, TypeMigration, TypeMigrator,
+};
 use crate::utils::db::CborStoreExt;
+use anyhow::Context as _;
 use cid::Cid;
 use fil_actor_init_state::{v10::State as InitStateNew, v9::State as InitStateOld};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
-
-use crate::state_migration::common::{
-    ActorMigration, ActorMigrationInput, ActorMigrationOutput, TypeMigration, TypeMigrator,
-};
 
 pub struct InitMigrator(Cid);
 
@@ -32,7 +32,7 @@ impl<BS: Blockstore> ActorMigration<BS> for InitMigrator {
     ) -> anyhow::Result<Option<ActorMigrationOutput>> {
         let in_state: InitStateOld = store
             .get_cbor(&input.head)?
-            .ok_or_else(|| anyhow::anyhow!("Init actor: could not read v9 state"))?;
+            .context("Init actor: could not read v9 state")?;
 
         let out_state: InitStateNew = TypeMigrator::migrate_type(in_state, &store)?;
 

--- a/src/state_migration/nv19/miner.rs
+++ b/src/state_migration/nv19/miner.rs
@@ -4,17 +4,16 @@
 //! This module contains the migration logic for the `NV19` upgrade for the
 //! Miner actor.
 
-use std::sync::Arc;
-
-use crate::utils::db::CborStoreExt;
-use cid::Cid;
-use fil_actor_miner_state::{v10::State as MinerStateOld, v11::State as MinerStateNew};
-use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
-
 use crate::state_migration::common::{
     ActorMigration, ActorMigrationInput, ActorMigrationOutput, TypeMigration, TypeMigrator,
 };
+use crate::utils::db::CborStoreExt;
+use anyhow::Context as _;
+use cid::Cid;
+use fil_actor_miner_state::{v10::State as MinerStateOld, v11::State as MinerStateNew};
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::CborStore as _;
+use std::sync::Arc;
 
 pub struct MinerMigrator(Cid);
 
@@ -32,7 +31,7 @@ impl<BS: Blockstore> ActorMigration<BS> for MinerMigrator {
     ) -> anyhow::Result<Option<ActorMigrationOutput>> {
         let in_state: MinerStateOld = store
             .get_cbor(&input.head)?
-            .ok_or_else(|| anyhow::anyhow!("Miner actor: could not read v10 state"))?;
+            .context("Miner actor: could not read v10 state")?;
 
         let out_state: MinerStateNew = TypeMigrator::migrate_type(in_state, &store)?;
 

--- a/src/state_migration/nv19/power.rs
+++ b/src/state_migration/nv19/power.rs
@@ -4,10 +4,10 @@
 //! This module contains the migration logic for the `NV19` upgrade for the
 //! Power actor.
 
-use std::sync::Arc;
-
 use crate::shim::sector::convert_window_post_proof_v1_to_v1p1;
+use crate::state_migration::common::{ActorMigration, ActorMigrationInput, ActorMigrationOutput};
 use crate::utils::db::CborStoreExt;
+use anyhow::Context as _;
 use cid::Cid;
 use fil_actor_power_state::{
     v10::{Claim as ClaimV10, State as StateV10},
@@ -18,8 +18,7 @@ use fil_actors_shared::v11::{
 };
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
-
-use crate::state_migration::common::{ActorMigration, ActorMigrationInput, ActorMigrationOutput};
+use std::sync::Arc;
 
 pub struct PowerMigrator(Cid);
 
@@ -38,7 +37,7 @@ impl<BS: Blockstore> ActorMigration<BS> for PowerMigrator {
     ) -> anyhow::Result<Option<ActorMigrationOutput>> {
         let in_state: StateV10 = store
             .get_cbor(&input.head)?
-            .ok_or_else(|| anyhow::anyhow!("Power actor: could not read v10 state"))?;
+            .context("Power actor: could not read v10 state")?;
 
         let in_claims = make_map_with_root_and_bitwidth(&in_state.claims, &store, HAMT_BIT_WIDTH)?;
 

--- a/src/state_migration/tests/mod.rs
+++ b/src/state_migration/tests/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     shim::state_tree::StateRoot,
     state_migration::run_state_migrations,
 };
-use anyhow::*;
 use cid::Cid;
 use futures::{AsyncWriteExt, TryStreamExt};
 use fvm_ipld_encoding::CborStore;
@@ -21,7 +20,7 @@ use std::{str::FromStr, sync::Arc};
 
 #[ignore = "flaky"]
 #[tokio::test]
-async fn test_nv17_state_migration_calibnet() -> Result<()> {
+async fn test_nv17_state_migration_calibnet() -> anyhow::Result<()> {
     // forest_filecoin::state_migration: State migration at height Shark(epoch 16800) was successful,
     // Previous state: bafy2bzacedxtdhqjsrw2twioyaeomdk4z7umhgfv36vzrrotjb4woutphqgyg,
     // new state: bafy2bzacecrejypa2rqdh3geg2u3qdqdrejrfqvh2ykqcrnyhleehpiynh4k4.
@@ -38,7 +37,7 @@ async fn test_nv17_state_migration_calibnet() -> Result<()> {
 
 #[ignore = "flaky"]
 #[tokio::test]
-async fn test_nv18_state_migration_calibnet() -> Result<()> {
+async fn test_nv18_state_migration_calibnet() -> anyhow::Result<()> {
     // State migration at height Hygge(epoch 322354) was successful,
     // Previous state: bafy2bzacedjqwdqxlkyyuohmtcfciekl5qh2s4yf67neiuuhkibbteqoucvsm,
     // new state: bafy2bzacedhhgkmr26rbr3yujounnz2ufiwrlvamogyabgfv6uvwq3rlv4t2i.
@@ -55,7 +54,7 @@ async fn test_nv18_state_migration_calibnet() -> Result<()> {
 
 #[ignore = "flaky"]
 #[tokio::test]
-async fn test_nv19_state_migration_calibnet() -> Result<()> {
+async fn test_nv19_state_migration_calibnet() -> anyhow::Result<()> {
     // State migration at height Lightning(epoch 489094) was successful,
     // Previous state: bafy2bzacedgamjgha75e7w2cgklfdgtmumsj7nadqppnpz3wexl2wl6dexsle,
     // new state: bafy2bzacebhjx4uqtg6c65km46wiiq45dbbeckqhs2oontwdzba335nxk6bia.
@@ -75,7 +74,7 @@ async fn test_state_migration(
     network: NetworkChain,
     old_state: Cid,
     expected_new_state: Cid,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     // Car files are cached under data folder for Go test to pick up without network access
     let car_path = PathBuf::from(format!("./src/state_migration/tests/data/{old_state}.car"));
     if !car_path.is_file() {
@@ -101,7 +100,7 @@ async fn test_state_migration(
                 writer.flush().await?;
                 writer.close().await?;
 
-                Ok(())
+                anyhow::Ok(())
             },
         )
         .await?;

--- a/src/state_migration/type_migrations/miner/state_v10_to_v11.rs
+++ b/src/state_migration/type_migrations/miner/state_v10_to_v11.rs
@@ -3,6 +3,7 @@
 
 use crate::shim::sector::convert_window_post_proof_v1_to_v1p1;
 use crate::utils::db::CborStoreExt;
+use anyhow::Context as _;
 use fil_actor_miner_state::{
     v10::{MinerInfo as MinerInfoV10, State as MinerStateV10},
     v11::{MinerInfo as MinerInfoV11, State as MinerStateV11},
@@ -16,7 +17,7 @@ impl TypeMigration<MinerStateV10, MinerStateV11> for TypeMigrator {
     fn migrate_type(from: MinerStateV10, store: &impl Blockstore) -> anyhow::Result<MinerStateV11> {
         let in_info: MinerInfoV10 = store
             .get_cbor(&from.info)?
-            .ok_or_else(|| anyhow::anyhow!("Miner info: could not read v10 state"))?;
+            .context("Miner info: could not read v10 state")?;
 
         let out_proof_type = convert_window_post_proof_v1_to_v1p1(in_info.window_post_proof_type)
             .map_err(|e| anyhow::anyhow!(e))?;

--- a/src/state_migration/type_migrations/miner/state_v8_to_v9.rs
+++ b/src/state_migration/type_migrations/miner/state_v8_to_v9.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::utils::db::CborStoreExt;
+use anyhow::Context as _;
 use fil_actor_miner_state::{
     v8::{MinerInfo as MinerInfoV8, State as MinerStateV8},
     v9::{MinerInfo as MinerInfoV9, State as MinerStateV9},
@@ -15,7 +16,7 @@ impl TypeMigration<MinerStateV8, MinerStateV9> for TypeMigrator {
     fn migrate_type(from: MinerStateV8, store: &impl Blockstore) -> anyhow::Result<MinerStateV9> {
         let in_info: MinerInfoV8 = store
             .get_cbor(&from.info)?
-            .ok_or_else(|| anyhow::anyhow!("Miner info: could not read v8 state"))?;
+            .context("Miner info: could not read v8 state")?;
 
         let out_info: MinerInfoV9 = TypeMigrator::migrate_type(in_info, store)?;
 

--- a/src/statediff/resolve.rs
+++ b/src/statediff/resolve.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use anyhow::Context;
+use anyhow::Context as _;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;

--- a/src/tool/subcommands/archive_cmd.rs
+++ b/src/tool/subcommands/archive_cmd.rs
@@ -13,7 +13,7 @@ use crate::db::car::{AnyCar, RandomAccessFileReader};
 use crate::ipld::{stream_graph, unordered_stream_graph};
 use crate::networks::{calibnet, mainnet, ChainConfig, NetworkChain};
 use crate::shim::clock::{ChainEpoch, EPOCHS_IN_DAY, EPOCH_DURATION_SECONDS};
-use anyhow::{bail, Context as _, Result};
+use anyhow::{bail, Context as _};
 use chrono::NaiveDateTime;
 use clap::Subcommand;
 use dialoguer::{theme::ColorfulTheme, Confirm};
@@ -84,7 +84,7 @@ pub enum ArchiveCommands {
 }
 
 impl ArchiveCommands {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(self) -> anyhow::Result<()> {
         match self {
             Self::Info { snapshot } => {
                 println!(
@@ -151,14 +151,17 @@ impl std::fmt::Display for ArchiveInfo {
 impl ArchiveInfo {
     // Scan a CAR archive to identify which network it belongs to and how many
     // tipsets/messages are available. Progress is rendered to stdout.
-    fn from_store(store: AnyCar<impl RandomAccessFileReader>) -> Result<Self> {
+    fn from_store(store: AnyCar<impl RandomAccessFileReader>) -> anyhow::Result<Self> {
         Self::from_store_with(store, true)
     }
 
     // Scan a CAR archive to identify which network it belongs to and how many
     // tipsets/messages are available. Progress is optionally rendered to
     // stdout.
-    fn from_store_with(store: AnyCar<impl RandomAccessFileReader>, progress: bool) -> Result<Self> {
+    fn from_store_with(
+        store: AnyCar<impl RandomAccessFileReader>,
+        progress: bool,
+    ) -> anyhow::Result<Self> {
         let root = store.heaviest_tipset()?;
         let root_epoch = root.epoch();
 
@@ -233,7 +236,7 @@ impl ArchiveInfo {
 
 // Print a mapping of epochs to block headers in yaml format. This mapping can
 // be used by Forest to quickly identify tipsets.
-fn print_checkpoints(snapshot_files: Vec<PathBuf>) -> Result<()> {
+fn print_checkpoints(snapshot_files: Vec<PathBuf>) -> anyhow::Result<()> {
     let store = ManyCar::try_from(snapshot_files).context("couldn't read input CAR file")?;
     let root = store.heaviest_tipset()?;
 
@@ -299,7 +302,7 @@ async fn do_export(
     diff: Option<ChainEpoch>,
     diff_depth: Option<ChainEpochDelta>,
     force: bool,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     let ts = Arc::new(root);
     let store = Arc::new(store);
 
@@ -393,7 +396,7 @@ async fn merge_snapshots(
     snapshot_files: Vec<PathBuf>,
     output_path: PathBuf,
     force: bool,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     use crate::db::car::forest;
 
     let store = ManyCar::try_from(snapshot_files)?;

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -288,7 +288,7 @@ where
 
         let mut assert_cid_exists = |cid: Cid| async move {
             let data = db.get(&cid)?;
-            data.ok_or_else(|| anyhow::anyhow!("Broken IPLD link at epoch: {height}"))
+            data.with_context(|| format!("Broken IPLD link at epoch: {height}"))
         };
 
         for h in tipset.blocks() {

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -19,7 +19,7 @@ use crate::shim::machine::MultiEngine;
 use crate::state_manager::apply_block_messages;
 use crate::utils::db::car_stream::CarStream;
 use crate::utils::proofs_api::paramfetch::ensure_params_downloaded;
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Context as _};
 use cid::Cid;
 use clap::Subcommand;
 use dialoguer::{theme::ColorfulTheme, Confirm};
@@ -111,7 +111,7 @@ pub enum SnapshotCommands {
 }
 
 impl SnapshotCommands {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(self) -> anyhow::Result<()> {
         match self {
             Self::Fetch {
                 directory,
@@ -233,7 +233,7 @@ async fn validate_with_blockstore<BlockstoreT>(
     check_links: u32,
     check_network: Option<NetworkChain>,
     check_stateroots: u32,
-) -> Result<()>
+) -> anyhow::Result<()>
 where
     BlockstoreT: Blockstore + Send + Sync + 'static,
 {
@@ -268,7 +268,7 @@ where
 // required to sync to the network and snapshot files usually disgard data after
 // 2000 epochs. Validity can be verified by ensuring there are no bad IPLD or
 // broken links in the N most recent epochs.
-async fn validate_ipld_links<DB>(ts: Tipset, db: &DB, epochs: u32) -> Result<()>
+async fn validate_ipld_links<DB>(ts: Tipset, db: &DB, epochs: u32) -> anyhow::Result<()>
 where
     DB: Blockstore + Send + Sync,
 {
@@ -306,12 +306,12 @@ where
 // Forest keeps a list of known tipsets for each network. Finding a known tipset
 // short-circuits the search for the genesis block. If no genesis block can be
 // found or if the genesis block is unrecognizable, an error is returned.
-fn query_network(ts: &Tipset, db: impl Blockstore) -> Result<NetworkChain> {
+fn query_network(ts: &Tipset, db: impl Blockstore) -> anyhow::Result<NetworkChain> {
     let pb = validation_spinner("Identifying genesis block:").with_finish(
         indicatif::ProgressFinish::AbandonWithMessage("✅ found!".into()),
     );
 
-    fn match_genesis_block(block_cid: Cid) -> Result<NetworkChain> {
+    fn match_genesis_block(block_cid: Cid) -> anyhow::Result<NetworkChain> {
         if block_cid == *calibnet::GENESIS_CID {
             Ok(NetworkChain::Calibnet)
         } else if block_cid == *mainnet::GENESIS_CID {
@@ -341,7 +341,7 @@ async fn validate_stateroots<DB>(
     db: &Arc<DB>,
     network: NetworkChain,
     epochs: u32,
-) -> Result<()>
+) -> anyhow::Result<()>
 where
     DB: Blockstore + Send + Sync + 'static,
 {

--- a/src/utils/db/file_backed_obj.rs
+++ b/src/utils/db/file_backed_obj.rs
@@ -113,15 +113,14 @@ impl FileBackedObject for ChainMeta {
 
 #[cfg(test)]
 mod tests {
-    use anyhow::*;
+    use super::*;
+    use anyhow::ensure;
     use cid::multihash::{self, MultihashDigest};
     use rand::Rng;
     use tempfile::TempDir;
 
-    use super::*;
-
     #[test]
-    fn cid_round_trip() -> Result<()> {
+    fn cid_round_trip() -> anyhow::Result<()> {
         let mut bytes = [0; 1024];
         rand::rngs::OsRng.fill(&mut bytes);
         let cid = Cid::new_v0(multihash::Code::Sha2_256.digest(bytes.as_slice()))?;
@@ -137,6 +136,6 @@ mod tests {
             FileBacked::load_from_file_or_create(file_path, Default::default)?;
         ensure!(obj1.inner() == obj2.inner());
 
-        Ok(())
+        anyhow::Ok(())
     }
 }

--- a/src/utils/db/file_backed_obj.rs
+++ b/src/utils/db/file_backed_obj.rs
@@ -114,28 +114,25 @@ impl FileBackedObject for ChainMeta {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::ensure;
     use cid::multihash::{self, MultihashDigest};
     use rand::Rng;
     use tempfile::TempDir;
 
     #[test]
-    fn cid_round_trip() -> anyhow::Result<()> {
+    fn cid_round_trip() {
         let mut bytes = [0; 1024];
         rand::rngs::OsRng.fill(&mut bytes);
-        let cid = Cid::new_v0(multihash::Code::Sha2_256.digest(bytes.as_slice()))?;
-        let serialized = cid.serialize()?;
-        let deserialized = Cid::deserialize(&serialized)?;
-        ensure!(cid == deserialized);
+        let cid = Cid::new_v0(multihash::Code::Sha2_256.digest(bytes.as_slice())).unwrap();
+        let serialized = cid.serialize().unwrap();
+        let deserialized = Cid::deserialize(&serialized).unwrap();
+        assert_eq!(cid, deserialized);
 
-        let dir = TempDir::new()?;
+        let dir = TempDir::new().unwrap();
         let file_path = dir.path().join("CID");
         let obj1: FileBacked<Cid> =
-            FileBacked::load_from_file_or_create(file_path.clone(), || cid)?;
+            FileBacked::load_from_file_or_create(file_path.clone(), || cid).unwrap();
         let obj2: FileBacked<Cid> =
-            FileBacked::load_from_file_or_create(file_path, Default::default)?;
-        ensure!(obj1.inner() == obj2.inner());
-
-        anyhow::Ok(())
+            FileBacked::load_from_file_or_create(file_path, Default::default).unwrap();
+        assert_eq!(obj1.inner(), obj2.inner());
     }
 }

--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -105,7 +105,6 @@ pub fn prover_id_from_u64(id: u64) -> ProverId {
 
 #[cfg(test)]
 mod tests {
-    use anyhow::ensure;
     use itertools::Itertools;
     use libipld::Ipld;
     use rand::Rng;
@@ -141,17 +140,15 @@ mod tests {
     }
 
     #[test]
-    fn cannot_serialize_byte_array_overflow() -> anyhow::Result<()> {
+    fn cannot_serialize_byte_array_overflow() {
         let bytes = ByteArray {
             inner: vec![0; BYTE_ARRAY_MAX_LEN + 1],
         };
 
-        ensure!(
+        assert!(
             format!("{}", serde_ipld_dagcbor::to_vec(&bytes).err().unwrap())
                 .contains("Array exceed max length")
         );
-
-        Ok(())
     }
 
     #[test]
@@ -170,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn cannot_deserialize_byte_array_overflow() -> anyhow::Result<()> {
+    fn cannot_deserialize_byte_array_overflow() {
         let max_length_bytes = ByteArray {
             inner: vec![0; BYTE_ARRAY_MAX_LEN],
         };
@@ -181,18 +178,17 @@ mod tests {
         overflow_encoding[encoding_len - BYTE_ARRAY_MAX_LEN - 1] = 1;
         overflow_encoding.push(0);
 
-        ensure!(format!(
+        assert!(format!(
             "{}",
             from_slice_with_fallback::<ByteArray>(&overflow_encoding)
                 .err()
                 .unwrap()
         )
         .contains("Array exceed max length"));
-        Ok(())
     }
 
     #[test]
-    fn parity_tests() -> anyhow::Result<()> {
+    fn parity_tests() {
         use cs_serde_bytes;
 
         #[derive(Deserialize, Serialize)]
@@ -207,9 +203,10 @@ mod tests {
         let a = A(array.to_vec());
         let b = B(array.to_vec());
 
-        ensure!(serde_json::to_string_pretty(&a)? == serde_json::to_string_pretty(&b)?);
-
-        Ok(())
+        assert_eq!(
+            serde_json::to_string_pretty(&a).unwrap(),
+            serde_json::to_string_pretty(&b).unwrap()
+        );
     }
 
     #[test]

--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -105,7 +105,7 @@ pub fn prover_id_from_u64(id: u64) -> ProverId {
 
 #[cfg(test)]
 mod tests {
-    use anyhow::{ensure, Result};
+    use anyhow::ensure;
     use itertools::Itertools;
     use libipld::Ipld;
     use rand::Rng;
@@ -141,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    fn cannot_serialize_byte_array_overflow() -> Result<()> {
+    fn cannot_serialize_byte_array_overflow() -> anyhow::Result<()> {
         let bytes = ByteArray {
             inner: vec![0; BYTE_ARRAY_MAX_LEN + 1],
         };
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn cannot_deserialize_byte_array_overflow() -> Result<()> {
+    fn cannot_deserialize_byte_array_overflow() -> anyhow::Result<()> {
         let max_length_bytes = ByteArray {
             inner: vec![0; BYTE_ARRAY_MAX_LEN],
         };

--- a/src/utils/io/mmap.rs
+++ b/src/utils/io/mmap.rs
@@ -92,11 +92,10 @@ mod tests {
     use std::fs;
 
     use super::*;
-    use anyhow::Result;
     use quickcheck_macros::quickcheck;
 
     #[quickcheck]
-    fn test_mmap_read_at_and_size(bytes: Vec<u8>) -> Result<()> {
+    fn test_mmap_read_at_and_size(bytes: Vec<u8>) -> anyhow::Result<()> {
         let tmp = tempfile::Builder::new().tempfile()?.into_temp_path();
         fs::write(&tmp, &bytes)?;
         let mmap = Mmap::map(&fs::File::open(&tmp)?)?;

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -15,7 +15,7 @@ use crate::shim::{
     econ::TokenAmount,
 };
 use crate::utils::io::read_file_to_string;
-use anyhow::Context;
+use anyhow::Context as _;
 use base64::{prelude::BASE64_STANDARD, Engine};
 use clap::{arg, Subcommand};
 use dialoguer::{theme::ColorfulTheme, Password};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,7 +3,6 @@
 
 use std::path::PathBuf;
 
-use anyhow::Result;
 use assert_cmd::Command;
 use tempfile::TempDir;
 
@@ -45,7 +44,7 @@ impl CommonEnv for Command {
     }
 }
 
-pub fn create_tmp_config() -> Result<(PathBuf, TempDir)> {
+pub fn create_tmp_config() -> anyhow::Result<(PathBuf, TempDir)> {
     let temp_dir = tempfile::tempdir()?;
 
     let config = format!(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -44,8 +44,8 @@ impl CommonEnv for Command {
     }
 }
 
-pub fn create_tmp_config() -> anyhow::Result<(PathBuf, TempDir)> {
-    let temp_dir = tempfile::tempdir()?;
+pub fn create_tmp_config() -> (PathBuf, TempDir) {
+    let temp_dir = tempfile::tempdir().expect("couldn't create temp dir");
 
     let config = format!(
         r#"
@@ -59,7 +59,7 @@ type = "calibnet"
     );
 
     let config_file = temp_dir.path().join("config.toml");
-    std::fs::write(&config_file, config)?;
+    std::fs::write(&config_file, config).expect("couldn't write config");
 
-    Ok((config_file, temp_dir))
+    (config_file, temp_dir)
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::{io::Write, net::SocketAddr, path::PathBuf, str::FromStr};
 
-use anyhow::*;
+use anyhow::{ensure, Context as _};
 use assert_cmd::Command;
 use forest_filecoin::{Client, Config};
 use rand::Rng;
@@ -95,7 +95,7 @@ fn test_reading_configuration_from_file() {
 }
 
 #[test]
-fn test_config_env_var() -> Result<()> {
+fn test_config_env_var() -> anyhow::Result<()> {
     let expected_config = Config {
         client: Client {
             rpc_token: Some("some_rpc_token".into()),

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::{io::Write, net::SocketAddr, path::PathBuf, str::FromStr};
 
-use anyhow::{ensure, Context as _};
 use assert_cmd::Command;
 use forest_filecoin::{Client, Config};
 use rand::Rng;
@@ -95,7 +94,7 @@ fn test_reading_configuration_from_file() {
 }
 
 #[test]
-fn test_config_env_var() -> anyhow::Result<()> {
+fn test_config_env_var() {
     let expected_config = Config {
         client: Client {
             rpc_token: Some("some_rpc_token".into()),
@@ -105,10 +104,10 @@ fn test_config_env_var() -> anyhow::Result<()> {
         ..Config::default()
     };
 
-    let mut config_file = tempfile::Builder::new().tempfile()?;
+    let mut config_file = tempfile::Builder::new().tempfile().unwrap();
     config_file
-        .write_all(toml::to_string(&expected_config)?.as_bytes())
-        .context("Failed writing configuration!")?;
+        .write_all(toml::to_string(&expected_config).unwrap().as_bytes())
+        .unwrap();
 
     let cmd = Command::cargo_bin("forest-cli")
         .unwrap()
@@ -119,12 +118,9 @@ fn test_config_env_var() -> anyhow::Result<()> {
         .success();
 
     let output = &cmd.get_output().stdout;
-    let actual_config =
-        toml::from_str::<Config>(std::str::from_utf8(output)?).context("Invalid configuration!")?;
+    let actual_config = toml::from_str::<Config>(std::str::from_utf8(output).unwrap()).unwrap();
 
-    ensure!(expected_config == actual_config);
-
-    Ok(())
+    assert_eq!(expected_config, actual_config);
 }
 
 #[test]

--- a/tests/db_migration_tests.rs
+++ b/tests/db_migration_tests.rs
@@ -4,10 +4,9 @@
 pub mod common;
 
 use crate::common::{create_tmp_config, daemon, CommonArgs, CommonEnv};
-use anyhow::Result;
 
 #[test]
-fn failing_migration_should_not_fail_daemon() -> Result<()> {
+fn failing_migration_should_not_fail_daemon() -> anyhow::Result<()> {
     let (config_file, data_dir) = create_tmp_config()?;
 
     // Create an invalid, versioned database in the data directory.

--- a/tests/db_migration_tests.rs
+++ b/tests/db_migration_tests.rs
@@ -6,8 +6,8 @@ pub mod common;
 use crate::common::{create_tmp_config, daemon, CommonArgs, CommonEnv};
 
 #[test]
-fn failing_migration_should_not_fail_daemon() -> anyhow::Result<()> {
-    let (config_file, data_dir) = create_tmp_config()?;
+fn failing_migration_should_not_fail_daemon() {
+    let (config_file, data_dir) = create_tmp_config();
 
     // Create an invalid, versioned database in the data directory.
     // This will trigger a migration, which should fail. Forest should be able to recover from
@@ -17,7 +17,7 @@ fn failing_migration_should_not_fail_daemon() -> anyhow::Result<()> {
     // - The new, fresh database which should be used by the daemon.
 
     let bad_db_path = data_dir.path().join("calibnet").join("0.12.1");
-    std::fs::create_dir_all(&bad_db_path)?;
+    std::fs::create_dir_all(&bad_db_path).unwrap();
     daemon()
         .common_env()
         .common_args()
@@ -36,6 +36,4 @@ fn failing_migration_should_not_fail_daemon() -> anyhow::Result<()> {
         .join("calibnet")
         .join(forest_version)
         .exists());
-
-    Ok(())
 }

--- a/tests/db_mode_tests.rs
+++ b/tests/db_mode_tests.rs
@@ -7,7 +7,7 @@ use crate::common::{create_tmp_config, daemon, CommonArgs, CommonEnv};
 
 #[test]
 fn current_mode_should_create_current_version_if_no_migrations() -> anyhow::Result<()> {
-    let (config_file, data_dir) = create_tmp_config()?;
+    let (config_file, data_dir) = create_tmp_config();
 
     daemon()
         .common_env()
@@ -33,7 +33,7 @@ fn current_mode_should_create_current_version_if_no_migrations() -> anyhow::Resu
 
 #[test]
 fn development_mode_should_create_named_db() -> anyhow::Result<()> {
-    let (config_file, data_dir) = create_tmp_config()?;
+    let (config_file, data_dir) = create_tmp_config();
 
     daemon()
         .common_env()

--- a/tests/db_mode_tests.rs
+++ b/tests/db_mode_tests.rs
@@ -4,10 +4,9 @@
 pub mod common;
 
 use crate::common::{create_tmp_config, daemon, CommonArgs, CommonEnv};
-use anyhow::Result;
 
 #[test]
-fn current_mode_should_create_current_version_if_no_migrations() -> Result<()> {
+fn current_mode_should_create_current_version_if_no_migrations() -> anyhow::Result<()> {
     let (config_file, data_dir) = create_tmp_config()?;
 
     daemon()
@@ -33,7 +32,7 @@ fn current_mode_should_create_current_version_if_no_migrations() -> Result<()> {
 }
 
 #[test]
-fn development_mode_should_create_named_db() -> Result<()> {
+fn development_mode_should_create_named_db() -> anyhow::Result<()> {
     let (config_file, data_dir) = create_tmp_config()?;
 
     daemon()

--- a/tests/db_mode_tests.rs
+++ b/tests/db_mode_tests.rs
@@ -6,7 +6,7 @@ pub mod common;
 use crate::common::{create_tmp_config, daemon, CommonArgs, CommonEnv};
 
 #[test]
-fn current_mode_should_create_current_version_if_no_migrations() -> anyhow::Result<()> {
+fn current_mode_should_create_current_version_if_no_migrations() {
     let (config_file, data_dir) = create_tmp_config();
 
     daemon()
@@ -27,12 +27,10 @@ fn current_mode_should_create_current_version_if_no_migrations() -> anyhow::Resu
         .join("calibnet")
         .join(forest_version)
         .exists());
-
-    Ok(())
 }
 
 #[test]
-fn development_mode_should_create_named_db() -> anyhow::Result<()> {
+fn development_mode_should_create_named_db() {
     let (config_file, data_dir) = create_tmp_config();
 
     daemon()
@@ -56,7 +54,8 @@ fn development_mode_should_create_named_db() -> anyhow::Result<()> {
             .join("azathoth")
             .join("chant"),
         "Rlyeh wgah nagl fhtagn",
-    )?;
+    )
+    .unwrap();
 
     daemon()
         .common_env()
@@ -76,9 +75,8 @@ fn development_mode_should_create_named_db() -> anyhow::Result<()> {
                 .join("calibnet")
                 .join("azathoth")
                 .join("chant")
-        )?,
+        )
+        .unwrap(),
         "Rlyeh wgah nagl fhtagn"
     );
-
-    Ok(())
 }

--- a/tests/import_snapshot_tests.rs
+++ b/tests/import_snapshot_tests.rs
@@ -3,14 +3,12 @@
 
 pub mod common;
 
-use anyhow::Result;
-
 use crate::common::{create_tmp_config, daemon, CommonEnv};
 
 // Ignored because it's flaky.
 #[test]
 #[ignore]
-fn importing_bad_snapshot_should_fail() -> Result<()> {
+fn importing_bad_snapshot_should_fail() -> anyhow::Result<()> {
     let (config_file, data_dir) = create_tmp_config()?;
     let temp_file = data_dir.path().join("bad-snapshot.car");
     std::fs::write(&temp_file, "bad-snapshot")?;

--- a/tests/import_snapshot_tests.rs
+++ b/tests/import_snapshot_tests.rs
@@ -9,7 +9,7 @@ use crate::common::{create_tmp_config, daemon, CommonEnv};
 #[test]
 #[ignore]
 fn importing_bad_snapshot_should_fail() -> anyhow::Result<()> {
-    let (config_file, data_dir) = create_tmp_config()?;
+    let (config_file, data_dir) = create_tmp_config();
     let temp_file = data_dir.path().join("bad-snapshot.car");
     std::fs::write(&temp_file, "bad-snapshot")?;
     daemon()

--- a/tests/import_snapshot_tests.rs
+++ b/tests/import_snapshot_tests.rs
@@ -8,10 +8,10 @@ use crate::common::{create_tmp_config, daemon, CommonEnv};
 // Ignored because it's flaky.
 #[test]
 #[ignore]
-fn importing_bad_snapshot_should_fail() -> anyhow::Result<()> {
+fn importing_bad_snapshot_should_fail() {
     let (config_file, data_dir) = create_tmp_config();
     let temp_file = data_dir.path().join("bad-snapshot.car");
-    std::fs::write(&temp_file, "bad-snapshot")?;
+    std::fs::write(&temp_file, "bad-snapshot").unwrap();
     daemon()
         .common_env()
         .arg("--rpc-address")
@@ -27,6 +27,4 @@ fn importing_bad_snapshot_should_fail() -> anyhow::Result<()> {
         .arg("--halt-after-import")
         .assert()
         .failure();
-
-    Ok(())
 }

--- a/tests/keystore_tests.rs
+++ b/tests/keystore_tests.rs
@@ -3,7 +3,6 @@
 
 pub mod common;
 
-use anyhow::Result;
 use forest_filecoin::{verify_token, JWT_IDENTIFIER};
 use forest_filecoin::{
     KeyStore, KeyStoreConfig, ENCRYPTED_KEYSTORE_NAME, FOREST_KEYSTORE_PHRASE_ENV, KEYSTORE_NAME,
@@ -13,7 +12,7 @@ use crate::common::{create_tmp_config, daemon, CommonArgs};
 
 // https://github.com/ChainSafe/forest/issues/2499
 #[test]
-fn forest_headless_encrypt_keystore_no_passphrase_should_fail() -> Result<()> {
+fn forest_headless_encrypt_keystore_no_passphrase_should_fail() -> anyhow::Result<()> {
     let (config_file, _data_dir) = create_tmp_config()?;
     daemon()
         .common_args()
@@ -26,7 +25,7 @@ fn forest_headless_encrypt_keystore_no_passphrase_should_fail() -> Result<()> {
 }
 
 #[test]
-fn forest_headless_no_encrypt_no_passphrase_should_succeed() -> Result<()> {
+fn forest_headless_no_encrypt_no_passphrase_should_succeed() -> anyhow::Result<()> {
     let (config_file, data_dir) = create_tmp_config()?;
     daemon()
         .common_args()
@@ -43,7 +42,7 @@ fn forest_headless_no_encrypt_no_passphrase_should_succeed() -> Result<()> {
 }
 
 #[test]
-fn forest_headless_encrypt_keystore_with_passphrase_should_succeed() -> Result<()> {
+fn forest_headless_encrypt_keystore_with_passphrase_should_succeed() -> anyhow::Result<()> {
     let (config_file, data_dir) = create_tmp_config()?;
     daemon()
         .env(FOREST_KEYSTORE_PHRASE_ENV, "hunter2")
@@ -58,7 +57,7 @@ fn forest_headless_encrypt_keystore_with_passphrase_should_succeed() -> Result<(
 }
 
 #[test]
-fn should_create_jwt_admin_token() -> Result<()> {
+fn should_create_jwt_admin_token() -> anyhow::Result<()> {
     let (config_file, data_dir) = create_tmp_config()?;
     let token_path = data_dir.path().join("admin-token");
     daemon()

--- a/tests/keystore_tests.rs
+++ b/tests/keystore_tests.rs
@@ -13,7 +13,7 @@ use crate::common::{create_tmp_config, daemon, CommonArgs};
 // https://github.com/ChainSafe/forest/issues/2499
 #[test]
 fn forest_headless_encrypt_keystore_no_passphrase_should_fail() -> anyhow::Result<()> {
-    let (config_file, _data_dir) = create_tmp_config()?;
+    let (config_file, _data_dir) = create_tmp_config();
     daemon()
         .common_args()
         .arg("--config")
@@ -26,7 +26,7 @@ fn forest_headless_encrypt_keystore_no_passphrase_should_fail() -> anyhow::Resul
 
 #[test]
 fn forest_headless_no_encrypt_no_passphrase_should_succeed() -> anyhow::Result<()> {
-    let (config_file, data_dir) = create_tmp_config()?;
+    let (config_file, data_dir) = create_tmp_config();
     daemon()
         .common_args()
         .arg("--config")
@@ -43,7 +43,7 @@ fn forest_headless_no_encrypt_no_passphrase_should_succeed() -> anyhow::Result<(
 
 #[test]
 fn forest_headless_encrypt_keystore_with_passphrase_should_succeed() -> anyhow::Result<()> {
-    let (config_file, data_dir) = create_tmp_config()?;
+    let (config_file, data_dir) = create_tmp_config();
     daemon()
         .env(FOREST_KEYSTORE_PHRASE_ENV, "hunter2")
         .common_args()
@@ -58,7 +58,7 @@ fn forest_headless_encrypt_keystore_with_passphrase_should_succeed() -> anyhow::
 
 #[test]
 fn should_create_jwt_admin_token() -> anyhow::Result<()> {
-    let (config_file, data_dir) = create_tmp_config()?;
+    let (config_file, data_dir) = create_tmp_config();
     let token_path = data_dir.path().join("admin-token");
     daemon()
         .common_args()

--- a/tests/keystore_tests.rs
+++ b/tests/keystore_tests.rs
@@ -12,7 +12,7 @@ use crate::common::{create_tmp_config, daemon, CommonArgs};
 
 // https://github.com/ChainSafe/forest/issues/2499
 #[test]
-fn forest_headless_encrypt_keystore_no_passphrase_should_fail() -> anyhow::Result<()> {
+fn forest_headless_encrypt_keystore_no_passphrase_should_fail() {
     let (config_file, _data_dir) = create_tmp_config();
     daemon()
         .common_args()
@@ -20,12 +20,10 @@ fn forest_headless_encrypt_keystore_no_passphrase_should_fail() -> anyhow::Resul
         .arg(config_file)
         .assert()
         .failure();
-
-    Ok(())
 }
 
 #[test]
-fn forest_headless_no_encrypt_no_passphrase_should_succeed() -> anyhow::Result<()> {
+fn forest_headless_no_encrypt_no_passphrase_should_succeed() {
     let (config_file, data_dir) = create_tmp_config();
     daemon()
         .common_args()
@@ -37,12 +35,10 @@ fn forest_headless_no_encrypt_no_passphrase_should_succeed() -> anyhow::Result<(
         .success();
 
     assert!(data_dir.path().join(KEYSTORE_NAME).exists());
-
-    Ok(())
 }
 
 #[test]
-fn forest_headless_encrypt_keystore_with_passphrase_should_succeed() -> anyhow::Result<()> {
+fn forest_headless_encrypt_keystore_with_passphrase_should_succeed() {
     let (config_file, data_dir) = create_tmp_config();
     daemon()
         .env(FOREST_KEYSTORE_PHRASE_ENV, "hunter2")
@@ -53,11 +49,10 @@ fn forest_headless_encrypt_keystore_with_passphrase_should_succeed() -> anyhow::
         .success();
 
     assert!(data_dir.path().join(ENCRYPTED_KEYSTORE_NAME).exists());
-    Ok(())
 }
 
 #[test]
-fn should_create_jwt_admin_token() -> anyhow::Result<()> {
+fn should_create_jwt_admin_token() {
     let (config_file, data_dir) = create_tmp_config();
     let token_path = data_dir.path().join("admin-token");
     daemon()
@@ -72,15 +67,13 @@ fn should_create_jwt_admin_token() -> anyhow::Result<()> {
         .success();
 
     // Grab the keystore and the private key
-    let keystore = KeyStore::new(KeyStoreConfig::Persistent(data_dir.path().to_owned()))?;
-    let key_info = keystore.get(JWT_IDENTIFIER)?;
+    let keystore = KeyStore::new(KeyStoreConfig::Persistent(data_dir.path().to_owned())).unwrap();
+    let key_info = keystore.get(JWT_IDENTIFIER).unwrap();
     let key = key_info.private_key();
 
     // Validate the token
     assert!(token_path.exists());
-    let token = std::fs::read_to_string(token_path)?;
-    let allow = verify_token(&token, key)?;
+    let token = std::fs::read_to_string(token_path).unwrap();
+    let allow = verify_token(&token, key).unwrap();
     assert!(allow.contains(&"admin".to_owned()));
-
-    Ok(())
 }


### PR DESCRIPTION
# Changes
- `opt.ok_or_else(|| anyhow::anyhow!("foo"))` -> `opt.context("foo")`
- `opt.ok_or_else(|| anyhow::anyhow!("foo {}", bar))` -> `opt.with_context(||format!("foo {}", bar))`
- `#[test] fn foo() -> anyhow::Result<()>` -> `#[test] fn foo()`
- Rationalise `anyhow` imports