### PR TITLE
fix: refactor TipsetRangeSyncerFuture into idiomatic futures

### DIFF
--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -696,7 +696,15 @@ where
             match self.as_mut().tipset_tasks.poll_join_next(cx) {
                 Poll::Ready(Some(Ok(Ok(_)))) => continue,
                 Poll::Ready(Some(Ok(Err(e)))) => return Poll::Ready(Err(e)),
-                Poll::Ready(Some(Err(e))) => panic!("{e}"),
+                Poll::Ready(Some(Err(e))) => {
+                    _ = {
+                        if e.is_panic() {
+                            e.into_panic()
+                        } else {
+                            panic!("Internal error: Tipset range syncer task unexpectedly canceled: {e}");
+                        }
+                    }
+                }
                 Poll::Ready(None) => return Poll::Ready(Ok(())),
                 Poll::Pending => return Poll::Pending,
             }

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -29,11 +29,12 @@ use crate::{
 use ahash::{HashMap, HashMapExt, HashSet};
 use cid::Cid;
 use futures::stream::TryStreamExt as _;
-use futures::{stream, stream::FuturesUnordered, Stream, StreamExt, TryFutureExt};
+use futures::{stream, stream::FuturesUnordered, StreamExt, TryFutureExt};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::to_vec;
 use nonempty::{nonempty, NonEmpty};
 use thiserror::Error;
+use tokio::task::JoinSet;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::chain_sync::{
@@ -103,6 +104,8 @@ pub enum TipsetRangeSyncerError {
     TipsetParentNotFound(ChainStoreError),
     #[error("Consensus error: {0}")]
     ConsensusError(FilecoinConsensusError),
+    #[error("Other error: {0}")]
+    Other(String),
 }
 
 impl<T> From<flume::SendError<T>> for TipsetRangeSyncerError {
@@ -575,14 +578,11 @@ enum InvalidBlockStrategy {
     Forgiving,
 }
 
-type TipsetRangeSyncerFuture =
-    Pin<Box<dyn Future<Output = Result<(), TipsetRangeSyncerError>> + Send>>;
-
 pub(in crate::chain_sync) struct TipsetRangeSyncer<DB> {
     pub proposed_head: Arc<Tipset>,
     pub current_head: Arc<Tipset>,
     tipsets_included: HashSet<TipsetKeys>,
-    tipset_tasks: Pin<Box<FuturesUnordered<TipsetRangeSyncerFuture>>>,
+    tipset_tasks: JoinSet<Result<(), TipsetRangeSyncerError>>,
     state_manager: Arc<StateManager<DB>>,
     network: SyncNetworkContext<DB>,
     chain_store: Arc<ChainStore<DB>>,
@@ -605,7 +605,7 @@ where
         bad_block_cache: Arc<BadBlockCache>,
         genesis: Arc<Tipset>,
     ) -> Result<Self, TipsetRangeSyncerError> {
-        let tipset_tasks = Box::pin(FuturesUnordered::new());
+        let mut tipset_tasks = JoinSet::new();
         let tipset_range_length = proposed_head.epoch() - current_head.epoch();
 
         // Ensure the difference in epochs between the proposed and current head is >= 0
@@ -613,7 +613,7 @@ where
             return Err(TipsetRangeSyncerError::InvalidTipsetRangeLength);
         }
 
-        tipset_tasks.push(sync_tipset_range(
+        tipset_tasks.spawn(sync_tipset_range(
             proposed_head.clone(),
             current_head.clone(),
             tracker,
@@ -667,7 +667,7 @@ where
         // Keep track of tipsets included
         self.tipsets_included.insert(new_key);
 
-        self.tipset_tasks.push(sync_tipset(
+        self.tipset_tasks.spawn(sync_tipset(
             additional_head,
             self.state_manager.clone(),
             self.chain_store.clone(),
@@ -695,9 +695,12 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         loop {
-            match self.as_mut().tipset_tasks.as_mut().poll_next(cx) {
-                Poll::Ready(Some(Ok(_))) => continue,
-                Poll::Ready(Some(Err(e))) => return Poll::Ready(Err(e)),
+            match self.as_mut().tipset_tasks.poll_join_next(cx) {
+                Poll::Ready(Some(Ok(Ok(_)))) => continue,
+                Poll::Ready(Some(Ok(Err(e)))) => return Poll::Ready(Err(e)),
+                Poll::Ready(Some(Err(e))) => {
+                    return Poll::Ready(Err(TipsetRangeSyncerError::Other(e.to_string())))
+                }
                 Poll::Ready(None) => return Poll::Ready(Ok(())),
                 Poll::Pending => return Poll::Pending,
             }
@@ -710,7 +713,7 @@ where
 /// messages going forward on the chain and validate each extension. Finally set
 /// the proposed head as the heaviest tipset.
 #[allow(clippy::too_many_arguments)]
-fn sync_tipset_range<DB: Blockstore + Sync + Send + 'static>(
+async fn sync_tipset_range<DB: Blockstore + Sync + Send + 'static>(
     proposed_head: Arc<Tipset>,
     current_head: Arc<Tipset>,
     tracker: crate::chain_sync::chain_muxer::WorkerState,
@@ -720,77 +723,75 @@ fn sync_tipset_range<DB: Blockstore + Sync + Send + 'static>(
     network: SyncNetworkContext<DB>,
     bad_block_cache: Arc<BadBlockCache>,
     genesis: Arc<Tipset>,
-) -> TipsetRangeSyncerFuture {
-    Box::pin(async move {
-        tracker
-            .write()
-            .init(current_head.clone(), proposed_head.clone());
+) -> Result<(), TipsetRangeSyncerError> {
+    tracker
+        .write()
+        .init(current_head.clone(), proposed_head.clone());
 
-        let parent_tipsets = match sync_headers_in_reverse(
-            tracker.clone(),
-            tipset_range_length,
-            proposed_head.clone(),
-            &current_head,
-            &bad_block_cache,
-            &chain_store,
-            network.clone(),
-        )
-        .await
-        {
-            Ok(parent_tipsets) => parent_tipsets,
-            Err(why) => {
-                tracker.write().error(why.to_string());
-                return Err(why);
-            }
-        };
-
-        // Persist the blocks from the synced Tipsets into the store
-        tracker.write().set_stage(SyncStage::Headers);
-        let headers: Vec<&BlockHeader> = parent_tipsets.iter().flat_map(|t| t.blocks()).collect();
-        if let Err(why) = persist_objects(chain_store.blockstore(), &headers) {
-            tracker.write().error(why.to_string());
-            return Err(why.into());
-        };
-
-        //  Sync and validate messages from the tipsets
-        tracker.write().set_stage(SyncStage::Messages);
-        if let Err(why) = sync_messages_check_state(
-            tracker.clone(),
-            state_manager,
-            network,
-            chain_store.clone(),
-            &bad_block_cache,
-            parent_tipsets,
-            &genesis,
-            InvalidBlockStrategy::Strict,
-        )
-        .await
-        {
-            error!("Sync messages check state failed for tipset range");
+    let parent_tipsets = match sync_headers_in_reverse(
+        tracker.clone(),
+        tipset_range_length,
+        proposed_head.clone(),
+        &current_head,
+        &bad_block_cache,
+        &chain_store,
+        network.clone(),
+    )
+    .await
+    {
+        Ok(parent_tipsets) => parent_tipsets,
+        Err(why) => {
             tracker.write().error(why.to_string());
             return Err(why);
-        };
-        tracker.write().set_stage(SyncStage::Complete);
+        }
+    };
 
-        // At this point the head is synced and it can be set in the store as the
-        // heaviest
-        debug!(
-            "Tipset range successfully verified: EPOCH = [{}, {}], HEAD_KEY = {:?}",
+    // Persist the blocks from the synced Tipsets into the store
+    tracker.write().set_stage(SyncStage::Headers);
+    let headers: Vec<&BlockHeader> = parent_tipsets.iter().flat_map(|t| t.blocks()).collect();
+    if let Err(why) = persist_objects(chain_store.blockstore(), &headers) {
+        tracker.write().error(why.to_string());
+        return Err(why.into());
+    };
+
+    //  Sync and validate messages from the tipsets
+    tracker.write().set_stage(SyncStage::Messages);
+    if let Err(why) = sync_messages_check_state(
+        tracker.clone(),
+        state_manager,
+        network,
+        chain_store.clone(),
+        &bad_block_cache,
+        parent_tipsets,
+        &genesis,
+        InvalidBlockStrategy::Strict,
+    )
+    .await
+    {
+        error!("Sync messages check state failed for tipset range");
+        tracker.write().error(why.to_string());
+        return Err(why);
+    };
+    tracker.write().set_stage(SyncStage::Complete);
+
+    // At this point the head is synced and it can be set in the store as the
+    // heaviest
+    debug!(
+        "Tipset range successfully verified: EPOCH = [{}, {}], HEAD_KEY = {:?}",
+        proposed_head.epoch(),
+        current_head.epoch(),
+        proposed_head.key()
+    );
+    if let Err(why) = chain_store.put_tipset(&proposed_head) {
+        error!(
+            "Putting tipset range head [EPOCH = {}, KEYS = {:?}] in the store failed: {}",
             proposed_head.epoch(),
-            current_head.epoch(),
-            proposed_head.key()
+            proposed_head.key(),
+            why
         );
-        if let Err(why) = chain_store.put_tipset(&proposed_head) {
-            error!(
-                "Putting tipset range head [EPOCH = {}, KEYS = {:?}] in the store failed: {}",
-                proposed_head.epoch(),
-                proposed_head.key(),
-                why
-            );
-            return Err(why.into());
-        };
-        Ok(())
-    })
+        return Err(why.into());
+    };
+    Ok(())
 }
 
 /// Download headers between the proposed head and the current one available
@@ -913,51 +914,49 @@ async fn sync_headers_in_reverse<DB: Blockstore + Sync + Send + 'static>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn sync_tipset<DB: Blockstore + Sync + Send + 'static>(
+async fn sync_tipset<DB: Blockstore + Sync + Send + 'static>(
     proposed_head: Arc<Tipset>,
     state_manager: Arc<StateManager<DB>>,
     chain_store: Arc<ChainStore<DB>>,
     network: SyncNetworkContext<DB>,
     bad_block_cache: Arc<BadBlockCache>,
     genesis: Arc<Tipset>,
-) -> TipsetRangeSyncerFuture {
-    Box::pin(async move {
-        // Persist the blocks from the proposed tipsets into the store
-        let headers: Vec<&BlockHeader> = proposed_head.blocks().iter().collect();
-        persist_objects(chain_store.blockstore(), &headers)?;
+) -> Result<(), TipsetRangeSyncerError> {
+    // Persist the blocks from the proposed tipsets into the store
+    let headers: Vec<&BlockHeader> = proposed_head.blocks().iter().collect();
+    persist_objects(chain_store.blockstore(), &headers)?;
 
-        // Sync and validate messages from the tipsets
-        if let Err(e) = sync_messages_check_state(
-            // Include a dummy WorkerState
-            crate::chain_sync::chain_muxer::WorkerState::default(),
-            state_manager,
-            network,
-            chain_store.clone(),
-            &bad_block_cache,
-            vec![proposed_head.clone()],
-            &genesis,
-            InvalidBlockStrategy::Forgiving,
-        )
-        .await
-        {
-            warn!("Sync messages check state failed for single tipset");
-            return Err(e);
-        }
+    // Sync and validate messages from the tipsets
+    if let Err(e) = sync_messages_check_state(
+        // Include a dummy WorkerState
+        crate::chain_sync::chain_muxer::WorkerState::default(),
+        state_manager,
+        network,
+        chain_store.clone(),
+        &bad_block_cache,
+        vec![proposed_head.clone()],
+        &genesis,
+        InvalidBlockStrategy::Forgiving,
+    )
+    .await
+    {
+        warn!("Sync messages check state failed for single tipset");
+        return Err(e);
+    }
 
-        // Add the tipset to the store. The tipset will be expanded with other blocks
-        // with the same [epoch, parents] before updating the heaviest Tipset in
-        // the store.
-        if let Err(why) = chain_store.put_tipset(&proposed_head) {
-            error!(
-                "Putting tipset [EPOCH = {}, KEYS = {:?}] in the store failed: {}",
-                proposed_head.epoch(),
-                proposed_head.key(),
-                why
-            );
-            return Err(why.into());
-        };
-        Ok(())
-    })
+    // Add the tipset to the store. The tipset will be expanded with other blocks
+    // with the same [epoch, parents] before updating the heaviest Tipset in
+    // the store.
+    if let Err(why) = chain_store.put_tipset(&proposed_head) {
+        error!(
+            "Putting tipset [EPOCH = {}, KEYS = {:?}] in the store failed: {}",
+            proposed_head.epoch(),
+            proposed_head.key(),
+            why
+        );
+        return Err(why.into());
+    };
+    Ok(())
 }
 
 /// Ask peers for the [`Message`]s that these [`Tipset`]s should contain.

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -697,12 +697,12 @@ where
                 Poll::Ready(Some(Ok(Ok(_)))) => continue,
                 Poll::Ready(Some(Ok(Err(e)))) => return Poll::Ready(Err(e)),
                 Poll::Ready(Some(Err(e))) => {
-                    _ = {
-                        if e.is_panic() {
-                            e.into_panic()
-                        } else {
-                            panic!("Internal error: Tipset range syncer task unexpectedly canceled: {e}");
-                        }
+                    if e.is_panic() {
+                        std::panic::resume_unwind(e.into_panic());
+                    } else {
+                        panic!(
+                            "Internal error: Tipset range syncer task unexpectedly canceled: {e}"
+                        );
                     }
                 }
                 Poll::Ready(None) => return Poll::Ready(Ok(())),

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -104,8 +104,6 @@ pub enum TipsetRangeSyncerError {
     TipsetParentNotFound(ChainStoreError),
     #[error("Consensus error: {0}")]
     ConsensusError(FilecoinConsensusError),
-    #[error("Other error: {0}")]
-    Other(String),
 }
 
 impl<T> From<flume::SendError<T>> for TipsetRangeSyncerError {
@@ -698,9 +696,7 @@ where
             match self.as_mut().tipset_tasks.poll_join_next(cx) {
                 Poll::Ready(Some(Ok(Ok(_)))) => continue,
                 Poll::Ready(Some(Ok(Err(e)))) => return Poll::Ready(Err(e)),
-                Poll::Ready(Some(Err(e))) => {
-                    return Poll::Ready(Err(TipsetRangeSyncerError::Other(e.to_string())))
-                }
+                Poll::Ready(Some(Err(e))) => panic!("{e}"),
                 Poll::Ready(None) => return Poll::Ready(Ok(())),
                 Poll::Pending => return Poll::Pending,
             }

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -697,12 +697,10 @@ where
                 Poll::Ready(Some(Ok(Ok(_)))) => continue,
                 Poll::Ready(Some(Ok(Err(e)))) => return Poll::Ready(Err(e)),
                 Poll::Ready(Some(Err(e))) => {
-                    if e.is_panic() {
-                        std::panic::resume_unwind(e.into_panic());
+                    if let Ok(p) = e.try_into_panic() {
+                        std::panic::resume_unwind(p);
                     } else {
-                        panic!(
-                            "Internal error: Tipset range syncer task unexpectedly canceled: {e}"
-                        );
+                        panic!("Internal error: Tipset range syncer task unexpectedly canceled");
                     }
                 }
                 Poll::Ready(None) => return Poll::Ready(Ok(())),

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -693,7 +693,7 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         loop {
-            match self.as_mut().tipset_tasks.poll_join_next(cx) {
+            match ready!(self.as_mut().tipset_tasks.poll_join_next(cx)) {
                 Poll::Ready(Some(Ok(Ok(_)))) => continue,
                 Poll::Ready(Some(Ok(Err(e)))) => return Poll::Ready(Err(e)),
                 Poll::Ready(Some(Err(e))) => {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/3185

Changes introduced in this pull request:

- refactor `TipsetRangeSyncerFuture` into idiomatic futures
- (`TipsetProcessorFuture` no longer exists)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
