### PR TITLE
fix(ci): use local FS for sccache on fuzzy

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,11 +24,6 @@ env:
   CI: 1
   CARGO_INCREMENTAL: 0
   CACHE_TIMEOUT_MINUTES: 5
-  SCCACHE_ENDPOINT: ${{ vars.SCCACHE_ENDPOINT }}
-  SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-  SCCACHE_REGION: ${{ vars.SCCACHE_REGION }}
-  AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
-  AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
   RUSTC_WRAPPER: "sccache"
   CC: "sccache clang"
   CXX: "sccache clang++"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Since `/home/fuzzy/.cache/sccache` is preserved after each CI job (and we need to clean it up periodically), there's no point in using a remote backend for `sccache` on `fuzzy`, to slightly speedup the job

Question: do we really need both `test` and `test-release`? As they won't run in parallel with the single `fuzzy` runner, disabling one of them could reduce the in-queue time.  @lemmih @LesnyRumcajs 

Changes introduced in this pull request:

- Update `sccache` config to use local FS for jobs that run on `fuzzy`

https://github.com/ChainSafe/forest/actions/runs/6466767740/job/17556501553?pr=3564#step:15:2

> Compile requests                     991
Compile requests executed            7[6](https://github.com/ChainSafe/forest/actions/runs/6466767740/job/17556501553?pr=3564#step:15:6)6
Cache hits                           [7](https://github.com/ChainSafe/forest/actions/runs/6466767740/job/17556501553?pr=3564#step:15:7)61
Cache hits (C/C++)                    60
Cache hits (Rust)                    701
Cache misses                           2
Cache misses (Rust)                    2

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
