### PR TITLE
remove flaky rolling db test

### DIFF
--- a/src/db/rolling/impls.rs
+++ b/src/db/rolling/impls.rs
@@ -276,34 +276,11 @@ mod tests {
     use cid::{multihash::MultihashDigest, Cid};
     use fvm_ipld_blockstore::Blockstore;
     use pretty_assertions::assert_eq;
-    use quickcheck_macros::quickcheck;
     use rand::Rng;
     use tempfile::TempDir;
 
     use super::*;
     use crate::libp2p_bitswap::BitswapStoreRead;
-
-    #[quickcheck]
-    fn ensure_settings_are_transferred(keys: Vec<String>) -> anyhow::Result<()> {
-        let db_root = TempDir::new()?;
-        let rolling_db = RollingDB::load_or_create(db_root.path().into(), Default::default())?;
-        // Write settings
-        for key in keys.iter() {
-            rolling_db.write_obj(key, key)?;
-        }
-
-        // Roll DB twice
-        rolling_db.next_current(1)?;
-        rolling_db.next_current(2)?;
-
-        // Check if settings are rolled over
-        for key in keys.iter() {
-            let v: String = rolling_db.read_obj(key)?.unwrap();
-            assert_eq!(&v, key);
-        }
-
-        Ok(())
-    }
 
     #[test]
     fn rolling_db_behaviour_tests() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- the test is sometimes timing out because of many values quickcheck wants to provide. The rolling db is going away, so let's not spend more time on this than necessary. See https://github.com/ChainSafe/forest/pull/3504

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
