### PR TITLE
chore: trace verbose coverage report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
 dependencies = [
  "serde",
 ]
@@ -6133,9 +6133,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]

--- a/scripts/gen_coverage_report.sh
+++ b/scripts/gen_coverage_report.sh
@@ -12,7 +12,7 @@
 # llvm-cov can be installed by running: cargo install cargo-llvm-cov
 #
 
-set +e
+set +euxo pipefail
 
 TMP_DIR=$(mktemp --directory)
 TOKEN_PATH="$TMP_DIR/forest_admin_token"


### PR DESCRIPTION
https://github.com/ChainSafe/forest/actions/runs/6484148389/job/17610655915

has no logs, and failed twice.
Maybe this will help?