### PR TITLE
wibble: fix RPC parameter in ci_check script 

### DIFF
--- a/scripts/devnet/ci_check.sh
+++ b/scripts/devnet/ci_check.sh
@@ -13,7 +13,7 @@ source .env
 # Allow for 300 seconds of sync time.
 function get_sync_height {
   curl --silent -X POST -H "Content-Type: application/json" \
-       --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.ChainHead","params":"null"}' \
+       --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.ChainHead","param":"null"}' \
        "http://127.0.0.1:${FOREST_RPC_PORT}/rpc/v0" | jq '.result.Height'
 }
 


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:

- Change `params` to `param`.

At present, the Forest RPC doesn't care if the `param` field is missing. But this may change in the future to align us more with Lotus. Ideally, we want a valid call to Forest to be a valid call to Lotus.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
