### PR TITLE
fix: remove unused cli options from `forest-cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9234,7 +9234,7 @@ checksum = "aefc3198c66d1ec34c6543abd945f813298180870aea61ab295af0604b4cd881"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2,17 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::ffi::OsString;
-use std::sync::Arc;
 
 use crate::cli_shared::logger;
 use crate::daemon::get_actual_chain_name;
-use crate::networks::ChainConfig;
 use crate::shim::address::{CurrentNetwork, Network};
-use crate::utils::{bail_moved_cmd, io::ProgressBar};
-use crate::{
-    cli::subcommands::{cli_error_and_die, Cli},
-    rpc_client::state_network_name,
-};
+use crate::utils::bail_moved_cmd;
+use crate::{cli::subcommands::Cli, rpc_client::state_network_name};
 use clap::Parser;
 
 use super::subcommands::Subcommand;
@@ -22,60 +17,42 @@ where
     ArgT: Into<OsString> + Clone,
 {
     // Capture Cli inputs
-    let Cli { opts, cmd } = Cli::parse_from(args);
+    let Cli { token, cmd } = Cli::parse_from(args);
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap()
         .block_on(async {
-            match opts.to_config() {
-                Ok((mut config, _)) => {
-                    logger::setup_logger(&opts);
-                    ProgressBar::set_progress_bars_visibility(config.client.show_progress_bars);
-                    if opts.dry_run {
-                        return Ok(());
-                    }
-                    let opts = &opts;
-                    if opts.chain.is_none() {
-                        if let Ok(name) = state_network_name((), &config.client.rpc_token).await {
-                            let name = get_actual_chain_name(&name);
-                            if name == "calibnet" {
-                                config.chain = Arc::new(ChainConfig::calibnet());
-                            } else if name == "devnet" {
-                                config.chain = Arc::new(ChainConfig::devnet());
-                            }
-                        }
-                    }
-                    if config.chain.is_testnet() {
-                        CurrentNetwork::set_global(Network::Testnet);
-                    }
-                    // Run command
-                    match cmd {
-                        Subcommand::Fetch(_cmd) => {
-                            bail_moved_cmd("fetch-params", "forest-tool fetch-params")
-                        }
-                        Subcommand::Chain(cmd) => cmd.run(config).await,
-                        Subcommand::Auth(cmd) => cmd.run(config).await,
-                        Subcommand::Net(cmd) => cmd.run(config).await,
-                        Subcommand::Wallet(..) => bail_moved_cmd("wallet", "forest-wallet"),
-                        Subcommand::Sync(cmd) => cmd.run(config).await,
-                        Subcommand::Mpool(cmd) => cmd.run(config).await,
-                        Subcommand::State(cmd) => cmd.run(config).await,
-                        Subcommand::Config(cmd) => cmd.run(&config, &mut std::io::stdout()),
-                        Subcommand::Send(cmd) => cmd.run(config).await,
-                        Subcommand::Info(cmd) => cmd.run(config, opts).await,
-                        Subcommand::DB(cmd) => cmd.run(&config).await,
-                        Subcommand::Snapshot(cmd) => cmd.run(config).await,
-                        Subcommand::Archive(cmd) => cmd.run().await,
-                        Subcommand::Attach(cmd) => cmd.run(config),
-                        Subcommand::Shutdown(cmd) => cmd.run(config).await,
-                        Subcommand::Car(..) => bail_moved_cmd("car", "forest-tool"),
-                    }
+            let mut config = crate::Config::default();
+            config.client.rpc_token = token;
+            logger::setup_logger(&crate::cli_shared::cli::CliOpts::default());
+            if let Ok(name) = state_network_name((), &config.client.rpc_token).await {
+                if get_actual_chain_name(&name) != "mainnet" {
+                    CurrentNetwork::set_global(Network::Testnet);
                 }
-                Err(e) => {
-                    cli_error_and_die(format!("Error parsing config: {e}"), 1);
+            }
+            // Run command
+            match cmd {
+                Subcommand::Fetch(_cmd) => {
+                    bail_moved_cmd("fetch-params", "forest-tool fetch-params")
                 }
+                Subcommand::Chain(cmd) => cmd.run(config).await,
+                Subcommand::Auth(cmd) => cmd.run(config).await,
+                Subcommand::Net(cmd) => cmd.run(config).await,
+                Subcommand::Wallet(..) => bail_moved_cmd("wallet", "forest-wallet"),
+                Subcommand::Sync(cmd) => cmd.run(config).await,
+                Subcommand::Mpool(cmd) => cmd.run(config).await,
+                Subcommand::State(cmd) => cmd.run(config).await,
+                Subcommand::Config(cmd) => cmd.run(&config, &mut std::io::stdout()),
+                Subcommand::Send(cmd) => cmd.run(config).await,
+                Subcommand::Info(cmd) => cmd.run(config).await,
+                Subcommand::DB(cmd) => cmd.run(&config).await,
+                Subcommand::Snapshot(cmd) => cmd.run(config).await,
+                Subcommand::Archive(cmd) => cmd.run().await,
+                Subcommand::Attach(cmd) => cmd.run(config),
+                Subcommand::Shutdown(cmd) => cmd.run(config).await,
+                Subcommand::Car(..) => bail_moved_cmd("car", "forest-tool"),
             }
         })
 }

--- a/src/cli/subcommands/info_cmd.rs
+++ b/src/cli/subcommands/info_cmd.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::blocks::Tipset;
-use crate::cli_shared::cli::CliOpts;
 use crate::lotus_json::LotusJson;
 use crate::rpc_client::{
     chain_head, node_ops::node_status, start_time, state_network_name, wallet_balance,
@@ -161,7 +160,7 @@ impl NodeStatusInfo {
 }
 
 impl InfoCommand {
-    pub async fn run(self, config: Config, _opts: &CliOpts) -> anyhow::Result<()> {
+    pub async fn run(self, config: Config) -> anyhow::Result<()> {
         let res = tokio::try_join!(
             node_status((), &config.client.rpc_token),
             chain_head(&config.client.rpc_token),

--- a/src/cli/subcommands/mod.rs
+++ b/src/cli/subcommands/mod.rs
@@ -25,7 +25,7 @@ use std::io::{self, Write};
 
 use crate::blocks::Tipset;
 pub(crate) use crate::cli_shared::cli::Config;
-use crate::cli_shared::cli::{CliOpts, HELP_MESSAGE};
+use crate::cli_shared::cli::HELP_MESSAGE;
 use crate::lotus_json::LotusJson;
 use crate::utils::version::FOREST_VERSION_STRING;
 use cid::Cid;
@@ -49,8 +49,9 @@ use crate::cli::subcommands::info_cmd::InfoCommand;
 #[command(name = env!("CARGO_PKG_NAME"), author = env!("CARGO_PKG_AUTHORS"), version = FOREST_VERSION_STRING.as_str(), about = env!("CARGO_PKG_DESCRIPTION"))]
 #[command(help_template(HELP_MESSAGE))]
 pub struct Cli {
-    #[command(flatten)]
-    pub opts: CliOpts,
+    /// Client JWT token to use for JSON-RPC authentication
+    #[arg(short, long)]
+    pub token: Option<String>,
     #[command(subcommand)]
     pub cmd: Subcommand,
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -63,3 +63,64 @@ fn test_download_location_of_proof_parameter_files_default() {
         .stdout(tmp_param_dir.to_string_lossy().into_owned() + "\n")
         .success();
 }
+
+// Verify that a configuration path can be set with `--config` flag. We
+// assume 'data_dir' will be created iff the configuration is correctly parsed.
+#[test]
+fn test_config_parameter() {
+    let tmp_dir = TempDir::new().unwrap().into_path();
+    let config = Config {
+        client: Client {
+            data_dir: tmp_dir.clone(),
+            encrypt_keystore: false,
+            ..Client::default()
+        },
+        ..Config::default()
+    };
+
+    std::fs::remove_dir(&tmp_dir).unwrap();
+
+    let mut config_file = tempfile::Builder::new().tempfile().unwrap();
+    config_file
+        .write_all(toml::to_string(&config).unwrap().as_bytes())
+        .expect("Failed writing configuration!");
+
+    Command::cargo_bin("forest")
+        .unwrap()
+        .arg("--config")
+        .arg(config_file.path())
+        .arg("--exit-after-init")
+        .assert()
+        .success();
+    assert!(tmp_dir.is_dir());
+}
+
+// Verify that a configuration path can be set with FOREST_CONFIG_PATH. We
+// assume 'data_dir' will be created iff the configuration is correctly parsed.
+#[test]
+fn test_config_env_var() {
+    let tmp_dir = TempDir::new().unwrap().into_path();
+    let config = Config {
+        client: Client {
+            data_dir: tmp_dir.clone(),
+            encrypt_keystore: false,
+            ..Client::default()
+        },
+        ..Config::default()
+    };
+
+    std::fs::remove_dir(&tmp_dir).unwrap();
+
+    let mut config_file = tempfile::Builder::new().tempfile().unwrap();
+    config_file
+        .write_all(toml::to_string(&config).unwrap().as_bytes())
+        .expect("Failed writing configuration!");
+
+    Command::cargo_bin("forest")
+        .unwrap()
+        .env("FOREST_CONFIG_PATH", config_file.path())
+        .arg("--exit-after-init")
+        .assert()
+        .success();
+    assert!(tmp_dir.is_dir());
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -88,7 +88,6 @@ fn test_config_parameter() {
         .common_args()
         .arg("--config")
         .arg(config_file.path())
-        .arg("--exit-after-init")
         .assert()
         .success();
     assert!(tmp_dir.is_dir());
@@ -118,7 +117,6 @@ fn test_config_env_var() {
     daemon()
         .common_args()
         .env("FOREST_CONFIG_PATH", config_file.path())
-        .arg("--exit-after-init")
         .assert()
         .success();
     assert!(tmp_dir.is_dir());

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::io::Write;
 
-use assert_cmd::Command;
 use forest_filecoin::{Client, Config};
 use tempfile::TempDir;
 
+pub mod common;
+use crate::common::{cli, daemon, tool, CommonArgs};
+
 #[test]
 fn test_config_subcommand_produces_valid_toml_configuration_dump() {
-    let cmd = Command::cargo_bin("forest-cli")
-        .unwrap()
+    let cmd = cli()
         .arg("--token")
         .arg("Azazello")
         .arg("config")
@@ -25,8 +26,7 @@ fn test_config_subcommand_produces_valid_toml_configuration_dump() {
 fn test_download_location_of_proof_parameter_files_env() {
     let tmp_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("forest-tool")
-        .unwrap()
+    tool()
         .env("FIL_PROOFS_PARAMETER_CACHE", tmp_dir.path())
         .arg("fetch-params")
         .arg("--keys")
@@ -53,8 +53,7 @@ fn test_download_location_of_proof_parameter_files_default() {
         .write_all(toml::to_string(&config).unwrap().as_bytes())
         .expect("Failed writing configuration!");
 
-    Command::cargo_bin("forest-tool")
-        .unwrap()
+    tool()
         .env("FOREST_CONFIG_PATH", config_file.path())
         .arg("fetch-params")
         .arg("--keys")
@@ -85,8 +84,8 @@ fn test_config_parameter() {
         .write_all(toml::to_string(&config).unwrap().as_bytes())
         .expect("Failed writing configuration!");
 
-    Command::cargo_bin("forest")
-        .unwrap()
+    daemon()
+        .common_args()
         .arg("--config")
         .arg(config_file.path())
         .arg("--exit-after-init")
@@ -116,8 +115,8 @@ fn test_config_env_var() {
         .write_all(toml::to_string(&config).unwrap().as_bytes())
         .expect("Failed writing configuration!");
 
-    Command::cargo_bin("forest")
-        .unwrap()
+    daemon()
+        .common_args()
         .env("FOREST_CONFIG_PATH", config_file.path())
         .arg("--exit-after-init")
         .assert()

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,10 +1,9 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
-use std::{io::Write, net::SocketAddr, path::PathBuf, str::FromStr};
+use std::io::Write;
 
 use assert_cmd::Command;
 use forest_filecoin::{Client, Config};
-use rand::Rng;
 use tempfile::TempDir;
 
 #[test]

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -11,8 +11,6 @@ use tempfile::TempDir;
 fn test_config_subcommand_produces_valid_toml_configuration_dump() {
     let cmd = Command::cargo_bin("forest-cli")
         .unwrap()
-        .arg("--rpc")
-        .arg("true")
         .arg("--token")
         .arg("Azazello")
         .arg("config")
@@ -22,105 +20,6 @@ fn test_config_subcommand_produces_valid_toml_configuration_dump() {
 
     let output = &cmd.get_output().stdout;
     toml::from_str::<Config>(std::str::from_utf8(output).unwrap()).expect("Invalid configuration!");
-}
-
-#[test]
-fn test_overrides_are_reflected_in_configuration_dump() {
-    let mut rng = rand::thread_rng();
-    let randomized_metrics_host = format!("127.0.0.1:{}", rng.gen::<u16>());
-
-    let cmd = Command::cargo_bin("forest-cli")
-        .unwrap()
-        .arg("--rpc")
-        .arg("true")
-        .arg("--token")
-        .arg("Azazello")
-        .arg("--metrics-address")
-        .arg(&randomized_metrics_host)
-        .arg("config")
-        .arg("dump")
-        .assert()
-        .success();
-
-    let output = &cmd.get_output().stdout;
-    let config = toml::from_str::<Config>(std::str::from_utf8(output).unwrap())
-        .expect("Invalid configuration!");
-
-    assert_eq!(
-        config.client.metrics_address,
-        SocketAddr::from_str(&randomized_metrics_host).unwrap()
-    );
-}
-
-#[test]
-fn test_reading_configuration_from_file() {
-    let mut rng = rand::thread_rng();
-
-    let expected_config = Config {
-        client: Client {
-            rpc_token: Some("Azazello".into()),
-            genesis_file: Some("cthulhu".into()),
-            encrypt_keystore: false,
-            metrics_address: SocketAddr::from_str(&format!("127.0.0.1:{}", rng.gen::<u16>()))
-                .unwrap(),
-            ..Client::default()
-        },
-        ..Config::default()
-    };
-
-    let mut config_file = tempfile::Builder::new().tempfile().unwrap();
-    config_file
-        .write_all(toml::to_string(&expected_config).unwrap().as_bytes())
-        .expect("Failed writing configuration!");
-
-    let cmd = Command::cargo_bin("forest-cli")
-        .unwrap()
-        .arg("--rpc")
-        .arg("true")
-        .arg("--token")
-        .arg("Azazello")
-        .arg("--config")
-        .arg(config_file.path())
-        .arg("config")
-        .arg("dump")
-        .assert()
-        .success();
-
-    let output = &cmd.get_output().stdout;
-    let actual_config = toml::from_str::<Config>(std::str::from_utf8(output).unwrap())
-        .expect("Invalid configuration!");
-
-    assert_eq!(expected_config, actual_config);
-}
-
-#[test]
-fn test_config_env_var() {
-    let expected_config = Config {
-        client: Client {
-            rpc_token: Some("some_rpc_token".into()),
-            data_dir: PathBuf::from("some_path_buf"),
-            ..Client::default()
-        },
-        ..Config::default()
-    };
-
-    let mut config_file = tempfile::Builder::new().tempfile().unwrap();
-    config_file
-        .write_all(toml::to_string(&expected_config).unwrap().as_bytes())
-        .unwrap();
-
-    let cmd = Command::cargo_bin("forest-cli")
-        .unwrap()
-        .env("FOREST_CONFIG_PATH", config_file.path())
-        .arg("config")
-        .arg("dump")
-        .assert()
-        .success();
-
-    let output = &cmd.get_output().stdout;
-    let actual_config = toml::from_str::<Config>(std::str::from_utf8(output).unwrap()).unwrap();
-
-    assert_eq!(expected_config, actual_config);
 }
 
 #[test]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- remove command-line flags that were meant for the daemon (such as `--halt-after-import`).

After:
```
forest-filecoin 0.13.0+git.6674ad36d
ChainSafe Systems <info@chainsafe.io>
Rust Filecoin implementation.

USAGE:
  forest-cli [OPTIONS] <COMMAND>

SUBCOMMANDS:
  chain     Interact with Filecoin blockchain
  auth      Manage RPC permissions
  net       Manage P2P network
  sync      Inspect or interact with the chain synchronizer
  mpool     Interact with the message pool
  state     Interact with and query Filecoin chain state
  config    Manage node configuration
  snapshot  Manage snapshots
  archive   Manage archives
  send      Send funds between accounts
  info      Print node info
  db        Database management
  attach    Attach to daemon via a JavaScript console
  shutdown  Shutdown Forest
  help      Print this message or the help of the given subcommand(s)

OPTIONS:
  -t, --token <TOKEN>  Client JWT token to use for JSON-RPC authentication
  -h, --help           Print help
  -V, --version        Print version
```

Before:
```
forest-filecoin 0.13.0+git.49aa652b0
ChainSafe Systems <info@chainsafe.io>
Rust Filecoin implementation.

USAGE:
  forest-cli [OPTIONS] <COMMAND>

SUBCOMMANDS:
  chain     Interact with Filecoin blockchain
  auth      Manage RPC permissions
  net       Manage P2P network
  sync      Inspect or interact with the chain synchronizer
  mpool     Interact with the message pool
  state     Interact with and query Filecoin chain state
  config    Manage node configuration
  snapshot  Manage snapshots
  archive   Manage archives
  send      Send funds between accounts
  info      Print node info
  db        Database management
  attach    Attach to daemon via a JavaScript console
  shutdown  Shutdown Forest
  help      Print this message or the help of the given subcommand(s)

OPTIONS:
  -c, --config <CONFIG>
          A TOML file containing relevant configurations
  -g, --genesis <GENESIS>
          The genesis CAR file
  -r, --rpc <RPC>
          Allow RPC to be active or not (default: true) [possible values: true, false]
  -t, --token <TOKEN>
          Client JWT token to use for JSON-RPC authentication
      --metrics-address <METRICS_ADDRESS>
          Address used for metrics collection server. By defaults binds on localhost on port 6116
      --rpc-address <RPC_ADDRESS>
          Address used for RPC. By defaults binds on localhost on port 2345
  -k, --kademlia <KADEMLIA>
          Allow Kademlia (default: true) [possible values: true, false]
      --mdns <MDNS>
          Allow MDNS (default: false) [possible values: true, false]
      --height <HEIGHT>
          Validate snapshot at given EPOCH, use a negative value -N to validate the last N EPOCH(s) starting at HEAD
      --head <HEAD>
          Sets the current HEAD epoch to validate to. Useful to specify a smaller range in conjunction with `height`, ignored if `height` is unspecified
      --import-snapshot <IMPORT_SNAPSHOT>
          Import a snapshot from a local CAR file or URL
      --consume-snapshot <CONSUME_SNAPSHOT>
          Import a snapshot from a local CAR file and delete it, or from a URL
      --halt-after-import
          Halt with exit code 0 after successfully importing a snapshot
      --import-chain <IMPORT_CHAIN>
          Import a chain from a local CAR file or URL
      --skip-load <SKIP_LOAD>
          Skips loading CAR file and uses header to index chain. Assumes a pre-loaded database [possible values: true, false]
      --req-window <REQ_WINDOW>
          Number of tipsets requested over chain exchange (default is 200)
      --tipset-sample-size <TIPSET_SAMPLE_SIZE>
          Number of tipsets to include in the sample that determines what the network head is
      --target-peer-count <TARGET_PEER_COUNT>
          Amount of Peers we want to be connected to (default is 75)
      --encrypt-keystore <ENCRYPT_KEYSTORE>
          Encrypt the key-store (default: true) [possible values: true, false]
      --chain <CHAIN>
          Choose network chain to sync to
      --detach
          Daemonize Forest process
      --auto-download-snapshot
          Automatically download a chain specific snapshot to sync with the Filecoin network if needed
      --color <COLOR>
          Enable or disable colored logging in `stdout` [default: auto]
      --show-progress-bars <SHOW_PROGRESS_BARS>
          Display progress bars mode [always, never, auto]. Auto will display if TTY
      --tokio-console
          Turn on tokio-console support for debugging
      --loki
          Send telemetry to `grafana loki`
      --loki-endpoint <LOKI_ENDPOINT>
          Endpoint of `grafana loki` [default: http://127.0.0.1:3100]
      --log-dir <LOG_DIR>
          Specify a directory into which rolling log files should be appended
      --exit-after-init
          Exit after basic daemon initialization
      --save-token <SAVE_TOKEN>
          If provided, indicates the file to which to save the admin token
      --track-peak-rss
          Track peak physical memory usage and print on exit
      --no-gc
          Disable the automatic database garbage collection
      --dry-run
          Check your command-line options and configuration file if one is used
  -h, --help
          Print help
  -V, --version
          Print version
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
