### PR TITLE
fix: don't drop colliding keys from ForestCAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
 ### Fixed
 
+- [#3590](https://github.com/ChainSafe/forest/pull/3590) Fix bug in ForestCAR
+  encoder that would cause corrupted archives if a hash-collision happened.
+
 ## Forest v0.13.0 "Holocron"
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9234,7 +9234,7 @@ checksum = "aefc3198c66d1ec34c6543abd945f813298180870aea61ab295af0604b4cd881"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- When gathering the mapping from hash to zstd frame offset, use a vector rather than a hashmap. Colliding hashes should be able to point to different zstd frames.

There is a small chance some of the archival ForestCAR files are invalid. Fortunately, it is easy to verify. I'll re-scan the files and re-generate any broken archives.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
