### PR TITLE
feat: basic validation of CAR files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 
 ### Added
 
+- [#3591](https://github.com/ChainSafe/forest/pull/3591) Add
+  `forest-tool car validate` command for checking non-filecoin invariants in CAR
+  files.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 
 ### Added
 
+- [#3591](https://github.com/ChainSafe/forest/pull/3591) Add
+  `forest-tool car validate` command for checking non-filecoin invariants in CAR
+  files.
+
 ### Changed
 
 ### Removed
@@ -43,9 +47,6 @@
 
 - [#3422](https://github.com/ChainSafe/forest/issues/3422) Add NV21 (Watermelon)
   support for calibration network.
-- [#3591](https://github.com/ChainSafe/forest/pull/3591) Add
-  `forest-tool car validate` command for checking non-filecoin invariants in CAR
-  files.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9504,7 +9504,7 @@ checksum = "aefc3198c66d1ec34c6543abd945f813298180870aea61ab295af0604b4cd881"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/src/tool/subcommands/car_cmd.rs
+++ b/src/tool/subcommands/car_cmd.rs
@@ -128,12 +128,12 @@ mod tests {
     use cid::Cid;
     use futures::{stream::iter, StreamExt, TryStreamExt};
     use std::io::Write;
-    use tempfile::{NamedTempFile, TempPath};
+    use tempfile::{TempPath, Builder};
     use tokio::io::AsyncWriteExt;
 
     #[tokio::test]
     async fn validate_junk_car() {
-        let mut temp_path = NamedTempFile::new_in(".").unwrap();
+        let mut temp_path = Builder::new().tempfile().unwrap();
         temp_path.write_all(&[0xde, 0xad, 0xbe, 0xef]).unwrap();
         assert!(validate(&temp_path.into_temp_path(), false, false)
             .await
@@ -142,7 +142,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_empty_car() {
-        let temp_path = NamedTempFile::new_in(".").unwrap();
+        let temp_path = Builder::new().tempfile().unwrap();
         assert!(validate(&temp_path.into_temp_path(), false, false)
             .await
             .is_err());
@@ -150,7 +150,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_mainnet_genesis() {
-        let mut temp_path = NamedTempFile::new_in(".").unwrap();
+        let mut temp_path = Builder::new().tempfile().unwrap();
         temp_path.write_all(mainnet::DEFAULT_GENESIS).unwrap();
         assert!(validate(&temp_path.into_temp_path(), false, true)
             .await
@@ -159,7 +159,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_calibnet_genesis() {
-        let mut temp_path = NamedTempFile::new_in(".").unwrap();
+        let mut temp_path = Builder::new().tempfile().unwrap();
         temp_path.write_all(calibnet::DEFAULT_GENESIS).unwrap();
         assert!(validate(&temp_path.into_temp_path(), false, true)
             .await
@@ -167,7 +167,7 @@ mod tests {
     }
 
     async fn create_raw_car_file(car_blocks: Vec<CarBlock>, ignored_cids: Vec<Cid>) -> TempPath {
-        let temp_path = NamedTempFile::new_in(".").unwrap().into_temp_path();
+        let temp_path = Builder::new().tempfile().unwrap().into_temp_path();
         let mut writer = tokio::fs::File::create(&temp_path).await.unwrap();
 
         let frames = forest::Encoder::compress_stream_default(iter(car_blocks).map(Ok)).map_ok(

--- a/src/tool/subcommands/car_cmd.rs
+++ b/src/tool/subcommands/car_cmd.rs
@@ -79,16 +79,16 @@ impl CarCommands {
     }
 }
 
-// At present, three invariants are checked:
-// - The CAR file is syntactically valid and all blocks can be streamed.
-// - Each block CID is checked against the hash of the block.
-// - Each block CID is looked-up in the on-disk index.
-//
-// Invariants related to Filecoin are not checked. For those, see `forest-tool
-// snapshot validate`.
-//
-// We do not check for duplicate blocks. Whether duplicate blocks are allowed or
-// not is vague in the specification.
+/// At present, three properties are checked:
+/// - The CAR file is syntactically valid and all blocks can be streamed.
+/// - Each block CID is checked against the hash of the block.
+/// - Each block CID is looked-up in the on-disk index.
+///
+/// Properties related to Filecoin are not checked. For those, see `forest-tool
+/// snapshot validate`.
+///
+/// We do not check for duplicate blocks. Whether duplicate blocks are allowed or
+/// not is vague in the specification.
 async fn validate(
     car_file: &Path,
     ignore_block_validity: bool,

--- a/src/tool/subcommands/car_cmd.rs
+++ b/src/tool/subcommands/car_cmd.rs
@@ -121,34 +121,42 @@ async fn validate(
 #[cfg(test)]
 mod tests {
     use super::validate;
-    use tempfile::NamedTempFile;
-    use std::io::Write;
     use crate::networks::{calibnet, mainnet};
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[tokio::test]
     async fn validate_junk_car() {
         let mut temp_path = NamedTempFile::new_in(".").unwrap();
-        temp_path.write_all(&[0xde,0xad,0xbe,0xef]).unwrap();
-        assert!(validate(&temp_path.into_temp_path(), false, false).await.is_err());
+        temp_path.write_all(&[0xde, 0xad, 0xbe, 0xef]).unwrap();
+        assert!(validate(&temp_path.into_temp_path(), false, false)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
     async fn validate_empty_car() {
         let temp_path = NamedTempFile::new_in(".").unwrap();
-        assert!(validate(&temp_path.into_temp_path(), false, false).await.is_err());
+        assert!(validate(&temp_path.into_temp_path(), false, false)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
     async fn validate_mainnet_genesis() {
         let mut temp_path = NamedTempFile::new_in(".").unwrap();
         temp_path.write_all(mainnet::DEFAULT_GENESIS).unwrap();
-        assert!(validate(&temp_path.into_temp_path(), false, true).await.is_ok());
+        assert!(validate(&temp_path.into_temp_path(), false, true)
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
     async fn validate_calibnet_genesis() {
         let mut temp_path = NamedTempFile::new_in(".").unwrap();
         temp_path.write_all(calibnet::DEFAULT_GENESIS).unwrap();
-        assert!(validate(&temp_path.into_temp_path(), false, true).await.is_ok());
+        assert!(validate(&temp_path.into_temp_path(), false, true)
+            .await
+            .is_ok());
     }
 }

--- a/src/tool/subcommands/car_cmd.rs
+++ b/src/tool/subcommands/car_cmd.rs
@@ -123,11 +123,32 @@ mod tests {
     use super::validate;
     use tempfile::NamedTempFile;
     use std::io::Write;
+    use crate::networks::{calibnet, mainnet};
 
     #[tokio::test]
     async fn validate_junk_car() {
         let mut temp_path = NamedTempFile::new_in(".").unwrap();
         temp_path.write_all(&[0xde,0xad,0xbe,0xef]).unwrap();
         assert!(validate(&temp_path.into_temp_path(), false, false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_empty_car() {
+        let temp_path = NamedTempFile::new_in(".").unwrap();
+        assert!(validate(&temp_path.into_temp_path(), false, false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_mainnet_genesis() {
+        let mut temp_path = NamedTempFile::new_in(".").unwrap();
+        temp_path.write_all(mainnet::DEFAULT_GENESIS).unwrap();
+        assert!(validate(&temp_path.into_temp_path(), false, true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn validate_calibnet_genesis() {
+        let mut temp_path = NamedTempFile::new_in(".").unwrap();
+        temp_path.write_all(calibnet::DEFAULT_GENESIS).unwrap();
+        assert!(validate(&temp_path.into_temp_path(), false, true).await.is_ok());
     }
 }

--- a/src/tool/subcommands/car_cmd.rs
+++ b/src/tool/subcommands/car_cmd.rs
@@ -84,6 +84,9 @@ impl CarCommands {
 // - Each block CID is checked against the hash of the block.
 // - Each block CID is looked-up in the on-disk index.
 //
+// Invariants related to Filecoin are not checked. For those, see `forest-tool
+// snapshot validate`.
+//
 // We do not check for duplicate blocks. Whether duplicate blocks are allowed or
 // not is vague in the specification.
 async fn validate(

--- a/src/tool/subcommands/car_cmd.rs
+++ b/src/tool/subcommands/car_cmd.rs
@@ -71,9 +71,9 @@ impl CarCommands {
             }
             Self::Validate {
                 car_file,
-                ignore_block_validity: check_block_validity,
-                ignore_forest_index: check_forest_index,
-            } => validate(car_file, check_block_validity, check_forest_index).await?,
+                ignore_block_validity,
+                ignore_forest_index,
+            } => validate(car_file, ignore_block_validity, ignore_forest_index).await?,
         }
         Ok(())
     }

--- a/src/tool/subcommands/car_cmd.rs
+++ b/src/tool/subcommands/car_cmd.rs
@@ -79,6 +79,13 @@ impl CarCommands {
     }
 }
 
+// At present, three invariants are checked:
+// - The CAR file is syntactically valid and all blocks can be streamed.
+// - Each block CID is checked against the hash of the block.
+// - Each block CID is looked-up in the on-disk index.
+//
+// We do not check for duplicate blocks. Whether duplicate blocks are allowed or
+// not is vague in the specification.
 async fn validate(
     car_file: PathBuf,
     ignore_block_validity: bool,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- add `forest-tool car validate` command.

This new command verifies the invariants expected to be true for all CAR files (not just Filecoin CAR files).

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
