### PR TITLE
chore: rework hosted docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,10 +41,10 @@ jobs:
           timeout_minutes: 5
           max_attempts: 3
           command: sudo make install-deps
-      - name: Link Checker (Repo)
+      - name: Link Checker (Repo Readme)
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-          args: --verbose --no-progress --timeout 60 --max-retries 6 --retry-wait-time 10 --exclude twitter.com 'README.md'
+          args: 'README.md'
           # Fail action on broken links
           fail: true
       - uses: hanabi1224/cache-cargo-bin-action@v1.0.0
@@ -59,11 +59,10 @@ jobs:
         env:
           CC: "sccache clang"
           CXX: "sccache clang++"
-      - name: Link Checker (Docs)
+      - name: Link Checker (Library Documentation)
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-          # Check all docs
-          args: --verbose --no-progress --timeout 60 --max-retries 6 --retry-wait-time 10 './target/doc/*/index.html'
+          args: './target/doc/forest_filecoin/**/index.html'
           # Fail action on broken links
           fail: true
       - name: Prepare rustdoc for publishing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,3 +259,7 @@ required-features = ["benchmark-private"]
 name = "car-index"
 harness = false
 required-features = ["benchmark-private"]
+
+[package.metadata.docs.rs]
+# See https://docs.rs/about/metadata
+rustdoc-args = ["--document-private-items"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-VENDORED_DOCS_TOOLCHAIN := "nightly-2023-08-28"
-
 # Using https://github.com/tonistiigi/xx
 # Use in Docker images when cross-compiling.
 install-xx:
@@ -122,16 +120,10 @@ mdbook:
 mdbook-build:
 	mdbook build ./documentation
 
-
-# When you visit https://chainsafe.github.io/forest/rustdoc you get an index.html
-# listing all crates that are documented (which is then published in CI).
-# This isn't included by default, so we use a nightly toolchain, and the
-# (unstable) `--enable-index-page` option.
-# https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#--index-page-provide-a-top-level-landing-page-for-docs
-# We document private items to ensure internal documentation is up-to-date (i.e passes lints)
+# These are the docs that are hosted at https://chainsafe.github.io/forest/rustdoc/.
+# The root index.html simply redirects to the main `forest-filecoin` library documentation.
 vendored-docs:
-	rustup toolchain install $(VENDORED_DOCS_TOOLCHAIN)
-	RUSTDOCFLAGS="--deny=warnings --allow=rustdoc::private-intra-doc-links --document-private-items -Zunstable-options --enable-index-page" \
-		cargo +$(VENDORED_DOCS_TOOLCHAIN) doc --workspace --no-deps
+	cargo doc --document-private-items
+	cp ./build/vendored-docs-redirect.index.html target/doc/index.html
 
 .PHONY: $(MAKECMDGOALS)

--- a/build/vendored-docs-redirect.index.html
+++ b/build/vendored-docs-redirect.index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<!-- See `Makefile::vendored-docs` for more information -->
+<html>
+
+<head>
+    <meta http-equiv="Refresh" content="0; url='./forest_filecoin/index.html'" />
+</head>
+
+</html>

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,10 @@
+# This is the common config used by lychee, our dead html link checker
+# See the github actions workflows to see the inputs
+# https://github.com/lycheeverse/lychee/blob/2109470dc380eaf66944b6bcfa86230e0a58e58f/lychee-bin/src/options.rs#L152
+
+verbose = "debug"
+no_progress = true
+exclude = ["twitter.com"]
+timeout = 60
+max_retries = 6
+retry_wait_time = 10

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,19 @@
 
 #![recursion_limit = "1024"]
 #![cfg_attr(not(test), deny(clippy::todo, clippy::dbg_macro))]
+#![cfg_attr(
+    doc,
+    deny(rustdoc::all),
+    allow(
+        // We build with `--document-private-items` on both docs.rs and our
+        // vendored docs.
+        rustdoc::private_intra_doc_links,
+        // See module `doctest_private` below.
+        rustdoc::private_doc_tests,
+        // TODO(aatifsyed): https://github.com/ChainSafe/forest/issues/3602
+        rustdoc::missing_crate_level_docs
+    )
+)]
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "rustalloc")] {

--- a/src/shim/mod.rs
+++ b/src/shim/mod.rs
@@ -23,6 +23,10 @@ pub mod trace;
 pub mod version;
 
 pub mod fvm_shared_latest {
+    // If `#[doc(inline)]`, we steal these docs from an external crate.
+    // But they contain dead links, which means our dead link checker (lychee)
+    // will complain.
+    #[doc(no_inline)]
     pub use fvm_shared4::*;
 }
 pub mod fvm_latest {

--- a/src/utils/encoding/fallback_de_ipld_dagcbor.rs
+++ b/src/utils/encoding/fallback_de_ipld_dagcbor.rs
@@ -647,7 +647,7 @@ where
 /// This is without the CBOR tag information. It is only the CBOR byte string identifier (major
 /// type 2), the number of bytes, and a null byte prefixed CID.
 ///
-/// The reason for not including the CBOR tag information is the [`Value`] implementation. That one
+/// The reason for not including the CBOR tag information is the `Value` implementation. That one
 /// starts to parse the bytes, before we could interfere. If the data only includes a CID, we are
 /// parsing over the tag to determine whether it is a CID or not and go from there.
 struct CidDeserializer<'a, R>(&'a mut Deserializer<R>);

--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -5,7 +5,7 @@ use crate::shim::address::Address;
 use blake2b_simd::Params;
 use filecoin_proofs_api::ProverId;
 use fvm_ipld_encoding::strict_bytes::{Deserialize, Serialize};
-pub use serde::{de, ser, Deserializer, Serializer};
+use serde::{de, ser, Deserializer, Serializer};
 
 mod fallback_de_ipld_dagcbor;
 


### PR DESCRIPTION
# Changes
- Include dependencies in hosted docs, which unblocks #3595 
- Move rustdoc `#[allow(..)]` and `#[deny(..)]` policies to `src/lib.rs`
- Include private items in builds for <https://docs.rs>
- Get rid of the nightly documentation toolchain, and just redirect <https://chainsafe.github.io/forest/rustdoc/> to <https://chainsafe.github.io/forest/rustdoc/forest_filecoin/>
  The previous landing page was ugly and empty
- Commonise `lychee` config
- Fix dead link bugs.
  Lychee previously didn't pick up eg https://chainsafe.github.io/forest/rustdoc/forest_filecoin/utils/encoding/de/index.html containing a dead link to https://chainsafe.github.io/forest/rustdoc/forest_filecoin/utils/encoding/trait.Deserialize.html