### PR TITLE
fix: reduce allocations in `ok_or` by switching to `ok_or_else`

### DIFF
--- a/src/chain/store/index.rs
+++ b/src/chain/store/index.rs
@@ -55,7 +55,8 @@ impl<DB: Blockstore> ChainIndex<DB> {
         }
 
         let ts = Arc::new(
-            Tipset::load(&self.db, tsk)?.ok_or(Error::NotFound(String::from("Key for header")))?,
+            Tipset::load(&self.db, tsk)?
+                .ok_or_else(|| Error::NotFound(String::from("Key for header")))?,
         );
         self.ts_cache.lock().put(tsk.clone(), ts.clone());
         metrics::LRU_CACHE_MISS

--- a/src/db/car/plain.rs
+++ b/src/db/car/plain.rs
@@ -306,8 +306,8 @@ fn cid_error_to_io_error(cid_error: cid::Error) -> io::Error {
 /// ```
 #[tracing::instrument(level = "trace", skip_all, ret)]
 fn read_header(mut reader: impl Read) -> io::Result<CarHeader> {
-    let header_len =
-        read_varint_body_length_or_eof(&mut reader)?.ok_or(io::Error::from(UnexpectedEof))?;
+    let header_len = read_varint_body_length_or_eof(&mut reader)?
+        .ok_or_else(|| io::Error::from(UnexpectedEof))?;
     let mut buffer = vec![0; usize::try_from(header_len).unwrap()];
     reader.read_exact(&mut buffer)?;
     from_slice_with_fallback(&buffer).map_err(|e| io::Error::new(InvalidData, e))

--- a/src/utils/db/car_stream.rs
+++ b/src/utils/db/car_stream.rs
@@ -97,10 +97,9 @@ impl<ReaderT: AsyncBufRead + Unpin> CarStream<ReaderT> {
         } else {
             FramedRead::new(Either::Left(reader), UviBytes::default())
         };
-        let header = read_header(&mut reader).await.ok_or(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "invalid header block",
-        ))?;
+        let header = read_header(&mut reader)
+            .await
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid header block"))?;
 
         // Read the first block and check if it is valid. This check helps to
         // catch invalid CAR files as soon as we open.

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -374,10 +374,14 @@ where
     Id: AsRef<str>,
 {
     fn fetch(&mut self, id: &Id) -> Result<&Source, Box<dyn std::fmt::Debug + '_>> {
+        fn id_not_found_error(id: impl AsRef<str>) -> Box<dyn std::fmt::Debug> {
+            Box::new(format!("{} not in cache", id.as_ref()))
+        }
+
         self.map
             .get(Utf8Path::new(&id))
             .map(|SourceFile { linewise, .. }| linewise)
-            .ok_or(Box::new(format!("{} not in cache", id.as_ref())))
+            .ok_or_else(|| id_not_found_error(id))
     }
 
     fn display<'a>(&self, id: &'a Id) -> Option<Box<dyn std::fmt::Display + 'a>> {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Encounter the issue when implementing https://github.com/ChainSafe/forest/pull/3605

Changes introduced in this pull request:

- reduce allocations in `Option::ok_or` by switching to `Option::ok_or_else`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
