### PR TITLE
feat: add `--metrics [flag]` to `forest`

### DIFF
--- a/src/cli_shared/cli/client.rs
+++ b/src/cli_shared/cli/client.rs
@@ -42,6 +42,7 @@ pub struct Client {
     pub data_dir: PathBuf,
     pub genesis_file: Option<String>,
     pub enable_rpc: bool,
+    pub enable_metrics_endpoint: bool,
     pub rpc_token: Option<String>,
     /// If this is true, then we do not validate the imported snapshot.
     /// Otherwise, we validate and compute the states.
@@ -82,6 +83,7 @@ impl Default for Client {
             data_dir: dir.data_dir().to_path_buf(),
             genesis_file: None,
             enable_rpc: true,
+            enable_metrics_endpoint: true,
             rpc_token: None,
             snapshot_path: None,
             snapshot: false,

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -49,6 +49,9 @@ pub struct CliOpts {
     /// Allow RPC to be active or not (default: true)
     #[arg(short, long)]
     pub rpc: Option<bool>,
+    /// Allow Metrics endpoint to be active or not (default: true)
+    #[arg(short, long)]
+    pub metrics: Option<bool>,
     /// Client JWT token to use for JSON-RPC authentication
     #[arg(short, long)]
     pub token: Option<String>,
@@ -186,9 +189,16 @@ impl CliOpts {
         } else {
             cfg.client.enable_rpc = false;
         }
-        if let Some(metrics_address) = self.metrics_address {
-            cfg.client.metrics_address = metrics_address;
+
+        if self.metrics.unwrap_or(cfg.client.enable_metrics_endpoint) {
+            cfg.client.enable_metrics_endpoint = true;
+            if let Some(metrics_address) = self.metrics_address {
+                cfg.client.metrics_address = metrics_address;
+            }
+        } else {
+            cfg.client.enable_metrics_endpoint = false;
         }
+
         if self.import_snapshot.is_some() && self.import_chain.is_some() {
             anyhow::bail!("Can't set import_snapshot and import_chain at the same time!")
         } else if self.import_snapshot.is_some() && self.consume_snapshot.is_some() {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -193,7 +193,7 @@ pub(super) async fn start(
         });
     }
 
-    {
+    if config.client.enable_metrics_endpoint {
         // Start Prometheus server port
         let prometheus_listener = TcpListener::bind(config.client.metrics_address).context(
             format!("could not bind to {}", config.client.metrics_address),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Adding an option to disable metrics endpoint (just like for RPC endpoint) to facilitate writing simple test for https://github.com/ChainSafe/forest/pull/3593

Changes introduced in this pull request:

- add `--metrics [flag]` to `forest` to control the availability of the Prometheus server

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
