### PR TITLE
feat/fix: simplify configuration for `forest-cli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 - [#3609](https://github.com/ChainSafe/forest/pull/3609) Add `--no-metrics`
   option to `forest` for controlling the availability of the metrics Prometheus
   server.
+- [#3613](https://github.com/ChainSafe/forest/pull/3613) Add `--expire-in`
+  parameter to token commands.
 
 ### Changed
 

--- a/scripts/gen_coverage_report.sh
+++ b/scripts/gen_coverage_report.sh
@@ -81,7 +81,7 @@ cov forest-wallet --token "$TOKEN" balance "$NEW_ADDR" | grep 0
 cov forest-cli --token "$TOKEN" send --from "$DEFAULT_ADDR" "$NEW_ADDR" 10attoFIL
 
 # Create a read-only token
-READ_TOKEN=$(cov forest-cli --token "$TOKEN" auth create-token --perm read)
+READ_TOKEN=$(cov forest-cli --token "$TOKEN" auth create-token --perm read --expire-in 1month)
 # Make sure that viewing the wallet fails with the read-only token
 cov forest-wallet --token "$READ_TOKEN" list && { echo "must fail"; return 1; }
 # Verifying a message should still work with the read-only token

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -7,6 +7,7 @@ use crate::cli_shared::logger;
 use crate::daemon::get_actual_chain_name;
 use crate::shim::address::{CurrentNetwork, Network};
 use crate::utils::bail_moved_cmd;
+use crate::Client;
 use crate::{cli::subcommands::Cli, rpc_client::state_network_name};
 use clap::Parser;
 
@@ -24,10 +25,12 @@ where
         .build()
         .unwrap()
         .block_on(async {
-            let mut config = crate::Config::default();
-            config.client.rpc_token = token;
+            let client = Client {
+                rpc_token: token,
+                ..Client::default()
+            };
             logger::setup_logger(&crate::cli_shared::cli::CliOpts::default());
-            if let Ok(name) = state_network_name((), &config.client.rpc_token).await {
+            if let Ok(name) = state_network_name((), &client.rpc_token).await {
                 if get_actual_chain_name(&name) != "mainnet" {
                     CurrentNetwork::set_global(Network::Testnet);
                 }
@@ -37,21 +40,21 @@ where
                 Subcommand::Fetch(_cmd) => {
                     bail_moved_cmd("fetch-params", "forest-tool fetch-params")
                 }
-                Subcommand::Chain(cmd) => cmd.run(config).await,
-                Subcommand::Auth(cmd) => cmd.run(config).await,
-                Subcommand::Net(cmd) => cmd.run(config).await,
+                Subcommand::Chain(cmd) => cmd.run(client).await,
+                Subcommand::Auth(cmd) => cmd.run(client).await,
+                Subcommand::Net(cmd) => cmd.run(client).await,
                 Subcommand::Wallet(..) => bail_moved_cmd("wallet", "forest-wallet"),
-                Subcommand::Sync(cmd) => cmd.run(config).await,
-                Subcommand::Mpool(cmd) => cmd.run(config).await,
-                Subcommand::State(cmd) => cmd.run(config).await,
-                Subcommand::Config(cmd) => cmd.run(&config, &mut std::io::stdout()),
-                Subcommand::Send(cmd) => cmd.run(config).await,
-                Subcommand::Info(cmd) => cmd.run(config).await,
-                Subcommand::DB(cmd) => cmd.run(&config).await,
-                Subcommand::Snapshot(cmd) => cmd.run(config).await,
+                Subcommand::Sync(cmd) => cmd.run(client).await,
+                Subcommand::Mpool(cmd) => cmd.run(client).await,
+                Subcommand::State(cmd) => cmd.run(client).await,
+                Subcommand::Config(cmd) => cmd.run(&mut std::io::stdout()),
+                Subcommand::Send(cmd) => cmd.run(client).await,
+                Subcommand::Info(cmd) => cmd.run(client).await,
+                Subcommand::DB(cmd) => cmd.run(client).await,
+                Subcommand::Snapshot(cmd) => cmd.run(client).await,
                 Subcommand::Archive(cmd) => cmd.run().await,
-                Subcommand::Attach(cmd) => cmd.run(config),
-                Subcommand::Shutdown(cmd) => cmd.run(config).await,
+                Subcommand::Attach(cmd) => cmd.run(client),
+                Subcommand::Shutdown(cmd) => cmd.run(client).await,
                 Subcommand::Car(..) => bail_moved_cmd("car", "forest-tool"),
             }
         })

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -7,7 +7,6 @@ use crate::cli_shared::logger;
 use crate::daemon::get_actual_chain_name;
 use crate::shim::address::{CurrentNetwork, Network};
 use crate::utils::bail_moved_cmd;
-use crate::Client;
 use crate::{cli::subcommands::Cli, rpc_client::state_network_name};
 use clap::Parser;
 
@@ -25,12 +24,8 @@ where
         .build()
         .unwrap()
         .block_on(async {
-            let client = Client {
-                rpc_token: token,
-                ..Client::default()
-            };
             logger::setup_logger(&crate::cli_shared::cli::CliOpts::default());
-            if let Ok(name) = state_network_name((), &client.rpc_token).await {
+            if let Ok(name) = state_network_name((), &token).await {
                 if get_actual_chain_name(&name) != "mainnet" {
                     CurrentNetwork::set_global(Network::Testnet);
                 }
@@ -40,21 +35,21 @@ where
                 Subcommand::Fetch(_cmd) => {
                     bail_moved_cmd("fetch-params", "forest-tool fetch-params")
                 }
-                Subcommand::Chain(cmd) => cmd.run(client).await,
-                Subcommand::Auth(cmd) => cmd.run(client).await,
-                Subcommand::Net(cmd) => cmd.run(client).await,
+                Subcommand::Chain(cmd) => cmd.run(token).await,
+                Subcommand::Auth(cmd) => cmd.run(token).await,
+                Subcommand::Net(cmd) => cmd.run(token).await,
                 Subcommand::Wallet(..) => bail_moved_cmd("wallet", "forest-wallet"),
-                Subcommand::Sync(cmd) => cmd.run(client).await,
-                Subcommand::Mpool(cmd) => cmd.run(client).await,
-                Subcommand::State(cmd) => cmd.run(client).await,
+                Subcommand::Sync(cmd) => cmd.run(token).await,
+                Subcommand::Mpool(cmd) => cmd.run(token).await,
+                Subcommand::State(cmd) => cmd.run(token).await,
                 Subcommand::Config(cmd) => cmd.run(&mut std::io::stdout()),
-                Subcommand::Send(cmd) => cmd.run(client).await,
-                Subcommand::Info(cmd) => cmd.run(client).await,
-                Subcommand::DB(cmd) => cmd.run(client).await,
-                Subcommand::Snapshot(cmd) => cmd.run(client).await,
+                Subcommand::Send(cmd) => cmd.run(token).await,
+                Subcommand::Info(cmd) => cmd.run(token).await,
+                Subcommand::DB(cmd) => cmd.run(token).await,
+                Subcommand::Snapshot(cmd) => cmd.run(token).await,
                 Subcommand::Archive(cmd) => cmd.run().await,
-                Subcommand::Attach(cmd) => cmd.run(client),
-                Subcommand::Shutdown(cmd) => cmd.run(client).await,
+                Subcommand::Attach(cmd) => cmd.run(token),
+                Subcommand::Shutdown(cmd) => cmd.run(token).await,
                 Subcommand::Car(..) => bail_moved_cmd("car", "forest-tool"),
             }
         })

--- a/src/cli/subcommands/attach_cmd.rs
+++ b/src/cli/subcommands/attach_cmd.rs
@@ -14,7 +14,6 @@ use crate::rpc_api::mpool_api::MpoolPushMessageResult;
 use crate::rpc_client::node_ops::node_status;
 use crate::rpc_client::*;
 use crate::shim::{address::Address, clock::ChainEpoch, message::Message};
-use crate::Client;
 use boa_engine::{
     object::{builtins::JsArray, FunctionObjectBuilder},
     prelude::JsObject,
@@ -358,9 +357,9 @@ impl AttachCommand {
         Ok(())
     }
 
-    pub fn run(self, client: Client) -> anyhow::Result<()> {
+    pub fn run(self, rpc_token: Option<String>) -> anyhow::Result<()> {
         let mut context = Context::default();
-        self.setup_context(&mut context, &client.rpc_token);
+        self.setup_context(&mut context, &rpc_token);
 
         self.import_prelude(&mut context)?;
 

--- a/src/cli/subcommands/attach_cmd.rs
+++ b/src/cli/subcommands/attach_cmd.rs
@@ -7,7 +7,6 @@ use std::{
     str::FromStr,
 };
 
-use super::Config;
 use crate::chain_sync::SyncStage;
 use crate::cli::humantoken;
 use crate::lotus_json::LotusJson;
@@ -15,6 +14,7 @@ use crate::rpc_api::mpool_api::MpoolPushMessageResult;
 use crate::rpc_client::node_ops::node_status;
 use crate::rpc_client::*;
 use crate::shim::{address::Address, clock::ChainEpoch, message::Message};
+use crate::Client;
 use boa_engine::{
     object::{builtins::JsArray, FunctionObjectBuilder},
     prelude::JsObject,
@@ -358,9 +358,9 @@ impl AttachCommand {
         Ok(())
     }
 
-    pub fn run(self, config: Config) -> anyhow::Result<()> {
+    pub fn run(self, client: Client) -> anyhow::Result<()> {
         let mut context = Context::default();
-        self.setup_context(&mut context, &config.client.rpc_token);
+        self.setup_context(&mut context, &client.rpc_token);
 
         self.import_prelude(&mut context)?;
 

--- a/src/cli/subcommands/auth_cmd.rs
+++ b/src/cli/subcommands/auth_cmd.rs
@@ -2,21 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::auth::*;
-use crate::libp2p::{Multiaddr, Protocol};
 use crate::rpc_api::auth_api::AuthNewParams;
-use crate::rpc_client::auth_new;
+use crate::rpc_client::{auth_new, API_INFO};
+use crate::Client;
+use chrono::Duration;
 use clap::Subcommand;
 use jsonrpc_v2::Error as JsonRpcError;
+use std::str::FromStr;
 
-use super::{handle_rpc_err, print_rpc_res_bytes, Config};
+use super::{handle_rpc_err, print_rpc_res_bytes};
 
 #[derive(Debug, Subcommand)]
 pub enum AuthCommands {
     /// Create a new Authentication token with given permission
     CreateToken {
-        /// permission to assign to the token, one of: read, write, sign, admin
+        /// Permission to assign to the token, one of: read, write, sign, admin
         #[arg(short, long)]
         perm: String,
+        /// Token is revoked after this duration
+        #[arg(long, default_value_t = humantime::Duration::from_str("2 months").expect("infallible"))]
+        expire_in: humantime::Duration,
     },
     /// Get RPC API Information
     ApiInfo {
@@ -40,27 +45,27 @@ fn process_perms(perm: String) -> Result<Vec<String>, JsonRpcError> {
 }
 
 impl AuthCommands {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         match self {
-            Self::CreateToken { perm } => {
+            Self::CreateToken {
+                perm,
+                expire_in: expiration,
+            } => {
                 let perm: String = perm.parse()?;
                 let perms = process_perms(perm).map_err(handle_rpc_err)?;
-                let token_exp = config.client.token_exp;
+                let token_exp = Duration::from_std(expiration.into())?;
                 let auth_params = AuthNewParams { perms, token_exp };
-                print_rpc_res_bytes(auth_new(auth_params, &config.client.rpc_token).await)
+                print_rpc_res_bytes(auth_new(auth_params, &client.rpc_token).await)
             }
             Self::ApiInfo { perm } => {
                 let perm: String = perm.parse()?;
                 let perms = process_perms(perm).map_err(handle_rpc_err)?;
-                let token_exp = config.client.token_exp;
+                let token_exp = client.token_exp;
                 let auth_params = AuthNewParams { perms, token_exp };
-                let token = auth_new(auth_params, &config.client.rpc_token)
+                let token = auth_new(auth_params, &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
-                let mut addr = Multiaddr::empty();
-                addr.push(config.client.rpc_address.ip().into());
-                addr.push(Protocol::Tcp(config.client.rpc_address.port()));
-                addr.push(Protocol::Http);
+                let addr = API_INFO.multiaddr.to_owned();
                 println!(
                     "FULLNODE_API_INFO=\"{}:{}\"",
                     String::from_utf8(token).map_err(|e| handle_rpc_err(e.into()))?,

--- a/src/cli/subcommands/auth_cmd.rs
+++ b/src/cli/subcommands/auth_cmd.rs
@@ -4,7 +4,6 @@
 use crate::auth::*;
 use crate::rpc_api::auth_api::AuthNewParams;
 use crate::rpc_client::{auth_new, API_INFO};
-use crate::Client;
 use chrono::Duration;
 use clap::Subcommand;
 use jsonrpc_v2::Error as JsonRpcError;
@@ -28,6 +27,9 @@ pub enum AuthCommands {
         /// permission to assign the token, one of: read, write, sign, admin
         #[arg(short, long)]
         perm: String,
+        /// Token is revoked after this duration
+        #[arg(long, default_value_t = humantime::Duration::from_str("2 months").expect("infallible"))]
+        expire_in: humantime::Duration,
     },
 }
 
@@ -45,24 +47,21 @@ fn process_perms(perm: String) -> Result<Vec<String>, JsonRpcError> {
 }
 
 impl AuthCommands {
-    pub async fn run(self, client: Client) -> anyhow::Result<()> {
+    pub async fn run(self, rpc_token: Option<String>) -> anyhow::Result<()> {
         match self {
-            Self::CreateToken {
-                perm,
-                expire_in: expiration,
-            } => {
+            Self::CreateToken { perm, expire_in } => {
                 let perm: String = perm.parse()?;
                 let perms = process_perms(perm).map_err(handle_rpc_err)?;
-                let token_exp = Duration::from_std(expiration.into())?;
+                let token_exp = Duration::from_std(expire_in.into())?;
                 let auth_params = AuthNewParams { perms, token_exp };
-                print_rpc_res_bytes(auth_new(auth_params, &client.rpc_token).await)
+                print_rpc_res_bytes(auth_new(auth_params, &rpc_token).await)
             }
-            Self::ApiInfo { perm } => {
+            Self::ApiInfo { perm, expire_in } => {
                 let perm: String = perm.parse()?;
                 let perms = process_perms(perm).map_err(handle_rpc_err)?;
-                let token_exp = client.token_exp;
+                let token_exp = Duration::from_std(expire_in.into())?;
                 let auth_params = AuthNewParams { perms, token_exp };
-                let token = auth_new(auth_params, &client.rpc_token)
+                let token = auth_new(auth_params, &rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 let addr = API_INFO.multiaddr.to_owned();

--- a/src/cli/subcommands/chain_cmd.rs
+++ b/src/cli/subcommands/chain_cmd.rs
@@ -4,6 +4,7 @@
 use crate::blocks::{Tipset, TipsetKeys};
 use crate::lotus_json::LotusJson;
 use crate::rpc_client::chain_ops::*;
+use crate::Client;
 use anyhow::bail;
 use cid::Cid;
 use clap::Subcommand;
@@ -56,20 +57,18 @@ pub enum ChainCommands {
 }
 
 impl ChainCommands {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         match self {
             Self::Block { cid } => {
-                print_rpc_res_pretty(chain_get_block((cid.into(),), &config.client.rpc_token).await)
+                print_rpc_res_pretty(chain_get_block((cid.into(),), &client.rpc_token).await)
             }
-            Self::Genesis => {
-                print_rpc_res_pretty(chain_get_genesis(&config.client.rpc_token).await)
+            Self::Genesis => print_rpc_res_pretty(chain_get_genesis(&client.rpc_token).await),
+            Self::Head => print_rpc_res_cids(chain_head(&client.rpc_token).await),
+            Self::Message { cid } => {
+                print_rpc_res_pretty(chain_get_message((cid.into(),), &client.rpc_token).await)
             }
-            Self::Head => print_rpc_res_cids(chain_head(&config.client.rpc_token).await),
-            Self::Message { cid } => print_rpc_res_pretty(
-                chain_get_message((cid.into(),), &config.client.rpc_token).await,
-            ),
             Self::ReadObj { cid } => {
-                print_rpc_res(chain_read_obj((cid.into(),), &config.client.rpc_token).await)
+                print_rpc_res(chain_read_obj((cid.into(),), &client.rpc_token).await)
             }
             Self::SetHead {
                 cids,
@@ -78,12 +77,9 @@ impl ChainCommands {
             } => {
                 maybe_confirm(no_confirm, SET_HEAD_CONFIRMATION_MESSAGE)?;
                 assert!(cids.is_empty(), "should be disallowed by clap");
-                tipset_by_epoch_or_offset(epoch, &config.client.rpc_token)
+                tipset_by_epoch_or_offset(epoch, &client.rpc_token)
                     .and_then(|tipset_json| {
-                        chain_set_head(
-                            (tipset_json.into_inner().key().clone(),),
-                            &config.client.rpc_token,
-                        )
+                        chain_set_head((tipset_json.into_inner().key().clone(),), &client.rpc_token)
                     })
                     .await
                     .map_err(handle_rpc_err)
@@ -94,12 +90,9 @@ impl ChainCommands {
                 force: no_confirm,
             } => {
                 maybe_confirm(no_confirm, SET_HEAD_CONFIRMATION_MESSAGE)?;
-                chain_set_head(
-                    (TipsetKeys::from_iter(cids.clone()),),
-                    &config.client.rpc_token,
-                )
-                .await
-                .map_err(handle_rpc_err)
+                chain_set_head((TipsetKeys::from_iter(cids.clone()),), &client.rpc_token)
+                    .await
+                    .map_err(handle_rpc_err)
             }
         }
     }

--- a/src/cli/subcommands/config_cmd.rs
+++ b/src/cli/subcommands/config_cmd.rs
@@ -10,17 +10,17 @@ use crate::cli::subcommands::Config;
 
 #[derive(Debug, Subcommand)]
 pub enum ConfigCommands {
-    /// Dump current configuration to standard output
+    /// Dump default configuration to standard output
     Dump,
 }
 
 impl ConfigCommands {
-    pub fn run<W: Write + Unpin>(self, config: &Config, sink: &mut W) -> anyhow::Result<()> {
+    pub fn run<W: Write + Unpin>(self, sink: &mut W) -> anyhow::Result<()> {
         match self {
             Self::Dump => writeln!(
                 sink,
                 "{}",
-                toml::to_string(config)
+                toml::to_string(&Config::default())
                     .context("Could not convert configuration to TOML format")?
             )
             .context("Failed to write the configuration"),
@@ -37,9 +37,7 @@ mod tests {
         let expected_config = Config::default();
         let mut sink = std::io::BufWriter::new(Vec::new());
 
-        ConfigCommands::Dump
-            .run(&expected_config, &mut sink)
-            .unwrap();
+        ConfigCommands::Dump.run(&mut sink).unwrap();
 
         let actual_config: Config = toml::from_str(std::str::from_utf8(sink.buffer()).unwrap())
             .expect("Invalid configuration!");

--- a/src/cli/subcommands/db_cmd.rs
+++ b/src/cli/subcommands/db_cmd.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use crate::rpc_api::progress_api::GetProgressType;
 use crate::rpc_client::{db_ops::db_gc, progress_ops::get_progress};
 use crate::utils::io::ProgressBar;
-use crate::Client;
 use chrono::Utc;
 use clap::Subcommand;
 
@@ -28,7 +27,7 @@ pub enum DBCommands {
 }
 
 impl DBCommands {
-    pub async fn run(self, client: Client) -> anyhow::Result<()> {
+    pub async fn run(self, rpc_token: Option<String>) -> anyhow::Result<()> {
         match self {
             Self::Stats => bail_moved_cmd("db stats", "forest-tool db stats"),
             Self::GC => {
@@ -61,7 +60,7 @@ impl DBCommands {
                     }
                 });
 
-                db_gc((), &client.rpc_token).await.map_err(handle_rpc_err)?;
+                db_gc((), &rpc_token).await.map_err(handle_rpc_err)?;
 
                 bar.lock().await.finish_println(&format!(
                     "Database garbage collection completed. took {}s",

--- a/src/cli/subcommands/db_cmd.rs
+++ b/src/cli/subcommands/db_cmd.rs
@@ -3,10 +3,10 @@
 
 use std::sync::Arc;
 
-use crate::cli_shared::cli::Config;
 use crate::rpc_api::progress_api::GetProgressType;
 use crate::rpc_client::{db_ops::db_gc, progress_ops::get_progress};
 use crate::utils::io::ProgressBar;
+use crate::Client;
 use chrono::Utc;
 use clap::Subcommand;
 
@@ -28,7 +28,7 @@ pub enum DBCommands {
 }
 
 impl DBCommands {
-    pub async fn run(self, config: &Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         match self {
             Self::Stats => bail_moved_cmd("db stats", "forest-tool db stats"),
             Self::GC => {
@@ -61,9 +61,7 @@ impl DBCommands {
                     }
                 });
 
-                db_gc((), &config.client.rpc_token)
-                    .await
-                    .map_err(handle_rpc_err)?;
+                db_gc((), &client.rpc_token).await.map_err(handle_rpc_err)?;
 
                 bar.lock().await.finish_println(&format!(
                     "Database garbage collection completed. took {}s",

--- a/src/cli/subcommands/info_cmd.rs
+++ b/src/cli/subcommands/info_cmd.rs
@@ -8,7 +8,6 @@ use crate::rpc_client::{
     wallet_default_address,
 };
 use crate::shim::econ::TokenAmount;
-use crate::Client;
 use chrono::{DateTime, Utc};
 use clap::Subcommand;
 
@@ -160,13 +159,13 @@ impl NodeStatusInfo {
 }
 
 impl InfoCommand {
-    pub async fn run(self, client: Client) -> anyhow::Result<()> {
+    pub async fn run(self, rpc_token: Option<String>) -> anyhow::Result<()> {
         let res = tokio::try_join!(
-            node_status((), &client.rpc_token),
-            chain_head(&client.rpc_token),
-            state_network_name((), &client.rpc_token),
-            start_time(&client.rpc_token),
-            wallet_default_address((), &client.rpc_token)
+            node_status((), &rpc_token),
+            chain_head(&rpc_token),
+            state_network_name((), &rpc_token),
+            start_time(&rpc_token),
+            wallet_default_address((), &rpc_token)
         );
 
         match res {
@@ -177,7 +176,7 @@ impl InfoCommand {
 
                 let default_wallet_address_balance = if let Some(def_addr) = &default_wallet_address
                 {
-                    let balance = wallet_balance((def_addr.clone(),), &client.rpc_token)
+                    let balance = wallet_balance((def_addr.clone(),), &rpc_token)
                         .await
                         .map_err(handle_rpc_err)?;
                     Some(balance)

--- a/src/cli/subcommands/info_cmd.rs
+++ b/src/cli/subcommands/info_cmd.rs
@@ -8,6 +8,7 @@ use crate::rpc_client::{
     wallet_default_address,
 };
 use crate::shim::econ::TokenAmount;
+use crate::Client;
 use chrono::{DateTime, Utc};
 use clap::Subcommand;
 
@@ -16,7 +17,6 @@ use humantime::format_duration;
 use num::BigInt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use super::Config;
 use crate::cli::humantoken::TokenAmountPretty;
 use crate::cli::subcommands::handle_rpc_err;
 
@@ -160,13 +160,13 @@ impl NodeStatusInfo {
 }
 
 impl InfoCommand {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         let res = tokio::try_join!(
-            node_status((), &config.client.rpc_token),
-            chain_head(&config.client.rpc_token),
-            state_network_name((), &config.client.rpc_token),
-            start_time(&config.client.rpc_token),
-            wallet_default_address((), &config.client.rpc_token)
+            node_status((), &client.rpc_token),
+            chain_head(&client.rpc_token),
+            state_network_name((), &client.rpc_token),
+            start_time(&client.rpc_token),
+            wallet_default_address((), &client.rpc_token)
         );
 
         match res {
@@ -177,7 +177,7 @@ impl InfoCommand {
 
                 let default_wallet_address_balance = if let Some(def_addr) = &default_wallet_address
                 {
-                    let balance = wallet_balance((def_addr.clone(),), &config.client.rpc_token)
+                    let balance = wallet_balance((def_addr.clone(),), &client.rpc_token)
                         .await
                         .map_err(handle_rpc_err)?;
                     Some(balance)

--- a/src/cli/subcommands/mpool_cmd.rs
+++ b/src/cli/subcommands/mpool_cmd.rs
@@ -87,7 +87,7 @@ async fn get_actor_sequence(
     let address = message.from;
     let get_actor_result = state_get_actor(
         (address.to_owned().into(), tipset.key().to_owned().into()),
-        &rpc_token,
+        rpc_token,
     )
     .await;
 

--- a/src/cli/subcommands/net_cmd.rs
+++ b/src/cli/subcommands/net_cmd.rs
@@ -4,7 +4,6 @@
 use crate::libp2p::{Multiaddr, Protocol};
 use crate::rpc_api::data_types::AddrInfo;
 use crate::rpc_client::net_ops::*;
-use crate::Client;
 use ahash::HashSet;
 use cid::multibase;
 use clap::Subcommand;
@@ -34,10 +33,10 @@ pub enum NetCommands {
 }
 
 impl NetCommands {
-    pub async fn run(self, client: Client) -> anyhow::Result<()> {
+    pub async fn run(self, rpc_token: Option<String>) -> anyhow::Result<()> {
         match self {
             Self::Listen => {
-                let info = net_addrs_listen((), &client.rpc_token)
+                let info = net_addrs_listen((), &rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 let addresses: Vec<String> = info
@@ -49,9 +48,7 @@ impl NetCommands {
                 Ok(())
             }
             Self::Info => {
-                let info = net_info((), &client.rpc_token)
-                    .await
-                    .map_err(handle_rpc_err)?;
+                let info = net_info((), &rpc_token).await.map_err(handle_rpc_err)?;
                 println!("forest libp2p swarm info:");
                 println!("num peers: {}", info.num_peers);
                 println!("num connections: {}", info.num_connections);
@@ -62,9 +59,7 @@ impl NetCommands {
                 Ok(())
             }
             Self::Peers => {
-                let addrs = net_peers((), &client.rpc_token)
-                    .await
-                    .map_err(handle_rpc_err)?;
+                let addrs = net_peers((), &rpc_token).await.map_err(handle_rpc_err)?;
                 let output: Vec<String> = addrs
                     .into_iter()
                     .filter_map(|info| {
@@ -115,14 +110,14 @@ impl NetCommands {
                     addrs,
                 };
 
-                net_connect((addr_info,), &client.rpc_token)
+                net_connect((addr_info,), &rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 println!("connect {id}: success");
                 Ok(())
             }
             Self::Disconnect { id } => {
-                net_disconnect((id.to_owned(),), &client.rpc_token)
+                net_disconnect((id.to_owned(),), &rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 println!("disconnect {id}: success");

--- a/src/cli/subcommands/net_cmd.rs
+++ b/src/cli/subcommands/net_cmd.rs
@@ -4,12 +4,13 @@
 use crate::libp2p::{Multiaddr, Protocol};
 use crate::rpc_api::data_types::AddrInfo;
 use crate::rpc_client::net_ops::*;
+use crate::Client;
 use ahash::HashSet;
 use cid::multibase;
 use clap::Subcommand;
 use itertools::Itertools;
 
-use super::{handle_rpc_err, print_stdout, Config};
+use super::{handle_rpc_err, print_stdout};
 use crate::cli::subcommands::cli_error_and_die;
 
 #[derive(Debug, Subcommand)]
@@ -33,10 +34,10 @@ pub enum NetCommands {
 }
 
 impl NetCommands {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         match self {
             Self::Listen => {
-                let info = net_addrs_listen((), &config.client.rpc_token)
+                let info = net_addrs_listen((), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 let addresses: Vec<String> = info
@@ -48,7 +49,7 @@ impl NetCommands {
                 Ok(())
             }
             Self::Info => {
-                let info = net_info((), &config.client.rpc_token)
+                let info = net_info((), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 println!("forest libp2p swarm info:");
@@ -61,7 +62,7 @@ impl NetCommands {
                 Ok(())
             }
             Self::Peers => {
-                let addrs = net_peers((), &config.client.rpc_token)
+                let addrs = net_peers((), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 let output: Vec<String> = addrs
@@ -114,14 +115,14 @@ impl NetCommands {
                     addrs,
                 };
 
-                net_connect((addr_info,), &config.client.rpc_token)
+                net_connect((addr_info,), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 println!("connect {id}: success");
                 Ok(())
             }
             Self::Disconnect { id } => {
-                net_disconnect((id.to_owned(),), &config.client.rpc_token)
+                net_disconnect((id.to_owned(),), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 println!("disconnect {id}: success");

--- a/src/cli/subcommands/send_cmd.rs
+++ b/src/cli/subcommands/send_cmd.rs
@@ -8,9 +8,10 @@ use crate::rpc_client::{mpool_push_message, wallet_default_address};
 use crate::shim::address::{Address, StrictAddress};
 use crate::shim::econ::TokenAmount;
 use crate::shim::message::{Message, METHOD_SEND};
+use crate::Client;
 use num::Zero as _;
 
-use super::{handle_rpc_err, Config};
+use super::handle_rpc_err;
 use crate::cli::humantoken;
 
 #[derive(Debug, clap::Args)]
@@ -32,12 +33,12 @@ pub struct SendCommand {
 }
 
 impl SendCommand {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         let from: Address = if let Some(from) = &self.from {
             StrictAddress::from_str(from)?.into()
         } else {
             Address::from_str(
-                &wallet_default_address((), &config.client.rpc_token)
+                &wallet_default_address((), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?
                     .ok_or_else(|| {
@@ -60,7 +61,7 @@ impl SendCommand {
             ..Default::default()
         };
 
-        let signed_msg = mpool_push_message((LotusJson(message), None), &config.client.rpc_token)
+        let signed_msg = mpool_push_message((LotusJson(message), None), &client.rpc_token)
             .await
             .map_err(handle_rpc_err)?
             .into_inner();

--- a/src/cli/subcommands/send_cmd.rs
+++ b/src/cli/subcommands/send_cmd.rs
@@ -8,7 +8,6 @@ use crate::rpc_client::{mpool_push_message, wallet_default_address};
 use crate::shim::address::{Address, StrictAddress};
 use crate::shim::econ::TokenAmount;
 use crate::shim::message::{Message, METHOD_SEND};
-use crate::Client;
 use num::Zero as _;
 
 use super::handle_rpc_err;
@@ -33,12 +32,12 @@ pub struct SendCommand {
 }
 
 impl SendCommand {
-    pub async fn run(self, client: Client) -> anyhow::Result<()> {
+    pub async fn run(self, rpc_token: Option<String>) -> anyhow::Result<()> {
         let from: Address = if let Some(from) = &self.from {
             StrictAddress::from_str(from)?.into()
         } else {
             Address::from_str(
-                &wallet_default_address((), &client.rpc_token)
+                &wallet_default_address((), &rpc_token)
                     .await
                     .map_err(handle_rpc_err)?
                     .ok_or_else(|| {
@@ -61,7 +60,7 @@ impl SendCommand {
             ..Default::default()
         };
 
-        let signed_msg = mpool_push_message((LotusJson(message), None), &client.rpc_token)
+        let signed_msg = mpool_push_message((LotusJson(message), None), &rpc_token)
             .await
             .map_err(handle_rpc_err)?
             .into_inner();

--- a/src/cli/subcommands/shutdown_cmd.rs
+++ b/src/cli/subcommands/shutdown_cmd.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::rpc_client::shutdown;
+use crate::Client;
 
-use super::{handle_rpc_err, Config};
+use super::handle_rpc_err;
 use crate::cli::subcommands::prompt_confirm;
 
 #[derive(Debug, clap::Args)]
@@ -14,13 +15,13 @@ pub struct ShutdownCommand {
 }
 
 impl ShutdownCommand {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         println!("Shutting down Forest node");
         if !self.force && !prompt_confirm() {
             println!("Aborted.");
             return Ok(());
         }
-        shutdown((), &config.client.rpc_token)
+        shutdown((), &client.rpc_token)
             .await
             .map_err(handle_rpc_err)?;
         Ok(())

--- a/src/cli/subcommands/shutdown_cmd.rs
+++ b/src/cli/subcommands/shutdown_cmd.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::rpc_client::shutdown;
-use crate::Client;
 
 use super::handle_rpc_err;
 use crate::cli::subcommands::prompt_confirm;
@@ -15,15 +14,13 @@ pub struct ShutdownCommand {
 }
 
 impl ShutdownCommand {
-    pub async fn run(self, client: Client) -> anyhow::Result<()> {
+    pub async fn run(self, rpc_token: Option<String>) -> anyhow::Result<()> {
         println!("Shutting down Forest node");
         if !self.force && !prompt_confirm() {
             println!("Aborted.");
             return Ok(());
         }
-        shutdown((), &client.rpc_token)
-            .await
-            .map_err(handle_rpc_err)?;
+        shutdown((), &rpc_token).await.map_err(handle_rpc_err)?;
         Ok(())
     }
 }

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -97,12 +97,10 @@ impl SnapshotCommands {
                     .map(|name| crate::daemon::get_actual_chain_name(&name).to_string())
                     .map_err(handle_rpc_err)?;
 
-                let LotusJson(tipset) = chain_get_tipset_by_height(
-                    (epoch, TipsetKeys::default()),
-                    &config.client.rpc_token,
-                )
-                .await
-                .map_err(handle_rpc_err)?;
+                let LotusJson(tipset) =
+                    chain_get_tipset_by_height((epoch, TipsetKeys::default()), &rpc_token)
+                        .await
+                        .map_err(handle_rpc_err)?;
 
                 let output_path = match output_path.is_dir() {
                     true => output_path.join(snapshot::filename(

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -8,7 +8,8 @@ use crate::db::car::forest::DEFAULT_FOREST_CAR_FRAME_SIZE;
 use crate::rpc_api::chain_api::ChainExportParams;
 use crate::rpc_client::{chain_ops::*, state_network_name};
 use crate::utils::bail_moved_cmd;
-use anyhow::{bail, Context as _};
+use crate::Client;
+use anyhow::Context as _;
 use chrono::Utc;
 use clap::Subcommand;
 use human_repr::HumanCount;
@@ -75,7 +76,7 @@ pub enum SnapshotCommands {
 }
 
 impl SnapshotCommands {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         match self {
             Self::Export {
                 output_path,
@@ -84,14 +85,14 @@ impl SnapshotCommands {
                 tipset,
                 depth,
             } => {
-                let chain_head = match chain_head(&config.client.rpc_token).await {
+                let chain_head = match chain_head(&client.rpc_token).await {
                     Ok(LotusJson(head)) => head,
                     Err(_) => cli_error_and_die("Could not get network head", 1),
                 };
 
                 let epoch = tipset.unwrap_or(chain_head.epoch());
 
-                let chain_name = state_network_name((), &config.client.rpc_token)
+                let chain_name = state_network_name((), &client.rpc_token)
                     .await
                     .map(|name| crate::daemon::get_actual_chain_name(&name).to_string())
                     .map_err(handle_rpc_err)?;
@@ -112,20 +113,12 @@ impl SnapshotCommands {
 
                 let params = ChainExportParams {
                     epoch,
-                    recent_roots: depth.unwrap_or(config.chain.recent_state_roots),
+                    recent_roots: depth.unwrap_or(Config::default().chain.recent_state_roots),
                     output_path: temp_path.to_path_buf(),
                     tipset_keys: chain_head.key().clone(),
                     skip_checksum,
                     dry_run,
                 };
-
-                let finality = config.chain.policy.chain_finality.min(epoch);
-                if params.recent_roots < finality {
-                    bail!(
-                        "For {}, depth has to be at least {finality}.",
-                        config.chain.network
-                    );
-                }
 
                 let handle = tokio::spawn({
                     let tmp_file = temp_path.to_owned();
@@ -154,7 +147,7 @@ impl SnapshotCommands {
                     }
                 });
 
-                let hash_result = chain_export(params, &config.client.rpc_token)
+                let hash_result = chain_export(params, &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
 

--- a/src/cli/subcommands/state_cmd.rs
+++ b/src/cli/subcommands/state_cmd.rs
@@ -7,7 +7,6 @@ use crate::lotus_json::LotusJson;
 use crate::rpc_client::state_ops::state_fetch_root;
 use crate::shim::clock::ChainEpoch;
 use crate::shim::econ::TokenAmount;
-use crate::Client;
 use cid::Cid;
 use clap::Subcommand;
 use serde_tuple::{self, Deserialize_tuple, Serialize_tuple};
@@ -36,12 +35,12 @@ pub enum StateCommands {
 }
 
 impl StateCommands {
-    pub async fn run(self, client: Client) -> anyhow::Result<()> {
+    pub async fn run(self, rpc_token: Option<String>) -> anyhow::Result<()> {
         match self {
             Self::Fetch { root, save_to_file } => {
                 println!(
                     "{}",
-                    state_fetch_root((LotusJson(root), save_to_file), &client.rpc_token)
+                    state_fetch_root((LotusJson(root), save_to_file), &rpc_token)
                         .await
                         .map_err(handle_rpc_err)?
                 );

--- a/src/cli/subcommands/state_cmd.rs
+++ b/src/cli/subcommands/state_cmd.rs
@@ -7,12 +7,12 @@ use crate::lotus_json::LotusJson;
 use crate::rpc_client::state_ops::state_fetch_root;
 use crate::shim::clock::ChainEpoch;
 use crate::shim::econ::TokenAmount;
+use crate::Client;
 use cid::Cid;
 use clap::Subcommand;
 use serde_tuple::{self, Deserialize_tuple, Serialize_tuple};
 
 use super::handle_rpc_err;
-use super::Config;
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 struct VestingSchedule {
@@ -36,12 +36,12 @@ pub enum StateCommands {
 }
 
 impl StateCommands {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         match self {
             Self::Fetch { root, save_to_file } => {
                 println!(
                     "{}",
-                    state_fetch_root((LotusJson(root), save_to_file), &config.client.rpc_token)
+                    state_fetch_root((LotusJson(root), save_to_file), &client.rpc_token)
                         .await
                         .map_err(handle_rpc_err)?
                 );

--- a/src/cli/subcommands/sync_cmd.rs
+++ b/src/cli/subcommands/sync_cmd.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use crate::rpc_client::*;
+use crate::Client;
 use crate::{chain_sync::SyncStage, lotus_json::LotusJson};
 use cid::Cid;
 use clap::Subcommand;
 use ticker::Ticker;
 
-use super::Config;
 use crate::cli::subcommands::{format_vec_pretty, handle_rpc_err};
 
 #[derive(Debug, Subcommand)]
@@ -40,14 +40,14 @@ pub enum SyncCommands {
 }
 
 impl SyncCommands {
-    pub async fn run(self, config: Config) -> anyhow::Result<()> {
+    pub async fn run(self, client: Client) -> anyhow::Result<()> {
         match self {
             Self::Wait { watch } => {
                 let ticker = Ticker::new(0.., Duration::from_secs(1));
                 let mut stdout = stdout();
 
                 for _ in ticker {
-                    let response = sync_status((), &config.client.rpc_token)
+                    let response = sync_status((), &client.rpc_token)
                         .await
                         .map_err(handle_rpc_err)?;
                     let state = &response.active_syncs[0];
@@ -94,7 +94,7 @@ impl SyncCommands {
                 Ok(())
             }
             Self::Status => {
-                let response = sync_status((), &config.client.rpc_token)
+                let response = sync_status((), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
 
@@ -133,7 +133,7 @@ impl SyncCommands {
             }
             Self::CheckBad { cid } => {
                 let cid: Cid = cid.parse()?;
-                let response = sync_check_bad((LotusJson(cid),), &config.client.rpc_token)
+                let response = sync_check_bad((LotusJson(cid),), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
 
@@ -146,7 +146,7 @@ impl SyncCommands {
             }
             Self::MarkBad { cid } => {
                 let cid: Cid = cid.parse()?;
-                sync_mark_bad((LotusJson(cid),), &config.client.rpc_token)
+                sync_mark_bad((LotusJson(cid),), &client.rpc_token)
                     .await
                     .map_err(handle_rpc_err)?;
                 println!("OK");


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Remove the `Config` and `Client` structures from the `forest-cli` command-line handling.
- Add `--expire-in` flags to `forest-cli auth create-token` and `forest-cli auth api-info` commands.
- Move `finality` out of the client. The node is responsible for correctness.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
