### PR TITLE
fix: use tipset timestamp in export path name

### DIFF
--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;
+use crate::blocks::TipsetKeys;
 use crate::cli::subcommands::{cli_error_and_die, handle_rpc_err};
 use crate::cli_shared::snapshot::{self, TrustedVendor};
 use crate::db::car::forest::DEFAULT_FOREST_CAR_FRAME_SIZE;
@@ -9,7 +10,7 @@ use crate::rpc_api::chain_api::ChainExportParams;
 use crate::rpc_client::{chain_ops::*, state_network_name};
 use crate::utils::bail_moved_cmd;
 use anyhow::{bail, Context as _};
-use chrono::Utc;
+use chrono::NaiveDateTime;
 use clap::Subcommand;
 use human_repr::HumanCount;
 use std::path::{Path, PathBuf};
@@ -96,11 +97,23 @@ impl SnapshotCommands {
                     .map(|name| crate::daemon::get_actual_chain_name(&name).to_string())
                     .map_err(handle_rpc_err)?;
 
+                let LotusJson(tipset) = chain_get_tipset_by_height(
+                    (epoch, TipsetKeys::default()),
+                    &config.client.rpc_token,
+                )
+                .await
+                .map_err(handle_rpc_err)?;
+
                 let output_path = match output_path.is_dir() {
                     true => output_path.join(snapshot::filename(
                         TrustedVendor::Forest,
                         chain_name,
-                        Utc::now().date_naive(),
+                        NaiveDateTime::from_timestamp_opt(
+                            tipset.min_ticket_block().timestamp() as i64,
+                            0,
+                        )
+                        .unwrap_or_default()
+                        .into(),
                         epoch,
                         true,
                     )),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Snapshot filenames should use the timestamp of the target epoch instead of `now()`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
