### PR TITLE
Remove calls to unwrap

### DIFF
--- a/src/cli/subcommands/attach_cmd.rs
+++ b/src/cli/subcommands/attach_cmd.rs
@@ -165,9 +165,8 @@ where
 {
     match result {
         Ok(v) => {
-            // TODO(elmattic): https://github.com/ChainSafe/forest/issues/3575
-            //                 Check if unwrap is safe here
-            let value: JsonValue = serde_json::to_value(v).unwrap();
+            let value: JsonValue =
+                serde_json::to_value(v).map_err(|e| JsError::from_opaque(e.to_string().into()))?;
             JsValue::from_json(&value, context)
         }
         Err(err) => {
@@ -201,9 +200,7 @@ macro_rules! bind_func {
                             let obj: JsObject = arr.into();
                             JsValue::from(obj)
                         };
-                        // TODO(elmattic): https://github.com/ChainSafe/forest/issues/3575
-                        //                 Check if unwrap is safe here
-                        let args = serde_json::from_value(value.to_json(context).unwrap())?;
+                        let args = serde_json::from_value(value.to_json(context)?)?;
                         handle.block_on($func(args, token))
                     });
                     check_result(context, result)


### PR DESCRIPTION
## Summary of changes

It would be challenging to prove that panics are impossible during serialization/deserialization of `JsValue`'s. Let's play it safe and remove the unwraps.

Changes introduced in this pull request:

- Remove calls to `unwrap` in the `attach` subcommand.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3575

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
