### PR TITLE
don't create test artefacts in repo root

### DIFF
--- a/src/utils/io/mmap.rs
+++ b/src/utils/io/mmap.rs
@@ -113,7 +113,10 @@ mod tests {
 
     #[test]
     fn test_out_of_band_mmap_read() {
-        let temp_file = tempfile::NamedTempFile::new_in(".").unwrap();
+        let temp_file = tempfile::Builder::new()
+            .tempfile()
+            .unwrap()
+            .into_temp_path();
         let mmap = Mmap::map(&fs::File::open(&temp_file).unwrap()).unwrap();
 
         let mut buffer = [];


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- more checks for actors bundle,
- don't create test artefacts in the repo root (without this change, each invocation of `make test` would create `actor_bundles.car.zst` in the root, making the directory dirty)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
