### PR TITLE
fix: forest is not able to sync when kademlia is disabled

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -231,6 +231,28 @@ jobs:
       - name: Snapshot export check
         run: ./scripts/tests/calibnet_export_check.sh
 
+  # Calibnet checks with discovery disabled
+  calibnet-no-discovery-check:
+    needs:
+      - build-ubuntu
+    name: Calibnet no discovery checks
+    runs-on: ubuntu-latest
+    steps:
+      # To help investigate transient test failures
+      - run: lscpu
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: forest-${{ runner.os }}
+          path: ~/.cargo/bin
+      # Permissions are lost during artifact-upload
+      # https://github.com/actions/upload-artifact#permission-loss
+      - name: Set permissions
+        run: |
+          chmod +x ~/.cargo/bin/forest*
+      - run: ./scripts/tests/calibnet_no_discovery_check.sh
+
   db-migration-checks:
     needs:
       - build-ubuntu

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -252,6 +252,7 @@ jobs:
         run: |
           chmod +x ~/.cargo/bin/forest*
       - run: ./scripts/tests/calibnet_no_discovery_check.sh
+        timeout-minutes: 10
 
   db-migration-checks:
     needs:

--- a/scripts/tests/calibnet_no_discovery_check.sh
+++ b/scripts/tests/calibnet_no_discovery_check.sh
@@ -9,8 +9,6 @@ $FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia f
 FULLNODE_API_INFO="$(cat admin_token):/ip4/127.0.0.1/tcp/2345/http"
 export FULLNODE_API_INFO
 
-wait_until_rpc_is_ready
-
 # Verify that one of the seed nodes has been connected to
 until $FOREST_CLI_PATH net peers | grep "bootstrap-0.calibration.fildev.network"; do
     sleep 1s;

--- a/scripts/tests/calibnet_no_discovery_check.sh
+++ b/scripts/tests/calibnet_no_discovery_check.sh
@@ -9,7 +9,7 @@ $FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia f
 FULLNODE_API_INFO="$(cat admin_token):/ip4/127.0.0.1/tcp/2345/http"
 export FULLNODE_API_INFO
 
-wait_util_rpc_is_ready
+wait_until_rpc_is_ready
 
 # Verify that one of the seed nodes has been connected to
 until $FOREST_CLI_PATH net peers | grep "bootstrap-0.calibration.fildev.network"; do

--- a/scripts/tests/calibnet_no_discovery_check.sh
+++ b/scripts/tests/calibnet_no_discovery_check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# This script tests forest behaviours when discovery(mdns and kademlia) is disabled
+
+source "$(dirname "$0")/harness.sh"
+
+$FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --log-dir "$LOG_DIRECTORY" --detach --save-token ./admin_token
+FULLNODE_API_INFO="$(cat admin_token):/ip4/127.0.0.1/tcp/2345/http"
+export FULLNODE_API_INFO
+
+wait_util_rpc_is_ready
+
+# Verify that one of the seed nodes has been connected to
+until $FOREST_CLI_PATH net peers | grep "bootstrap-0.calibration.fildev.network"; do
+    sleep 1s;
+done

--- a/scripts/tests/harness.sh
+++ b/scripts/tests/harness.sh
@@ -80,21 +80,6 @@ function forest_print_logs_and_metrics {
   cat "$LOG_DIRECTORY"/*
 }
 
-function wait_until_rpc_is_ready {
-  # Wait for Forest to be ready. We can assume that it is ready when the
-  # RPC server is up. This checks if Forest's RPC endpoint is up.
-  function call_forest_chain_head {
-    curl --silent -X POST -H "Content-Type: application/json" \
-          --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.ChainHead","params":"null"}' \
-          "http://127.0.0.1:2345/rpc/v0"
-  }
-
-  until call_forest_chain_head; do
-      echo "Forest is unavailable - sleeping for 1s"
-      sleep 1s
-  done
-}
-
 function forest_cleanup {
   if pkill -0 forest 2>/dev/null; then
     forest_print_logs_and_metrics

--- a/scripts/tests/harness.sh
+++ b/scripts/tests/harness.sh
@@ -80,7 +80,7 @@ function forest_print_logs_and_metrics {
   cat "$LOG_DIRECTORY"/*
 }
 
-function wait_util_rpc_is_ready {
+function wait_until_rpc_is_ready {
   # Wait for Forest to be ready. We can assume that it is ready when the
   # RPC server is up. This checks if Forest's RPC endpoint is up.
   function call_forest_chain_head {

--- a/scripts/tests/harness.sh
+++ b/scripts/tests/harness.sh
@@ -80,6 +80,21 @@ function forest_print_logs_and_metrics {
   cat "$LOG_DIRECTORY"/*
 }
 
+function wait_util_rpc_is_ready {
+  # Wait for Forest to be ready. We can assume that it is ready when the
+  # RPC server is up. This checks if Forest's RPC endpoint is up.
+  function call_forest_chain_head {
+    curl --silent -X POST -H "Content-Type: application/json" \
+          --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.ChainHead","params":"null"}' \
+          "http://127.0.0.1:2345/rpc/v0"
+  }
+
+  until call_forest_chain_head; do
+      echo "Forest is unavailable - sleeping for 1s"
+      sleep 1s
+  done
+}
+
 function forest_cleanup {
   if pkill -0 forest 2>/dev/null; then
     forest_print_logs_and_metrics

--- a/src/libp2p/discovery.rs
+++ b/src/libp2p/discovery.rs
@@ -153,7 +153,7 @@ impl<'a> DiscoveryConfig<'a> {
             peers,
             peer_addresses,
             target_peer_count,
-            user_defined,
+            custom_seed_peers: user_defined,
             pending_dial_opts: VecDeque::new(),
         })
     }
@@ -185,7 +185,7 @@ pub struct DiscoveryBehaviour {
     /// Number of connected peers to pause discovery on.
     target_peer_count: u64,
     /// Seed peers
-    user_defined: Vec<(PeerId, Multiaddr)>,
+    custom_seed_peers: Vec<(PeerId, Multiaddr)>,
     /// Options to configure dials to known peers.
     pending_dial_opts: VecDeque<DialOpts>,
 }
@@ -207,7 +207,7 @@ impl DiscoveryBehaviour {
             active_kad.bootstrap().map_err(|e| e.to_string())
         } else {
             // Manually dial to seed peers when kademlia is disabled
-            for (peer_id, address) in &self.user_defined {
+            for (peer_id, address) in &self.custom_seed_peers {
                 self.pending_dial_opts.push_back(
                     DialOpts::peer_id(*peer_id)
                         .condition(PeerCondition::Disconnected)

--- a/src/libp2p/discovery.rs
+++ b/src/libp2p/discovery.rs
@@ -186,7 +186,7 @@ pub struct DiscoveryBehaviour {
     target_peer_count: u64,
     /// Seed peers
     user_defined: Vec<(PeerId, Multiaddr)>,
-    /// Options to configure dials to a known peer.
+    /// Options to configure dials to known peers.
     pending_dial_opts: VecDeque<DialOpts>,
 }
 

--- a/src/libp2p/discovery.rs
+++ b/src/libp2p/discovery.rs
@@ -16,7 +16,10 @@ use libp2p::{
     mdns::{tokio::Behaviour as Mdns, Event as MdnsEvent},
     multiaddr::Protocol,
     swarm::{
-        behaviour::toggle::Toggle, derive_prelude::*, NetworkBehaviour, PollParameters, ToSwarm,
+        behaviour::toggle::Toggle,
+        derive_prelude::*,
+        dial_opts::{DialOpts, PeerCondition},
+        NetworkBehaviour, PollParameters, ToSwarm,
     },
     StreamProtocol,
 };
@@ -122,9 +125,9 @@ impl<'a> DiscoveryConfig<'a> {
 
         let kademlia_opt = if enable_kademlia {
             let mut kademlia = kad::Behaviour::with_config(local_peer_id, store, kad_config);
-            for (peer_id, addr) in user_defined {
-                kademlia.add_address(&peer_id, addr);
-                peers.insert(peer_id);
+            for (peer_id, addr) in &user_defined {
+                kademlia.add_address(peer_id, addr.clone());
+                peers.insert(*peer_id);
             }
             if let Err(e) = kademlia.bootstrap() {
                 warn!("Kademlia bootstrap failed: {}", e);
@@ -150,6 +153,8 @@ impl<'a> DiscoveryConfig<'a> {
             peers,
             peer_addresses,
             target_peer_count,
+            user_defined,
+            pending_dial_opts: VecDeque::new(),
         })
     }
 }
@@ -179,6 +184,10 @@ pub struct DiscoveryBehaviour {
     peer_addresses: HashMap<PeerId, HashSet<Multiaddr>>,
     /// Number of connected peers to pause discovery on.
     target_peer_count: u64,
+    /// Seed peers
+    user_defined: Vec<(PeerId, Multiaddr)>,
+    /// Options to configure dials to a known peer.
+    pending_dial_opts: VecDeque<DialOpts>,
 }
 
 impl DiscoveryBehaviour {
@@ -197,6 +206,15 @@ impl DiscoveryBehaviour {
         if let Some(active_kad) = self.kademlia.as_mut() {
             active_kad.bootstrap().map_err(|e| e.to_string())
         } else {
+            // Manually dial to seed peers when kademlia is disabled
+            for (peer_id, address) in &self.user_defined {
+                self.pending_dial_opts.push_back(
+                    DialOpts::peer_id(*peer_id)
+                        .condition(PeerCondition::Disconnected)
+                        .addresses(vec![address.clone()])
+                        .build(),
+                );
+            }
             Err("Kademlia is not activated".to_string())
         }
     }
@@ -314,6 +332,11 @@ impl NetworkBehaviour for DiscoveryBehaviour {
         // Immediately process the content of `discovered`.
         if let Some(ev) = self.pending_events.pop_front() {
             return Poll::Ready(ToSwarm::GenerateEvent(ev));
+        }
+
+        // Dial to peers
+        if let Some(opts) = self.pending_dial_opts.pop_front() {
+            return Poll::Ready(ToSwarm::Dial { opts });
         }
 
         // Poll the stream that fires when we need to start a random Kademlia query.


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Connect to seed peers when `kademlia` is disabled

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3633

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
