### PR TITLE
fix: listen on p2p endpoints before being detached

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -23,7 +23,7 @@ use crate::genesis::{get_network_name_from_genesis, read_genesis_header};
 use crate::key_management::{
     KeyStore, KeyStoreConfig, ENCRYPTED_KEYSTORE_NAME, FOREST_KEYSTORE_PHRASE_ENV,
 };
-use crate::libp2p::{Libp2pConfig, Libp2pService, PeerId, PeerManager};
+use crate::libp2p::{Libp2pConfig, Libp2pService, PeerManager};
 use crate::message_pool::{MessagePool, MpoolConfig, MpoolRpcProvider};
 use crate::rpc::start_rpc;
 use crate::rpc_api::data_types::RPCState;
@@ -149,11 +149,6 @@ pub(super) async fn start(
     let start_time = chrono::Utc::now();
     let path: PathBuf = config.client.data_dir.join("libp2p");
     let net_keypair = crate::libp2p::keypair::get_or_create_keypair(&path)?;
-
-    // Hint at the multihash which has to go in the `/p2p/<multihash>` part of the
-    // peer's multiaddress. Useful if others want to use this node to bootstrap
-    // from.
-    info!("PeerId: {}", PeerId::from(net_keypair.public()));
 
     let mut keystore = load_or_create_keystore(&config).await?;
 
@@ -300,7 +295,8 @@ pub(super) async fn start(
         net_keypair,
         &network_name,
         genesis_cid,
-    )?;
+    )
+    .await?;
 
     let network_rx = p2p_service.network_receiver();
     let network_send = p2p_service.network_sender();


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Currently, RPC and metrics endpoints are listened on before a forest node is detached. This PR tries to make p2p endpoints being listened on before a forest node is detached as well, to facilitate getting peer addresses in testing scripts without extra waiting 
(and remove `wait_until_p2p_is_ready` in https://github.com/ChainSafe/forest/pull/3593/files#diff-176041f18568d006c10ca85238739cb3238bd6c39f777bdab37a5ce55fa69fa7R108)

Changes introduced in this pull request:

- listen on p2p endpoints before being detached
- fail fast if the no provided listen addresses are valid

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
