### PR TITLE
fix: remove peer_tipset_epoch metric records for disconnected peers

### DIFF
--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -411,10 +411,12 @@ where
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .with_label_values(&[metrics::values::PEER_DISCONNECTED])
                     .inc();
-                // Unset heaviest tipset for disconnected peers
-                metrics::PEER_TIPSET_EPOCH
-                    .with_label_values(&[peer_id.to_string().as_str()])
-                    .set(-1);
+                // Remove peer id labels for disconnected peers
+                if let Err(e) =
+                    metrics::PEER_TIPSET_EPOCH.remove_label_values(&[peer_id.to_string().as_str()])
+                {
+                    debug!("{e}");
+                }
                 // Spawn and immediately move on to the next event
                 tokio::task::spawn(Self::handle_peer_disconnected_event(
                     network.clone(),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/3509

The change was originally introduced as part of https://github.com/ChainSafe/forest/pull/3593/files#diff-15b238f8e8b4bd891cf02219c996ebe094b39e766988d33755861440bb118b27R420 but it's no longer relevant to that PR 

More discussion here: https://github.com/ChainSafe/forest/pull/3593#discussion_r1369815140

Changes introduced in this pull request:

- remove peer_tipset_epoch metric records for disconnected peers to avoid bloating metrics

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
