### PR TITLE
daemon: download only bundles for the given network

### DIFF
--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -22,8 +22,10 @@ pub async fn load_actor_bundles(
         ACTOR_BUNDLES
             .iter()
             .filter(|bundle| {
-                !db.has(&bundle.manifest).unwrap_or(false)
-                    && discriminant(network) == discriminant(&bundle.network)
+                !db.has(&bundle.manifest).unwrap_or(false) &&
+                // Comparing only the discriminant is enough. All devnets share the same
+                // actor bundle.
+                discriminant(network) == discriminant(&bundle.network)
             })
             .map(
                 |ActorBundleInfo {

--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -9,6 +9,7 @@ use anyhow::ensure;
 use futures::{stream::FuturesUnordered, TryStreamExt};
 use fvm_ipld_blockstore::Blockstore;
 use std::io::Cursor;
+use std::mem::discriminant;
 use tracing::warn;
 
 /// Tries to load the missing actor bundles to the blockstore. If the bundle is
@@ -21,7 +22,8 @@ pub async fn load_actor_bundles(
         ACTOR_BUNDLES
             .iter()
             .filter(|bundle| {
-                !db.has(&bundle.manifest).unwrap_or(false) && &bundle.network == network
+                !db.has(&bundle.manifest).unwrap_or(false)
+                    && discriminant(network) == discriminant(&bundle.network)
             })
             .map(
                 |ActorBundleInfo {

--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{
-    networks::{ActorBundleInfo, ACTOR_BUNDLES},
+    networks::{ActorBundleInfo, NetworkChain, ACTOR_BUNDLES},
     utils::{db::car_util::load_car, net::http_get},
 };
 use anyhow::ensure;
@@ -13,16 +13,22 @@ use tracing::warn;
 
 /// Tries to load the missing actor bundles to the blockstore. If the bundle is
 /// not present, it will be downloaded.
-pub async fn load_actor_bundles(db: &impl Blockstore) -> anyhow::Result<()> {
+pub async fn load_actor_bundles(
+    db: &impl Blockstore,
+    network: &NetworkChain,
+) -> anyhow::Result<()> {
     FuturesUnordered::from_iter(
         ACTOR_BUNDLES
             .iter()
-            .filter(|bundle| !db.has(&bundle.manifest).unwrap_or(false))
+            .filter(|bundle| {
+                !db.has(&bundle.manifest).unwrap_or(false) && &bundle.network == network
+            })
             .map(
                 |ActorBundleInfo {
                      manifest: root,
                      url,
                      alt_url,
+                     network: _,
                  }| async move {
                     let response = if let Ok(response) = http_get(url).await {
                         response

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -180,7 +180,7 @@ pub(super) async fn start(
     load_all_forest_cars(&db, &forest_car_db_dir)?;
 
     if config.client.load_actors {
-        load_actor_bundles(&db).await?;
+        load_actor_bundles(&db, &config.chain).await?;
     }
 
     let mut services = JoinSet::new();

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -18,6 +18,10 @@ use tracing::warn;
 use crate::utils::db::car_stream::{CarStream, CarWriter};
 use crate::utils::net::http_get;
 
+use std::str::FromStr;
+
+use super::NetworkChain;
+
 #[derive(Debug)]
 pub struct ActorBundleInfo {
     pub manifest: Cid,
@@ -26,6 +30,7 @@ pub struct ActorBundleInfo {
     /// Note that we host the bundles and so we need to update the bucket
     /// ourselves when a new bundle is released.
     pub alt_url: Url,
+    pub network: NetworkChain,
 }
 
 macro_rules! actor_bundle_info {
@@ -47,7 +52,8 @@ macro_rules! actor_bundle_info {
                             "/builtin-actors-",
                             $network,
                             ".car"
-                        ).parse().unwrap()
+                        ).parse().unwrap(),
+                    network: NetworkChain::from_str($network).unwrap(),
                 },
             )*
         ]
@@ -76,6 +82,7 @@ pub async fn generate_actor_bundle(output: &Path) -> anyhow::Result<()> {
              manifest: root,
              url,
              alt_url,
+             network: _,
          }| async move {
             let response = if let Ok(response) = http_get(url).await {
                 response
@@ -149,6 +156,7 @@ mod tests {
                  manifest,
                  url,
                  alt_url,
+                 network: _,
              }| async move {
                 let (primary, alt) = match (http_get(url).await, http_get(alt_url).await) {
                     (Ok(primary), Ok(alt)) => (primary, alt),

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -44,7 +44,7 @@ impl FromStr for NetworkChain {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "mainnet" => Ok(NetworkChain::Mainnet),
-            "calibnet" => Ok(NetworkChain::Calibnet),
+            "calibnet" | "calibrationnet" => Ok(NetworkChain::Calibnet),
             name => Ok(NetworkChain::Devnet(name.to_owned())),
         }
     }

--- a/src/state_migration/tests/mod.rs
+++ b/src/state_migration/tests/mod.rs
@@ -111,7 +111,7 @@ async fn test_state_migration(
     let store = Arc::new(
         crate::db::car::plain::PlainCar::new(RandomAccessFile::open(&car_path).unwrap()).unwrap(),
     );
-    load_actor_bundles(&store).await.unwrap();
+    load_actor_bundles(&store, &network).await.unwrap();
 
     let chain_config = Arc::new(ChainConfig::from_chain(&network));
     let height_info = &chain_config.height_infos[height as usize];

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -357,7 +357,7 @@ where
     let last_epoch = ts.epoch() - epochs as i64;
 
     // Bundles are required when doing state migrations.
-    load_actor_bundles(&db).await?;
+    load_actor_bundles(&db, &network).await?;
 
     // Set proof parameter data dir and make sure the proofs are available
     crate::utils::proofs_api::paramfetch::set_proofs_parameter_cache_dir_env(


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- there is no point in downloading bundles for calibnet and devnet when running mainnet-only. This change makes it so that only actor bundles for the network at hand are downloaded.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
