### PR TITLE
test: compare Lotus compatibility for `StateAccountKey`, `StateCirculatingSupply` and `StateDecodeParams`

### DIFF
--- a/src/rpc_api/mod.rs
+++ b/src/rpc_api/mod.rs
@@ -235,6 +235,7 @@ pub mod state_api {
     pub const STATE_READ_STATE: &str = "Filecoin.StateReadState";
     pub const STATE_MINER_ACTIVE_SECTORS: &str = "Filecoin.StateMinerActiveSectors";
     pub const STATE_ACCOUNT_KEY: &str = "Filecoin.StateAccountKey";
+    pub const STATE_CIRCULATING_SUPPLY: &str = "Filecoin.StateCirculatingSupply";
 }
 
 /// Gas API

--- a/src/rpc_api/mod.rs
+++ b/src/rpc_api/mod.rs
@@ -234,6 +234,7 @@ pub mod state_api {
     pub const STATE_GET_RANDOMNESS_FROM_BEACON: &str = "Filecoin.StateGetRandomnessFromBeacon";
     pub const STATE_READ_STATE: &str = "Filecoin.StateReadState";
     pub const STATE_MINER_ACTIVE_SECTORS: &str = "Filecoin.StateMinerActiveSectors";
+    pub const STATE_ACCOUNT_KEY: &str = "Filecoin.StateAccountKey";
 }
 
 /// Gas API

--- a/src/rpc_api/mod.rs
+++ b/src/rpc_api/mod.rs
@@ -236,6 +236,7 @@ pub mod state_api {
     pub const STATE_MINER_ACTIVE_SECTORS: &str = "Filecoin.StateMinerActiveSectors";
     pub const STATE_ACCOUNT_KEY: &str = "Filecoin.StateAccountKey";
     pub const STATE_CIRCULATING_SUPPLY: &str = "Filecoin.StateCirculatingSupply";
+    pub const STATE_DECODE_PARAMS: &str = "Filecoin.StateDecodeParams";
 }
 
 /// Gas API

--- a/src/rpc_client/state_ops.rs
+++ b/src/rpc_client/state_ops.rs
@@ -79,4 +79,8 @@ impl ApiInfo {
     ) -> RpcRequest<Vec<SectorOnChainInfo>> {
         RpcRequest::new(STATE_MINER_ACTIVE_SECTORS, (actor, tsk))
     }
+
+    pub fn state_account_key_req(addr: Address, tsk: TipsetKeys) -> RpcRequest<Address> {
+        RpcRequest::new(STATE_ACCOUNT_KEY, (addr, tsk))
+    }
 }

--- a/src/rpc_client/state_ops.rs
+++ b/src/rpc_client/state_ops.rs
@@ -9,7 +9,7 @@ use crate::{
         data_types::{ApiActorState, SectorOnChainInfo},
         state_api::*,
     },
-    shim::{address::Address, clock::ChainEpoch, state_tree::ActorState},
+    shim::{address::Address, clock::ChainEpoch, econ::TokenAmount, state_tree::ActorState},
 };
 use cid::Cid;
 use fil_actor_interface::miner::MinerPower;
@@ -82,5 +82,9 @@ impl ApiInfo {
 
     pub fn state_account_key_req(addr: Address, tsk: TipsetKeys) -> RpcRequest<Address> {
         RpcRequest::new(STATE_ACCOUNT_KEY, (addr, tsk))
+    }
+
+    pub fn state_circulating_supply_req(tsk: TipsetKeys) -> RpcRequest<TokenAmount> {
+        RpcRequest::new(STATE_CIRCULATING_SUPPLY, (tsk,))
     }
 }

--- a/src/rpc_client/state_ops.rs
+++ b/src/rpc_client/state_ops.rs
@@ -53,7 +53,7 @@ impl ApiInfo {
         RpcRequest::new(STATE_NETWORK_NAME, ())
     }
 
-    pub fn state_miner_power(miner: Address, tsk: TipsetKeys) -> RpcRequest<MinerPower> {
+    pub fn state_miner_power_req(miner: Address, tsk: TipsetKeys) -> RpcRequest<MinerPower> {
         RpcRequest::new(STATE_MINOR_POWER, (miner, tsk))
     }
 

--- a/src/rpc_client/state_ops.rs
+++ b/src/rpc_client/state_ops.rs
@@ -9,11 +9,15 @@ use crate::{
         data_types::{ApiActorState, SectorOnChainInfo},
         state_api::*,
     },
-    shim::{address::Address, clock::ChainEpoch, econ::TokenAmount, state_tree::ActorState},
+    shim::{
+        address::Address, clock::ChainEpoch, econ::TokenAmount, message::MethodNum,
+        state_tree::ActorState,
+    },
 };
 use cid::Cid;
 use fil_actor_interface::miner::MinerPower;
 use fil_actors_shared::v10::runtime::DomainSeparationTag;
+use libipld_core::ipld::Ipld;
 
 use super::{ApiInfo, JsonRpcError, RpcRequest};
 
@@ -86,5 +90,14 @@ impl ApiInfo {
 
     pub fn state_circulating_supply_req(tsk: TipsetKeys) -> RpcRequest<TokenAmount> {
         RpcRequest::new(STATE_CIRCULATING_SUPPLY, (tsk,))
+    }
+
+    pub fn state_decode_params_req(
+        recipient: Address,
+        method_number: MethodNum,
+        params: Vec<u8>,
+        tsk: TipsetKeys,
+    ) -> RpcRequest<Ipld> {
+        RpcRequest::new(STATE_DECODE_PARAMS, (recipient, method_number, params, tsk))
     }
 }

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -286,7 +286,7 @@ fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
                     msg.cid()?,
                 )));
                 tests.push(RpcTest::identity(ApiInfo::state_account_key_req(
-                    msg.from.into(),
+                    msg.from(),
                     root_tsk.clone(),
                 )));
             }

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -298,6 +298,14 @@ fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
                     msg.from(),
                     root_tsk.clone(),
                 )));
+                if !msg.params().is_empty() {
+                    tests.push(RpcTest::identity(ApiInfo::state_decode_params_req(
+                        msg.to(),
+                        msg.method_num(),
+                        msg.params().to_vec(),
+                        root_tsk.clone(),
+                    )));
+                }
             }
             tests.push(RpcTest::basic(ApiInfo::state_miner_power_req(
                 *block.miner_address(),

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -13,6 +13,7 @@ use crate::blocks::Tipset;
 use crate::blocks::TipsetKeys;
 use crate::db::car::ManyCar;
 use crate::lotus_json::HasLotusJson;
+use crate::message::Message as _;
 use crate::rpc_client::{ApiInfo, JsonRpcError, RpcRequest};
 use crate::shim::address::Address;
 
@@ -273,6 +274,7 @@ fn state_tests(shared_tipset: &Tipset) -> Vec<RpcTest> {
 fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
     let mut tests = vec![];
     let shared_tipset = store.heaviest_tipset()?;
+    let root_tsk = shared_tipset.key().clone();
     tests.extend(chain_tests_with_tipset(&shared_tipset));
     tests.extend(state_tests(&shared_tipset));
 
@@ -283,10 +285,18 @@ fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
                 tests.push(RpcTest::identity(ApiInfo::chain_get_message_req(
                     msg.cid()?,
                 )));
+                tests.push(RpcTest::identity(ApiInfo::state_account_key_req(
+                    msg.from.into(),
+                    root_tsk.clone(),
+                )));
             }
             for msg in secp_messages {
                 tests.push(RpcTest::identity(ApiInfo::chain_get_message_req(
                     msg.cid()?,
+                )));
+                tests.push(RpcTest::identity(ApiInfo::state_account_key_req(
+                    msg.from(),
+                    root_tsk.clone(),
                 )));
             }
             tests.push(RpcTest::basic(ApiInfo::state_miner_power(

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -304,6 +304,9 @@ fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
                 tipset.key().clone(),
             )))
         }
+        tests.push(RpcTest::basic(ApiInfo::state_circulating_supply_req(
+            tipset.key().clone(),
+        )))
     }
     Ok(tests)
 }

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -299,7 +299,7 @@ fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
                     root_tsk.clone(),
                 )));
             }
-            tests.push(RpcTest::basic(ApiInfo::state_miner_power(
+            tests.push(RpcTest::basic(ApiInfo::state_miner_power_req(
                 *block.miner_address(),
                 tipset.key().clone(),
             )))


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Tests for `StateAccountKey`, `StateCirculatingSupply` and `StateDecodeParams`. Note, Forest does not support these methods yet.
- The tests are run manually with the `forest-tool api compare` command.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Part of #3639

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
