### PR TITLE
test: check compatibility for three more RPC calls

### DIFF
--- a/scripts/tests/calibnet_wallet_check.sh
+++ b/scripts/tests/calibnet_wallet_check.sh
@@ -36,8 +36,10 @@ ADDR_ONE=$($FOREST_WALLET_PATH list | tail -1 | cut -d ' ' -f1)
 sleep 5s
 
 $FOREST_WALLET_PATH export "$ADDR_ONE" > preloaded_wallet.test.key
-if ! cmp -s preloaded_wallet.key preloaded_wallet.test.key; then
-    echo ".key files should match"
+$FOREST_WALLET_PATH delete "$ADDR_ONE"
+ROUNDTRIP_ADDR=$($FOREST_WALLET_PATH import preloaded_wallet.test.key)
+if [[ $ADDR_ONE != $ROUNDTRIP_ADDR ]]; then
+    echo "Wallet address should be the same after a roundtrip"
     exit 1
 fi
 

--- a/scripts/tests/calibnet_wallet_check.sh
+++ b/scripts/tests/calibnet_wallet_check.sh
@@ -38,7 +38,7 @@ sleep 5s
 $FOREST_WALLET_PATH export "$ADDR_ONE" > preloaded_wallet.test.key
 $FOREST_WALLET_PATH delete "$ADDR_ONE"
 ROUNDTRIP_ADDR=$($FOREST_WALLET_PATH import preloaded_wallet.test.key)
-if [[ $ADDR_ONE != $ROUNDTRIP_ADDR ]]; then
+if [[ "$ADDR_ONE" != "$ROUNDTRIP_ADDR" ]]; then
     echo "Wallet address should be the same after a roundtrip"
     exit 1
 fi

--- a/src/lotus_json/key_info.rs
+++ b/src/lotus_json/key_info.rs
@@ -17,7 +17,7 @@ impl HasLotusJson for KeyInfo {
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({
-                "Type": "bls",
+                "Type": 2,
                 "PrivateKey": "aGVsbG8gd29ybGQh"
             }),
             Self::new(

--- a/src/lotus_json/signature.rs
+++ b/src/lotus_json/signature.rs
@@ -16,7 +16,7 @@ impl HasLotusJson for Signature {
 
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
-            json!({"Type": "bls", "Data": "aGVsbG8gd29ybGQh"}),
+            json!({"Type": 2, "Data": "aGVsbG8gd29ybGQh"}),
             Signature {
                 sig_type: crate::shim::crypto::SignatureType::Bls,
                 bytes: Vec::from_iter(*b"hello world!"),

--- a/src/lotus_json/signature_type.rs
+++ b/src/lotus_json/signature_type.rs
@@ -22,7 +22,7 @@ impl HasLotusJson for SignatureType {
     type LotusJson = SignatureTypeLotusJson;
 
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
-        vec![(json!("bls"), SignatureType::Bls)]
+        vec![(json!(2), SignatureType::Bls)]
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {

--- a/src/lotus_json/signature_type.rs
+++ b/src/lotus_json/signature_type.rs
@@ -7,9 +7,9 @@ use crate::shim::crypto::SignatureType;
 // Lotus uses signature types under two names: `KeyType` and `SigType`.
 // `KeyType` can be deserialized from a string but `SigType` must always be an
 // integer. For more information, see
-// https://github.com/filecoin-project/go-state-types/blob/master/crypto/signature.go
+// https://github.com/filecoin-project/go-state-types/blob/a0445436230e221ab1828ad170623fcfe00c8263/crypto/signature.go
 // and
-// https://github.com/filecoin-project/lotus/blob/v1.23.3/chain/types/keystore.go#L47
+// https://github.com/filecoin-project/lotus/blob/7bb1f98ac6f5a6da2cc79afc26d8cd9fe323eb30/chain/types/keystore.go#L47
 
 #[derive(Deserialize, Serialize)]
 #[serde(untagged)] // try an int, then a string

--- a/src/lotus_json/signature_type.rs
+++ b/src/lotus_json/signature_type.rs
@@ -4,11 +4,16 @@
 use super::*;
 use crate::shim::crypto::SignatureType;
 
+// Lotus uses signature types under two names: `KeyType` and `SigType`.
+// `KeyType` can be deserialized from a string but `SigType` must always be an
+// integer. For more information, see
+// https://github.com/filecoin-project/go-state-types/blob/master/crypto/signature.go
+// and
+// https://github.com/filecoin-project/lotus/blob/v1.23.3/chain/types/keystore.go#L47
+
 #[derive(Deserialize, Serialize)]
 #[serde(untagged)] // try an int, then a string
 pub enum SignatureTypeLotusJson {
-    // Lotus also accepts ints when deserializing - we need this for our test vectors
-    // https://github.com/filecoin-project/lotus/blob/v1.23.3/chain/types/keystore.go#L47
     Integer(SignatureType),
     String(Stringify<SignatureType>),
 }
@@ -21,8 +26,7 @@ impl HasLotusJson for SignatureType {
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        // always serialize as a string, since lotus deprecates ints
-        SignatureTypeLotusJson::String(Stringify(self))
+        SignatureTypeLotusJson::Integer(self)
     }
 
     fn from_lotus_json(lotus_json: Self::LotusJson) -> Self {

--- a/src/lotus_json/signed_message.rs
+++ b/src/lotus_json/signed_message.rs
@@ -37,7 +37,7 @@ impl HasLotusJson for SignedMessage {
                         "/": "bafy2bzaced3xdk2uf6azekyxgcttujvy3fzyeqmibtpjf2fxcpfdx2zcx4s3g"
                     },
                 },
-                "Signature": {"Type": "bls", "Data": "aGVsbG8gd29ybGQh"}
+                "Signature": {"Type": 2, "Data": "aGVsbG8gd29ybGQh"}
             }),
             SignedMessage {
                 message: crate::shim::message::Message::default(),

--- a/src/rpc_api/mod.rs
+++ b/src/rpc_api/mod.rs
@@ -234,6 +234,7 @@ pub mod state_api {
     pub const STATE_GET_RANDOMNESS_FROM_BEACON: &str = "Filecoin.StateGetRandomnessFromBeacon";
     pub const STATE_READ_STATE: &str = "Filecoin.StateReadState";
     pub const STATE_MINER_ACTIVE_SECTORS: &str = "Filecoin.StateMinerActiveSectors";
+    pub const STATE_LOOKUP_ID: &str = "Filecoin.StateLookupID";
 }
 
 /// Gas API

--- a/src/rpc_client/state_ops.rs
+++ b/src/rpc_client/state_ops.rs
@@ -79,4 +79,8 @@ impl ApiInfo {
     ) -> RpcRequest<Vec<SectorOnChainInfo>> {
         RpcRequest::new(STATE_MINER_ACTIVE_SECTORS, (actor, tsk))
     }
+
+    pub fn state_lookup_id_req(addr: Address, tsk: TipsetKeys) -> RpcRequest<Option<Address>> {
+        RpcRequest::new(STATE_LOOKUP_ID, (addr, tsk))
+    }
 }

--- a/src/rpc_client/state_ops.rs
+++ b/src/rpc_client/state_ops.rs
@@ -90,6 +90,7 @@ impl ApiInfo {
 
     pub fn state_network_version_req(tsk: TipsetKeys) -> RpcRequest<NetworkVersion> {
         RpcRequest::new(STATE_NETWORK_VERSION, (tsk,))
+    }
 
     pub fn state_account_key_req(addr: Address, tsk: TipsetKeys) -> RpcRequest<Address> {
         RpcRequest::new(STATE_ACCOUNT_KEY, (addr, tsk))

--- a/src/rpc_client/state_ops.rs
+++ b/src/rpc_client/state_ops.rs
@@ -9,7 +9,7 @@ use crate::{
         data_types::{ApiActorState, SectorOnChainInfo},
         state_api::*,
     },
-    shim::{address::Address, clock::ChainEpoch, state_tree::ActorState},
+    shim::{address::Address, clock::ChainEpoch, state_tree::ActorState, version::NetworkVersion},
 };
 use cid::Cid;
 use fil_actor_interface::miner::MinerPower;
@@ -82,5 +82,9 @@ impl ApiInfo {
 
     pub fn state_lookup_id_req(addr: Address, tsk: TipsetKeys) -> RpcRequest<Option<Address>> {
         RpcRequest::new(STATE_LOOKUP_ID, (addr, tsk))
+    }
+
+    pub fn state_network_version_req(tsk: TipsetKeys) -> RpcRequest<NetworkVersion> {
+        RpcRequest::new(STATE_NETWORK_VERSION, (tsk,))
     }
 }

--- a/src/shim/version.rs
+++ b/src/shim/version.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::ops::{Deref, DerefMut};
 
+use crate::lotus_json::lotus_json_with_self;
+
 use super::fvm_shared_latest::version::NetworkVersion as NetworkVersion_latest;
 pub use fvm_shared2::version::NetworkVersion as NetworkVersion_v2;
 use fvm_shared3::version::NetworkVersion as NetworkVersion_v3;
@@ -28,6 +30,8 @@ use serde::{Deserialize, Serialize};
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct NetworkVersion(pub NetworkVersion_latest);
+
+lotus_json_with_self!(NetworkVersion);
 
 impl NetworkVersion {
     pub const V0: Self = Self(NetworkVersion_latest::new(0));

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -298,6 +298,8 @@ fn wallet_tests() -> Vec<RpcTest> {
     vec![
         RpcTest::identity(ApiInfo::wallet_balance_req(known_wallet.to_string())),
         RpcTest::identity(ApiInfo::wallet_verify_req(known_wallet, text, signature)),
+        // This method requires write access in Lotus. Not sure why.
+        // RpcTest::basic(ApiInfo::wallet_default_address_req()),
     ]
 }
 

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -298,8 +298,10 @@ fn wallet_tests() -> Vec<RpcTest> {
     vec![
         RpcTest::identity(ApiInfo::wallet_balance_req(known_wallet.to_string())),
         RpcTest::identity(ApiInfo::wallet_verify_req(known_wallet, text, signature)),
-        // This method requires write access in Lotus. Not sure why.
+        // These methods require write access in Lotus. Not sure why.
         // RpcTest::basic(ApiInfo::wallet_default_address_req()),
+        // RpcTest::basic(ApiInfo::wallet_list_req()),
+        // RpcTest::basic(ApiInfo::wallet_has_req(known_wallet.to_string())),
     ]
 }
 

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -274,6 +274,9 @@ fn state_tests(shared_tipset: &Tipset) -> Vec<RpcTest> {
             Address::new_id(0xdeadbeef),
             shared_tipset.key().clone(),
         )),
+        RpcTest::identity(ApiInfo::state_network_version_req(
+            shared_tipset.key().clone(),
+        )),
     ]
 }
 

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -265,6 +265,15 @@ fn state_tests(shared_tipset: &Tipset) -> Vec<RpcTest> {
             *shared_block.miner_address(),
             shared_tipset.key().clone(),
         )),
+        RpcTest::identity(ApiInfo::state_lookup_id_req(
+            *shared_block.miner_address(),
+            shared_tipset.key().clone(),
+        )),
+        // This should return `Address::new_id(0xdeadbeef)`
+        RpcTest::identity(ApiInfo::state_lookup_id_req(
+            Address::new_id(0xdeadbeef),
+            shared_tipset.key().clone(),
+        )),
     ]
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `StateLookupID`
- `StateNetworkVersion`
- `WalletBalance`
- Changed `SignatureType` to always be encoded as an integer. Lotus requires this in certain places.
- Test wallet import/export roundtripping in a more flexible way.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Part of #3639

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
