### PR TITLE
fix: align forest-cli chain message output with lotus

### DIFF
--- a/src/lotus_json/signed_message.rs
+++ b/src/lotus_json/signed_message.rs
@@ -16,6 +16,13 @@ pub struct SignedMessageLotusJson {
     cid: LotusJson<Option<Cid>>,
 }
 
+impl SignedMessageLotusJson {
+    pub fn with_cid(mut self, cid: Cid) -> Self {
+        self.cid = LotusJson(Some(cid));
+        self
+    }
+}
+
 impl HasLotusJson for SignedMessage {
     type LotusJson = SignedMessageLotusJson;
 

--- a/src/rpc_client/chain_ops.rs
+++ b/src/rpc_client/chain_ops.rs
@@ -84,6 +84,7 @@ impl ApiInfo {
         RpcRequest::new(CHAIN_EXPORT, params)
     }
 
+    #[allow(dead_code)]
     pub async fn chain_get_message(&self, cid: Cid) -> Result<Message, JsonRpcError> {
         self.call(Self::chain_get_message_req(cid)).await
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/3639

Lotus uses `ChainReadObj` API to print full signed message in `lotus chain getmessage [CID]` output, this PR tries to match it in `forest-cli chain message -c [CID]`.

Note: The output still slightly differs, `forest-cli` prints `SignatureType` in string format while `lotus` prints it in Integer format, which has been addressed by https://github.com/ChainSafe/forest/pull/3698

Changes introduced in this pull request:

- align forest-cli chain message output with lotus

`forest-cli chain message -c bafy2bzacedpkf2v5kgm4mvvljer6q3s45yfcdzaiyl3xdoivt5m53iv77v76w` output
```json
{
  "Message": {
    "Version": 0,
    "To": "t410famf46pkqzlieylsxhenre5ajqkutbbrb652rziy",
    "From": "t410fot3vkzzorqg4alowvghvxx4mhofhtazixbm6z2i",
    "Nonce": 26944,
    "Value": "0",
    "GasLimit": 33780427,
    "GasFeeCap": "201100",
    "GasPremium": "200900",
    "Method": 3844450837,
    "Params": "WMTq9dBOAAAAAAAAAAAAAAAAdPdVZy6MDcAt1qmPW9+MO4p5gygAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC91cGRhdGUgaGVhbHRoYm90XzMxNDE1OV81IHNldCBjb3VudGVyPWNvdW50ZXIrMQAAAAAAAAAAAAAAAAAAAAAA",
    "CID": {
      "/": "bafy2bzaceb2wxksv3na5ziqyay2wemn7tuigp2i4tvudg3jvsuzmdmvcivmzy"
    }
  },
  "Signature": {
    "Type": "delegated",
    "Data": "m4Fj5Bw0AGkLYj7XMnVDx6HHjFihzYpJ1bGOwQLee4kkQ4OcMhUsyigHLUldQ23l81+wgG0KVypQQciAznT7+wE="
  },
  "CID": {
    "/": "bafy2bzacedpkf2v5kgm4mvvljer6q3s45yfcdzaiyl3xdoivt5m53iv77v76w"
  }
}
```

`lotus chain getmessage bafy2bzacedpkf2v5kgm4mvvljer6q3s45yfcdzaiyl3xdoivt5m53iv77v76w` output:
```json
{
  "Message": {
    "Version": 0,
    "To": "t410famf46pkqzlieylsxhenre5ajqkutbbrb652rziy",
    "From": "t410fot3vkzzorqg4alowvghvxx4mhofhtazixbm6z2i",
    "Nonce": 26944,
    "Value": "0",
    "GasLimit": 33780427,
    "GasFeeCap": "201100",
    "GasPremium": "200900",
    "Method": 3844450837,
    "Params": "WMTq9dBOAAAAAAAAAAAAAAAAdPdVZy6MDcAt1qmPW9+MO4p5gygAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC91cGRhdGUgaGVhbHRoYm90XzMxNDE1OV81IHNldCBjb3VudGVyPWNvdW50ZXIrMQAAAAAAAAAAAAAAAAAAAAAA",
    "CID": {
      "/": "bafy2bzaceb2wxksv3na5ziqyay2wemn7tuigp2i4tvudg3jvsuzmdmvcivmzy"
    }
  },
  "Signature": {
    "Type": 3,
    "Data": "m4Fj5Bw0AGkLYj7XMnVDx6HHjFihzYpJ1bGOwQLee4kkQ4OcMhUsyigHLUldQ23l81+wgG0KVypQQciAznT7+wE="
  },
  "CID": {
    "/": "bafy2bzacedpkf2v5kgm4mvvljer6q3s45yfcdzaiyl3xdoivt5m53iv77v76w"
  }
}
```

lotus code:
```go
var ChainGetMsgCmd = &cli.Command{
	Name:      "getmessage",
	Aliases:   []string{"get-message", "get-msg"},
	Usage:     "Get and print a message by its cid",
	ArgsUsage: "[messageCid]",
	Action: func(cctx *cli.Context) error {
		afmt := NewAppFmt(cctx.App)

		if cctx.NArg() != 1 {
			return IncorrectNumArgs(cctx)
		}

		api, closer, err := GetFullNodeAPI(cctx)
		if err != nil {
			return err
		}
		defer closer()
		ctx := ReqContext(cctx)

		c, err := cid.Decode(cctx.Args().First())
		if err != nil {
			return xerrors.Errorf("failed to parse cid input: %w", err)
		}

		mb, err := api.ChainReadObj(ctx, c)
		if err != nil {
			return xerrors.Errorf("failed to read object: %w", err)
		}

		var i interface{}
		m, err := types.DecodeMessage(mb)
		if err != nil {
			sm, err := types.DecodeSignedMessage(mb)
			if err != nil {
				return xerrors.Errorf("failed to decode object as a message: %w", err)
			}
			i = sm
		} else {
			i = m
		}

		enc, err := json.MarshalIndent(i, "", "  ")
		if err != nil {
			return err
		}

		afmt.Println(string(enc))
		return nil
	},
}
```



## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
