### PR TITLE
fix(libp2p): reduce connection limits

### DIFF
--- a/src/libp2p/behaviour.rs
+++ b/src/libp2p/behaviour.rs
@@ -106,13 +106,30 @@ impl ForestBehaviour {
             .target_peer_count(config.target_peer_count as u64)
             .finish()?;
 
+        const MAX_ESTABLISHED_PER_PEER: u32 = 4;
         let connection_limits = connection_limits::Behaviour::new(
             connection_limits::ConnectionLimits::default()
-                .with_max_pending_incoming(Some(4096))
-                .with_max_pending_outgoing(Some(8192))
-                .with_max_established_incoming(Some(8192))
-                .with_max_established_outgoing(Some(8192))
-                .with_max_established_per_peer(Some(5)),
+                .with_max_pending_incoming(Some(
+                    config
+                        .target_peer_count
+                        .saturating_mul(MAX_ESTABLISHED_PER_PEER),
+                ))
+                .with_max_pending_outgoing(Some(
+                    config
+                        .target_peer_count
+                        .saturating_mul(MAX_ESTABLISHED_PER_PEER),
+                ))
+                .with_max_established_incoming(Some(
+                    config
+                        .target_peer_count
+                        .saturating_mul(MAX_ESTABLISHED_PER_PEER),
+                ))
+                .with_max_established_outgoing(Some(
+                    config
+                        .target_peer_count
+                        .saturating_mul(MAX_ESTABLISHED_PER_PEER),
+                ))
+                .with_max_established_per_peer(Some(MAX_ESTABLISHED_PER_PEER)),
         );
 
         info!("libp2p Forest version: {}", FOREST_VERSION_STRING.as_str());


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As a follow-up of https://github.com/ChainSafe/forest/pull/3713
Currently, `target_peer_count` is only used to decide whether or not to perform proactive kad queries, while it does not prevent forest from accepting inbound connections. When total connections reach 2k+(test on @0.16.0, @0.15.2 and @0.15.0), timeout rate of `hello` and `bitswap` become high. This PR tries to setup `connection_limits` behaviour with `target_peer_count` to limit the total active connections

Manually tested on mainnet, smaller connection limits could also mitigate timeouts in `bitswap` and `hello` 

Changes introduced in this pull request:

- Calculate the connection limits from `target_peer_count`, instead of using static values.

Manually tested on mainnet, forest is able to sync with normal performance.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
