### PR TITLE
feat: implement Filecoin.StateAccountKey RPC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 - [#3720](https://github.com/ChainSafe/forest/pull/3720) Implement the
   `Filecoin.GetParentMessages` lotus-compatible RPC API.
+- [#3735](https://github.com/ChainSafe/forest/pull/3735) Implement the
+  `Filecoin.StateAccountKey` lotus-compatible RPC API.
 - [#3727](https://github.com/ChainSafe/forest/pull/3727) Added glif.io calibnet
   bootstrap node peer
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -110,6 +110,7 @@ where
             .with_method(STATE_REPLAY, state_replay::<DB>)
             .with_method(STATE_NETWORK_NAME, state_network_name::<DB>)
             .with_method(STATE_NETWORK_VERSION, state_get_network_version::<DB>)
+            .with_method(STATE_ACCOUNT_KEY, state_account_key::<DB>)
             .with_method(STATE_GET_ACTOR, state_get_actor::<DB>)
             .with_method(STATE_MARKET_BALANCE, state_market_balance::<DB>)
             .with_method(STATE_MARKET_DEALS, state_market_deals::<DB>)

--- a/src/rpc/state_api.rs
+++ b/src/rpc/state_api.rs
@@ -85,6 +85,23 @@ pub(in crate::rpc) async fn state_get_network_version<DB: Blockstore>(
     Ok(data.state_manager.get_network_version(ts.epoch()))
 }
 
+/// gets the public key address of the given ID address
+/// See <https://github.com/filecoin-project/lotus/blob/master/documentation/en/api-v0-methods.md#StateAccountKey>
+pub(in crate::rpc) async fn state_account_key<DB: Blockstore>(
+    data: Data<RPCState<DB>>,
+    Params(LotusJson((address, tipset_keys))): Params<LotusJson<(Address, TipsetKeys)>>,
+) -> Result<LotusJson<Address>, JsonRpcError>
+where
+    DB: Blockstore + Send + Sync + 'static,
+{
+    let ts_opt = data.chain_store.load_tipset(&tipset_keys)?;
+    Ok(LotusJson(
+        data.state_manager
+            .resolve_to_deterministic_address(address, ts_opt)
+            .await?,
+    ))
+}
+
 pub(crate) async fn state_get_actor<DB: Blockstore>(
     data: Data<RPCState<DB>>,
     Params(LotusJson((addr, tsk))): Params<LotusJson<(Address, TipsetKeys)>>,

--- a/src/rpc_api/mod.rs
+++ b/src/rpc_api/mod.rs
@@ -85,6 +85,7 @@ pub static ACCESS_MAP: Lazy<HashMap<&str, Access>> = Lazy::new(|| {
     access.insert(state_api::STATE_WAIT_MSG, Access::Read);
     access.insert(state_api::STATE_NETWORK_NAME, Access::Read);
     access.insert(state_api::STATE_NETWORK_VERSION, Access::Read);
+    access.insert(state_api::STATE_ACCOUNT_KEY, Access::Read);
     access.insert(state_api::STATE_FETCH_ROOT, Access::Read);
     access.insert(state_api::STATE_GET_RANDOMNESS_FROM_BEACON, Access::Read);
     access.insert(state_api::STATE_READ_STATE, Access::Read);

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -292,7 +292,7 @@ where
         }
     }
 
-    /// ResolveToDeterministicAddr returns the public key type of
+    /// Returns the public key type of
     /// address(`BLS`/`SECP256K1`) of an actor identified by `addr`,
     /// or its delegated address.
     pub fn resolve_to_deterministic_addr(

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -308,7 +308,8 @@ where
                     .get_actor(&addr)?
                     .with_context(|| format!("failed to find actor: {addr}"))?;
 
-                // if state.Version() >= types.StateTreeVersion5
+                // A workaround to implement `if state.Version() >= types.StateTreeVersion5`
+                // When state tree version is not available in rust APIs
                 if !matches!(self, Self::FvmV2(_) | Self::V0(_)) {
                     if let Some(address) = actor.delegated_address {
                         return Ok(address.into());

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -291,6 +291,36 @@ where
             StateTree::V0(_) => bail!("StateTree::set_actor not supported on old state trees"),
         }
     }
+
+    /// ResolveToDeterministicAddr returns the public key type of
+    /// address(`BLS`/`SECP256K1`) of an actor identified by `addr`,
+    /// or its delegated address.
+    pub fn resolve_to_deterministic_addr(
+        &self,
+        store: &impl Blockstore,
+        addr: Address,
+    ) -> anyhow::Result<Address> {
+        use crate::shim::address::Protocol::*;
+        match addr.protocol() {
+            BLS | Secp256k1 | Delegated => Ok(addr),
+            _ => {
+                let actor = self
+                    .get_actor(&addr)?
+                    .with_context(|| format!("failed to find actor: {addr}"))?;
+
+                // if state.Version() >= types.StateTreeVersion5
+                if matches!(self, Self::FvmV4(_) | Self::FvmV3(_)) {
+                    if let Some(address) = actor.delegated_address {
+                        return Ok(address.into());
+                    }
+                }
+
+                let account_state =
+                    fil_actor_interface::account::State::load(store, actor.code, actor.state)?;
+                Ok(account_state.pubkey_address().into())
+            }
+        }
+    }
 }
 
 /// `Newtype` to wrap different versions of `fvm::state_tree::ActorState`

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -309,7 +309,7 @@ where
                     .with_context(|| format!("failed to find actor: {addr}"))?;
 
                 // if state.Version() >= types.StateTreeVersion5
-                if matches!(self, Self::FvmV4(_) | Self::FvmV3(_)) {
+                if !matches!(self, Self::FvmV2(_) | Self::V0(_)) {
                     if let Some(address) = actor.delegated_address {
                         return Ok(address.into());
                     }

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -1120,7 +1120,7 @@ where
             BLS | Secp256k1 | Delegated => Ok(address),
             Actor => anyhow::bail!("cannot resolve actor address to key address"),
             _ => {
-                let ts = ts.unwrap_or(self.chain_store().heaviest_tipset());
+                let ts = ts.unwrap_or_else(|| self.chain_store().heaviest_tipset());
                 // First try to resolve the actor in the parent state, so we don't have to compute anything.
                 let state =
                     StateTree::new_from_root(self.chain_store().db.clone(), ts.parent_state())?;

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -1110,6 +1110,35 @@ where
         )
     }
 
+    pub async fn resolve_to_deterministic_address(
+        self: &Arc<Self>,
+        address: Address,
+        ts: Option<Arc<Tipset>>,
+    ) -> anyhow::Result<Address> {
+        use crate::shim::address::Protocol::*;
+        match address.protocol() {
+            BLS | Secp256k1 | Delegated => Ok(address),
+            Actor => anyhow::bail!("cannot resolve actor address to key address"),
+            _ => {
+                let ts = ts.unwrap_or(self.chain_store().heaviest_tipset());
+                // First try to resolve the actor in the parent state, so we don't have to compute anything.
+                let state =
+                    StateTree::new_from_root(self.chain_store().db.clone(), ts.parent_state())?;
+
+                if let Ok(address) =
+                    state.resolve_to_deterministic_addr(self.chain_store().blockstore(), address)
+                {
+                    return Ok(address);
+                }
+
+                // If that fails, compute the tip-set and try again.
+                let (state_root, _) = self.tipset_state(&ts).await?;
+                let state = StateTree::new_from_root(self.chain_store().db.clone(), &state_root)?;
+                state.resolve_to_deterministic_addr(self.chain_store().blockstore(), address)
+            }
+        }
+    }
+
     fn chain_rand(&self, tipset: Arc<Tipset>) -> ChainRand<DB> {
         ChainRand::new(
             self.chain_config.clone(),

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -339,6 +339,10 @@ fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
                         msg.from(),
                         root_tsk.clone(),
                     )));
+                    tests.push(RpcTest::identity(ApiInfo::state_account_key_req(
+                        msg.from(),
+                        Default::default(),
+                    )));
                 }
             }
             for msg in secp_messages {
@@ -349,6 +353,10 @@ fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
                     tests.push(RpcTest::identity(ApiInfo::state_account_key_req(
                         msg.from(),
                         root_tsk.clone(),
+                    )));
+                    tests.push(RpcTest::identity(ApiInfo::state_account_key_req(
+                        msg.from(),
+                        Default::default(),
                     )));
                     if !msg.params().is_empty() {
                         tests.push(RpcTest::identity(ApiInfo::state_decode_params_req(


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/3639

Changes introduced in this pull request:

- implement Filecoin.StateAccountKey RPC API

(Manually changed the code to compare the last 500 tipsets)
```
     Running `target/release/forest-tool api compare /home/me/fr/snapshots/calibnet/forest_snapshot_calibnet_2023-11-21_height_1108092.forest.car.zst --filter StateAccount`
| RPC Method                     | Forest | Lotus |
|--------------------------------|--------|-------|
| Filecoin.StateAccountKey (476) | Valid  | Valid |
```

Lotus code:
```go
func (m *StateModule) StateAccountKey(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error) {
	ts, err := m.Chain.GetTipSetFromKey(ctx, tsk)
	if err != nil {
		return address.Undef, xerrors.Errorf("loading tipset %s: %w", tsk, err)
	}

	return m.StateManager.ResolveToDeterministicAddress(ctx, addr, ts)
}

// ResolveToDeterministicAddress is similar to `vm.ResolveToDeterministicAddr` but does not allow `Actor` type of addresses.
// Uses the `TipSet` `ts` to generate the VM state.
func (sm *StateManager) ResolveToDeterministicAddress(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error) {
	switch addr.Protocol() {
	case address.BLS, address.SECP256K1, address.Delegated:
		return addr, nil
	case address.Actor:
		return address.Undef, xerrors.New("cannot resolve actor address to key address")
	default:
	}

	if ts == nil {
		ts = sm.cs.GetHeaviestTipSet()
	}

	cst := cbor.NewCborStore(sm.cs.StateBlockstore())

	// First try to resolve the actor in the parent state, so we don't have to compute anything.
	tree, err := state.LoadStateTree(cst, ts.ParentState())
	if err != nil {
		return address.Undef, xerrors.Errorf("failed to load parent state tree at tipset %s: %w", ts.Parents(), err)
	}

	resolved, err := vm.ResolveToDeterministicAddr(tree, cst, addr)
	if err == nil {
		return resolved, nil
	}

	// If that fails, compute the tip-set and try again.
	st, _, err := sm.TipSetState(ctx, ts)
	if err != nil {
		return address.Undef, xerrors.Errorf("resolve address failed to get tipset %s state: %w", ts, err)
	}

	tree, err = state.LoadStateTree(cst, st)
	if err != nil {
		return address.Undef, xerrors.Errorf("failed to load state tree at tipset %s: %w", ts, err)
	}

	return vm.ResolveToDeterministicAddr(tree, cst, addr)
}

// ResolveToDeterministicAddr returns the public key type of address
// (`BLS`/`SECP256K1`) of an actor identified by `addr`, or its
// delegated address.
func ResolveToDeterministicAddr(state types.StateTree, cst cbor.IpldStore, addr address.Address) (address.Address, error) {
	if addr.Protocol() == address.BLS || addr.Protocol() == address.SECP256K1 || addr.Protocol() == address.Delegated {
		return addr, nil
	}

	act, err := state.GetActor(addr)
	if err != nil {
		return address.Undef, xerrors.Errorf("failed to find actor: %s", addr)
	}

	if state.Version() >= types.StateTreeVersion5 {
		if act.Address != nil {
			// If there _is_ an f4 address, return it as "key" address
			return *act.Address, nil
		}
	}

	aast, err := account.Load(adt.WrapStore(context.TODO(), cst), act)
	if err != nil {
		return address.Undef, xerrors.Errorf("failed to get account actor state for %s: %w", addr, err)
	}
	return aast.PubkeyAddress()

}
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
