### PR TITLE
fix: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,20 @@ updates:
     # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#example-disabling-version-updates-for-some-dependencies
     ignore:
       - dependency-name: "cid"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "*ipld*"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "bls-signatures"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "fvm*"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "filecoin*"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
     # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
     groups:
       patch-versions:
@@ -23,7 +33,6 @@ updates:
       fil-actors:
         patterns:
           - "fil_actor*"
-
   # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Allow patch version updates for ignored fvm related crates to align with https://github.com/ChainSafe/fil-actor-states/blob/main/.github/dependabot.yml
- `groups` setting is not picked up in this repo for some reason while it works fine in https://github.com/ChainSafe/fil-actor-states, giving it another try.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
