### PR TITLE
feat: add `--n-tipsets` option to `forest-tool api compare`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   `Filecoin.GetParentMessages` lotus-compatible RPC API.
 - [#3727](https://github.com/ChainSafe/forest/pull/3727) Added glif.io calibnet
   bootstrap node peer
+- [#3737](https://github.com/ChainSafe/forest/pull/3737) Added `--n-tipsets`
+  option to `forest-tool api compre`
 
 ### Changed
 

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -38,6 +38,9 @@ pub enum ApiCommands {
         /// Cancel test run on the first failure
         #[arg(long)]
         fail_fast: bool,
+        #[arg(short, long, default_value = "20")]
+        /// The number of tipsets to use to generate test cases.
+        n_tipsets: usize,
     },
 }
 
@@ -50,7 +53,8 @@ impl ApiCommands {
                 snapshot_files,
                 filter,
                 fail_fast,
-            } => compare_apis(forest, lotus, snapshot_files, filter, fail_fast).await?,
+                n_tipsets,
+            } => compare_apis(forest, lotus, snapshot_files, filter, fail_fast, n_tipsets).await?,
         }
         Ok(())
     }
@@ -307,9 +311,8 @@ fn wallet_tests() -> Vec<RpcTest> {
 }
 
 // Extract tests that use chain-specific data such as block CIDs or message
-// CIDs. Right now, only the last 20 tipsets are used. It would be nice to
-// sample a greater range.
-fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
+// CIDs. Right now, only the last `n_tipsets` tipsets are used.
+fn snapshot_tests(store: &ManyCar, n_tipsets: usize) -> anyhow::Result<Vec<RpcTest>> {
     let mut tests = vec![];
     let shared_tipset = store.heaviest_tipset()?;
     let root_tsk = shared_tipset.key().clone();
@@ -317,7 +320,7 @@ fn snapshot_tests(store: &ManyCar) -> anyhow::Result<Vec<RpcTest>> {
     tests.extend(state_tests(&shared_tipset));
 
     let mut seen = CidHashSet::default();
-    for tipset in shared_tipset.chain(&store).take(20) {
+    for tipset in shared_tipset.chain(&store).take(n_tipsets) {
         tests.push(RpcTest::identity(
             ApiInfo::chain_get_messages_in_tipset_req(tipset.key().clone()),
         ));
@@ -395,6 +398,7 @@ async fn compare_apis(
     snapshot_files: Vec<PathBuf>,
     filter: String,
     fail_fast: bool,
+    n_tipsets: usize,
 ) -> anyhow::Result<()> {
     let mut tests = vec![];
 
@@ -408,7 +412,7 @@ async fn compare_apis(
 
     if !snapshot_files.is_empty() {
         let store = ManyCar::try_from(snapshot_files)?;
-        tests.extend(snapshot_tests(&store)?);
+        tests.extend(snapshot_tests(&store, n_tipsets)?);
     }
 
     tests.sort_by_key(|test| test.request.method_name);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to address 
> Right now, only the last 20 tipsets are used. It would be nice to sample a greater range.

Changes introduced in this pull request:

- add `--n-tipsets` option to `forest-tool api compare` to allow customizing the number of tipsets to test against

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
