### PR TITLE
fix: bump tipset lookup cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
 ### Fixed
 
+- [#3751](https://github.com/ChainSafe/forest/pull/3751) Workaround for
+  performance bug that prevents Forest from syncing to the network.
+
 ## Forest 0.16.2 "November Rain"
 
 ### Breaking

--- a/src/chain/store/index.rs
+++ b/src/chain/store/index.rs
@@ -15,7 +15,7 @@ use parking_lot::Mutex;
 
 use crate::chain::Error;
 
-const DEFAULT_TIPSET_CACHE_SIZE: NonZeroUsize = nonzero!(8192usize);
+const DEFAULT_TIPSET_CACHE_SIZE: NonZeroUsize = nonzero!(131072_usize);
 
 type TipsetCache = Mutex<LruCache<TipsetKeys, Arc<Tipset>>>;
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Tipset lookup _must_ be fast. Looking up tipsets in `O(n)` time breaks Forest.
- This PR is a work-around until we can implement a better lookup function.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
