### PR TITLE
chore: remove `hyper` from Cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1360,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2430,12 +2430,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3119,7 +3119,6 @@ dependencies = [
  "http-range-header",
  "human-repr",
  "humantime",
- "hyper",
  "indexmap 2.1.0",
  "indicatif",
  "integer-encoding",
@@ -3213,7 +3212,7 @@ dependencies = [
  "tracing-chrome",
  "tracing-loki",
  "tracing-subscriber",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
  "url",
  "walkdir",
  "zstd",
@@ -4615,9 +4614,9 @@ checksum = "8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae"
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -5927,9 +5926,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeaf4ad7403de93e699c191202f017118df734d3850b01e13a3a8b2e6953d3c9"
+checksum = "995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6"
 
 [[package]]
 name = "nonzero_ext"
@@ -9041,7 +9040,6 @@ checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 dependencies = [
  "asynchronous-codec 0.6.2",
  "bytes",
- "tokio-util",
 ]
 
 [[package]]
@@ -9049,6 +9047,10 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+dependencies = [
+ "bytes",
+ "tokio-util",
+]
 
 [[package]]
 name = "untrusted"
@@ -9176,9 +9178,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -9186,9 +9188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -9201,9 +9203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -9213,9 +9215,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9223,9 +9225,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9236,9 +9238,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ hex = { version = "0.4", features = ["serde"] }
 http = "0.2.8"
 human-repr = "1.0"
 humantime = "2.1.0"
-hyper = "0.14"
 indexmap = { version = "2.1", features = ["serde"] }
 indicatif = { version = "0.17.6", features = ["tokio"] }
 integer-encoding = "4.0"
@@ -118,7 +117,7 @@ mimalloc = { version = "0.1.39", optional = true, default-features = false }
 multiaddr = "0.18"
 multimap = "0.9.0"
 nom = "7.1.3"
-nonempty = "0.8.0"
+nonempty = "0.9.0"
 nonzero_ext = "0.3.0"
 num = "0.4.0"
 num-bigint = "0.4"
@@ -183,7 +182,7 @@ tracing-appender = "0.2"
 tracing-chrome = "0.7.1"
 tracing-loki = { version = "0.2", default-features = false, features = ["compat-0-2-1", "rustls"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-unsigned-varint = { version = "0.7", features = ["codec"] }
+unsigned-varint = { version = "0.8", features = ["codec"] }
 url = { version = "2.3", features = ["serde"] }
 walkdir = "2"
 zstd = "0.13"

--- a/src/utils/reqwest_resume/mod.rs
+++ b/src/utils/reqwest_resume/mod.rs
@@ -12,7 +12,6 @@
 
 use bytes::Bytes;
 use futures::{ready, FutureExt as _, Stream, TryFutureExt as _};
-use hyper::header::{self, HeaderMap, HeaderValue};
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -74,8 +73,8 @@ impl RequestBuilder {
         };
         let accept_byte_ranges = response
             .headers()
-            .get(header::ACCEPT_RANGES)
-            .map(HeaderValue::as_bytes)
+            .get(http::header::ACCEPT_RANGES)
+            .map(http::HeaderValue::as_bytes)
             == Some(b"bytes");
         let resp = Response {
             client,
@@ -140,10 +139,10 @@ impl Stream for Decoder {
                         break Poll::Ready(Some(Err(err)));
                     }
                     let builder = self.client.request(self.method.clone(), self.url.clone());
-                    let mut headers = HeaderMap::new();
-                    let value = HeaderValue::from_str(&std::format!("bytes={}-", self.pos))
+                    let mut headers = http::HeaderMap::new();
+                    let value = http::HeaderValue::from_str(&std::format!("bytes={}-", self.pos))
                         .expect("unreachable");
-                    headers.insert(header::RANGE, value);
+                    headers.insert(http::header::RANGE, value);
                     let builder = builder.headers(headers);
                     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
                     self.decoder = Box::pin(

--- a/src/utils/reqwest_resume/tests.rs
+++ b/src/utils/reqwest_resume/tests.rs
@@ -6,7 +6,7 @@ use axum::body::Body;
 use axum::response::IntoResponse;
 use bytes::Bytes;
 use const_random::const_random;
-use futures::stream::{self};
+use futures::stream;
 use http_range_header::parse_range_header;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::ops::Range;
@@ -82,7 +82,7 @@ async fn test_resumable_get() {
     let addr = listener.local_addr().unwrap();
     create_flaky_server(listener);
 
-    let resp = get(reqwest::Url::parse(&format!("http://{addr}/")).unwrap())
+    let resp = get(reqwest::Url::parse(&format!("http://{addr}")).unwrap())
         .await
         .unwrap();
 
@@ -92,7 +92,7 @@ async fn test_resumable_get() {
         .collect::<Vec<Bytes>>()
         .await
         .concat();
-    assert_eq!(&RANDOM_BYTES[..], &data[..]);
+    assert_eq!(Bytes::from_static(&RANDOM_BYTES), data);
 }
 
 #[tokio::test]
@@ -101,7 +101,7 @@ async fn test_non_resumable_get() {
     let addr = listener.local_addr().unwrap();
     create_flaky_server(listener);
 
-    let resp = reqwest::get(reqwest::Url::parse(&format!("http://{addr}/")).unwrap())
+    let resp = reqwest::get(reqwest::Url::parse(&format!("http://{addr}")).unwrap())
         .await
         .unwrap();
 

--- a/src/utils/reqwest_resume/tests.rs
+++ b/src/utils/reqwest_resume/tests.rs
@@ -1,25 +1,21 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
+
 use crate::utils::reqwest_resume::get;
+use axum::response::IntoResponse;
 use bytes::Bytes;
 use const_random::const_random;
 use futures::stream::StreamExt;
 use http_range_header::parse_range_header;
-use hyper::header::{self, HeaderValue};
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server};
-use std::convert::Infallible;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::ops::Range;
-use std::time::Duration;
-use tokio::time::sleep;
 
 const CHUNK_LEN: usize = 2048;
 // `RANDOM_BYTES` size is arbitrarily chosen. We could use something smaller or bigger here.
 // The only constraint is that `CHUNK_LEN < RANDOM_BYTES.len()`.
 const RANDOM_BYTES: [u8; 8192] = const_random!([u8; 8192]);
 
-fn get_range(value: &HeaderValue) -> Range<usize> {
+fn get_range(value: &http::HeaderValue) -> Range<usize> {
     let s = std::str::from_utf8(value.as_bytes()).unwrap();
     let parse_ranges = parse_range_header(s).unwrap();
     parse_ranges
@@ -35,52 +31,49 @@ fn get_range(value: &HeaderValue) -> Range<usize> {
 
 /// Sends a subset of `RANDOM_BYTES` data on each request. This function will introduce an error
 /// to simulate a flaky server by aborting the connection after sending the data.
-async fn handle_request(req: Request<Body>) -> Result<Response<Body>, Infallible> {
-    let (mut sender, body) = Body::channel();
-
-    let range = req
-        .headers()
-        .get(header::RANGE)
+async fn handle_request(headers: http::HeaderMap) -> impl IntoResponse {
+    let range = headers
+        .get(http::header::RANGE)
         .map_or(0..CHUNK_LEN, get_range);
-    tokio::task::spawn(async move {
+    println!("range: {range:?}");
+    let (status_code, data) = if range.is_empty() {
+        (http::StatusCode::RANGE_NOT_SATISFIABLE, Bytes::default())
+    } else {
         let mut subset: Bytes = RANDOM_BYTES[range.clone()].into();
         subset.truncate(CHUNK_LEN);
-        sender.send_data(subset).await.unwrap();
-        // Abort only if we don't have sent all the data. This will be signaled by an empty range.
-        if !range.is_empty() {
-            // Sleep to ensure the data is sent before the connection is closed.
-            sleep(Duration::from_millis(100)).await;
-            // `abort` will close the connection with an error so we can test the
-            // resume functionality.
-            sender.abort();
-        }
-    });
+        (http::StatusCode::PARTIAL_CONTENT, subset)
+    };
 
-    let mut response: Response<_> = Response::new(body);
-    response
-        .headers_mut()
-        .insert(header::ACCEPT_RANGES, HeaderValue::from_static("bytes"));
-    Ok(response)
+    let response_headers = [(http::header::ACCEPT_RANGES, "bytes")];
+    (status_code, response_headers, data)
 }
 
-async fn create_flaky_server() -> SocketAddr {
-    let make_svc =
-        make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle_request)) });
+fn create_listener() -> TcpListener {
+    TcpListener::bind(SocketAddr::new(
+        Ipv4Addr::LOCALHOST.into(),
+        0, /* OS-assigned */
+    ))
+    .unwrap()
+}
 
-    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0 /* OS-assigned */);
-
-    let server = Server::bind(&addr).serve(make_svc);
-    let addr = server.local_addr();
-
-    tokio::task::spawn(server);
-    addr
+fn create_flaky_server(listener: TcpListener) {
+    tokio::task::spawn(async move {
+        let app = axum::Router::new().route("/", axum::routing::get(handle_request));
+        axum::Server::from_tcp(listener)
+            .unwrap()
+            .serve(app.into_make_service())
+            .await
+            .unwrap()
+    });
 }
 
 #[tokio::test]
 async fn test_resumable_get() {
-    let addr = create_flaky_server().await;
+    let listener = create_listener();
+    let addr = listener.local_addr().unwrap();
+    create_flaky_server(listener);
 
-    let resp = get(reqwest::Url::parse(&format!("http://{addr}")).unwrap())
+    let resp = get(reqwest::Url::parse(&format!("http://{addr}/")).unwrap())
         .await
         .unwrap();
 
@@ -90,14 +83,16 @@ async fn test_resumable_get() {
         .collect::<Vec<Bytes>>()
         .await
         .concat();
-    assert_eq!(Bytes::from_static(&RANDOM_BYTES), data);
+    assert_eq!(&RANDOM_BYTES[..], &data[..]);
 }
 
 #[tokio::test]
 async fn test_non_resumable_get() {
-    let addr = create_flaky_server().await;
+    let listener = create_listener();
+    let addr = listener.local_addr().unwrap();
+    create_flaky_server(listener);
 
-    let resp = reqwest::get(reqwest::Url::parse(&format!("http://{addr}")).unwrap())
+    let resp = reqwest::get(reqwest::Url::parse(&format!("http://{addr}/")).unwrap())
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As a follow-up of https://github.com/ChainSafe/forest/pull/3753

Changes introduced in this pull request:

- remove `hyper` from Cargo dependencies so that we don't need to manually upgrade it to `1.0`
- bump minor versions of `nonempty` and `unsigned-varint`
- bump patch versions

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
