### PR TITLE
increase stack size to 64 MiB for FVM calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,6 +3243,7 @@ dependencies = [
  "slotmap",
  "smallvec",
  "smart-default",
+ "stacker",
  "static_assertions",
  "statrs",
  "strum",
@@ -8213,6 +8214,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ similar = "2.2.1"
 slotmap = "1.0"
 smallvec = "1.11"
 smart-default = "0.7.1"
+stacker = "0.1.15"
 static_assertions = "1.1.0"
 statrs = "0.16"
 strum = { version = "0.25", features = ["derive"] }

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -501,36 +501,41 @@ where
         // "next" tipset
         let epoch = ts.epoch() + 1;
         let genesis_info = GenesisInfo::from_chain_config(self.chain_config());
-        let mut vm = VM::new(
-            ExecutionContext {
-                heaviest_tipset: Arc::clone(&ts),
-                state_tree_root: st,
-                epoch,
-                rand: Box::new(chain_rand),
-                base_fee: ts.blocks()[0].parent_base_fee().clone(),
-                circ_supply: genesis_info.get_circulating_supply(
+
+        // FVM requires a stack size of 64MiB. The alternative is to use `ThreadedExecutor` from
+        // FVM, but that introduces some constraints, and possible deadlocks.
+        let ret = stacker::grow(64 << 20, || -> anyhow::Result<ApplyRet> {
+            let mut vm = VM::new(
+                ExecutionContext {
+                    heaviest_tipset: Arc::clone(&ts),
+                    state_tree_root: st,
                     epoch,
-                    &self.blockstore_owned(),
-                    &st,
-                )?,
-                chain_config: self.chain_config().clone(),
-                chain_index: Arc::clone(&self.chain_store().chain_index),
-                timestamp: ts.min_timestamp(),
-            },
-            &self.engine,
-            VMTrace::NotTraced,
-        )?;
+                    rand: Box::new(chain_rand),
+                    base_fee: ts.blocks()[0].parent_base_fee().clone(),
+                    circ_supply: genesis_info.get_circulating_supply(
+                        epoch,
+                        &self.blockstore_owned(),
+                        &st,
+                    )?,
+                    chain_config: self.chain_config().clone(),
+                    chain_index: Arc::clone(&self.chain_store().chain_index),
+                    timestamp: ts.min_timestamp(),
+                },
+                &self.engine,
+                VMTrace::NotTraced,
+            )?;
 
-        for msg in prior_messages {
-            vm.apply_message(msg)?;
-        }
-        let from_actor = vm
-            .get_actor(&message.from())
-            .map_err(|e| Error::Other(format!("Could not get actor from state: {e}")))?
-            .ok_or_else(|| Error::Other("cant find actor in state tree".to_string()))?;
-        message.set_sequence(from_actor.sequence);
+            for msg in prior_messages {
+                vm.apply_message(msg)?;
+            }
+            let from_actor = vm
+                .get_actor(&message.from())
+                .map_err(|e| Error::Other(format!("Could not get actor from state: {e}")))?
+                .ok_or_else(|| Error::Other("cant find actor in state tree".to_string()))?;
+            message.set_sequence(from_actor.sequence);
 
-        let ret = vm.apply_message(message)?;
+            vm.apply_message(message)
+        })?;
 
         Ok(InvocResult {
             msg: message.message().clone(),
@@ -1429,13 +1434,17 @@ where
         if epoch_i > parent_epoch {
             // step 2: running cron for any null-tipsets
             let timestamp = genesis_timestamp + ((EPOCH_DURATION_SECONDS * epoch_i) as u64);
-            let mut vm = create_vm(parent_state, epoch_i, timestamp)?;
-            // run cron for null rounds if any
-            if let Err(e) = vm.run_cron(epoch_i, callback.as_mut()) {
-                error!("Beginning of epoch cron failed to run: {}", e);
-            }
 
-            parent_state = vm.flush()?;
+            // FVM requires a stack size of 64MiB. The alternative is to use `ThreadedExecutor` from
+            // FVM, but that introduces some constraints, and possible deadlocks.
+            parent_state = stacker::grow(64 << 20, || -> anyhow::Result<Cid> {
+                let mut vm = create_vm(parent_state, epoch_i, timestamp)?;
+                // run cron for null rounds if any
+                if let Err(e) = vm.run_cron(epoch_i, callback.as_mut()) {
+                    error!("Beginning of epoch cron failed to run: {}", e);
+                }
+                vm.flush()
+            })?;
         }
 
         // step 3: run migrations
@@ -1449,14 +1458,18 @@ where
     let block_messages = BlockMessages::for_tipset(&chain_index.db, &tipset)
         .map_err(|e| Error::Other(e.to_string()))?;
 
-    let mut vm = create_vm(parent_state, epoch, tipset.min_timestamp())?;
+    // FVM requires a stack size of 64MiB. The alternative is to use `ThreadedExecutor` from
+    // FVM, but that introduces some constraints, and possible deadlocks.
+    stacker::grow(64 << 20, || -> anyhow::Result<(Cid, Cid)> {
+        let mut vm = create_vm(parent_state, epoch, tipset.min_timestamp())?;
 
-    // step 4: apply tipset messages
-    let receipts = vm.apply_block_messages(&block_messages, epoch, callback)?;
+        // step 4: apply tipset messages
+        let receipts = vm.apply_block_messages(&block_messages, epoch, callback)?;
 
-    // step 5: construct receipt root from receipts and flush the state-tree
-    let receipt_root = Amt::new_from_iter(&chain_index.db, receipts)?;
-    let state_root = vm.flush()?;
+        // step 5: construct receipt root from receipts and flush the state-tree
+        let receipt_root = Amt::new_from_iter(&chain_index.db, receipts)?;
+        let state_root = vm.flush()?;
 
-    Ok((state_root, receipt_root))
+        Ok((state_root, receipt_root))
+    })
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- in light of a deadlock in https://github.com/ChainSafe/forest/pull/3756, this is an alternative to achieve 64 MiB stack required by FVM.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
