### PR TITLE
Use global HTTP client in reqwest_resume

### DIFF
--- a/src/utils/reqwest_resume/mod.rs
+++ b/src/utils/reqwest_resume/mod.rs
@@ -10,6 +10,7 @@
 //! Some modifications have been done to update the code regarding `tokio`,
 //! replace the `hyperx` dependency with `hyper` and add two unit tests.
 
+use crate::utils::net::global_http_client;
 use bytes::Bytes;
 use futures::{ready, FutureExt as _, Stream, TryFutureExt as _};
 use std::{
@@ -36,11 +37,9 @@ impl ClientExt for reqwest::Client {
 #[derive(Debug)]
 pub struct Client(reqwest::Client);
 impl Client {
-    /// Constructs a new `Client`.
-    ///
-    /// See [`reqwest::Client::new()`].
+    /// Constructs a new `Client` using the global Forest HTTP client.
     pub fn new() -> Self {
-        Self(reqwest::Client::new())
+        Self(global_http_client())
     }
     /// Convenience method to make a `GET` request to a URL.
     ///


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- use the global HTTP client in the `reqwest_resume`, same as in the rest of the Forest codebase.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
