### PR TITLE
chore: bump rubocop version to 1.58 and correct offenses

### DIFF
--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -33,7 +33,7 @@ jobs:
           ruby-version: '3.0'
       - name: Run rubocop
         run: |
-          gem install rubocop -v 1.57 --no-document
+          gem install rubocop -v 1.58 --no-document
           rubocop scripts/
   run-js-linters:
     runs-on: ubuntu-latest

--- a/scripts/linters/find_unused_deps.rb
+++ b/scripts/linters/find_unused_deps.rb
@@ -20,14 +20,14 @@ Dir.glob('**/*.toml').each do |file|
   crate_dir = File.dirname(file)
   toml = TomlRB.load_file(file)
   crates = Set.new
-  toml['dependencies']&.each do |crate_name, _|
+  toml['dependencies']&.each_key do |crate_name|
     crates.add crate_name
   end
-  toml['dev-dependencies']&.each do |crate_name, _|
+  toml['dev-dependencies']&.each_key do |crate_name|
     crates.add crate_name
   end
   if toml['workspace']
-    toml['workspace']['dependencies']&.each do |crate_name, _|
+    toml['workspace']['dependencies']&.each_key do |crate_name|
       crates.add crate_name
     end
   end


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Bumped `rubocop` version from 1.57 to 1.58 and corrected the resulting "offenses."

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3780 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
