### PR TITLE
CI: fuzzy is down, switching to buildjet

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,8 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Build images and push to GHCR
     # Change to `buildjet-8vcpu-ubuntu-2204` if `fuzzy` is down.
-    runs-on: fuzzy
+    # runs-on: fuzzy
+    runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 30
     steps:
       - name: List cached docker images

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,8 @@ env:
 jobs:
   tests:
     # Change to `buildjet-8vcpu-ubuntu-2204` if `fuzzy` is down.
-    runs-on: fuzzy
+    # runs-on: fuzzy
+    runs-on: buildjet-8vcpu-ubuntu-2204
     # Run the job only if the PR is not a draft.
     # This is done to limit the runner cost.
     if: github.event.pull_request.draft == false
@@ -59,7 +60,8 @@ jobs:
       - run: make test
   tests-release:
     # Change to `buildjet-8vcpu-ubuntu-2204` if `fuzzy` is down.
-    runs-on: fuzzy
+    # runs-on: fuzzy
+    runs-on: buildjet-8vcpu-ubuntu-2204
     # Run the job only if the PR is not a draft.
     # This is done to limit the runner cost.
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fuzzy is still being re-homed. Use buildjet until the transfer is complete.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
