### PR TITLE
fix: shorten help message for `state-compute` when listing available commands

### DIFF
--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -98,7 +98,7 @@ pub enum SnapshotCommands {
     /// the messages at EPOCH, and prints the resulting hash of the state of the world.
     ///
     /// If --json is supplied, details about each message execution will printed.
-    #[command(about = "Compute the state CID at a given epoch")]
+    #[command(about = "Compute the state hash at a given epoch")]
     ComputeState {
         /// Path to a snapshot CAR, which may be zstd compressed
         snapshot: PathBuf,

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -98,6 +98,7 @@ pub enum SnapshotCommands {
     /// the messages at EPOCH, and prints the resulting hash of the state of the world.
     ///
     /// If --json is supplied, details about each message execution will printed.
+    #[command(about = "Compute the state CID at a given epoch")]
     ComputeState {
         /// Path to a snapshot CAR, which may be zstd compressed
         snapshot: PathBuf,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Use a shorter help message when listing available commands.
- Full help message is still available when asking for help with the `state-compute` command.

Before:
```
$ cargo run --bin forest-tool -- snapshot 
Manage snapshots

Usage: forest-tool snapshot <COMMAND>

Commands:
  fetch          Fetches the most recent snapshot from a trusted, pre-defined location
  validate       Validates the snapshot
  compress       Make this snapshot suitable for use as a compressed car-backed blockstore
  compute-state  Filecoin keeps track of "the state of the world", including: wallets and their balances; storage providers and their deals; etc...
  help           Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

After:
```
$ cargo run --bin forest-tool -- snapshot 
Manage snapshots

Usage: forest-tool snapshot <COMMAND>

Commands:
  fetch          Fetches the most recent snapshot from a trusted, pre-defined location
  validate       Validates the snapshot
  compress       Make this snapshot suitable for use as a compressed car-backed blockstore
  compute-state  Compute the state hash at a given epoch
  help           Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

Full help message is still available:

```
$ cargo run --bin forest-tool -- snapshot compute-state --help
Filecoin keeps track of "the state of the world", including: wallets and their balances; storage providers and their deals; etc...

It does this by (essentially) hashing the state of the world.

The world can change when new blocks are mined and transmitted. A block may contain a message to e.g transfer FIL between two parties. Blocks are ordered by "epoch", which can be thought of as a timestamp.

Snapshots contain (among other things) these messages.

The command calculates the state of the world at EPOCH-1, applies all the messages at EPOCH, and prints the resulting hash of the state of the world.

If --json is supplied, details about each message execution will printed.

Usage: forest-tool snapshot compute-state [OPTIONS] --epoch <EPOCH> <SNAPSHOT>

Arguments:
  <SNAPSHOT>
          Path to a snapshot CAR, which may be zstd compressed

Options:
      --epoch <EPOCH>
          Which epoch to compute the state transition for

      --json
          Generate JSON output

  -h, --help
          Print help (see a summary with '-h')
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3725

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
