### PR TITLE
feat: add timeout to api compare command

### DIFF
--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -18,6 +18,7 @@ use std::env;
 use std::fmt;
 use std::marker::PhantomData;
 use std::str::FromStr;
+use std::time::Duration;
 
 use crate::libp2p::{Multiaddr, Protocol};
 use crate::lotus_json::HasLotusJson;
@@ -31,6 +32,7 @@ pub const DEFAULT_HOST: &str = "127.0.0.1";
 pub const DEFAULT_MULTIADDRESS: &str = "/ip4/127.0.0.1/tcp/2345/http";
 pub const DEFAULT_PORT: u16 = 2345;
 pub const DEFAULT_PROTOCOL: &str = "http";
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Debug)]
 pub struct ApiInfo {
@@ -95,7 +97,10 @@ impl ApiInfo {
 
         debug!("Using JSON-RPC v2 HTTP URL: {}", api_url);
 
-        let request = global_http_client().post(api_url).json(&rpc_req);
+        let request = global_http_client()
+            .post(api_url)
+            .timeout(req.timeout)
+            .json(&rpc_req);
         let request = match self.token.as_ref() {
             Some(token) => request.header(http0::header::AUTHORIZATION, token),
             _ => request,
@@ -260,6 +265,7 @@ pub struct RpcRequest<T = serde_json::Value> {
     params: serde_json::Value,
     result_type: PhantomData<T>,
     rpc_endpoint: &'static str,
+    timeout: Duration,
 }
 
 impl<T> RpcRequest<T> {
@@ -273,6 +279,7 @@ impl<T> RpcRequest<T> {
             ),
             result_type: PhantomData,
             rpc_endpoint: "rpc/v0",
+            timeout: DEFAULT_TIMEOUT,
         }
     }
 
@@ -286,7 +293,12 @@ impl<T> RpcRequest<T> {
             ),
             result_type: PhantomData,
             rpc_endpoint: "rpc/v1",
+            timeout: DEFAULT_TIMEOUT,
         }
+    }
+
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
     }
 
     // Discard type information about the response.
@@ -296,6 +308,7 @@ impl<T> RpcRequest<T> {
             params: self.params,
             result_type: PhantomData,
             rpc_endpoint: self.rpc_endpoint,
+            timeout: self.timeout,
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Some APIs are designed to not fail fast when a request cannot be fulfilled, e.g. StateWaitMsg. This PR tries to add a timeout to `RpcTest` to prevent the test command from waiting infinitely.

Changes introduced in this pull request:

- add default timeout 1min
- add `fn with_timeout` to `RpcTest`
- add `Timeout` to `EndpointStatus`

Example output (By tweaking the timeout setting locally)
```
| RPC Method                 | Forest  | Lotus |
|----------------------------|---------|-------|
| Filecoin.StateWaitMsg (24) | Timeout | Valid |
| Filecoin.StateWaitMsg (2)  | Valid   | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
