### PR TITLE
fix: refine `get_receipt` logic

### DIFF
--- a/src/shim/executor.rs
+++ b/src/shim/executor.rs
@@ -155,17 +155,17 @@ impl Receipt {
         receipts: &Cid,
         i: u64,
     ) -> anyhow::Result<Option<Self>> {
-        // Try Receipt_v2 first
+        // Try Receipt_v4 first. (Receipt_v4 and Receipt_v3 are identical, use v4 here)
         if let Ok(amt) = Amtv0::load(receipts, db) {
             if let Ok(receipts) = amt.get(i) {
-                return Ok(receipts.cloned().map(Receipt::V2));
+                return Ok(receipts.cloned().map(Receipt::V4));
             }
         }
 
-        // Receipt_v4 and Receipt_v3 are identical, use v4 here
+        // Fallback to Receipt_v2.
         let amt = Amtv0::load(receipts, db)?;
         let receipts = amt.get(i)?;
-        Ok(receipts.cloned().map(Receipt::V4))
+        Ok(receipts.cloned().map(Receipt::V2))
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Try loading receipt amt into `Receipt_v4` first, then fallback to `Receipt_v2`.
- Add `Receipt_v2` compatibility to `FileCoin.GetParentReceipts` RPC API

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
