### PR TITLE
chore: migrate from `prometheus` to `prometheus_client` (part1)

### DIFF
--- a/src/libp2p/behaviour.rs
+++ b/src/libp2p/behaviour.rs
@@ -17,7 +17,7 @@ use libp2p::{
     swarm::NetworkBehaviour,
     Multiaddr,
 };
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::libp2p::{
     chain_exchange::ChainExchangeBehaviour,
@@ -95,9 +95,7 @@ impl ForestBehaviour {
             ],
             Default::default(),
         );
-        if let Err(err) = crate::libp2p_bitswap::register_metrics(prometheus::default_registry()) {
-            warn!("Fail to register prometheus metrics for libp2p_bitswap: {err}");
-        }
+        crate::libp2p_bitswap::register_metrics(&mut crate::metrics::DEFAULT_REGISTRY.write());
 
         let discovery = DiscoveryConfig::new(local_key.public(), network_name)
             .with_mdns(config.mdns)

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -290,9 +290,7 @@ where
         let mut bitswap_outbound_request_stream =
             bitswap_request_manager.outbound_request_stream().fuse();
         let mut peer_ops_rx_stream = self.peer_manager.peer_ops_rx().stream().fuse();
-        let mut libp2p_registry = Default::default();
-        let metrics = Metrics::new(&mut libp2p_registry);
-        crate::metrics::add_metrics_registry("libp2p".into(), libp2p_registry).await;
+        let metrics = Metrics::new(&mut crate::metrics::DEFAULT_REGISTRY.write());
         loop {
             select! {
                 swarm_event = swarm_stream.next() => match swarm_event {

--- a/src/libp2p_bitswap/behaviour.rs
+++ b/src/libp2p_bitswap/behaviour.rs
@@ -49,7 +49,7 @@ impl BitswapBehaviour {
             match request.ty {
                 RequestType::Have => metrics::message_counter_outbound_request_have().inc(),
                 RequestType::Block => metrics::message_counter_outbound_request_block().inc(),
-            }
+            };
         }
         self.inner
             .send_request(peer, vec![BitswapMessage::Request(request)])
@@ -64,7 +64,7 @@ impl BitswapBehaviour {
         match response.1 {
             BitswapResponse::Have(..) => metrics::message_counter_outbound_response_have().inc(),
             BitswapResponse::Block(..) => metrics::message_counter_outbound_response_block().inc(),
-        }
+        };
         self.inner
             .send_request(peer, vec![BitswapMessage::Response(response.0, response.1)])
     }

--- a/src/libp2p_bitswap/metrics.rs
+++ b/src/libp2p_bitswap/metrics.rs
@@ -2,142 +2,149 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use once_cell::sync::Lazy;
-use prometheus::{core::*, *};
+use parking_lot::MappedRwLockReadGuard;
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::{counter::Counter, family::Family, gauge::Gauge, histogram::Histogram},
+    registry::Registry,
+};
 
-static MESSAGE_SIZE: Lazy<IntCounterVec> = Lazy::new(|| {
-    IntCounterVec::new(
-        Opts::new("bitswap_message_size", "Size of bitswap messages"),
-        &["type"],
-    )
-    .expect("Infallible")
-});
-static MESSAGE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    IntCounterVec::new(
-        Opts::new("bitswap_message_count", "Number of bitswap messages"),
-        &["type"],
-    )
-    .expect("Infallible")
-});
-static CONTAINER_CAPACITIES: Lazy<GenericGaugeVec<AtomicU64>> = Lazy::new(|| {
-    GenericGaugeVec::new(
-        Opts::new(
-            "bitswap_container_capacities",
-            "Capacity for each bitswap container",
-        ),
-        &["type"],
-    )
-    .expect("Infallible")
-});
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct TypeLabel {
+    r#type: &'static str,
+}
+
+impl TypeLabel {
+    fn new(t: &'static str) -> Self {
+        Self { r#type: t }
+    }
+}
+
+static MESSAGE_COUNTER: Lazy<Family<TypeLabel, Counter>> = Lazy::new(Default::default);
+static CONTAINER_CAPACITIES: Lazy<Family<TypeLabel, Gauge>> = Lazy::new(Default::default);
 pub(in crate::libp2p_bitswap) static GET_BLOCK_TIME: Lazy<Histogram> = Lazy::new(|| {
-    Histogram::with_opts(HistogramOpts {
-        common_opts: Opts::new("bitswap_get_block_time", "Duration of get_block"),
-        buckets: vec![
+    Histogram::new(
+        [
             0.1, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
-        ],
-    })
-    .expect("Infallible")
+        ]
+        .into_iter(),
+    )
 });
 
 /// Register bitswap metrics
-pub fn register_metrics(registry: &Registry) -> anyhow::Result<()> {
-    registry.register(Box::new(MESSAGE_SIZE.clone()))?;
-    registry.register(Box::new(MESSAGE_COUNTER.clone()))?;
-    registry.register(Box::new(CONTAINER_CAPACITIES.clone()))?;
-    registry.register(Box::new(GET_BLOCK_TIME.clone()))?;
-
-    Ok(())
+pub fn register_metrics(registry: &mut Registry) {
+    registry.register(
+        "bitswap_message_count",
+        "Number of bitswap messages",
+        MESSAGE_COUNTER.clone(),
+    );
+    registry.register(
+        "bitswap_container_capacities",
+        "Capacity for each bitswap container",
+        CONTAINER_CAPACITIES.clone(),
+    );
+    registry.register(
+        "bitswap_get_block_time",
+        "Duration of get_block",
+        GET_BLOCK_TIME.clone(),
+    );
 }
 
-pub(in crate::libp2p_bitswap) fn inbound_stream_count() -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["inbound_stream_count"])
+pub(in crate::libp2p_bitswap) fn inbound_stream_count<'a>() -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_stream_count"))
 }
 
-pub(in crate::libp2p_bitswap) fn outbound_stream_count() -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["outbound_stream_count"])
+pub(in crate::libp2p_bitswap) fn outbound_stream_count<'a>() -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("outbound_stream_count"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_get_block_success() -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["get_block_success"])
+pub(in crate::libp2p_bitswap) fn message_counter_get_block_success<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("get_block_success"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_get_block_failure() -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["get_block_failure"])
+pub(in crate::libp2p_bitswap) fn message_counter_get_block_failure<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("get_block_failure"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_request_have() -> GenericCounter<AtomicU64>
-{
-    MESSAGE_COUNTER.with_label_values(&["inbound_request_have"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_request_have<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_request_have"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_request_block() -> GenericCounter<AtomicU64>
-{
-    MESSAGE_COUNTER.with_label_values(&["inbound_request_block"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_request_block<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_request_block"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_outbound_request_cancel(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["outbound_request_cancel"])
+pub(in crate::libp2p_bitswap) fn message_counter_outbound_request_cancel<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("outbound_request_cancel"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_outbound_request_block(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["outbound_request_block"])
+pub(in crate::libp2p_bitswap) fn message_counter_outbound_request_block<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("outbound_request_block"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_outbound_request_have() -> GenericCounter<AtomicU64>
-{
-    MESSAGE_COUNTER.with_label_values(&["outbound_request_have"])
+pub(in crate::libp2p_bitswap) fn message_counter_outbound_request_have<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("outbound_request_have"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_have_yes(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["inbound_response_have_yes"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_have_yes<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_response_have_yes"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_have_no(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["inbound_response_have_no"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_have_no<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_response_have_no"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["inbound_response_block"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_response_block"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block_update_db(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["inbound_response_block_update_db"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block_update_db<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_response_block_update_db"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block_already_exists_in_db(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["inbound_response_block_already_exists_in_db"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block_already_exists_in_db<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new(
+        "inbound_response_block_already_exists_in_db",
+    ))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block_not_requested(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["inbound_response_block_not_requested"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block_not_requested<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_response_block_not_requested"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block_update_db_failure(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["inbound_response_block_update_db_failure"])
+pub(in crate::libp2p_bitswap) fn message_counter_inbound_response_block_update_db_failure<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("inbound_response_block_update_db_failure"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_outbound_response_have(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["outbound_response_have"])
+pub(in crate::libp2p_bitswap) fn message_counter_outbound_response_have<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("outbound_response_have"))
 }
 
-pub(in crate::libp2p_bitswap) fn message_counter_outbound_response_block(
-) -> GenericCounter<AtomicU64> {
-    MESSAGE_COUNTER.with_label_values(&["outbound_response_block"])
+pub(in crate::libp2p_bitswap) fn message_counter_outbound_response_block<'a>(
+) -> MappedRwLockReadGuard<'a, Counter> {
+    MESSAGE_COUNTER.get_or_create(&TypeLabel::new("outbound_response_block"))
 }
 
-pub(in crate::libp2p_bitswap) fn peer_container_capacity() -> GenericGauge<AtomicU64> {
-    CONTAINER_CAPACITIES.with_label_values(&["peer_container_capacity"])
+pub(in crate::libp2p_bitswap) fn peer_container_capacity<'a>() -> MappedRwLockReadGuard<'a, Gauge> {
+    CONTAINER_CAPACITIES.get_or_create(&TypeLabel::new("peer_container_capacity"))
 }
 
-pub(in crate::libp2p_bitswap) fn response_channel_container_capacity() -> GenericGauge<AtomicU64> {
-    CONTAINER_CAPACITIES.with_label_values(&["response_channel_container_capacity"])
+pub(in crate::libp2p_bitswap) fn response_channel_container_capacity<'a>(
+) -> MappedRwLockReadGuard<'a, Gauge> {
+    CONTAINER_CAPACITIES.get_or_create(&TypeLabel::new("response_channel_container_capacity"))
 }

--- a/src/libp2p_bitswap/request_manager.rs
+++ b/src/libp2p_bitswap/request_manager.rs
@@ -125,7 +125,6 @@ impl BitswapRequestManager {
         validate_peer: Option<Arc<ValidatePeerCallback>>,
     ) {
         let start = Instant::now();
-        let timer = metrics::GET_BLOCK_TIME.start_timer();
         let store_cloned = store.clone();
         task::spawn(async move {
             let mut success = store.contains(&cid).unwrap_or_default();
@@ -156,7 +155,7 @@ impl BitswapRequestManager {
                 }
             }
 
-            timer.observe_duration();
+            metrics::GET_BLOCK_TIME.observe((Instant::now() - start).as_secs_f64());
         });
     }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/2610

Changes introduced in this pull request:

- migrate from `prometheus` to `prometheus_client` under `src/libp2p_bitswap`

Metrics (now):
```
# HELP bitswap_message_count Number of bitswap messages.
# TYPE bitswap_message_count counter
bitswap_message_count_total{type="inbound_response_block"} 1
bitswap_message_count_total{type="inbound_response_block_update_db"} 1
bitswap_message_count_total{type="outbound_request_block"} 1
bitswap_message_count_total{type="inbound_response_have_yes"} 22
bitswap_message_count_total{type="outbound_stream_count"} 54
bitswap_message_count_total{type="outbound_response_have"} 5
bitswap_message_count_total{type="outbound_request_have"} 28
bitswap_message_count_total{type="inbound_stream_count"} 25
bitswap_message_count_total{type="outbound_request_cancel"} 28
bitswap_message_count_total{type="inbound_request_have"} 5
bitswap_message_count_total{type="get_block_success"} 1
# HELP bitswap_container_capacities Capacity for each bitswap container.
# TYPE bitswap_container_capacities gauge
bitswap_container_capacities{type="peer_container_capacity"} 56
bitswap_container_capacities{type="response_channel_container_capacity"} 3
# HELP bitswap_get_block_time Duration of get_block.
# TYPE bitswap_get_block_time histogram
bitswap_get_block_time_sum 0.862921399
bitswap_get_block_time_count 1
bitswap_get_block_time_bucket{le="0.1"} 0
bitswap_get_block_time_bucket{le="0.5"} 0
bitswap_get_block_time_bucket{le="0.75"} 0
bitswap_get_block_time_bucket{le="1.0"} 1
bitswap_get_block_time_bucket{le="1.5"} 1
bitswap_get_block_time_bucket{le="2.0"} 1
bitswap_get_block_time_bucket{le="3.0"} 1
bitswap_get_block_time_bucket{le="4.0"} 1
bitswap_get_block_time_bucket{le="5.0"} 1
bitswap_get_block_time_bucket{le="6.0"} 1
bitswap_get_block_time_bucket{le="7.0"} 1
bitswap_get_block_time_bucket{le="8.0"} 1
bitswap_get_block_time_bucket{le="9.0"} 1
bitswap_get_block_time_bucket{le="10.0"} 1
bitswap_get_block_time_bucket{le="+Inf"} 1
```

Metrics (before):
```
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
