### PR TITLE
fix: use `.first()` instead of `[0]` for NonEmpty block headers in Tipset

### DIFF
--- a/src/chain/store/base_fee.rs
+++ b/src/chain/store/base_fee.rs
@@ -87,7 +87,7 @@ where
     }
 
     // Compute next base fee based on the current gas limit and parent base fee.
-    let parent_base_fee = &ts.block_headers()[0].parent_base_fee;
+    let parent_base_fee = &ts.block_headers().first().parent_base_fee;
     Ok(compute_next_base_fee(
         parent_base_fee,
         total_limit,

--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -413,7 +413,7 @@ where
                     network.clone(),
                     chain_store.clone(),
                     peer_id,
-                    *genesis.block_headers()[0].cid(),
+                    *genesis.block_headers().first().cid(),
                 ));
                 return Ok(None);
             }

--- a/src/cli/subcommands/mpool_cmd.rs
+++ b/src/cli/subcommands/mpool_cmd.rs
@@ -240,7 +240,7 @@ impl MpoolCommands {
                 local,
             } => {
                 let tipset = api.chain_head().await?;
-                let curr_base_fee = tipset.block_headers()[0].parent_base_fee.to_owned();
+                let curr_base_fee = tipset.block_headers().first().parent_base_fee.to_owned();
 
                 let atto_str = api.chain_get_min_base_fee(basefee_lookback).await?;
                 let min_base_fee = TokenAmount::from_atto(atto_str.parse::<BigInt>()?);

--- a/src/message_pool/msgpool/msg_pool.rs
+++ b/src/message_pool/msgpool/msg_pool.rs
@@ -646,7 +646,7 @@ fn verify_msg_before_add(
         .on_chain_message(to_vec(m)?.len());
     valid_for_block_inclusion(m.message(), min_gas.total(), NEWEST_NETWORK_VERSION)?;
     if !cur_ts.block_headers().is_empty() {
-        let base_fee = &cur_ts.block_headers()[0].parent_base_fee;
+        let base_fee = &cur_ts.block_headers().first().parent_base_fee;
         let base_fee_lower_bound =
             get_base_fee_lower_bound(base_fee, BASE_FEE_LOWER_BOUND_FACTOR_CONSERVATIVE);
         if m.gas_fee_cap() < base_fee_lower_bound {

--- a/src/message_pool/msgpool/test_provider.rs
+++ b/src/message_pool/msgpool/test_provider.rs
@@ -189,7 +189,7 @@ impl Provider for TestApi {
     }
 
     fn messages_for_tipset(&self, h: &Tipset) -> Result<Vec<ChainMessage>, Error> {
-        let (us, s) = self.messages_for_block(&h.block_headers()[0])?;
+        let (us, s) = self.messages_for_block(h.block_headers().first())?;
         let mut msgs = Vec::new();
 
         for msg in us {
@@ -262,7 +262,7 @@ pub fn mock_block_with_parents(
     let height = parents.epoch() + 1;
 
     let mut weight_inc = BigInt::from(weight);
-    weight_inc = &parents.block_headers()[0].weight + weight_inc;
+    weight_inc = &parents.block_headers().first().weight + weight_inc;
     let fmt_str = format!("===={ticket_sequence}=====");
     let ticket = Ticket::new(VRFProof::new(fmt_str.clone().into_bytes()));
     let election_proof = ElectionProof {
@@ -276,7 +276,7 @@ pub fn mock_block_with_parents(
         parents: parents.key().clone(),
         message_receipts: c,
         messages: c,
-        state_root: parents.block_headers()[0].state_root,
+        state_root: parents.block_headers().first().state_root,
         weight: weight_inc,
         epoch: height,
         ..Default::default()

--- a/src/rpc/chain_api.rs
+++ b/src/rpc/chain_api.rs
@@ -288,7 +288,7 @@ pub(in crate::rpc) async fn chain_set_head<DB: Blockstore>(
                 .chain_store()
                 .unmark_block_as_validated(&cid);
         }
-        let parents = &current.block_headers()[0].parents;
+        let parents = &current.block_headers().first().parents;
         current = data
             .state_manager
             .chain_store()
@@ -305,16 +305,16 @@ pub(crate) async fn chain_get_min_base_fee<DB: Blockstore>(
     Params((basefee_lookback,)): Params<(u32,)>,
 ) -> Result<String, JsonRpcError> {
     let mut current = data.state_manager.chain_store().heaviest_tipset();
-    let mut min_base_fee = current.block_headers()[0].parent_base_fee.clone();
+    let mut min_base_fee = current.block_headers().first().parent_base_fee.clone();
 
     for _ in 0..basefee_lookback {
-        let parents = &current.block_headers()[0].parents;
+        let parents = &current.block_headers().first().parents;
         current = data
             .state_manager
             .chain_store()
             .load_required_tipset(parents)?;
 
-        min_base_fee = min_base_fee.min(current.block_headers()[0].parent_base_fee.to_owned());
+        min_base_fee = min_base_fee.min(current.block_headers().first().parent_base_fee.to_owned());
     }
 
     Ok(min_base_fee.atto().to_string())

--- a/src/rpc/gas_api.rs
+++ b/src/rpc/gas_api.rs
@@ -36,7 +36,7 @@ fn estimate_fee_cap<DB: Blockstore>(
 ) -> Result<TokenAmount, JsonRpcError> {
     let ts = data.state_manager.chain_store().heaviest_tipset();
 
-    let parent_base_fee = &ts.block_headers()[0].parent_base_fee;
+    let parent_base_fee = &ts.block_headers().first().parent_base_fee;
     let increase_factor =
         (1.0 + (BASE_FEE_MAX_CHANGE_DENOM as f64).recip()).powf(max_queue_blks as f64);
 

--- a/src/state_manager/chain_rand.rs
+++ b/src/state_manager/chain_rand.rs
@@ -125,7 +125,7 @@ where
             beacon.max_beacon_round_for_epoch(self.chain_config.network_version(epoch), epoch);
 
         for _ in 0..20 {
-            let cbe = &rand_ts.block_headers()[0].beacon_entries;
+            let cbe = &rand_ts.block_headers().first().beacon_entries;
             for v in cbe {
                 if v.round() == round {
                     return Ok(v.clone());

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -426,7 +426,7 @@ where
                 state_tree_root: *state_cid,
                 epoch: height,
                 rand: Box::new(rand),
-                base_fee: tipset.block_headers()[0].parent_base_fee.clone(),
+                base_fee: tipset.block_headers().first().parent_base_fee.clone(),
                 circ_supply: genesis_info.get_vm_circulating_supply(
                     height,
                     &self.blockstore_owned(),
@@ -515,7 +515,7 @@ where
                     state_tree_root: st,
                     epoch,
                     rand: Box::new(chain_rand),
-                    base_fee: ts.block_headers()[0].parent_base_fee.clone(),
+                    base_fee: ts.block_headers().first().parent_base_fee.clone(),
                     circ_supply: genesis_info.get_vm_circulating_supply(
                         epoch,
                         &self.blockstore_owned(),
@@ -752,7 +752,7 @@ where
                 } else {
                     crate::chain::get_parent_receipt(
                         self.blockstore(),
-                        &tipset.block_headers()[0],
+                        tipset.block_headers().first(),
                         index,
                     )
                     .map_err(|err| Error::Other(err.to_string()))


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/3861 and follow-up of https://github.com/ChainSafe/forest/pull/3858

Changes introduced in this pull request:

- use `.first()` instead of `[0]` for NonEmpty block headers in Tipset

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
