### PR TITLE
fix: remove filops snapshot provider and fix ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 
 ### Removed
 
+- [#3878](https://github.com/ChainSafe/forest/issues/3878): FILOps is no longer
+  serving lite snapshots. Removed `filops` option from
+  `forest-tool snapshot fetch --vendor [vendor]`.
+
 ### Fixed
 
 ## Forest 0.16.4 "Speedy Gonzales"

--- a/scripts/tests/forest_cli_check.sh
+++ b/scripts/tests/forest_cli_check.sh
@@ -25,48 +25,6 @@ function num-files-here() {
 "$FOREST_TOOL_PATH" db destroy --chain calibnet --force
 "$FOREST_TOOL_PATH" db destroy --chain calibnet --force
 
-
-: fetch snapshot
-pushd "$(mktemp --directory)"
-    "$FOREST_TOOL_PATH" snapshot fetch --chain calibnet --vendor forest
-    "$FOREST_TOOL_PATH" snapshot fetch --chain calibnet --vendor filops
-    # this will fail if they happen to have the same height - we should change the format of our filenames
-    test "$(num-files-here)" -eq 2
-
-    : verify that we are byte-for-byte identical with filops
-    zstd -d filops_*.car.zst
-    "$FOREST_TOOL_PATH" archive export filops_*.car -o exported_snapshot.car.zst
-    zstd -d exported_snapshot.car.zst
-    cmp --silent filops_*.car exported_snapshot.car
-
-    : verify that the exported snapshot is in ForestCAR.zst format
-    assert_eq "$(forest_query_format exported_snapshot.car.zst)" "ForestCARv1.zst"
-
-    # There are a bunch of tests that need fixing, disabling for now.
-    # See https://github.com/ChainSafe/forest/issues/3518.
-    #: verify that diff exports contain the expected number of state roots
-    #EPOCH=$(forest_query_epoch exported_snapshot.car.zst)
-    #"$FOREST_TOOL_PATH" archive export --epoch $((EPOCH-1100)) --depth 900 --output-path base_snapshot.forest.car.zst exported_snapshot.car.zst
-
-    #BASE_EPOCH=$(forest_query_epoch base_snapshot.forest.car.zst)
-    #assert_eq "$BASE_EPOCH" $((EPOCH-1100))
-
-    # This assertion is not true in the presence of null tipsets
-    #BASE_STATE_ROOTS=$(forest_query_state_roots base_snapshot.forest.car.zst)
-    #assert_eq "$BASE_STATE_ROOTS" 900
-
-    #"$FOREST_TOOL_PATH" archive export --diff "$BASE_EPOCH" -o diff_snapshot.forest.car.zst exported_snapshot.car.zst
-    # This assertion is not true in the presence of null tipsets
-    #DIFF_STATE_ROOTS=$(forest_query_state_roots diff_snapshot.forest.car.zst)
-    #assert_eq "$DIFF_STATE_ROOTS" 1100
-
-    #: Validate the union of a snapshot and a diff
-    #"$FOREST_TOOL_PATH" snapshot validate --check-network calibnet base_snapshot.forest.car.zst diff_snapshot.forest.car.zst
-rm -- *
-popd
-
-
-
 : validate latest calibnet snapshot
 pushd "$(mktemp --directory)"
     : : fetch a compressed calibnet snapshot

--- a/src/cli_shared/snapshot.rs
+++ b/src/cli_shared/snapshot.rs
@@ -453,15 +453,4 @@ mod tests {
             "forest_snapshot_calibnet_2023-09-14_height_911888.forest.car.zst"
         );
     }
-
-    #[test]
-    fn content_disposition_filops() {
-        assert_eq!(
-            parse_content_disposition(&HeaderValue::from_static(
-                "attachment; filename=\"911520_2023_09_14T06_13_00Z.car.zst\""
-            ))
-            .unwrap(),
-            "911520_2023_09_14T06_13_00Z.car.zst"
-        );
-    }
 }

--- a/src/cli_shared/snapshot.rs
+++ b/src/cli_shared/snapshot.rs
@@ -36,7 +36,6 @@ use crate::cli_shared::snapshot::parse::ParsedFilename;
 pub enum TrustedVendor {
     #[default]
     Forest,
-    Filops,
 }
 
 /// Create a filename in the "full" format. See [`parse`].
@@ -161,22 +160,13 @@ define_urls!(
     const FOREST_MAINNET_COMPRESSED: &str = "https://forest-archive.chainsafe.dev/latest/mainnet/";
     const FOREST_CALIBNET_COMPRESSED: &str =
         "https://forest-archive.chainsafe.dev/latest/calibnet/";
-    const FILOPS_MAINNET_COMPRESSED: &str =
-        "https://snapshots.mainnet.filops.net/minimal/latest.zst";
-    const FILOPS_CALIBNET_COMPRESSED: &str =
-        "https://snapshots.calibrationnet.filops.net/minimal/latest.zst";
 );
 
 pub fn stable_url(vendor: TrustedVendor, chain: &NetworkChain) -> anyhow::Result<Url> {
     let s = match (vendor, chain) {
         (TrustedVendor::Forest, NetworkChain::Mainnet) => FOREST_MAINNET_COMPRESSED,
         (TrustedVendor::Forest, NetworkChain::Calibnet) => FOREST_CALIBNET_COMPRESSED,
-        (TrustedVendor::Filops, NetworkChain::Mainnet) => FILOPS_MAINNET_COMPRESSED,
-        (TrustedVendor::Filops, NetworkChain::Calibnet) => FILOPS_CALIBNET_COMPRESSED,
-        (
-            TrustedVendor::Forest | TrustedVendor::Filops,
-            NetworkChain::Butterflynet | NetworkChain::Devnet(_),
-        ) => {
+        (TrustedVendor::Forest, NetworkChain::Butterflynet | NetworkChain::Devnet(_)) => {
             bail!("unsupported chain {chain}")
         }
     };


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Filops snapshot service has been shut down, update the code and CI accordingly.

https://github.com/ChainSafe/forest/actions/runs/7551462787/job/20562704877?pr=3873#step:6:50
```
+ forest-tool snapshot fetch --chain calibnet --vendor filops
2024-01-17T08:24:58.902367Z ERROR forest_filecoin::cli_shared::cli: Failed fetching the snapshot: error sending request for url (https://snapshots.calibrationnet.filops.net/minimal/latest.zst): error trying to connect: dns error: failed to lookup address information: No address associated with hostname
```

Changes introduced in this pull request:

- remove `Filops` from `TrustedVendor`
- fix CI

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
