### PR TITLE
fix(ci): add timeout to CI check scripts

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -121,6 +121,7 @@ jobs:
           chmod +x ~/.cargo/bin/forest*
       - name: forest-cli check
         run: ./scripts/tests/forest_cli_check.sh
+        timeout-minutes: 15
 
   # tool-specific tests
   forest-tool-check:
@@ -169,6 +170,7 @@ jobs:
           chmod +x ~/.cargo/bin/forest*
       - name: Other commands check
         run: ./scripts/tests/calibnet_other_check.sh
+        timeout-minutes: 15
 
   # forest stateless mode tests done on calibnet
   calibnet-stateless-mode-check:
@@ -219,6 +221,7 @@ jobs:
           chmod +x ~/.cargo/bin/forest*
       - name: Migration Regression Tests
         run: ./scripts/tests/calibnet_migration_regression_tests.sh
+        timeout-minutes: 15
 
   # Wallet checks (sending, exporting key, balances...)
   calibnet-wallet-check:
@@ -247,6 +250,7 @@ jobs:
           if [[ "$CALIBNET_WALLET" != "" ]]; then
             ./scripts/tests/calibnet_wallet_check.sh "$CALIBNET_WALLET"
           fi
+        timeout-minutes: 15
 
   # Snapshot export checks
   calibnet-export-check:
@@ -270,6 +274,7 @@ jobs:
           chmod +x ~/.cargo/bin/forest*
       - name: Snapshot export check
         run: ./scripts/tests/calibnet_export_check.sh
+        timeout-minutes: 15
 
   # Calibnet checks with discovery disabled
   calibnet-no-discovery-checks:
@@ -335,6 +340,7 @@ jobs:
           chmod +x ~/.cargo/bin/forest*
       - name: Database migration checks
         run: ./scripts/tests/calibnet_db_migration.sh
+        timeout-minutes: 15
 
   db-migration-checks-car-db:
     needs:
@@ -354,6 +360,7 @@ jobs:
           chmod +x ~/.cargo/bin/forest*
       - name: Database migration checks with car_db folder
         run: ./scripts/tests/calibnet_db_migration_car_db.sh
+        timeout-minutes: 15
 
   local-devnet-check:
     name: Devnet checks
@@ -368,7 +375,9 @@ jobs:
           name: forest-${{ runner.os }}
       - name: Devnet setup
         run: ./scripts/devnet/ci_setup.sh
+        timeout-minutes: 15
       - name: Devnet check
         run: ./scripts/devnet/ci_check.sh
+        timeout-minutes: 15
       - name: Dump docker logs
         uses: jwalton/gh-docker-logs@v2


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

CI check scripts sometimes fail after 1h, this PR adds timeouts to all the scripts so that they fail fast.

e.g. https://github.com/ChainSafe/forest/actions/runs/7566287643/job/20603550273?pr=3881

Changes introduced in this pull request:

- add timeout to CI check scripts

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
