### PR TITLE
fix: use NonEmpty for active_syncs in RPCSyncState

### DIFF
--- a/src/cli/subcommands/attach_cmd.rs
+++ b/src/cli/subcommands/attach_cmd.rs
@@ -257,14 +257,14 @@ async fn sleep_tipsets(epochs: ChainEpochDelta, api: ApiInfo) -> anyhow::Result<
     let mut epoch = None;
     loop {
         let state = api.sync_status().await?;
-        if state.active_syncs[0].stage() == SyncStage::Complete {
+        if state.active_syncs.first().stage() == SyncStage::Complete {
             if let Some(prev) = epoch {
-                let curr = state.active_syncs[0].epoch();
+                let curr = state.active_syncs.first().epoch();
                 if (curr - prev) >= epochs {
                     return Ok(());
                 }
             } else {
-                epoch = Some(state.active_syncs[0].epoch());
+                epoch = Some(state.active_syncs.first().epoch());
             }
         }
         time::sleep(time::Duration::from_secs(1)).await;

--- a/src/cli/subcommands/sync_cmd.rs
+++ b/src/cli/subcommands/sync_cmd.rs
@@ -47,7 +47,7 @@ impl SyncCommands {
 
                 for _ in ticker {
                     let response = api.sync_status().await?;
-                    let state = &response.active_syncs[0];
+                    let state = response.active_syncs.first();
 
                     let target_height = if let Some(tipset) = state.target() {
                         tipset.epoch()
@@ -93,7 +93,7 @@ impl SyncCommands {
             Self::Status => {
                 let response = api.sync_status().await?;
 
-                let state = &response.active_syncs[0];
+                let state = response.active_syncs.first();
                 let base = state.base();
                 let elapsed_time = state.get_elapsed_time();
                 let target = state.target();

--- a/src/lotus_json/nonempty.rs
+++ b/src/lotus_json/nonempty.rs
@@ -3,11 +3,10 @@
 
 use super::*;
 use ::nonempty::NonEmpty;
-use serde::Serialize;
 
 impl<T> HasLotusJson for NonEmpty<T>
 where
-    T: HasLotusJson + Serialize + DeserializeOwned,
+    T: HasLotusJson,
 {
     type LotusJson = NonEmpty<<T as HasLotusJson>::LotusJson>;
 

--- a/src/rpc/sync_api.rs
+++ b/src/rpc/sync_api.rs
@@ -8,6 +8,7 @@ use crate::rpc_api::data_types::{RPCState, RPCSyncState};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
+use nonempty::nonempty;
 use parking_lot::RwLock;
 
 /// Checks if a given block is marked as bad.
@@ -36,7 +37,7 @@ async fn clone_state(state: &RwLock<SyncState>) -> SyncState {
 pub(in crate::rpc) async fn sync_state<DB: Blockstore>(
     data: Data<RPCState<DB>>,
 ) -> Result<RPCSyncState, JsonRpcError> {
-    let active_syncs = vec![clone_state(data.sync_state.as_ref()).await];
+    let active_syncs = nonempty![clone_state(data.sync_state.as_ref()).await];
     Ok(RPCSyncState { active_syncs })
 }
 
@@ -170,7 +171,10 @@ mod tests {
         let st_copy = state.sync_state.clone();
 
         match sync_state(Data(state.clone())).await {
-            Ok(ret) => assert_eq!(ret.active_syncs, vec![clone_state(st_copy.as_ref()).await]),
+            Ok(ret) => assert_eq!(
+                ret.active_syncs,
+                nonempty![clone_state(st_copy.as_ref()).await]
+            ),
             Err(e) => std::panic::panic_any(e),
         }
 
@@ -180,8 +184,10 @@ mod tests {
 
         match sync_state(Data(state.clone())).await {
             Ok(ret) => {
-                assert_ne!(ret.active_syncs, vec![]);
-                assert_eq!(ret.active_syncs, vec![clone_state(st_copy.as_ref()).await]);
+                assert_eq!(
+                    ret.active_syncs,
+                    nonempty![clone_state(st_copy.as_ref()).await]
+                );
             }
             Err(e) => std::panic::panic_any(e),
         }

--- a/src/rpc_api/data_types.rs
+++ b/src/rpc_api/data_types.rs
@@ -44,6 +44,7 @@ use fvm_ipld_encoding::{BytesDe, RawBytes};
 use jsonrpc_v2::{MapRouter as JsonRpcMapRouter, Server as JsonRpcServer};
 use libipld_core::ipld::Ipld;
 use libp2p::PeerId;
+use nonempty::NonEmpty;
 use num_bigint::BigInt;
 use parking_lot::RwLock as SyncRwLock;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -72,7 +73,7 @@ where
 #[serde(rename_all = "PascalCase")]
 pub struct RPCSyncState {
     #[serde(with = "crate::lotus_json")]
-    pub active_syncs: Vec<SyncState>,
+    pub active_syncs: NonEmpty<SyncState>,
 }
 
 lotus_json_with_self!(RPCSyncState);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/3861

Changes introduced in this pull request:

- Change `active_syncs: Vec<SyncState>` to `active_syncs: NonEmpty<SyncState>`
- Replace `active_syncs[0]` with `active_syncs.first()`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
