### PR TITLE
chore(ci): bump lotus version in devnet check

### DIFF
--- a/scripts/devnet/lotus.dockerfile
+++ b/scripts/devnet/lotus.dockerfile
@@ -1,11 +1,11 @@
 # Lotus binaries image, to be used in the local devnet with Forest.
-FROM golang:1.20.7-bullseye AS lotus-builder
+FROM golang:1.20-bullseye AS lotus-builder
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang ocl-icd-opencl-dev ocl-icd-libopencl1 jq libhwloc-dev 
 
 WORKDIR /lotus
 
-RUN git clone --depth 1 --branch v1.25.0 https://github.com/filecoin-project/lotus.git .
+RUN git clone --depth 1 --branch v1.25.2 https://github.com/filecoin-project/lotus.git .
 
 # Update the schedules to have the migration faster than it is by default.
 COPY update-schedules.diff .


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

I have recently seen quite a few ci failures in the devnet checks job, this PR tries to upgrade lotus to the latest and see if the issue get mitigated (even not we need the upgrade anyway)

Changes introduced in this pull request:

- bump lotus version in devnet check CI job

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
