### PR TITLE
timeout on paramfetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
 ### Fixed
 
+- [#3857](https://github.com/ChainSafe/forest/pull/3907) Timeout parameter fetch
+  to 30 minutes to avoid it getting stuck on IPFS gateway issues.
+
 ## Forest 0.16.5 "Pinecone Deactivation"
 
 Non-mandatory upgrade including mostly new RPC endpoints. The option to use an

--- a/src/utils/proofs_api/paramfetch.rs
+++ b/src/utils/proofs_api/paramfetch.rs
@@ -179,7 +179,7 @@ async fn fetch_params(path: &Path, info: &ParameterData) -> anyhow::Result<()> {
     let gw = std::env::var(GATEWAY_ENV).unwrap_or_else(|_| GATEWAY.to_owned());
     info!("Fetching param file {} from {gw}", path.display());
     let backoff = ExponentialBackoffBuilder::default()
-        // Up to 30 minutes for download the file. This may be harsh,
+        // Up to 30 minutes for downloading the file. This may be drastic,
         // but the gateway proved to be unreliable at times and we
         // don't want to get stuck here. Better to fail fast and retry.
         .with_max_elapsed_time(Some(Duration::from_secs(60 * 30)))


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Given that the log got stuck at `forest::progress: Loading 3180 (elapsed time: 9s)`, it means that it was using the `reader` method from the `utils/net.rs` file. Now, it means that either a snapshot was being downloaded or there was a download from IPFS (`download_ipfs_file_trustlessly`). Snapshot download during snapshot validation? Certainly not. It means we need to muzzle the IPFS download and fail faster.


Changes introduced in this pull request:

- added a timeout of 30 minutes to the parameters fetch.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3857

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
