### PR TITLE
fix(ci): build and push fat docker image before the slim one

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Build the fat image first, for details see <https://github.com/ChainSafe/forest/pull/3912>
       # This step yields the following labels
       # - {date}-{sha}-fat, e.g. 2023-01-19-da4692d-fat,
       # - edge-fat

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,34 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # This step yields the following labels
+      # - {date}-{sha}-fat, e.g. 2023-01-19-da4692d-fat,
+      # - edge-fat
+      # - tag-fat (if pushed).
+      - name: Docker Meta fat
+        id: metafat
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/chainsafe/forest
+          flavor: |
+            latest=false
+            suffix=-fat
+          tags: |
+            type=raw,value={{date 'YYYY-MM-DD'}}-{{sha}}
+            type=ref,event=tag
+            type=edge
+      
+      - name: Build fat image and push to GitHub Container Registry
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          tags: ${{ steps.metafat.outputs.tags }}
+          labels: ${{ steps.metafat.outputs.labels }}
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+          # Compile Docker image only for ARM64 for a regular PR to save some CI time.
+          platforms: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/arm64' }}
+          target: fat-image
+
+      # This step yields the following labels
       # - date+sha, e.g. 2023-01-19-da4692d,
       # - tag (if pushed).
       - name: Docker Meta
@@ -78,31 +106,6 @@ jobs:
           # Compile Docker image only for ARM64 for a regular PR to save some CI time.
           platforms: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/arm64' }}
           target: slim-image
-      # This step yields the following labels
-      # - {date}-{sha}-fat, e.g. 2023-01-19-da4692d-fat,
-      # - edge-fat
-      # - tag-fat (if pushed).
-      - name: Docker Meta fat
-        id: metafat
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/chainsafe/forest
-          flavor: |
-            latest=false
-            suffix=-fat
-          tags: |
-            type=raw,value={{date 'YYYY-MM-DD'}}-{{sha}}
-            type=ref,event=tag
-            type=edge
-      - name: Build fat image and push to GitHub Container Registry
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          tags: ${{ steps.metafat.outputs.tags }}
-          labels: ${{ steps.metafat.outputs.labels }}
-          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
-          # Compile Docker image only for ARM64 for a regular PR to save some CI time.
-          platforms: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/arm64' }}
-          target: fat-image
+
       - name: List docker images
         run: docker image ls


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/3892 and a follow-up of https://github.com/ChainSafe/forest/pull/3902

The fat image is built on top of the slim one with extra steps fetching data from the internet. There's a chance that the slim image is successfully built and pushed but the fat image fails. After reversing the order, it should either both fail(fail fast) or both succeed as the build-slim-image step should have been cached when the build-fat-image step is successful.

Changes introduced in this pull request:

- build and push fat docker image before the slim one

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
