### PR TITLE
fix(ci): cleanup `forest-tool-check` job that checks nothing

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -124,27 +124,6 @@ jobs:
         run: ./scripts/tests/forest_cli_check.sh
         timeout-minutes: 15
 
-  # tool-specific tests
-  forest-tool-check:
-    needs:
-      - build-ubuntu
-    name: Forest TOOL checks
-    runs-on: ubuntu-latest
-    steps:
-      # To help investigate transient test failures
-      - run: lscpu
-      - name: Checkout Sources
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: forest-${{ runner.os }}
-          path: ~/.cargo/bin
-      # Permissions are lost during artifact-upload
-      # https://github.com/actions/upload-artifact#permission-loss
-      - name: Set permissions
-        run: |
-          chmod +x ~/.cargo/bin/forest*
-
   # miscallenous tests done on calibnet
   calibnet-check:
     needs:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- cleanup `forest-tool-check` job that does not run any test scripts

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
