### PR TITLE
fix(ci): cache proof param files in `forest-cli-check` job

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -110,6 +110,10 @@ jobs:
     steps:
       # To help investigate transient test failures
       - run: lscpu
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.FIL_PROOFS_PARAMETER_CACHE }}
+          key: proof-params-keys
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

We still see CI timeout failures when downloading the proof parameter files, see https://github.com/ChainSafe/forest/actions/runs/7706724002/job/21002879420#step:6:29
This PR tries to mitigate the issue by caching proof param files in that job

Changes introduced in this pull request:

- cache proof param files in `forest-cli-check` job

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
