### PR TITLE
fix: progress rates were overcounted by 5x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
   to 30 minutes to avoid it getting stuck on IPFS gateway issues.
 - [#3901](https://github.com/ChainSafe/forest/pull/3901) Fix timeout issue in
   `forest-cli snapshot export`.
+- [#3919](https://github.com/ChainSafe/forest/pull/3919) Fix misreporting when
+  logging progress.
 
 ## Forest 0.16.5 "Pinecone Deactivation"
 

--- a/src/utils/io/progress_log.rs
+++ b/src/utils/io/progress_log.rs
@@ -221,6 +221,7 @@ mod tests {
     fn test_progress_msg_bytes() {
         let mut progress = Progress::new("test");
         let now = progress.start;
+        progress.last_logged -= Duration::from_secs(1);
         progress.item_type = ItemType::Bytes;
         progress.total_items = Some(1024 * 1024 * 1024);
         progress.set(1024 * 1024 * 1024);
@@ -234,14 +235,14 @@ mod tests {
         progress.last_logged_items = 1024 * 1024 * 1024 / 3;
         assert_eq!(
             progress.msg(now + Duration::from_secs(125)),
-            "test 512 MiB / 1 GiB, 50%, 170.7 MiB/s, elapsed time: 2m 5s"
+            "test 512 MiB / 1 GiB, 50%, 1.4 MiB/s, elapsed time: 2m 5s"
         );
 
         progress.set(1024 * 1024 * 1024 / 10);
         progress.last_logged_items = 1024 * 1024 * 1024 / 11;
         assert_eq!(
             progress.msg(now + Duration::from_secs(10)),
-            "test 102.4 MiB / 1 GiB, 9%, 9.3 MiB/s, elapsed time: 10s"
+            "test 102.4 MiB / 1 GiB, 9%, 866.6 KiB/s, elapsed time: 10s"
         );
     }
 
@@ -254,22 +255,22 @@ mod tests {
         progress.set(1024);
         progress.last_logged_items = 1024 / 2;
         assert_eq!(
-            progress.msg(now),
-            "test 1024 / 1024, 100%, 512 items/s, elapsed time: 0s"
+            progress.msg(now + Duration::from_secs(1)),
+            "test 1024 / 1024, 100%, 512 items/s, elapsed time: 1s"
         );
 
         progress.set(1024 / 2);
         progress.last_logged_items = 1024 / 3;
         assert_eq!(
             progress.msg(now + Duration::from_secs(125)),
-            "test 512 / 1024, 50%, 171 items/s, elapsed time: 2m 5s"
+            "test 512 / 1024, 50%, 1 items/s, elapsed time: 2m 5s"
         );
 
         progress.set(1024 / 10);
-        progress.last_logged_items = 1024 / 11;
+        progress.last_logged_items = 0;
         assert_eq!(
             progress.msg(now + Duration::from_secs(10)),
-            "test 102 / 1024, 9%, 9 items/s, elapsed time: 10s"
+            "test 102 / 1024, 9%, 10 items/s, elapsed time: 10s"
         );
     }
 }

--- a/src/utils/io/progress_log.rs
+++ b/src/utils/io/progress_log.rs
@@ -147,6 +147,7 @@ impl Progress {
         let message = &self.message;
         let elapsed_secs = (now - self.start).as_secs_f64();
         let elapsed_duration = format_duration(Duration::from_secs(elapsed_secs as u64));
+        let seconds_since_last_msg = (now - self.last_logged).as_secs_f64();
 
         let at = match self.item_type {
             ItemType::Bytes => human_bytes(self.completed_items as f64),
@@ -161,17 +162,17 @@ impl Progress {
                     ItemType::Bytes => human_bytes(total as f64),
                     ItemType::Items => total.to_string(),
                 };
-                output += &format!(", {:0}%", self.completed_items * 100 / total);
+                output += &format!(", {}%", self.completed_items * 100 / total);
             }
             output
         } else {
             String::new()
         };
 
-        let diff = self.completed_items - self.last_logged_items;
+        let diff = (self.completed_items - self.last_logged_items) as f64 / seconds_since_last_msg;
         let speed = match self.item_type {
-            ItemType::Bytes => format!("{}/s", human_bytes(diff as f64)),
-            ItemType::Items => format!("{diff} items/s"),
+            ItemType::Bytes => format!("{}/s", human_bytes(diff)),
+            ItemType::Items => format!("{diff:.0} items/s"),
         };
 
         format!("{message} {at}{total}, {speed}, elapsed time: {elapsed_duration}")

--- a/src/utils/io/progress_log.rs
+++ b/src/utils/io/progress_log.rs
@@ -242,7 +242,7 @@ mod tests {
 
         progress.set(1024 * 1024 * 1024 / 10);
         progress.last_logged_items = 1024 * 1024;
-        // Going from 1MiB to 102.4MiB in 10s should show (1MiB-102.4MiB)/10s = ~10.1 MiB/s
+        // Going from 1MiB to 102.4MiB in 10s should show (102.4MiB-1MiB)/10s = ~10.1 MiB/s
         assert_eq!(
             progress.msg(now + Duration::from_secs(10)),
             "test 102.4 MiB / 1 GiB, 9%, 10.1 MiB/s, elapsed time: 10s"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Divide by `time_in_seconds` to get the real progress in units per second.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
