### PR TITLE
fix: propagate RPC error messages

### DIFF
--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -114,6 +114,23 @@ impl ApiInfo {
         if response.status() == http0::StatusCode::NOT_FOUND {
             return Err(JsonRpcError::METHOD_NOT_FOUND);
         }
+        if response.status() == http0::StatusCode::FORBIDDEN {
+            let msg = if self.token.is_none() {
+                "Permission denied: Token required."
+            } else {
+                "Permission denied: Insufficient rights."
+            };
+            return Err(JsonRpcError {
+                code: response.status().as_u16() as i64,
+                message: Cow::Borrowed(msg),
+            });
+        }
+        if !response.status().is_success() {
+            return Err(JsonRpcError {
+                code: response.status().as_u16() as i64,
+                message: Cow::Owned(response.text().await?),
+            });
+        }
         let rpc_res: JsonRpcResponse<T::LotusJson> = response.json().await?;
 
         match rpc_res {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Propagate user-friendly (friendlier?) error messages.

Calling `forest-wallet list` without a token:
Before: `Error: error decoding response body: expected value at line 1 column 1 (code=0)`
After: `Error: Permission denied: Token required. (code=403)`

Creating a new key-pair with a read-only token:
Before: `Error: error decoding response body: expected value at line 1 column 1 (code=0)`
After: `Error: Permission denied: Insufficient rights. (code=403)`

Using an invalid token:
Before: `Error: error decoding response body: expected value at line 1 column 1 (code=0)`
After: `Error: Unknown error after making RPC call. Code: 0. Error: "InvalidToken"  (code=500)`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
