### PR TITLE
fix: use NonEmpty type for car roots

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -11,6 +11,7 @@ use crate::utils::stream::par_buffer;
 use anyhow::Context as _;
 use digest::Digest;
 use fvm_ipld_blockstore::Blockstore;
+use nonempty::NonEmpty;
 use std::sync::Arc;
 use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 
@@ -26,7 +27,8 @@ pub async fn export<D: Digest>(
 ) -> anyhow::Result<Option<digest::Output<D>>, Error> {
     let db = Arc::new(db);
     let stateroot_lookup_limit = tipset.epoch() - lookup_depth;
-    let roots = tipset.key().cids.clone().into_iter().collect();
+    let roots = NonEmpty::from_vec(tipset.key().cids.clone().into_iter().collect())
+        .context("Tipset key is empty")?;
 
     // Wrap writer in optional checksum calculator
     let mut writer = AsyncWriterWithChecksum::<D, _>::new(BufWriter::new(writer), !skip_checksum);

--- a/src/chain_sync/network_context.rs
+++ b/src/chain_sync/network_context.rs
@@ -24,6 +24,7 @@ use anyhow::Context as _;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
+use nonempty::NonEmpty;
 use serde::de::DeserializeOwned;
 use std::future::Future;
 use tokio::sync::Semaphore;
@@ -227,7 +228,8 @@ where
         T: TryFrom<TipsetBundle, Error = String> + Send + Sync + 'static,
     {
         let request = ChainExchangeRequest {
-            start: tsk.cids.clone().into_iter().collect(),
+            start: NonEmpty::from_vec(tsk.cids.clone().into_iter().collect())
+                .ok_or_else(|| "tipset keys cannot be empty".to_owned())?,
             request_len,
             options,
         };

--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -82,9 +82,9 @@ pub async fn load_actor_bundles_from_server(
             .iter()
             .filter(|bundle| {
                 !db.has(&bundle.manifest).unwrap_or(false) &&
-        // Comparing only the discriminant is enough. All devnets share the same
-        // actor bundle.
-        discriminant(network) == discriminant(&bundle.network)
+                // Comparing only the discriminant is enough. All devnets share the same
+                // actor bundle.
+                discriminant(network) == discriminant(&bundle.network)
             })
             .map(
                 |ActorBundleInfo {
@@ -102,7 +102,7 @@ pub async fn load_actor_bundles_from_server(
                     let bytes = response.bytes().await?;
                     let header = load_car(db, Cursor::new(bytes)).await?;
                     ensure!(header.roots.len() == 1);
-                    ensure!(&header.roots[0] == root);
+                    ensure!(header.roots.first() == root);
                     Ok(())
                 },
             ),

--- a/src/libp2p/chain_exchange/message.rs
+++ b/src/libp2p/chain_exchange/message.rs
@@ -7,6 +7,7 @@ use crate::blocks::{Block, CachingBlockHeader, FullTipset, Tipset, BLOCK_MESSAGE
 use crate::message::SignedMessage;
 use crate::shim::message::Message;
 use cid::Cid;
+use nonempty::NonEmpty;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_tuple::{self, Deserialize_tuple, Serialize_tuple};
 
@@ -20,7 +21,7 @@ pub const MESSAGES: u64 = 0b10;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
 pub struct ChainExchangeRequest {
     /// The tipset [Cid] to start the request from.
-    pub start: Vec<Cid>,
+    pub start: NonEmpty<Cid>,
     /// The amount of tipsets to request.
     pub request_len: u64,
     /// 1 for Block only, 2 for Messages only, 3 for Blocks and Messages.

--- a/src/libp2p/chain_exchange/provider.rs
+++ b/src/libp2p/chain_exchange/provider.rs
@@ -142,21 +142,20 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
+    use super::{
+        super::{HEADERS, MESSAGES},
+        *,
+    };
     use crate::blocks::{CachingBlockHeader, RawBlockHeader};
     use crate::db::MemoryDB;
     use crate::genesis::EXPORT_SR_40;
     use crate::networks::ChainConfig;
     use crate::shim::address::Address;
     use crate::utils::db::car_util::load_car;
+    use nonempty::NonEmpty;
+    use std::sync::Arc;
 
-    use super::{
-        super::{HEADERS, MESSAGES},
-        *,
-    };
-
-    async fn populate_db() -> (Vec<Cid>, Arc<MemoryDB>) {
+    async fn populate_db() -> (NonEmpty<Cid>, Arc<MemoryDB>) {
         let db = Arc::new(MemoryDB::default());
         // The cids are the tipset cids of the most recent tipset (39th)
         let header = load_car(&db, EXPORT_SR_40).await.unwrap();

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -4,12 +4,13 @@
 use std::io::{self, Cursor};
 use std::path::Path;
 
-use anyhow::ensure;
+use anyhow::{ensure, Context as _};
 use async_compression::tokio::write::ZstdEncoder;
 use cid::Cid;
 use futures::stream::FuturesUnordered;
 use futures::{stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
+use nonempty::NonEmpty;
 use once_cell::sync::Lazy;
 use reqwest::Url;
 use tokio::fs::File;
@@ -99,7 +100,7 @@ pub async fn generate_actor_bundle(output: &Path) -> anyhow::Result<()> {
             let car = CarStream::new(Cursor::new(bytes)).await?;
             ensure!(car.header.version == 1);
             ensure!(car.header.roots.len() == 1);
-            ensure!(&car.header.roots[0] == root);
+            ensure!(car.header.roots.first() == root);
             anyhow::Ok((*root, car.try_collect::<Vec<_>>().await?))
         },
     ))
@@ -127,7 +128,7 @@ pub async fn generate_actor_bundle(output: &Path) -> anyhow::Result<()> {
     stream::iter(blocks)
         .map(io::Result::Ok)
         .forward(CarWriter::new_carv1(
-            roots.into_iter().collect(),
+            NonEmpty::from_vec(roots).context("car roots cannot be empty")?,
             ZstdEncoder::with_quality(
                 File::create(&output).await?,
                 async_compression::Level::Precise(17),
@@ -209,7 +210,8 @@ mod tests {
                     "Roots for {url} and {alt_url} do not match"
                 );
                 assert_eq!(
-                    car_primary.header.roots[0], *manifest,
+                    car_primary.header.roots.first(),
+                    manifest,
                     "Manifest for {url} and {alt_url} does not match"
                 );
 

--- a/src/rpc/state_api.rs
+++ b/src/rpc/state_api.rs
@@ -33,6 +33,7 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{CborStore, DAG_CBOR};
 use jsonrpc_v2::{Data, Error as JsonRpcError, Params};
 use libipld_core::ipld::Ipld;
+use nonempty::nonempty;
 use num_bigint::BigInt;
 use parking_lot::Mutex;
 use std::path::PathBuf;
@@ -473,7 +474,7 @@ pub async fn state_fetch_root<DB: Blockstore + Sync + Send + 'static>(
 
     let (car_tx, car_handle) = if let Some(save_to_file) = save_to_file {
         let (car_tx, car_rx) = flume::bounded(100);
-        let roots = vec![root_cid];
+        let roots = nonempty![root_cid];
         let file = tokio::fs::File::create(save_to_file).await?;
 
         let car_handle = tokio::spawn(async move {

--- a/src/tool/subcommands/archive_cmd.rs
+++ b/src/tool/subcommands/archive_cmd.rs
@@ -52,6 +52,7 @@ use futures::TryStreamExt;
 use fvm_ipld_blockstore::Blockstore;
 use indicatif::ProgressIterator;
 use itertools::Itertools;
+use nonempty::NonEmpty;
 use sha2::Sha256;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -463,7 +464,8 @@ async fn merge_snapshots(
 
     let store = ManyCar::try_from(snapshot_files)?;
     let heaviest_tipset = store.heaviest_tipset()?;
-    let roots = heaviest_tipset.key().cids.clone().into_iter().collect();
+    let roots = NonEmpty::from_vec(heaviest_tipset.key().cids.clone().into_iter().collect())
+        .context("tipset key cannot be empty")?;
 
     if !force && output_path.exists() {
         let have_permission = Confirm::with_theme(&ColorfulTheme::default())

--- a/src/tool/subcommands/benchmark_cmd.rs
+++ b/src/tool/subcommands/benchmark_cmd.rs
@@ -19,6 +19,7 @@ use futures::{StreamExt, TryStreamExt};
 use fvm_ipld_encoding::DAG_CBOR;
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
+use nonempty::NonEmpty;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -249,7 +250,8 @@ async fn benchmark_exporting(
     );
     crate::db::car::forest::Encoder::write(
         &mut dest,
-        ts.key().cids.clone().into_iter().collect(),
+        NonEmpty::from_vec(ts.key().cids.clone().into_iter().collect())
+            .context("car roots cannot be empty")?,
         frames,
     )
     .await?;

--- a/src/utils/db/car_util.rs
+++ b/src/utils/db/car_util.rs
@@ -51,6 +51,7 @@ mod tests {
     use futures::{StreamExt, TryStreamExt};
     use fvm_ipld_encoding::DAG_CBOR;
     use itertools::Itertools;
+    use nonempty::{nonempty, NonEmpty};
     use pretty_assertions::assert_eq;
     use quickcheck::Arbitrary;
     use quickcheck_macros::quickcheck;
@@ -69,8 +70,8 @@ mod tests {
             self.into_forest_car_zst_bytes_with_roots().await.1
         }
 
-        async fn into_forest_car_zst_bytes_with_roots(self) -> (Vec<Cid>, Vec<u8>) {
-            let roots = vec![self.0[0].cid];
+        async fn into_forest_car_zst_bytes_with_roots(self) -> (NonEmpty<Cid>, Vec<u8>) {
+            let roots = nonempty![self.0[0].cid];
             let frames = crate::db::car::forest::Encoder::compress_stream(
                 8000_usize.next_power_of_two(),
                 zstd::DEFAULT_COMPRESSION_LEVEL as _,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Part of https://github.com/ChainSafe/forest/issues/3861

As per the [IPLD CAR doc](https://ipld.io/specs/transport/car/carv1/#constraints)
> The roots array must contain one or more CIDs, each of which should be present somewhere in the remainder of the CAR.

Changes introduced in this pull request:

- use NonEmpty type for car roots
- change `roots[0]` to `roots.first()`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
