### PR TITLE
fix: check if all blocks are within clock drift in `evaluate_network_head`

### DIFF
--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -570,8 +570,8 @@ where
         let block_delay = self.state_manager.chain_config().block_delay_secs as u64;
 
         let evaluator = async move {
-            let mut tipsets = vec![];
-            loop {
+            let mut tipsets = Vec::with_capacity(tipset_sample_size);
+            while tipsets.len() < tipset_sample_size {
                 let event = match p2p_messages.recv_async().await {
                     Ok(event) => event,
                     Err(why) => {
@@ -628,10 +628,6 @@ where
                 if tipset.blocks().iter().all(is_block_valid) {
                     // Add to tipset sample
                     tipsets.push(tipset);
-                }
-
-                if tipsets.len() >= tipset_sample_size {
-                    break;
                 }
             }
 

--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -600,28 +600,36 @@ where
                     }
                 };
 
-                let header = tipset.blocks().first().header();
                 let now_epoch = chrono::Utc::now()
                     .timestamp()
                     .saturating_add(block_delay as i64 - 1)
                     .saturating_sub(genesis.block_headers().first().timestamp as i64)
                     / block_delay as i64;
-                if !header.is_within_clock_drift() {
-                    warn!(
-                        "Skipping tipset with invalid block timestamp from the future, now_epoch: {now_epoch}, epoch: {}, timestamp: {}",
-                        header.epoch, header.timestamp
-                    );
-                    continue;
-                } else if tipset.epoch() > now_epoch {
-                    warn!(
-                            "Skipping tipset with invalid epoch from the future, now_epoch: {now_epoch}, epoch: {}, timestamp: {}",
+
+                let is_block_valid = |block: &Block| -> bool {
+                    let header = &block.header;
+                    if !header.is_within_clock_drift() {
+                        warn!(
+                            "Skipping tipset with invalid block timestamp from the future, now_epoch: {now_epoch}, epoch: {}, timestamp: {}",
                             header.epoch, header.timestamp
                         );
-                    continue;
+                        false
+                    } else if tipset.epoch() > now_epoch {
+                        warn!(
+                                "Skipping tipset with invalid epoch from the future, now_epoch: {now_epoch}, epoch: {}, timestamp: {}",
+                                header.epoch, header.timestamp
+                            );
+                        false
+                    } else {
+                        true
+                    }
+                };
+
+                if tipset.blocks().iter().all(is_block_valid) {
+                    // Add to tipset sample
+                    tipsets.push(tipset);
                 }
 
-                // Add to tipset sample
-                tipsets.push(tipset);
                 if tipsets.len() >= tipset_sample_size {
                     break;
                 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

The previous fix in https://github.com/ChainSafe/forest/pull/3914 assumes it's sufficient to check only the first block, but we are still seeing timed-out CI jobs stuck in `sync wait`. This PR changes the logic to check all blocks

Changes introduced in this pull request:

- check all blocks are within clock drift in `evaluate_network_head`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
