### PR TITLE
Move `HeightInfos` to a `HashMap`

### DIFF
--- a/src/interpreter/fvm4.rs
+++ b/src/interpreter/fvm4.rs
@@ -195,7 +195,7 @@ impl<DB: Blockstore + Send + Sync + 'static> Consensus for ForestExterns<DB> {
             let watermelonfix_height = self
                 .chain_config
                 .height_infos
-                .get(Height::WatermelonFix as usize)
+                .get(&Height::WatermelonFix)
                 .context("Missing WatermelonFix for calibnet")?
                 .epoch;
 

--- a/src/networks/butterflynet/mod.rs
+++ b/src/networks/butterflynet/mod.rs
@@ -63,27 +63,28 @@ pub const ETH_CHAIN_ID: u64 = 3141592;
 
 /// Height epochs.
 pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
-    [
-        HeightInfo {
-            height: Height::Thunder,
-            epoch: -1,
-            bundle: Some(
-                Cid::try_from("bafy2bzaceaiy4dsxxus5xp5n5i4tjzkb7sc54mjz7qnk2efhgmsrobjesxnza")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Watermelon,
-            epoch: 400,
-            bundle: Some(
-                Cid::try_from("bafy2bzacectxvbk77ntedhztd6sszp2btrtvsmy7lp2ypnrk6yl74zb34t2cq")
-                    .unwrap(),
-            ),
-        },
-    ]
-    .iter()
-    .map(|info| (info.height, info.clone()))
-    .collect()
+    HashMap::from_iter([
+        (
+            Height::Thunder,
+            HeightInfo {
+                epoch: -1,
+                bundle: Some(
+                    Cid::try_from("bafy2bzaceaiy4dsxxus5xp5n5i4tjzkb7sc54mjz7qnk2efhgmsrobjesxnza")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Watermelon,
+            HeightInfo {
+                epoch: 400,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacectxvbk77ntedhztd6sszp2btrtvsmy7lp2ypnrk6yl74zb34t2cq")
+                        .unwrap(),
+                ),
+            },
+        ),
+    ])
 });
 
 pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 1]> = Lazy::new(|| {

--- a/src/networks/butterflynet/mod.rs
+++ b/src/networks/butterflynet/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use ahash::HashMap;
 use cid::Cid;
 use libp2p::Multiaddr;
 use once_cell::sync::Lazy;
@@ -61,108 +62,8 @@ pub static DEFAULT_BOOTSTRAP: Lazy<Vec<Multiaddr>> =
 pub const ETH_CHAIN_ID: u64 = 3141592;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: Lazy<[HeightInfo; 22]> = Lazy::new(|| {
+pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
     [
-        HeightInfo {
-            height: Height::Breeze,
-            epoch: -50,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Smoke,
-            epoch: -2,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Ignition,
-            epoch: -3,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::ActorsV2,
-            epoch: -3,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Tape,
-            epoch: -4,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Liftoff,
-            epoch: -6,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Kumquat,
-            epoch: -7,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Calico,
-            epoch: -9,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Persian,
-            epoch: -10,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Orange,
-            epoch: -11,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Trust,
-            epoch: -13,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Norwegian,
-            epoch: -14,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Turbo,
-            epoch: -15,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Hyperdrive,
-            epoch: -16,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Chocolate,
-            epoch: -17,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::OhSnap,
-            epoch: -18,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Skyr,
-            epoch: -19,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Shark,
-            epoch: -20,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Hygge,
-            epoch: -21,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Lightning,
-            epoch: -22,
-            bundle: None,
-        },
         HeightInfo {
             height: Height::Thunder,
             epoch: -1,
@@ -180,6 +81,9 @@ pub static HEIGHT_INFOS: Lazy<[HeightInfo; 22]> = Lazy::new(|| {
             ),
         },
     ]
+    .iter()
+    .map(|info| (info.height, info.clone()))
+    .collect()
 });
 
 pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 1]> = Lazy::new(|| {

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use ahash::HashMap;
 use cid::Cid;
 use libp2p::Multiaddr;
 use once_cell::sync::Lazy;
@@ -30,93 +31,8 @@ const LIGHTNING_ROLLOVER_PERIOD: i64 = 3120;
 pub const ETH_CHAIN_ID: u64 = 314159;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: Lazy<[HeightInfo; 24]> = Lazy::new(|| {
+pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
     [
-        HeightInfo {
-            height: Height::Breeze,
-            epoch: -1,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Smoke,
-            epoch: -2,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Ignition,
-            epoch: -3,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::ActorsV2,
-            epoch: 30,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Tape,
-            epoch: 60,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Liftoff,
-            epoch: -5,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Kumquat,
-            epoch: 90,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Calico,
-            epoch: 120,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Persian,
-            epoch: 130,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Orange,
-            epoch: 300,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Trust,
-            epoch: 330,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Norwegian,
-            epoch: 360,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Turbo,
-            epoch: 390,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Hyperdrive,
-            epoch: 420,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Chocolate,
-            epoch: 450,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::OhSnap,
-            epoch: 480,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Skyr,
-            epoch: 510,
-            bundle: None,
-        },
         HeightInfo {
             height: Height::Shark,
             epoch: 16_800,
@@ -171,6 +87,9 @@ pub static HEIGHT_INFOS: Lazy<[HeightInfo; 24]> = Lazy::new(|| {
             ),
         },
     ]
+    .iter()
+    .map(|info| (info.height, info.clone()))
+    .collect()
 });
 
 pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 1]> = Lazy::new(|| {

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -32,64 +32,166 @@ pub const ETH_CHAIN_ID: u64 = 314159;
 
 /// Height epochs.
 pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
-    [
-        HeightInfo {
-            height: Height::Shark,
-            epoch: 16_800,
-            bundle: Some(
-                Cid::try_from("bafy2bzacedbedgynklc4dgpyxippkxmba2mgtw7ecntoneclsvvl4klqwuyyy")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Hygge,
-            epoch: 322_354,
-            bundle: Some(
-                Cid::try_from("bafy2bzaced25ta3j6ygs34roprilbtb3f6mxifyfnm7z7ndquaruxzdq3y7lo")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Lightning,
-            epoch: LIGHTNING_EPOCH,
-            bundle: Some(
-                Cid::try_from("bafy2bzacedhuowetjy2h4cxnijz2l64h4mzpk5m256oywp4evarpono3cjhco")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Thunder,
-            epoch: LIGHTNING_EPOCH + LIGHTNING_ROLLOVER_PERIOD,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Watermelon,
-            epoch: 1013134,
-            bundle: Some(
-                Cid::try_from("bafy2bzacedrunxfqta5skb7q7x32lnp4efz2oq7fn226ffm7fu5iqs62jkmvs")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::WatermelonFix,
-            epoch: 1_070_494,
-            bundle: Some(
-                Cid::try_from("bafy2bzacebl4w5ptfvuw6746w7ev562idkbf5ppq72e6zub22435ws2rukzru")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::WatermelonFix2,
-            epoch: 1_108_174,
-            bundle: Some(
-                Cid::try_from("bafy2bzacednzb3pkrfnbfhmoqtb3bc6dgvxszpqklf3qcc7qzcage4ewzxsca")
-                    .unwrap(),
-            ),
-        },
-    ]
-    .iter()
-    .map(|info| (info.height, info.clone()))
-    .collect()
+    HashMap::from_iter([
+        (
+            Height::ActorsV2,
+            HeightInfo {
+                epoch: 30,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Tape,
+            HeightInfo {
+                epoch: 60,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Kumquat,
+            HeightInfo {
+                epoch: 90,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Calico,
+            HeightInfo {
+                epoch: 120,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Persian,
+            HeightInfo {
+                epoch: 130,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Orange,
+            HeightInfo {
+                epoch: 300,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Trust,
+            HeightInfo {
+                epoch: 330,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Norwegian,
+            HeightInfo {
+                epoch: 360,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Turbo,
+            HeightInfo {
+                epoch: 390,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Hyperdrive,
+            HeightInfo {
+                epoch: 420,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Chocolate,
+            HeightInfo {
+                epoch: 450,
+                bundle: None,
+            },
+        ),
+        (
+            Height::OhSnap,
+            HeightInfo {
+                epoch: 480,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Skyr,
+            HeightInfo {
+                epoch: 510,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Shark,
+            HeightInfo {
+                epoch: 16_800,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacedbedgynklc4dgpyxippkxmba2mgtw7ecntoneclsvvl4klqwuyyy")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Hygge,
+            HeightInfo {
+                epoch: 322_354,
+                bundle: Some(
+                    Cid::try_from("bafy2bzaced25ta3j6ygs34roprilbtb3f6mxifyfnm7z7ndquaruxzdq3y7lo")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Lightning,
+            HeightInfo {
+                epoch: LIGHTNING_EPOCH,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacedhuowetjy2h4cxnijz2l64h4mzpk5m256oywp4evarpono3cjhco")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Thunder,
+            HeightInfo {
+                epoch: LIGHTNING_EPOCH + LIGHTNING_ROLLOVER_PERIOD,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Watermelon,
+            HeightInfo {
+                epoch: 1_013_134,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacedrunxfqta5skb7q7x32lnp4efz2oq7fn226ffm7fu5iqs62jkmvs")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::WatermelonFix,
+            HeightInfo {
+                epoch: 1_070_494,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacebl4w5ptfvuw6746w7ev562idkbf5ppq72e6zub22435ws2rukzru")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::WatermelonFix2,
+            HeightInfo {
+                epoch: 1_108_174,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacednzb3pkrfnbfhmoqtb3bc6dgvxszpqklf3qcc7qzcage4ewzxsca")
+                        .unwrap(),
+                ),
+            },
+        ),
+    ])
 });
 
 pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 1]> = Lazy::new(|| {

--- a/src/networks/devnet/mod.rs
+++ b/src/networks/devnet/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use ahash::HashMap;
 use cid::Cid;
 use once_cell::sync::Lazy;
 
@@ -15,93 +16,8 @@ pub const ETH_CHAIN_ID: u64 = 31415926;
 /// Height epochs.
 /// Environment variable names follow
 /// <https://github.com/filecoin-project/lotus/blob/8f73f157933435f5020d7b8f23bee9e4ab71cb1c/build/params_2k.go#L108>
-pub static HEIGHT_INFOS: Lazy<[HeightInfo; 22]> = Lazy::new(|| {
+pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
     [
-        HeightInfo {
-            height: Height::Breeze,
-            epoch: get_upgrade_height_from_env("FOREST_BREEZE_HEIGHT").unwrap_or(-50),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Smoke,
-            epoch: get_upgrade_height_from_env("FOREST_SMOKE_HEIGHT").unwrap_or(-2),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Ignition,
-            epoch: get_upgrade_height_from_env("FOREST_IGNITION_HEIGHT").unwrap_or(-3),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::ActorsV2,
-            epoch: get_upgrade_height_from_env("FOREST_ACTORSV2_HEIGHT").unwrap_or(-3),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Tape,
-            epoch: get_upgrade_height_from_env("FOREST_TAPE_HEIGHT").unwrap_or(-4),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Liftoff,
-            epoch: get_upgrade_height_from_env("FOREST_LIFTOFF_HEIGHT").unwrap_or(-6),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Kumquat,
-            epoch: get_upgrade_height_from_env("FOREST_KUMQUAT_HEIGHT").unwrap_or(-7),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Calico,
-            epoch: get_upgrade_height_from_env("FOREST_CALICO_HEIGHT").unwrap_or(-9),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Persian,
-            epoch: get_upgrade_height_from_env("FOREST_PERSIAN_HEIGHT").unwrap_or(-10),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Orange,
-            epoch: get_upgrade_height_from_env("FOREST_ORANGE_HEIGHT").unwrap_or(-11),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Trust,
-            epoch: get_upgrade_height_from_env("FOREST_ACTORSV3_HEIGHT").unwrap_or(-13),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Norwegian,
-            epoch: get_upgrade_height_from_env("FOREST_NORWEGIAN_HEIGHT").unwrap_or(-14),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Turbo,
-            epoch: get_upgrade_height_from_env("FOREST_ACTORSV4_HEIGHT").unwrap_or(-15),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Hyperdrive,
-            epoch: get_upgrade_height_from_env("FOREST_HYPERDRIVE_HEIGHT").unwrap_or(-16),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Chocolate,
-            epoch: get_upgrade_height_from_env("FOREST_CHOCOLATE_HEIGHT").unwrap_or(-17),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::OhSnap,
-            epoch: get_upgrade_height_from_env("FOREST_OHSNAP_HEIGHT").unwrap_or(-18),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Skyr,
-            epoch: get_upgrade_height_from_env("FOREST_SKYR_HEIGHT").unwrap_or(-19),
-            bundle: None,
-        },
         HeightInfo {
             height: Height::Shark,
             epoch: get_upgrade_height_from_env("FOREST_SHARK_HEIGHT").unwrap_or(-20),
@@ -140,6 +56,9 @@ pub static HEIGHT_INFOS: Lazy<[HeightInfo; 22]> = Lazy::new(|| {
             ),
         },
     ]
+    .iter()
+    .map(|info| (info.height, info.clone()))
+    .collect()
 });
 
 pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 2]> = Lazy::new(|| {

--- a/src/networks/devnet/mod.rs
+++ b/src/networks/devnet/mod.rs
@@ -17,48 +17,55 @@ pub const ETH_CHAIN_ID: u64 = 31415926;
 /// Environment variable names follow
 /// <https://github.com/filecoin-project/lotus/blob/8f73f157933435f5020d7b8f23bee9e4ab71cb1c/build/params_2k.go#L108>
 pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
-    [
-        HeightInfo {
-            height: Height::Shark,
-            epoch: get_upgrade_height_from_env("FOREST_SHARK_HEIGHT").unwrap_or(-20),
-            bundle: Some(
-                Cid::try_from("bafy2bzacedozk3jh2j4nobqotkbofodq4chbrabioxbfrygpldgoxs3zwgggk")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Hygge,
-            epoch: get_upgrade_height_from_env("FOREST_HYGGE_HEIGHT").unwrap_or(-21),
-            bundle: Some(
-                Cid::try_from("bafy2bzacebzz376j5kizfck56366kdz5aut6ktqrvqbi3efa2d4l2o2m653ts")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Lightning,
-            epoch: get_upgrade_height_from_env("FOREST_LIGHTNING_HEIGHT").unwrap_or(-22),
-            bundle: Some(
-                Cid::try_from("bafy2bzaceay35go4xbjb45km6o46e5bib3bi46panhovcbedrynzwmm3drr4i")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Thunder,
-            epoch: get_upgrade_height_from_env("FOREST_THUNDER_HEIGHT").unwrap_or(-1),
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Watermelon,
-            epoch: get_upgrade_height_from_env("FOREST_WATERMELON_HEIGHT").unwrap_or(200),
-            bundle: Some(
-                Cid::try_from("bafy2bzaceasjdukhhyjbegpli247vbf5h64f7uvxhhebdihuqsj2mwisdwa6o")
-                    .unwrap(),
-            ),
-        },
-    ]
-    .iter()
-    .map(|info| (info.height, info.clone()))
-    .collect()
+    HashMap::from_iter([
+        (
+            Height::Shark,
+            HeightInfo {
+                epoch: get_upgrade_height_from_env("FOREST_SHARK_HEIGHT").unwrap_or(-20),
+                bundle: Some(
+                    Cid::try_from("bafy2bzacedozk3jh2j4nobqotkbofodq4chbrabioxbfrygpldgoxs3zwgggk")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Hygge,
+            HeightInfo {
+                epoch: get_upgrade_height_from_env("FOREST_HYGGE_HEIGHT").unwrap_or(-21),
+                bundle: Some(
+                    Cid::try_from("bafy2bzacebzz376j5kizfck56366kdz5aut6ktqrvqbi3efa2d4l2o2m653ts")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Lightning,
+            HeightInfo {
+                epoch: get_upgrade_height_from_env("FOREST_LIGHTNING_HEIGHT").unwrap_or(-22),
+                bundle: Some(
+                    Cid::try_from("bafy2bzaceay35go4xbjb45km6o46e5bib3bi46panhovcbedrynzwmm3drr4i")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Thunder,
+            HeightInfo {
+                epoch: get_upgrade_height_from_env("FOREST_THUNDER_HEIGHT").unwrap_or(-1),
+                bundle: None,
+            },
+        ),
+        (
+            Height::Watermelon,
+            HeightInfo {
+                epoch: get_upgrade_height_from_env("FOREST_WATERMELON_HEIGHT").unwrap_or(200),
+                bundle: Some(
+                    Cid::try_from("bafy2bzaceasjdukhhyjbegpli247vbf5h64f7uvxhhebdihuqsj2mwisdwa6o")
+                        .unwrap(),
+                ),
+            },
+        ),
+    ])
 });
 
 pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 2]> = Lazy::new(|| {

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -35,134 +35,174 @@ pub const ETH_CHAIN_ID: u64 = 314;
 
 /// Height epochs.
 pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
-    [
-        HeightInfo {
-            height: Height::Breeze,
-            epoch: 41_280,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Smoke,
-            epoch: SMOKE_HEIGHT,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Ignition,
-            epoch: 94_000,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::ActorsV2,
-            epoch: 138_720,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Tape,
-            epoch: 140_760,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Liftoff,
-            epoch: 148_888,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Kumquat,
-            epoch: 170_000,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Calico,
-            epoch: 265_200,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Persian,
-            epoch: 272_400,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Orange,
-            epoch: 336_458,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Trust,
-            epoch: 550_321,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Norwegian,
-            epoch: 665_280,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Turbo,
-            epoch: 712_320,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Hyperdrive,
-            epoch: 892_800,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Chocolate,
-            epoch: 1_231_620,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::OhSnap,
-            epoch: 1_594_680,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Skyr,
-            epoch: 1_960_320,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Shark,
-            epoch: 2_383_680,
-            bundle: Some(
-                Cid::try_from("bafy2bzaceb6j6666h36xnhksu3ww4kxb6e25niayfgkdnifaqi6m6ooc66i6i")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Hygge,
-            epoch: 2_683_348,
-            bundle: Some(
-                Cid::try_from("bafy2bzacecsuyf7mmvrhkx2evng5gnz5canlnz2fdlzu2lvcgptiq2pzuovos")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Lightning,
-            epoch: 2_809_800,
-            bundle: Some(
-                Cid::try_from("bafy2bzacecnhaiwcrpyjvzl4uv4q3jzoif26okl3m66q3cijp3dfwlcxwztwo")
-                    .unwrap(),
-            ),
-        },
-        HeightInfo {
-            height: Height::Thunder,
-            epoch: 2_809_800 + LIGHTNING_ROLLOVER_PERIOD,
-            bundle: None,
-        },
-        HeightInfo {
-            height: Height::Watermelon,
-            // 2023-12-12T13:30:00Z
-            epoch: 3_469_380,
-            bundle: Some(
-                Cid::try_from("bafy2bzaceapkgfggvxyllnmuogtwasmsv5qi2qzhc2aybockd6kag2g5lzaio")
-                    .unwrap(),
-            ),
-        },
-    ]
-    .iter()
-    .map(|info| (info.height, info.clone()))
-    .collect()
+    HashMap::from_iter([
+        (
+            Height::Breeze,
+            HeightInfo {
+                epoch: 41_280,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Smoke,
+            HeightInfo {
+                epoch: SMOKE_HEIGHT,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Ignition,
+            HeightInfo {
+                epoch: 94_000,
+                bundle: None,
+            },
+        ),
+        (
+            Height::ActorsV2,
+            HeightInfo {
+                epoch: 138_720,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Tape,
+            HeightInfo {
+                epoch: 140_760,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Liftoff,
+            HeightInfo {
+                epoch: 148_888,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Kumquat,
+            HeightInfo {
+                epoch: 170_000,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Calico,
+            HeightInfo {
+                epoch: 265_200,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Persian,
+            HeightInfo {
+                epoch: 272_400,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Orange,
+            HeightInfo {
+                epoch: 336_458,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Trust,
+            HeightInfo {
+                epoch: 550_321,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Norwegian,
+            HeightInfo {
+                epoch: 665_280,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Turbo,
+            HeightInfo {
+                epoch: 712_320,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Hyperdrive,
+            HeightInfo {
+                epoch: 892_800,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Chocolate,
+            HeightInfo {
+                epoch: 1_231_620,
+                bundle: None,
+            },
+        ),
+        (
+            Height::OhSnap,
+            HeightInfo {
+                epoch: 1_594_680,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Skyr,
+            HeightInfo {
+                epoch: 1_960_320,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Shark,
+            HeightInfo {
+                epoch: 2_383_680,
+                bundle: Some(
+                    Cid::try_from("bafy2bzaceb6j6666h36xnhksu3ww4kxb6e25niayfgkdnifaqi6m6ooc66i6i")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Hygge,
+            HeightInfo {
+                epoch: 2_683_348,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacecsuyf7mmvrhkx2evng5gnz5canlnz2fdlzu2lvcgptiq2pzuovos")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Lightning,
+            HeightInfo {
+                epoch: 2_809_800,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacecnhaiwcrpyjvzl4uv4q3jzoif26okl3m66q3cijp3dfwlcxwztwo")
+                        .unwrap(),
+                ),
+            },
+        ),
+        (
+            Height::Thunder,
+            HeightInfo {
+                epoch: 2_809_800 + LIGHTNING_ROLLOVER_PERIOD,
+                bundle: None,
+            },
+        ),
+        (
+            Height::Watermelon,
+            HeightInfo {
+                epoch: 3_469_380,
+                bundle: Some(
+                    Cid::try_from("bafy2bzaceapkgfggvxyllnmuogtwasmsv5qi2qzhc2aybockd6kag2g5lzaio")
+                        .unwrap(),
+                ),
+            },
+        ),
+    ])
 });
 
 pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 3]> = Lazy::new(|| {

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::shim::clock::ChainEpoch;
+use ahash::HashMap;
 use cid::Cid;
 use libp2p::Multiaddr;
 use once_cell::sync::Lazy;
@@ -33,7 +34,7 @@ const LIGHTNING_ROLLOVER_PERIOD: i64 = 2880 * 21;
 pub const ETH_CHAIN_ID: u64 = 314;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: Lazy<[HeightInfo; 22]> = Lazy::new(|| {
+pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
     [
         HeightInfo {
             height: Height::Breeze,
@@ -159,6 +160,9 @@ pub static HEIGHT_INFOS: Lazy<[HeightInfo; 22]> = Lazy::new(|| {
             ),
         },
     ]
+    .iter()
+    .map(|info| (info.height, info.clone()))
+    .collect()
 });
 
 pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 3]> = Lazy::new(|| {

--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -71,7 +71,7 @@ where
     static BUNDLE_CHECKED: AtomicBool = AtomicBool::new(false);
     if !BUNDLE_CHECKED.load(atomic::Ordering::Relaxed) {
         BUNDLE_CHECKED.store(true, atomic::Ordering::Relaxed);
-        for info in &chain_config.height_infos {
+        for info in chain_config.height_infos.values() {
             for (height, _) in &mappings {
                 if height == &info.height {
                     assert!(

--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -71,9 +71,9 @@ where
     static BUNDLE_CHECKED: AtomicBool = AtomicBool::new(false);
     if !BUNDLE_CHECKED.load(atomic::Ordering::Relaxed) {
         BUNDLE_CHECKED.store(true, atomic::Ordering::Relaxed);
-        for info in chain_config.height_infos.values() {
+        for (info_height, info) in chain_config.height_infos.iter() {
             for (height, _) in &mappings {
-                if height == &info.height {
+                if height == info_height {
                     assert!(
                         info.bundle.is_some(),
                         "Actor bundle info for height {height} needs to be defined in `src/networks/mod.rs` to run state migration"

--- a/src/state_migration/nv17/migration.rs
+++ b/src/state_migration/nv17/migration.rs
@@ -140,7 +140,7 @@ where
 {
     let new_manifest_cid = chain_config
         .height_infos
-        .get(Height::Shark as usize)
+        .get(&Height::Shark)
         .ok_or_else(|| anyhow!("no height info for network version NV17"))?
         .bundle
         .as_ref()

--- a/src/state_migration/nv17/miner.rs
+++ b/src/state_migration/nv17/miner.rs
@@ -616,8 +616,8 @@ mod tests {
         let (new_manifest_cid, _new_manifest) = make_test_manifest(&store, "fil/9/");
 
         let mut chain_config = ChainConfig::calibnet();
-        if let Some(bundle) = &mut chain_config.height_infos[Height::Shark as usize].bundle {
-            *bundle = new_manifest_cid;
+        if let Some(entry) = chain_config.height_infos.get_mut(&Height::Shark) {
+            entry.bundle = Some(new_manifest_cid);
         }
         let new_state_cid =
             super::super::run_migration(&chain_config, &store, &tree_root, 200).unwrap();
@@ -649,8 +649,8 @@ mod tests {
         let state_tree_old_root = state_tree_old.flush().unwrap();
         let (new_manifest_cid, _new_manifest) = make_test_manifest(&store, "fil/9/");
         let mut chain_config = ChainConfig::calibnet();
-        if let Some(bundle) = &mut chain_config.height_infos[Height::Shark as usize].bundle {
-            *bundle = new_manifest_cid;
+        if let Some(entry) = chain_config.height_infos.get_mut(&Height::Shark) {
+            entry.bundle = Some(new_manifest_cid);
         }
         let new_state_cid =
             super::super::run_migration(&chain_config, &store, &state_tree_old_root, 200).unwrap();

--- a/src/state_migration/nv18/migration.rs
+++ b/src/state_migration/nv18/migration.rs
@@ -76,7 +76,7 @@ where
 {
     let new_manifest_cid = chain_config
         .height_infos
-        .get(Height::Hygge as usize)
+        .get(&Height::Hygge)
         .ok_or_else(|| anyhow!("no height info for network version NV18"))?
         .bundle
         .as_ref()

--- a/src/state_migration/nv19/migration.rs
+++ b/src/state_migration/nv19/migration.rs
@@ -75,7 +75,7 @@ where
 {
     let new_manifest_cid = chain_config
         .height_infos
-        .get(Height::Lightning as usize)
+        .get(&Height::Lightning)
         .ok_or_else(|| anyhow!("no height info for network version NV19"))?
         .bundle
         .as_ref()

--- a/src/state_migration/nv21/migration.rs
+++ b/src/state_migration/nv21/migration.rs
@@ -111,7 +111,7 @@ where
 {
     let new_manifest_cid = chain_config
         .height_infos
-        .get(Height::Watermelon as usize)
+        .get(&Height::Watermelon)
         .context("no height info for network version NV21")?
         .bundle
         .as_ref()

--- a/src/state_migration/nv21/miner.rs
+++ b/src/state_migration/nv21/miner.rs
@@ -364,8 +364,8 @@ mod tests {
         let (new_manifest_cid, _new_manifest) = make_test_manifest(&store, "fil/12/");
 
         let mut chain_config = ChainConfig::devnet();
-        if let Some(bundle) = &mut chain_config.height_infos[Height::Watermelon as usize].bundle {
-            *bundle = new_manifest_cid;
+        if let Some(entry) = chain_config.height_infos.get_mut(&Height::Watermelon) {
+            entry.bundle = Some(new_manifest_cid);
         }
         let new_state_cid =
             super::super::run_migration(&chain_config, &store, &tree_root, 200).unwrap();

--- a/src/state_migration/nv21fix/migration.rs
+++ b/src/state_migration/nv21fix/migration.rs
@@ -137,7 +137,7 @@ where
 
     let new_manifest_cid = chain_config
         .height_infos
-        .get(Height::WatermelonFix as usize)
+        .get(&Height::WatermelonFix)
         .context("no height info for calibration network version NV21 (fixed)")?
         .bundle
         .as_ref()

--- a/src/state_migration/nv21fix2/migration.rs
+++ b/src/state_migration/nv21fix2/migration.rs
@@ -137,7 +137,7 @@ where
 
     let new_manifest_cid = chain_config
         .height_infos
-        .get(Height::WatermelonFix2 as usize)
+        .get(&Height::WatermelonFix2)
         .context("no height info for network version NV21 (fixed again)")?
         .bundle
         .as_ref()

--- a/src/state_migration/tests/mod.rs
+++ b/src/state_migration/tests/mod.rs
@@ -114,7 +114,7 @@ async fn test_state_migration(
     load_actor_bundles(&store, &network).await.unwrap();
 
     let chain_config = Arc::new(ChainConfig::from_chain(&network));
-    let height_info = &chain_config.height_infos[height as usize];
+    let height_info = &chain_config.height_infos[&height];
 
     let state_root: StateRoot = store.get_cbor(&old_state).unwrap().unwrap();
     println!("Actor root (for Go test): {}", state_root.actors);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- move height infos to a map, to avoid indexing errors and/or the need to declare all the heights for the network logic to work correctly.
- removed heights not used by the current chains

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
