### PR TITLE
remove unused token param from deamon

### DIFF
--- a/src/cli_shared/cli/client.rs
+++ b/src/cli_shared/cli/client.rs
@@ -42,7 +42,6 @@ pub struct Client {
     pub genesis_file: Option<String>,
     pub enable_rpc: bool,
     pub enable_metrics_endpoint: bool,
-    pub rpc_token: Option<String>,
     /// If this is true, then we do not validate the imported snapshot.
     /// Otherwise, we validate and compute the states.
     pub snapshot: bool,
@@ -85,7 +84,6 @@ impl Default for Client {
             genesis_file: None,
             enable_rpc: true,
             enable_metrics_endpoint: true,
-            rpc_token: None,
             snapshot_path: None,
             snapshot: false,
             consume_snapshot: false,

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -50,9 +50,6 @@ pub struct CliOpts {
     /// Disable Metrics endpoint
     #[arg(short, long)]
     pub no_metrics: bool,
-    /// Client JWT token to use for JSON-RPC authentication
-    #[arg(short, long)]
-    pub token: Option<String>,
     /// Address used for metrics collection server. By defaults binds on
     /// localhost on port 6116.
     #[arg(long)]
@@ -163,10 +160,6 @@ impl CliOpts {
             cfg.client.enable_rpc = true;
             if let Some(rpc_address) = self.rpc_address {
                 cfg.client.rpc_address = rpc_address;
-            }
-
-            if self.token.is_some() {
-                cfg.client.rpc_token = self.token.to_owned();
             }
         } else {
             cfg.client.enable_rpc = false;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `--token` doesn't make sense it the daemon context (it does from the `forest-cli`, though). It was unused anyway.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/2076

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
