### PR TITLE
fix incorrect keystore phrase env

### DIFF
--- a/documentation/src/environment_variables.md
+++ b/documentation/src/environment_variables.md
@@ -6,7 +6,7 @@ process.
 
 | Environment variable       | Value                            | Default | Description                                                               |
 | -------------------------- | -------------------------------- | ------- | ------------------------------------------------------------------------- |
-| FOREST_KEYSTORE_PHRASE_ENV | any text                         | empty   | The passphrase for the encrypted keystore                                 |
+| FOREST_KEYSTORE_PHRASE     | any text                         | empty   | The passphrase for the encrypted keystore                                 |
 | FOREST_CAR_LOADER_FILE_IO  | 1 or true                        | false   | Load CAR files with `RandomAccessFile` instead of `Mmap`                  |
 | FOREST_DB_DEV_MODE         | [see here](#-forest_db_dev_mode) | current | The database to use in development mode                                   |
 | FOREST_ACTOR_BUNDLE_PATH   | file path                        | empty   | Path to the local actor bundle, download from remote servers when not set |


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fix incorrect keystore phrase environmental variable name in the docs, see: https://github.com/ChainSafe/forest/blob/11b21eebf872ca22b3860b3a174eac856662d6c3/src/key_management/keystore.rs#L34

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
