### PR TITLE
add keypair to peerid command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   `Filecoin.ChainGetPath` lotus-compatible RPC API.
 - [#3849](https://github.com/ChainSafe/forest/pull/3849/) Add
   `forest-tool shed summarize-tipsets`.
+- [#3893](https://github.com/ChainSafe/forest/pull/3983) Add
+  `forest-tool shed peer-id-from-key-pair`.
 
 ### Changed
 

--- a/src/libp2p/keypair.rs
+++ b/src/libp2p/keypair.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use tracing::{info, trace};
+use tracing::{debug, info, trace};
 
 use crate::{
     libp2p::Keypair,
@@ -14,7 +14,7 @@ const KEYPAIR_FILE: &str = "keypair";
 /// Returns the libp2p key-pair for the node, generating a new one if it doesn't exist
 /// in the data directory.
 pub fn get_or_create_keypair(data_dir: &Path) -> anyhow::Result<Keypair> {
-    match get_keypair(data_dir) {
+    match get_keypair(&data_dir.join(KEYPAIR_FILE)) {
         Some(keypair) => Ok(keypair),
         None => create_and_save_keypair(data_dir),
     }
@@ -43,9 +43,8 @@ fn create_and_save_keypair(path: &Path) -> anyhow::Result<Keypair> {
 }
 
 // Fetch key-pair from disk, returning none if it cannot be decoded.
-fn get_keypair(data_dir: &Path) -> Option<Keypair> {
-    let path_to_file = data_dir.join(KEYPAIR_FILE);
-    match read_file_to_vec(&path_to_file) {
+pub fn get_keypair(path_to_file: &Path) -> Option<Keypair> {
+    match read_file_to_vec(path_to_file) {
         Err(e) => {
             info!("Networking keystore not found!");
             trace!("Error {e}");
@@ -53,7 +52,7 @@ fn get_keypair(data_dir: &Path) -> Option<Keypair> {
         }
         Ok(mut vec) => match crate::libp2p::ed25519::Keypair::try_from_bytes(&mut vec) {
             Ok(kp) => {
-                info!("Recovered libp2p keypair from {}", path_to_file.display());
+                debug!("Recovered libp2p keypair from {}", path_to_file.display());
                 Some(kp.into())
             }
             Err(e) => {

--- a/src/tool/subcommands/shed_cmd.rs
+++ b/src/tool/subcommands/shed_cmd.rs
@@ -1,7 +1,9 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::rpc_client::ApiInfo;
+use std::path::PathBuf;
+
+use crate::{libp2p::keypair::get_keypair, rpc_client::ApiInfo};
 use anyhow::Context as _;
 use clap::Subcommand;
 use futures::{StreamExt as _, TryFutureExt as _, TryStreamExt as _};
@@ -21,6 +23,11 @@ pub enum ShedCommands {
         height: Option<u32>,
         #[arg(long)]
         ancestors: u32,
+    },
+    /// Generate a `PeerId` from the given key-pair file.
+    PeerIdFromKeyPair {
+        /// Path to the key-pair file.
+        keypair: PathBuf,
     },
 }
 
@@ -65,6 +72,11 @@ impl ShedCommands {
                         println!("- {}", cid);
                     }
                 }
+            }
+            ShedCommands::PeerIdFromKeyPair { keypair } => {
+                let keypair = get_keypair(&keypair)
+                    .with_context(|| format!("couldn't get keypair from {}", keypair.display()))?;
+                println!("{}", keypair.public().to_peer_id());
             }
         }
         Ok(())

--- a/tests/tool_tests.rs
+++ b/tests/tool_tests.rs
@@ -41,3 +41,30 @@ fn state_migration_actor_bundle_runs() {
     assert!(bundle.exists());
     assert!(zstd::decode_all(std::fs::File::open(&bundle).unwrap()).is_ok());
 }
+
+#[test]
+fn peer_id_from_keypair() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let keypair = libp2p::identity::ed25519::Keypair::generate();
+
+    let keypair_file = temp_dir.path().join("keypair");
+    std::fs::write(&keypair_file, keypair.to_bytes()).unwrap();
+
+    let keypair: libp2p::identity::Keypair = keypair.into();
+    let expected_peer_id = keypair.public().to_peer_id().to_string();
+
+    tool()
+        .arg("shed")
+        .arg("peer-id-from-key-pair")
+        .arg(&keypair_file)
+        .assert()
+        .success()
+        .stdout(format!("{expected_peer_id}\n"));
+
+    tool()
+        .arg("shed")
+        .arg("peer-id-from-key-pair")
+        .arg(temp_dir.path().join("azathoth"))
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- added ` forest-tool shed peer-id-from-key-pair`
```
❯ forest-tool shed peer-id-from-key-pair ~/.local/share/forest/libp2p/keypair
12D3KooWArH4uiryCt2etoPU9gbQ7nToLWvDGPL1emC6m7ZsXUSk
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
