### PR TITLE
add backup tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   `forest-tool shed summarize-tipsets`.
 - [#3893](https://github.com/ChainSafe/forest/pull/3983) Add
   `forest-tool shed peer-id-from-key-pair`.
+- [#3981](https://github.com/ChainSafe/forest/issues/3981) Add
+  `forest-tool backup create|restore`.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,6 +3087,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,6 +3330,7 @@ dependencies = [
  "syn 2.0.50",
  "tabled",
  "tap",
+ "tar",
  "tempfile",
  "termios",
  "thiserror",
@@ -9005,6 +9018,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10519,6 +10543,17 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "rustix 0.38.31",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 tabled = "0.15"
 tap = "1"
+tar = "0.4"
 tempfile = "3.10"
 thiserror = "1.0"
 ticker = "0.1"

--- a/documentation/src/SUMMARY.md
+++ b/documentation/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Docker](./docker.md)
   - [Snapshot exporting](./snapshot_export.md)
   - [JavaScript Console](./js_console.md)
+  - [Backups](./backups.md)
   - [Troubleshooting](./trouble_shooting.md)
   - [Glossary](./glossary.md)
 

--- a/documentation/src/backups.md
+++ b/documentation/src/backups.md
@@ -1,0 +1,95 @@
+# Forest Backups
+
+> "_The condition of any backup is unknown until a restore is attempted._"
+> Everyone who deals with backups.
+
+## Manual backups
+
+The manual way requires knowledge of Forest internals and how it structures its
+data directory (which is not guaranteed to stay the same). Thus, it is
+recommended to use alternatives.
+
+## Backups with the `forest-tool`
+
+Forest comes with a `forest-tool` binary, which handles creating and recovering
+backups.
+
+### Basic usage
+
+:warning: **The Forest node should be offline during the backup process,
+especially when backing up the blockstore.**
+
+`forest-tool backup create` will create a backup file in the current working
+directory. It will contain the p2p keypair used to derive the `PeerId` and the
+keystore. If storing anywhere, make sure to encrypt it.
+
+```
+❯ forest-tool backup create
+Adding /home/rumcajs/.local/share/forest/libp2p/keypair to backup
+Adding /home/rumcajs/.local/share/forest/keystore.json to backup
+Backup complete: forest-backup-2024-02-22_17-18-43.tar
+```
+
+Afterwards, you can use `forest-tool backup restore <backup-file>` to restore
+those files. Note that this assumes that Forest is using the default
+configuration - if it's not the case, provide the configuration TOML file via
+the `--daemon-config` parameter.
+
+```
+❯ forest-tool backup restore forest-backup-2024-02-22_17-18-43.tar
+Restoring /home/rumcajs/.local/share/forest/libp2p/keypair
+Restoring /home/rumcajs/.local/share/forest/keystore.json
+Restore complete
+```
+
+There are other flags to the backup tool, most notably `--all`, that will back
+up the entire Forest data directory. Note that this includes the whole
+blockstore, which, for mainnet, can reach hundreds of gigabytes. It is not
+recommended outside development.
+
+### `backup`
+
+```
+Create and restore backups
+
+Usage: forest-tool backup <COMMAND>
+
+Commands:
+  create   Create a backup of the node. By default, only the p2p keypair and keystore are backed up. The node must be offline
+  restore  Restore a backup of the node from a file. The node must be offline
+  help     Print this message or the help of the given subcommand(s)
+```
+
+### `backup create`
+
+```
+Create a backup of the node. By default, only the p2p keypair and keystore are backed up. The node must be offline
+
+Usage: forest-tool backup create [OPTIONS]
+
+Options:
+      --backup-file <BACKUP_FILE>      Path to the output backup file if not using the default
+      --all                            Backup everything from the Forest data directory. This will override other options
+      --no-keypair                     Disables backing up the keypair
+      --no-keystore                    Disables backing up the keystore
+      --backup-chain <BACKUP_CHAIN>    Backs up the blockstore for the specified chain. If not provided, it will not be backed up
+      --include-proof-params           Include proof parameters in the backup
+  -d, --daemon-config <DAEMON_CONFIG>  Optional TOML file containing forest daemon configuration. If not provided, the default configuration will be used
+  -h, --help                           Print help
+```
+
+### `backup restore`
+
+```
+Restore a backup of the node from a file. The node must be offline
+
+Usage: forest-tool backup restore [OPTIONS] <BACKUP_FILE>
+
+Arguments:
+  <BACKUP_FILE>  Path to the backup file
+
+Options:
+  -d, --daemon-config <DAEMON_CONFIG>  Optional TOML file containing forest daemon configuration. If not provided, the default configuration will be used
+      --force                          Force restore even if files already exist WARNING: This will overwrite existing files
+  -h, --help                           Print help
+```

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -40,7 +40,7 @@ OPTIONS:
 pub struct CliOpts {
     /// A TOML file containing relevant configurations
     #[arg(short, long)]
-    pub config: Option<String>,
+    pub config: Option<PathBuf>,
     /// The genesis CAR file
     #[arg(short, long)]
     pub genesis: Option<String>,
@@ -151,7 +151,7 @@ pub struct CliOpts {
 
 impl CliOpts {
     pub fn to_config(&self) -> Result<(Config, Option<ConfigPath>), anyhow::Error> {
-        let (path, mut cfg) = read_config(&self.config, &self.chain)?;
+        let (path, mut cfg) = read_config(self.config.as_ref(), self.chain.clone())?;
 
         if let Some(genesis_file) = &self.genesis {
             cfg.client.genesis_file = Some(genesis_file.to_owned());
@@ -250,9 +250,9 @@ impl ConfigPath {
     }
 }
 
-pub fn find_config_path(config: &Option<String>) -> Option<ConfigPath> {
+pub fn find_config_path(config: Option<&PathBuf>) -> Option<ConfigPath> {
     if let Some(s) = config {
-        return Some(ConfigPath::Cli(PathBuf::from(s)));
+        return Some(ConfigPath::Cli(s.to_owned()));
     }
     if let Ok(s) = std::env::var("FOREST_CONFIG_PATH") {
         return Some(ConfigPath::Env(PathBuf::from(s)));

--- a/src/cli_shared/mod.rs
+++ b/src/cli_shared/mod.rs
@@ -20,8 +20,8 @@ pub fn chain_path(config: &Config) -> PathBuf {
 }
 
 pub fn read_config(
-    config_path_opt: &Option<String>,
-    chain_opt: &Option<NetworkChain>,
+    config_path_opt: Option<&PathBuf>,
+    chain_opt: Option<NetworkChain>,
 ) -> anyhow::Result<(Option<ConfigPath>, Config)> {
     let (path, mut config) = match find_config_path(config_path_opt) {
         Some(path) => {
@@ -33,7 +33,7 @@ pub fn read_config(
         None => (None, Config::default()),
     };
     if let Some(chain) = chain_opt {
-        config.chain = chain.clone();
+        config.chain = chain;
     }
     Ok((path, config))
 }
@@ -44,7 +44,7 @@ mod tests {
 
     #[test]
     fn read_config_default() {
-        let (config_path, config) = read_config(&None, &None).unwrap();
+        let (config_path, config) = read_config(None, None).unwrap();
 
         assert!(config_path.is_none());
         assert_eq!(config.chain, NetworkChain::Mainnet);
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn read_config_calibnet_override() {
-        let (config_path, config) = read_config(&None, &Some(NetworkChain::Calibnet)).unwrap();
+        let (config_path, config) = read_config(None, Some(NetworkChain::Calibnet)).unwrap();
 
         assert!(config_path.is_none());
         assert_eq!(config.chain, NetworkChain::Calibnet);
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn read_config_butterflynet_override() {
-        let (config_path, config) = read_config(&None, &Some(NetworkChain::Butterflynet)).unwrap();
+        let (config_path, config) = read_config(None, Some(NetworkChain::Butterflynet)).unwrap();
 
         assert!(config_path.is_none());
         assert_eq!(config.chain, NetworkChain::Butterflynet);
@@ -73,8 +73,7 @@ mod tests {
         let serialized_config = toml::to_string(&default_config).unwrap();
         std::fs::write(path.clone(), serialized_config).unwrap();
 
-        let (config_path, config) =
-            read_config(&Some(path.to_str().unwrap().into()), &None).unwrap();
+        let (config_path, config) = read_config(Some(&path), None).unwrap();
 
         assert_eq!(config_path.unwrap(), ConfigPath::Cli(path));
         assert_eq!(config.chain, NetworkChain::Mainnet);

--- a/src/tool/main.rs
+++ b/src/tool/main.rs
@@ -22,6 +22,7 @@ where
         .block_on(async {
             // Run command
             match cmd {
+                Subcommand::Backup(cmd) => cmd.run(),
                 Subcommand::Benchmark(cmd) => cmd.run().await,
                 Subcommand::StateMigration(cmd) => cmd.run().await,
                 Subcommand::Snapshot(cmd) => cmd.run().await,

--- a/src/tool/subcommands/backup_cmd.rs
+++ b/src/tool/subcommands/backup_cmd.rs
@@ -1,0 +1,433 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use anyhow::bail;
+use clap::Subcommand;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use crate::{cli_shared::read_config, networks::NetworkChain};
+
+#[derive(Subcommand)]
+pub enum BackupCommands {
+    /// Create a backup of the node. By default, only the peer-to-peer key-pair and key-store are backed up.
+    /// The node must be offline.
+    Create {
+        /// Path to the output backup file if not using the default
+        #[arg(long)]
+        backup_file: Option<PathBuf>,
+        /// Backup everything from the Forest data directory. This will override other options.
+        #[arg(long)]
+        all: bool,
+        /// Disables backing up the key-pair
+        #[arg(long)]
+        no_keypair: bool,
+        /// Disables backing up the key-store
+        #[arg(long)]
+        no_keystore: bool,
+        /// Backs up the blockstore for the specified chain. If not provided, it will not be backed up.
+        #[arg(long)]
+        backup_chain: Option<NetworkChain>,
+        /// Include proof parameters in the backup
+        #[arg(long)]
+        include_proof_params: bool,
+        /// Optional TOML file containing forest daemon configuration. If not provided, the default configuration will be used.
+        #[arg(short, long)]
+        daemon_config: Option<PathBuf>,
+    },
+    /// Restore a backup of the node from a file. The node must be offline.
+    Restore {
+        /// Path to the backup file
+        backup_file: PathBuf,
+        /// Optional TOML file containing forest daemon configuration. If not provided, the default configuration will be used.
+        #[arg(short, long)]
+        daemon_config: Option<PathBuf>,
+        /// Force restore even if files already exist
+        /// WARNING: This will overwrite existing files.
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+impl BackupCommands {
+    pub fn run(self) -> anyhow::Result<()> {
+        match self {
+            BackupCommands::Create {
+                backup_file,
+                all,
+                no_keypair,
+                no_keystore,
+                backup_chain,
+                include_proof_params,
+                daemon_config,
+            } => {
+                let (_, config) = read_config(daemon_config.as_ref(), backup_chain.clone())?;
+
+                let data_dir = &config.client.data_dir;
+
+                let backup_entries = if all {
+                    std::fs::read_dir(data_dir)?
+                        .filter_map(Result::ok)
+                        .map(|e| e.path())
+                        .collect()
+                } else {
+                    validate_and_add_entries(
+                        data_dir,
+                        no_keypair,
+                        no_keystore,
+                        backup_chain,
+                        include_proof_params,
+                    )?
+                };
+
+                let backup_file_path = if let Some(backup_file) = backup_file {
+                    backup_file
+                } else {
+                    let path = PathBuf::from(format!(
+                        "forest-backup-{}.tar",
+                        chrono::Utc::now().format("%Y-%m-%d_%H-%M-%S")
+                    ));
+                    if path.exists() {
+                        bail!("Backup file already exists at {}", path.display());
+                    }
+                    path
+                };
+
+                archive_entries(data_dir, backup_entries, &backup_file_path)?;
+                println!("Backup complete: {}", backup_file_path.display());
+
+                Ok(())
+            }
+            BackupCommands::Restore {
+                backup_file,
+                daemon_config,
+                force,
+            } => {
+                let (_, config) = read_config(daemon_config.as_ref(), None)?;
+                let data_dir = &config.client.data_dir;
+
+                extract_entries(data_dir, &backup_file, force)?;
+                println!("Restore complete");
+
+                Ok(())
+            }
+        }
+    }
+}
+
+fn extract_entries(data_dir: &Path, backup_file: &Path, force: bool) -> anyhow::Result<()> {
+    let backup_file = File::open(backup_file)?;
+    let mut archive = tar::Archive::new(backup_file);
+    for file in archive.entries()? {
+        let mut file = file?;
+        let path = file.path()?;
+        let path = data_dir.join(path);
+        if path.exists() && !force {
+            bail!(
+                "File already exists at {}. Use --force to overwrite.",
+                path.display()
+            );
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        println!("Restoring {}", path.display());
+        file.unpack(path)?;
+    }
+
+    Ok(())
+}
+
+fn archive_entries(
+    data_dir: &PathBuf,
+    backup_entries: Vec<PathBuf>,
+    backup_file_path: &Path,
+) -> anyhow::Result<()> {
+    let backup_file = File::create(backup_file_path)?;
+    let mut archive = tar::Builder::new(backup_file);
+    for entry in backup_entries {
+        let entry_canonicalized = entry.canonicalize()?;
+        let name = entry.strip_prefix(data_dir)?;
+
+        println!("Adding {} to backup", entry_canonicalized.display());
+        if entry_canonicalized.is_dir() {
+            archive.append_dir_all(name, entry_canonicalized)?;
+        } else {
+            archive.append_path_with_name(entry_canonicalized, name)?;
+        }
+    }
+    archive.into_inner()?;
+    Ok(())
+}
+
+fn validate_and_add_entries(
+    data_dir: &Path,
+    no_keypair: bool,
+    no_keystore: bool,
+    backup_chain: Option<NetworkChain>,
+    include_proof_params: bool,
+) -> anyhow::Result<Vec<PathBuf>> {
+    if no_keypair && no_keystore && backup_chain.is_none() && !include_proof_params {
+        bail!("Nothing to backup!");
+    }
+
+    let mut valid = true;
+    let mut backup_entries = vec![];
+
+    if !no_keypair {
+        let keypair_path = data_dir.join("libp2p").join("keypair");
+        if keypair_path.exists() {
+            backup_entries.push(keypair_path);
+        } else {
+            println!("Keypair not found at {}", keypair_path.display());
+            valid = false;
+        }
+    }
+
+    if !no_keystore {
+        let mut any_keystore_found = false;
+        for keystore in ["keystore.json", "keystore"].iter() {
+            let keystore_path = data_dir.join(keystore);
+            if keystore_path.exists() {
+                backup_entries.push(keystore_path);
+                any_keystore_found = true;
+            }
+        }
+        if !any_keystore_found {
+            println!("No keystore found at {}", data_dir.display());
+            valid = false;
+        }
+    }
+
+    if let Some(chain) = backup_chain {
+        let chain_path = data_dir.join(chain.to_string());
+        if chain_path.exists() {
+            backup_entries.push(chain_path);
+        } else {
+            println!("Chain data not found at {}", chain_path.display());
+            valid = false;
+        }
+    }
+
+    if include_proof_params {
+        let proof_params_path = data_dir.join("filecoin-proof-parameters");
+        if proof_params_path.exists() {
+            backup_entries.push(proof_params_path);
+        } else {
+            println!(
+                "Proof parameters not found at {}",
+                proof_params_path.display()
+            );
+            valid = false;
+        }
+    }
+
+    if !valid {
+        bail!("Backup aborted. Some files were not found.");
+    }
+
+    Ok(backup_entries)
+}
+
+#[cfg(test)]
+mod test {
+    use itertools::Itertools;
+    use tempfile::TempDir;
+    use walkdir::WalkDir;
+
+    use super::*;
+
+    #[test]
+    fn validate_and_add_entries_no_entries() {
+        let data_dir = PathBuf::from("test");
+        let result = validate_and_add_entries(
+            &data_dir, true,  // no_keypair
+            true,  // no_keystore
+            None,  // no backup_chain
+            false, // no include_proof_params
+        );
+        assert!(result.is_err());
+    }
+
+    fn create_test_data() -> (TempDir, Vec<PathBuf>) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let mut entries = vec![
+            data_dir.join("libp2p").join("keypair"),
+            data_dir.join("keystore.json"),
+            data_dir.join("keystore"),
+        ];
+
+        entries.iter().for_each(|entry| {
+            std::fs::create_dir_all(entry.parent().unwrap()).unwrap();
+            File::create(entry).unwrap();
+        });
+
+        let chain_path = data_dir.join("calibnet");
+        std::fs::create_dir_all(&chain_path).unwrap();
+        entries.push(chain_path);
+
+        let proof_params_path = data_dir.join("filecoin-proof-parameters");
+        std::fs::create_dir_all(&proof_params_path).unwrap();
+        entries.push(proof_params_path);
+
+        (temp_dir, entries)
+    }
+
+    #[test]
+    fn validate_and_add_entries_all() {
+        let (temp_dir, entries) = create_test_data();
+        let data_dir = temp_dir.path().to_path_buf();
+
+        let result = validate_and_add_entries(
+            &data_dir,
+            false,                        // include keypair
+            false,                        // include keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            true,                         // include proof_params
+        );
+
+        let backup_entries = result.unwrap();
+        itertools::assert_equal(entries.iter().sorted(), backup_entries.iter().sorted());
+    }
+
+    #[test]
+    fn validate_and_add_entries_no_keypair() {
+        let (temp_dir, _) = create_test_data();
+        let data_dir = temp_dir.path().to_path_buf();
+
+        std::fs::remove_file(data_dir.join("libp2p").join("keypair")).unwrap();
+
+        let result = validate_and_add_entries(
+            &data_dir,
+            false,                        // include keypair
+            false,                        // include keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            true,                         // include proof_params
+        );
+        assert!(result.is_err());
+
+        let result = validate_and_add_entries(
+            &data_dir,
+            true,                         // exclude keypair
+            false,                        // include keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            true,                         // include proof_params
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_and_add_entries_no_keystore() {
+        let (temp_dir, _) = create_test_data();
+        let data_dir = temp_dir.path().to_path_buf();
+
+        std::fs::remove_file(data_dir.join("keystore.json")).unwrap();
+        let result = validate_and_add_entries(
+            &data_dir,
+            false,                        // include keypair
+            false,                        // include keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            true,                         // include proof_params
+        );
+        // it should be fine - there is also the encrypted keystore
+        assert!(result.is_ok());
+
+        std::fs::remove_file(data_dir.join("keystore")).unwrap();
+        let result = validate_and_add_entries(
+            &data_dir,
+            false,                        // include keypair
+            false,                        // include keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            true,                         // include proof_params
+        );
+        assert!(result.is_err());
+
+        let result = validate_and_add_entries(
+            &data_dir,
+            false,                        // include keypair
+            true,                         // exclude keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            true,                         // include proof_params
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_and_add_entries_proof_params() {
+        let (temp_dir, _) = create_test_data();
+        let data_dir = temp_dir.path().to_path_buf();
+
+        std::fs::remove_dir_all(data_dir.join("filecoin-proof-parameters")).unwrap();
+        let result = validate_and_add_entries(
+            &data_dir,
+            false,                        // include keypair
+            false,                        // include keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            true,                         // include proof_params
+        );
+        assert!(result.is_err());
+
+        let result = validate_and_add_entries(
+            &data_dir,
+            false,                        // include keypair
+            false,                        // include keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            false,                        // exclude proof_params
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_and_add_entries_no_chain() {
+        let (temp_dir, _) = create_test_data();
+        let data_dir = temp_dir.path().to_path_buf();
+
+        std::fs::remove_dir_all(data_dir.join("calibnet")).unwrap();
+        let result = validate_and_add_entries(
+            &data_dir,
+            false,                        // include keypair
+            false,                        // include keystore
+            Some(NetworkChain::Calibnet), // backup the chain
+            true,                         // include proof_params
+        );
+        assert!(result.is_err());
+
+        let result = validate_and_add_entries(
+            &data_dir, false, // include keypair
+            false, // include keystore
+            None,  // no backup_chain
+            true,  // include proof_params
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn archive_extract_roundtrip() {
+        let (temp_dir, entries) = create_test_data();
+        let data_dir = temp_dir.path().to_path_buf();
+
+        let backup_file = tempfile::Builder::new().suffix(".tar").tempfile().unwrap();
+        archive_entries(&data_dir, entries.clone(), backup_file.path()).unwrap();
+
+        let restore_dir = tempfile::tempdir().unwrap();
+        extract_entries(restore_dir.path(), backup_file.path(), true).unwrap();
+
+        // get all entries recursively
+        let get_entries_recurse = |dir| {
+            WalkDir::new(dir)
+                .into_iter()
+                .filter_map(Result::ok)
+                .map(|entry| entry.path().strip_prefix(dir).unwrap().to_path_buf())
+                .sorted()
+                .collect::<Vec<PathBuf>>()
+        };
+        let restored = get_entries_recurse(restore_dir.path());
+        let original = get_entries_recurse(&data_dir);
+
+        assert!(restored.len() > entries.len());
+        itertools::assert_equal(original.iter(), restored.iter());
+    }
+}

--- a/src/tool/subcommands/db_cmd.rs
+++ b/src/tool/subcommands/db_cmd.rs
@@ -1,6 +1,8 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::path::PathBuf;
+
 use crate::cli::subcommands::prompt_confirm;
 use crate::cli_shared::{chain_path, read_config};
 use crate::db::db_engine::db_root;
@@ -14,7 +16,7 @@ pub enum DBCommands {
     Stats {
         /// Optional TOML file containing forest daemon configuration
         #[arg(short, long)]
-        config: Option<String>,
+        config: Option<PathBuf>,
         /// Optional chain, will override the chain section of configuration file if used
         #[arg(long)]
         chain: Option<NetworkChain>,
@@ -26,7 +28,7 @@ pub enum DBCommands {
         force: bool,
         /// Optional TOML file containing forest daemon configuration
         #[arg(short, long)]
-        config: Option<String>,
+        config: Option<PathBuf>,
         /// Optional chain, will override the chain section of configuration file if used
         #[arg(long)]
         chain: Option<NetworkChain>,
@@ -39,7 +41,7 @@ impl DBCommands {
             Self::Stats { config, chain } => {
                 use human_repr::HumanCount;
 
-                let (_, config) = read_config(config, chain)?;
+                let (_, config) = read_config(config.as_ref(), chain.clone())?;
 
                 let dir = db_root(&chain_path(&config))?;
                 println!("Database path: {}", dir.display());
@@ -52,7 +54,7 @@ impl DBCommands {
                 config,
                 chain,
             } => {
-                let (_, config) = read_config(config, chain)?;
+                let (_, config) = read_config(config.as_ref(), chain.clone())?;
 
                 let dir = chain_path(&config);
                 if !dir.is_dir() {

--- a/src/tool/subcommands/fetch_params_cmd.rs
+++ b/src/tool/subcommands/fetch_params_cmd.rs
@@ -1,6 +1,8 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::path::PathBuf;
+
 use crate::shim::sector::SectorSize;
 use crate::utils::proofs_api::paramfetch::{get_params_default, SectorSizeOpt};
 
@@ -23,12 +25,12 @@ pub struct FetchCommands {
     params_size: Option<String>,
     /// Optional TOML file containing forest daemon configuration
     #[arg(short, long)]
-    pub config: Option<String>,
+    pub config: Option<PathBuf>,
 }
 
 impl FetchCommands {
-    pub async fn run(&self) -> anyhow::Result<()> {
-        let (_, config) = read_config(&self.config, &None)?;
+    pub async fn run(self) -> anyhow::Result<()> {
+        let (_, config) = read_config(self.config.as_ref(), None)?;
 
         let sizes = if self.all {
             SectorSizeOpt::All

--- a/src/tool/subcommands/mod.rs
+++ b/src/tool/subcommands/mod.rs
@@ -1,15 +1,16 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-pub mod api_cmd;
-pub mod archive_cmd;
-pub mod benchmark_cmd;
-pub mod car_cmd;
-pub mod db_cmd;
-pub mod fetch_params_cmd;
+mod api_cmd;
+mod archive_cmd;
+mod backup_cmd;
+mod benchmark_cmd;
+mod car_cmd;
+mod db_cmd;
+mod fetch_params_cmd;
 mod shed_cmd;
-pub mod snapshot_cmd;
-pub mod state_migration_cmd;
+mod snapshot_cmd;
+mod state_migration_cmd;
 
 use crate::cli_shared::cli::HELP_MESSAGE;
 use crate::cli_shared::cli::*;
@@ -28,6 +29,10 @@ pub struct Cli {
 /// forest-tool sub-commands
 #[derive(clap::Subcommand)]
 pub enum Subcommand {
+    /// Create and restore backups
+    #[command(subcommand)]
+    Backup(backup_cmd::BackupCommands),
+
     /// Benchmark various Forest subsystems
     #[command(subcommand)]
     Benchmark(benchmark_cmd::BenchmarkCommands),

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -104,7 +104,7 @@ pub enum WalletCommands {
 }
 
 impl WalletCommands {
-    pub async fn run(&self, api: ApiInfo) -> anyhow::Result<()> {
+    pub async fn run(self, api: ApiInfo) -> anyhow::Result<()> {
         match self {
             Self::New { signature_type } => {
                 let signature_type = match signature_type.to_lowercase().as_str() {
@@ -215,14 +215,14 @@ impl WalletCommands {
                 Ok(())
             }
             Self::SetDefault { key } => {
-                let StrictAddress(key) = StrictAddress::from_str(key)
+                let StrictAddress(key) = StrictAddress::from_str(&key)
                     .with_context(|| format!("Invalid address: {key}"))?;
 
                 api.wallet_set_default(key).await?;
                 Ok(())
             }
             Self::Sign { address, message } => {
-                let StrictAddress(address) = StrictAddress::from_str(address)
+                let StrictAddress(address) = StrictAddress::from_str(&address)
                     .with_context(|| format!("Invalid address: {address}"))?;
 
                 let message = hex::decode(message).context("Message has to be a hex string")?;
@@ -244,7 +244,7 @@ impl WalletCommands {
             } => {
                 let sig_bytes =
                     hex::decode(signature).context("Signature has to be a hex string")?;
-                let StrictAddress(address) = StrictAddress::from_str(address)
+                let StrictAddress(address) = StrictAddress::from_str(&address)
                     .with_context(|| format!("Invalid address: {address}"))?;
                 let signature = match address.protocol() {
                     Protocol::Secp256k1 => Signature::new_secp256k1(sig_bytes),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- added `forest-tool backup` to abstract away the process of making backups for Forest.
- minor refactoring around the interfaces I stumbled upon.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3981

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
