### PR TITLE
fix(test): run cli sync wait in kad test

### DIFF
--- a/scripts/tests/calibnet_kademlia_check.sh
+++ b/scripts/tests/calibnet_kademlia_check.sh
@@ -24,10 +24,13 @@ cat <<- EOF > $CONFIG_PATH
 	kademlia = true
 EOF
 
-$FOREST_PATH --chain calibnet --encrypt-keystore false --auto-download-snapshot --config "$CONFIG_PATH" --rpc false --metrics-address 127.0.0.1:6117 &
+$FOREST_PATH --chain calibnet --encrypt-keystore false --auto-download-snapshot --config "$CONFIG_PATH" --save-token ./admin_token --rpc-address 127.0.0.1:12345 --metrics-address 127.0.0.1:6117 &
 FOREST_NODE_PID=$!
 # Verify that more peers are connected via kademlia
 until (( $(curl http://127.0.0.1:6117/metrics | grep full_peers | tail -n 1 | cut --delimiter=" " --fields=2) > 1 )); do
     sleep 1s;
 done
+
+FULLNODE_API_INFO="$(cat admin_token):/ip4/127.0.0.1/tcp/12345/http" $FOREST_CLI_PATH sync wait # allow the node to re-sync
+
 kill -KILL $FOREST_NODE_PID


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

In the current kademlia test, a forest node is bootstrapped with another forest node, and exit when more peers get connected. This PR extends the test to make sure the forest node can re-sync

Changes introduced in this pull request:

- run cli sync wait in kad test

CI log: https://github.com/ChainSafe/forest/actions/runs/8047437734/job/21976975078?pr=3989#step:7:1127
```
2024-02-26T10:44:00.408135Z  INFO forest_filecoin::chain_sync::tipset_syncer: Successfully synced tipset range: [1387259, 1387260]


Worker: 0; Base: 1387259; Target: 1387260; (diff: 1)
State: complete; Current Epoch: 1387260; Todo: 0



Done!
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
