### PR TITLE
feat(daemon): add `--p2p-listen-address` arg to `forest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 ### Added
 
 - [#3995](https://github.com/ChainSafe/forest/pull/3995) Add
-  `--p2p-listening-address` option to `forest` to override p2p addresses that
+  `--p2p-listen-address` option to `forest` to override p2p addresses that
   forest listens on
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 
 ### Added
 
+- [#3995](https://github.com/ChainSafe/forest/pull/3995) Add
+  `--p2p-listening-address` option to `forest` to override p2p addresses that
+  forest listens on
+
 ### Changed
 
 ### Removed
@@ -51,9 +55,6 @@ upgrade will result in difficulty connecting to the mainnet network.
   `forest-tool shed peer-id-from-key-pair`.
 - [#3981](https://github.com/ChainSafe/forest/issues/3981) Add
   `forest-tool backup create|restore`.
-- [#3995](https://github.com/ChainSafe/forest/pull/3995) Add
-  `--p2p-listening-address` option to `forest` to override p2p addresses that
-  forest listens on
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,9 @@
   `forest-tool shed peer-id-from-key-pair`.
 - [#3981](https://github.com/ChainSafe/forest/issues/3981) Add
   `forest-tool backup create|restore`.
-- [#3995](https://github.com/ChainSafe/forest/pull/3995) Add `--p2p-address`
-  option to `forest` to override p2p addresses that forest listens on
+- [#3995](https://github.com/ChainSafe/forest/pull/3995) Add
+  `--p2p-listening-address` option to `forest` to override p2p addresses that
+  forest listens on
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   `forest-tool shed peer-id-from-key-pair`.
 - [#3981](https://github.com/ChainSafe/forest/issues/3981) Add
   `forest-tool backup create|restore`.
+- [#3995](https://github.com/ChainSafe/forest/pull/3995) Add `--p2p-address`
+  option to `forest` to override p2p addresses that forest listens on
 
 ### Changed
 

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -16,6 +16,7 @@ use crate::utils::misc::LoggingColor;
 use ahash::HashSet;
 use clap::Parser;
 use directories::ProjectDirs;
+use libp2p::Multiaddr;
 use tracing::error;
 
 pub use self::{client::*, config::*};
@@ -57,6 +58,9 @@ pub struct CliOpts {
     /// Address used for RPC. By defaults binds on localhost on port 2345.
     #[arg(long)]
     pub rpc_address: Option<SocketAddr>,
+    /// P2P addresses, e.g. `--p2p-address /ip4/0.0.0.0/tcp/12345 --p2p-address /ip4/0.0.0.0/tcp/12346`
+    #[arg(long)]
+    pub p2p_address: Option<Vec<Multiaddr>>,
     /// Allow Kademlia (default: true)
     #[arg(short, long)]
     pub kademlia: Option<bool>,
@@ -172,6 +176,10 @@ impl CliOpts {
             if let Some(metrics_address) = self.metrics_address {
                 cfg.client.metrics_address = metrics_address;
             }
+        }
+
+        if let Some(addresses) = &self.p2p_address {
+            cfg.network.listening_multiaddrs = addresses.clone();
         }
 
         if self.import_snapshot.is_some() && self.import_chain.is_some() {

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -58,7 +58,7 @@ pub struct CliOpts {
     /// Address used for RPC. By defaults binds on localhost on port 2345.
     #[arg(long)]
     pub rpc_address: Option<SocketAddr>,
-    /// P2P addresses, e.g. `--p2p-address /ip4/0.0.0.0/tcp/12345 --p2p-address /ip4/0.0.0.0/tcp/12346`
+    /// P2P addresses, e.g., `--p2p-address /ip4/0.0.0.0/tcp/12345 --p2p-address /ip4/0.0.0.0/tcp/12346`
     #[arg(long)]
     pub p2p_address: Option<Vec<Multiaddr>>,
     /// Allow Kademlia (default: true)

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -58,9 +58,9 @@ pub struct CliOpts {
     /// Address used for RPC. By defaults binds on localhost on port 2345.
     #[arg(long)]
     pub rpc_address: Option<SocketAddr>,
-    /// P2P addresses, e.g., `--p2p-address /ip4/0.0.0.0/tcp/12345 --p2p-address /ip4/0.0.0.0/tcp/12346`
+    /// P2P listening addresses, e.g., `--p2p-listening-address /ip4/0.0.0.0/tcp/12345 --p2p-listening-address /ip4/0.0.0.0/tcp/12346`
     #[arg(long)]
-    pub p2p_address: Option<Vec<Multiaddr>>,
+    pub p2p_listening_address: Option<Vec<Multiaddr>>,
     /// Allow Kademlia (default: true)
     #[arg(short, long)]
     pub kademlia: Option<bool>,
@@ -178,7 +178,7 @@ impl CliOpts {
             }
         }
 
-        if let Some(addresses) = &self.p2p_address {
+        if let Some(addresses) = &self.p2p_listening_address {
             cfg.network.listening_multiaddrs = addresses.clone();
         }
 

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -58,9 +58,9 @@ pub struct CliOpts {
     /// Address used for RPC. By defaults binds on localhost on port 2345.
     #[arg(long)]
     pub rpc_address: Option<SocketAddr>,
-    /// P2P listening addresses, e.g., `--p2p-listening-address /ip4/0.0.0.0/tcp/12345 --p2p-listening-address /ip4/0.0.0.0/tcp/12346`
+    /// P2P listen addresses, e.g., `--p2p-listen-address /ip4/0.0.0.0/tcp/12345 --p2p-listen-address /ip4/0.0.0.0/tcp/12346`
     #[arg(long)]
-    pub p2p_listening_address: Option<Vec<Multiaddr>>,
+    pub p2p_listen_address: Option<Vec<Multiaddr>>,
     /// Allow Kademlia (default: true)
     #[arg(short, long)]
     pub kademlia: Option<bool>,
@@ -178,7 +178,7 @@ impl CliOpts {
             }
         }
 
-        if let Some(addresses) = &self.p2p_listening_address {
+        if let Some(addresses) = &self.p2p_listen_address {
             cfg.network.listening_multiaddrs = addresses.clone();
         }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As part of https://github.com/ChainSafe/forest/issues/3990
This PR allows overriding p2p listening addresses via CLI options, which is easier than using a config file. The next step is updating `forest-iac` to publicly expose the p2p addresses of forest nodes to allow accepting connections from new peers, to improve discoverability and connectivity.

Changes introduced in this pull request:

- Add `--p2p-listen-address` CLI option to `forest` daemon
- (To specify multiple addresses, `--p2p-listen-address A --p2p-listen-address B`)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
