### PR TITLE
fix: compile HasLotusJson::snapshots for test target only

### DIFF
--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -511,6 +511,7 @@ mod lotus_json {
     impl HasLotusJson for Tipset {
         type LotusJson = TipsetLotusJson;
 
+        #[cfg(test)]
         fn snapshots() -> Vec<(serde_json::Value, Self)> {
             use serde_json::json;
             vec![(

--- a/src/chain_sync/sync_state.rs
+++ b/src/chain_sync/sync_state.rs
@@ -138,6 +138,7 @@ mod lotus_json {
     use std::sync::Arc;
 
     use serde::{Deserialize, Serialize};
+    #[cfg(test)]
     use serde_json::json;
 
     #[derive(Serialize, Deserialize)]
@@ -161,6 +162,7 @@ mod lotus_json {
     impl HasLotusJson for SyncState {
         type LotusJson = SyncStateLotusJson;
 
+        #[cfg(test)]
         fn snapshots() -> Vec<(serde_json::Value, Self)> {
             vec![(
                 json!({

--- a/src/lotus_json/actor_state.rs
+++ b/src/lotus_json/actor_state.rs
@@ -19,6 +19,7 @@ pub struct ActorStateLotusJson {
 impl HasLotusJson for ActorState {
     type LotusJson = ActorStateLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({

--- a/src/lotus_json/address.rs
+++ b/src/lotus_json/address.rs
@@ -8,6 +8,7 @@ use crate::shim::address::Address;
 impl HasLotusJson for Address {
     type LotusJson = Stringify<Address>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(json!("f00"), Address::default())]
     }

--- a/src/lotus_json/beacon_entry.rs
+++ b/src/lotus_json/beacon_entry.rs
@@ -15,6 +15,7 @@ pub struct BeaconEntryLotusJson {
 impl HasLotusJson for BeaconEntry {
     type LotusJson = BeaconEntryLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(json!({"Round": 0, "Data": null}), BeaconEntry::default())]
     }

--- a/src/lotus_json/big_int.rs
+++ b/src/lotus_json/big_int.rs
@@ -8,6 +8,7 @@ use num::BigInt;
 impl HasLotusJson for BigInt {
     type LotusJson = Stringify<BigInt>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(json!("1"), BigInt::from(1))]
     }

--- a/src/lotus_json/block_header.rs
+++ b/src/lotus_json/block_header.rs
@@ -43,6 +43,7 @@ pub struct BlockHeaderLotusJson {
 impl HasLotusJson for CachingBlockHeader {
     type LotusJson = BlockHeaderLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         use serde_json::json;
 

--- a/src/lotus_json/cid.rs
+++ b/src/lotus_json/cid.rs
@@ -12,6 +12,7 @@ pub struct CidLotusJsonGeneric<const S: usize> {
 impl<const S: usize> HasLotusJson for ::cid::CidGeneric<S> {
     type LotusJson = CidLotusJsonGeneric<S>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         unimplemented!("only Cid<64> is tested, below")
     }

--- a/src/lotus_json/election_proof.rs
+++ b/src/lotus_json/election_proof.rs
@@ -15,6 +15,7 @@ pub struct ElectionProofLotusJson {
 impl HasLotusJson for ElectionProof {
     type LotusJson = ElectionProofLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({

--- a/src/lotus_json/gossip_block.rs
+++ b/src/lotus_json/gossip_block.rs
@@ -17,6 +17,7 @@ pub struct GossipBlockLotusJson {
 impl HasLotusJson for GossipBlock {
     type LotusJson = GossipBlockLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         use serde_json::json;
 

--- a/src/lotus_json/key_info.rs
+++ b/src/lotus_json/key_info.rs
@@ -14,6 +14,7 @@ pub struct KeyInfoLotusJson {
 impl HasLotusJson for KeyInfo {
     type LotusJson = KeyInfoLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({

--- a/src/lotus_json/message.rs
+++ b/src/lotus_json/message.rs
@@ -34,6 +34,7 @@ pub struct MessageLotusJson {
 impl HasLotusJson for Message {
     type LotusJson = MessageLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -127,6 +127,7 @@ use fil_actor_interface::{miner::DeadlineInfo, power::Claim};
 use fil_actors_shared::fvm_ipld_bitfield::json::BitFieldJson;
 use fil_actors_shared::fvm_ipld_bitfield::BitField;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(test)]
 use serde_json::json;
 use std::{fmt::Display, str::FromStr};
 #[cfg(test)]
@@ -142,6 +143,7 @@ pub trait HasLotusJson: Sized {
     ///
     /// If using [`decl_and_test`], this test is automatically run for you, but if the test
     /// is out-of-module, you must call [`assert_all_snapshots`] manually.
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)>;
     fn into_lotus_json(self) -> Self::LotusJson;
     fn from_lotus_json(lotus_json: Self::LotusJson) -> Self;
@@ -420,7 +422,7 @@ macro_rules! lotus_json_with_self {
         $(
             impl $crate::lotus_json::HasLotusJson for $domain_ty {
                 type LotusJson = Self;
-                fn snapshots() -> Vec<(serde_json::Value, Self)> {
+                #[cfg(test)] fn snapshots() -> Vec<(serde_json::Value, Self)> {
                     unimplemented!("tests are trivial for HasLotusJson<LotusJson = Self>")
                 }
                 fn into_lotus_json(self) -> Self::LotusJson {
@@ -459,6 +461,7 @@ pub struct ClaimLotusJson {
 
 impl HasLotusJson for Claim {
     type LotusJson = ClaimLotusJson;
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![]
     }
@@ -478,6 +481,7 @@ impl HasLotusJson for Claim {
 
 impl<T: HasLotusJson> HasLotusJson for (T,) {
     type LotusJson = (T::LotusJson,);
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         unimplemented!("tests are trivial for HasLotusJson<LotusJson = Self>")
     }
@@ -491,6 +495,7 @@ impl<T: HasLotusJson> HasLotusJson for (T,) {
 
 impl<A: HasLotusJson, B: HasLotusJson> HasLotusJson for (A, B) {
     type LotusJson = (A::LotusJson, B::LotusJson);
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         unimplemented!("tests are trivial for HasLotusJson<LotusJson = Self>")
     }
@@ -507,6 +512,7 @@ impl<A: HasLotusJson, B: HasLotusJson> HasLotusJson for (A, B) {
 
 impl<A: HasLotusJson, B: HasLotusJson, C: HasLotusJson> HasLotusJson for (A, B, C) {
     type LotusJson = (A::LotusJson, B::LotusJson, C::LotusJson);
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         unimplemented!("tests are trivial for HasLotusJson<LotusJson = Self>")
     }
@@ -530,6 +536,7 @@ impl<A: HasLotusJson, B: HasLotusJson, C: HasLotusJson, D: HasLotusJson> HasLotu
     for (A, B, C, D)
 {
     type LotusJson = (A::LotusJson, B::LotusJson, C::LotusJson, D::LotusJson);
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         unimplemented!("tests are trivial for HasLotusJson<LotusJson = Self>")
     }
@@ -553,6 +560,7 @@ impl<A: HasLotusJson, B: HasLotusJson, C: HasLotusJson, D: HasLotusJson> HasLotu
 
 impl HasLotusJson for Ipld {
     type LotusJson = IpldJson;
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![]
     }
@@ -566,6 +574,7 @@ impl HasLotusJson for Ipld {
 
 impl HasLotusJson for BitField {
     type LotusJson = BitFieldJson;
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![]
     }

--- a/src/lotus_json/nonempty.rs
+++ b/src/lotus_json/nonempty.rs
@@ -10,6 +10,7 @@ where
 {
     type LotusJson = NonEmpty<<T as HasLotusJson>::LotusJson>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         unimplemented!("only NonEmpty<Cid> is tested, below")
     }

--- a/src/lotus_json/opt.rs
+++ b/src/lotus_json/opt.rs
@@ -9,6 +9,7 @@ where
 {
     type LotusJson = Option<T::LotusJson>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         unimplemented!("only Option<Cid> is tested, below")
     }

--- a/src/lotus_json/po_st_proof.rs
+++ b/src/lotus_json/po_st_proof.rs
@@ -16,6 +16,7 @@ pub struct PoStProofLotusJson {
 impl HasLotusJson for PoStProof {
     type LotusJson = PoStProofLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({

--- a/src/lotus_json/raw_bytes.rs
+++ b/src/lotus_json/raw_bytes.rs
@@ -19,6 +19,7 @@ quickcheck! {
 impl HasLotusJson for RawBytes {
     type LotusJson = VecU8LotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!("aGVsbG8gd29ybGQh"),

--- a/src/lotus_json/receipt.rs
+++ b/src/lotus_json/receipt.rs
@@ -20,6 +20,7 @@ pub struct ReceiptLotusJson {
 impl HasLotusJson for Receipt {
     type LotusJson = ReceiptLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![
             (

--- a/src/lotus_json/registered_po_st_proof.rs
+++ b/src/lotus_json/registered_po_st_proof.rs
@@ -9,6 +9,7 @@ use super::*;
 impl HasLotusJson for RegisteredPoStProof {
     type LotusJson = i64;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!(0),

--- a/src/lotus_json/registered_seal_proof.rs
+++ b/src/lotus_json/registered_seal_proof.rs
@@ -8,6 +8,7 @@ use fvm_shared3::sector::RegisteredSealProof as RegisteredSealProofV3;
 impl HasLotusJson for RegisteredSealProof {
     type LotusJson = i64;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!(0),

--- a/src/lotus_json/sector_info.rs
+++ b/src/lotus_json/sector_info.rs
@@ -16,6 +16,7 @@ pub struct SectorInfoLotusJson {
 impl HasLotusJson for SectorInfo {
     type LotusJson = SectorInfoLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({

--- a/src/lotus_json/signature.rs
+++ b/src/lotus_json/signature.rs
@@ -14,6 +14,7 @@ pub struct SignatureLotusJson {
 impl HasLotusJson for Signature {
     type LotusJson = SignatureLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({"Type": 2, "Data": "aGVsbG8gd29ybGQh"}),

--- a/src/lotus_json/signature_type.rs
+++ b/src/lotus_json/signature_type.rs
@@ -21,6 +21,7 @@ pub enum SignatureTypeLotusJson {
 impl HasLotusJson for SignatureType {
     type LotusJson = SignatureTypeLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(json!(2), SignatureType::Bls)]
     }

--- a/src/lotus_json/signed_message.rs
+++ b/src/lotus_json/signed_message.rs
@@ -26,6 +26,7 @@ impl SignedMessageLotusJson {
 impl HasLotusJson for SignedMessage {
     type LotusJson = SignedMessageLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({

--- a/src/lotus_json/sync_stage.rs
+++ b/src/lotus_json/sync_stage.rs
@@ -7,6 +7,7 @@ use crate::chain_sync::SyncStage;
 impl HasLotusJson for SyncStage {
     type LotusJson = Stringify<SyncStage>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(json!("idle worker"), Self::Idle)]
     }

--- a/src/lotus_json/ticket.rs
+++ b/src/lotus_json/ticket.rs
@@ -14,6 +14,7 @@ pub struct TicketLotusJson {
 impl HasLotusJson for Ticket {
     type LotusJson = TicketLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!({"VRFProof": "aGVsbG8gd29ybGQh"}),

--- a/src/lotus_json/tipset_keys.rs
+++ b/src/lotus_json/tipset_keys.rs
@@ -3,17 +3,17 @@
 
 use super::*;
 use crate::blocks::TipsetKey;
-use crate::cid_collections::FrozenCidVec;
 use ::cid::Cid;
 
 impl HasLotusJson for TipsetKey {
     type LotusJson = LotusJson<Vec<Cid>>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!([{"/": "baeaaaaa"}]),
             TipsetKey {
-                cids: FrozenCidVec::from_iter([::cid::Cid::default()]),
+                cids: [::cid::Cid::default()].into_iter().collect(),
             },
         )]
     }

--- a/src/lotus_json/token_amount.rs
+++ b/src/lotus_json/token_amount.rs
@@ -14,6 +14,7 @@ pub struct TokenAmountLotusJson {
 impl HasLotusJson for TokenAmount {
     type LotusJson = TokenAmountLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(json!("1"), TokenAmount::from_atto(1))]
     }

--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -11,6 +11,7 @@ where
 {
     type LotusJson = VecLotusJson<T::LotusJson>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         unimplemented!("only Vec<Cid> is tested, below")
     }

--- a/src/lotus_json/vec_u8.rs
+++ b/src/lotus_json/vec_u8.rs
@@ -15,6 +15,7 @@ struct Inner(#[serde(with = "base64_standard")] Vec<u8>);
 impl HasLotusJson for Vec<u8> {
     type LotusJson = VecU8LotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![
             (json!("aGVsbG8gd29ybGQh"), Vec::from_iter(*b"hello world!")),

--- a/src/lotus_json/vrf_proof.rs
+++ b/src/lotus_json/vrf_proof.rs
@@ -8,6 +8,7 @@ use super::*;
 impl HasLotusJson for VRFProof {
     type LotusJson = LotusJson<Vec<u8>>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!("aGVsbG8gd29ybGQh"),

--- a/src/rpc_api/data_types.rs
+++ b/src/rpc_api/data_types.rs
@@ -206,6 +206,7 @@ pub struct ApiMessageLotusJson {
 
 impl HasLotusJson for ApiMessage {
     type LotusJson = ApiMessageLotusJson;
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![]
     }
@@ -229,6 +230,7 @@ pub struct ApiTipsetKey(pub Option<TipsetKey>);
 impl HasLotusJson for ApiTipsetKey {
     type LotusJson = LotusJson<Vec<Cid>>;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![]
     }
@@ -328,6 +330,7 @@ pub struct MinerInfoLotusJson {
 
 impl HasLotusJson for MinerInfo {
     type LotusJson = MinerInfoLotusJson;
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![]
     }
@@ -399,6 +402,7 @@ pub struct BeneficiaryTermLotusJson {
 impl HasLotusJson for BeneficiaryTerm {
     type LotusJson = BeneficiaryTermLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(Value, Self)> {
         vec![]
     }
@@ -435,6 +439,7 @@ pub struct PendingBeneficiaryChangeLotusJson {
 impl HasLotusJson for PendingBeneficiaryChange {
     type LotusJson = PendingBeneficiaryChangeLotusJson;
 
+    #[cfg(test)]
     fn snapshots() -> Vec<(Value, Self)> {
         vec![]
     }
@@ -509,6 +514,7 @@ lotus_json_with_self!(MiningBaseInfo);
 
 impl HasLotusJson for MinerPower {
     type LotusJson = MinerPowerLotusJson;
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![]
     }
@@ -586,6 +592,7 @@ pub struct ActorStateJson {
 
 impl HasLotusJson for ActorState {
     type LotusJson = ActorStateJson;
+    #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![]
     }

--- a/src/rpc_api/mod.rs
+++ b/src/rpc_api/mod.rs
@@ -198,7 +198,9 @@ pub mod chain_api {
     use std::{path::PathBuf, sync::Arc};
 
     use super::data_types::ApiTipsetKey;
-    use crate::blocks::{RawBlockHeader, Tipset};
+    #[cfg(test)]
+    use crate::blocks::RawBlockHeader;
+    use crate::blocks::Tipset;
     use crate::lotus_json::lotus_json_with_self;
     #[cfg(test)]
     use crate::lotus_json::{assert_all_snapshots, assert_unchanged_via_json};
@@ -250,6 +252,7 @@ pub mod chain_api {
     impl HasLotusJson for PathChange {
         type LotusJson = PathChange<LotusJson<Tipset>>;
 
+        #[cfg(test)]
         fn snapshots() -> Vec<(serde_json::Value, Self)> {
             use serde_json::json;
             vec![(
@@ -618,6 +621,7 @@ pub mod eth_api {
     impl HasLotusJson for BlockNumberOrHash {
         type LotusJson = String;
 
+        #[cfg(test)]
         fn snapshots() -> Vec<(serde_json::Value, Self)> {
             vec![]
         }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Originally part of https://github.com/ChainSafe/forest/pull/3964 . to drop `Default` derives for non test targets
Using a separate PR to make both easier to review

Changes introduced in this pull request:

- compile HasLotusJson::snapshots for test target only

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
