### PR TITLE
Query DB optims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 
 ### Added
 
+- [#3555](https://github.com/ChainSafe/forest/issues/3555) Add Forest database
+  query optimizations when serving with many car files.
+
 ### Changed
 
 ### Removed

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -17,7 +17,7 @@ use std::{
     time,
 };
 use tokio::io::AsyncWriteExt;
-use tracing::{debug, info};
+use tracing::info;
 use url::Url;
 use walkdir::WalkDir;
 
@@ -25,7 +25,7 @@ pub fn load_all_forest_cars<T>(store: &ManyCar<T>, forest_car_db_dir: &Path) -> 
     if !forest_car_db_dir.is_dir() {
         fs::create_dir_all(forest_car_db_dir)?;
     }
-    for file in WalkDir::new(forest_car_db_dir)
+    let iter = WalkDir::new(forest_car_db_dir)
         .max_depth(1)
         .into_iter()
         .filter_map(|entry| {
@@ -37,13 +37,8 @@ pub fn load_all_forest_cars<T>(store: &ManyCar<T>, forest_car_db_dir: &Path) -> 
                 }
             }
             None
-        })
-    {
-        let car = ForestCar::try_from(file.as_path())
-            .with_context(|| format!("Error loading car DB at {}", file.display()))?;
-        store.read_only(car.into());
-        debug!("Loaded car DB at {}", file.display());
-    }
+        });
+    store.read_only_files(iter)?;
 
     Ok(())
 }

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -17,7 +17,7 @@ use std::{
     time,
 };
 use tokio::io::AsyncWriteExt;
-use tracing::info;
+use tracing::{debug, info};
 use url::Url;
 use walkdir::WalkDir;
 
@@ -25,7 +25,7 @@ pub fn load_all_forest_cars<T>(store: &ManyCar<T>, forest_car_db_dir: &Path) -> 
     if !forest_car_db_dir.is_dir() {
         fs::create_dir_all(forest_car_db_dir)?;
     }
-    let iter = WalkDir::new(forest_car_db_dir)
+    for file in WalkDir::new(forest_car_db_dir)
         .max_depth(1)
         .into_iter()
         .filter_map(|entry| {
@@ -37,8 +37,13 @@ pub fn load_all_forest_cars<T>(store: &ManyCar<T>, forest_car_db_dir: &Path) -> 
                 }
             }
             None
-        });
-    store.read_only_files(iter)?;
+        })
+    {
+        let car = ForestCar::try_from(file.as_path())
+            .with_context(|| format!("Error loading car DB at {}", file.display()))?;
+        store.read_only(car.into())?;
+        debug!("Loaded car DB at {}", file.display());
+    }
 
     Ok(())
 }

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -135,9 +135,10 @@ impl<WriterT> ManyCar<WriterT> {
     }
 }
 
-impl<ReaderT: super::RandomAccessFileReader> From<AnyCar<ReaderT>> for ManyCar<MemoryDB> {
-    fn from(any_car: AnyCar<ReaderT>) -> Self {
-        ManyCar::default().with_read_only(any_car).unwrap()
+impl<ReaderT: super::RandomAccessFileReader> TryFrom<AnyCar<ReaderT>> for ManyCar<MemoryDB> {
+    type Error = anyhow::Error;
+    fn try_from(any_car: AnyCar<ReaderT>) -> anyhow::Result<Self> {
+        ManyCar::default().with_read_only(any_car)
     }
 }
 
@@ -235,7 +236,7 @@ mod tests {
 
     #[test]
     fn many_car_calibnet_heaviest() {
-        let many = ManyCar::from(AnyCar::try_from(calibnet::DEFAULT_GENESIS).unwrap());
+        let many = ManyCar::try_from(AnyCar::try_from(calibnet::DEFAULT_GENESIS).unwrap()).unwrap();
         let heaviest = many.heaviest_tipset().unwrap();
         assert_eq!(
             heaviest.min_ticket_block(),

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -93,7 +93,7 @@ impl<WriterT> ManyCar<WriterT> {
         Ok(self)
     }
 
-    fn read_only<ReaderT: super::RandomAccessFileReader>(
+    pub fn read_only<ReaderT: super::RandomAccessFileReader>(
         &self,
         any_car: AnyCar<ReaderT>,
     ) -> anyhow::Result<()> {

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -21,7 +21,6 @@ use parking_lot::{Mutex, RwLock};
 use std::cmp::Ord;
 use std::collections::BinaryHeap;
 use std::{path::PathBuf, sync::Arc};
-use tracing::debug;
 
 struct WithHeaviestEpoch {
     pub car: AnyCar<Box<dyn super::RandomAccessFileReader>>,
@@ -121,10 +120,7 @@ impl<WriterT> ManyCar<WriterT> {
 
     pub fn read_only_files(&self, files: impl Iterator<Item = PathBuf>) -> anyhow::Result<()> {
         for file in files {
-            let car = AnyCar::new(EitherMmapOrRandomAccessFile::open(&file)?)?;
-            debug!("Loaded car DB at {}", file.display());
-
-            self.read_only(car)?;
+            self.read_only(AnyCar::new(EitherMmapOrRandomAccessFile::open(file)?)?)?;
         }
 
         Ok(())

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -30,7 +30,10 @@ struct WithHeaviestEpoch {
 
 impl WithHeaviestEpoch {
     pub fn new(car: AnyCar<Box<dyn super::RandomAccessFileReader>>) -> anyhow::Result<Self> {
-        let heaviest_epoch = car.heaviest_tipset()?.epoch();
+        let heaviest_epoch = car
+            .heaviest_tipset()
+            .context("store doesn't have a heaviest tipset")?
+            .epoch();
         Ok(Self {
             car,
             heaviest_epoch,
@@ -103,8 +106,7 @@ impl<WriterT> ManyCar<WriterT> {
         let car = any_car
             .with_cache(self.shared_cache.clone(), key)
             .into_dyn();
-        read_only
-            .push(WithHeaviestEpoch::new(car).context("store doesn't have a heaviest tipset")?);
+        read_only.push(WithHeaviestEpoch::new(car)?);
 
         Ok(())
     }

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -126,18 +126,12 @@ impl<WriterT> ManyCar<WriterT> {
         Ok(())
     }
 
-    // TODO: update
     pub fn heaviest_tipset(&self) -> anyhow::Result<Tipset> {
-        let tipsets = self
-            .read_only
+        self.read_only
             .read()
-            .iter()
+            .peek()
             .map(|w| AnyCar::heaviest_tipset(&w.car))
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        tipsets
-            .into_iter()
-            .max_by_key(Tipset::epoch)
-            .context("ManyCar store doesn't have a heaviest tipset")
+            .context("ManyCar store doesn't have a heaviest tipset")?
     }
 }
 

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -129,8 +129,7 @@ impl<WriterT: Blockstore> Blockstore for ManyCar<WriterT> {
             return Ok(Some(value));
         }
         for reader in self.read_only.read().iter() {
-            let opt = reader.get(k)?;
-            if let Some(val) = opt {
+            if let Some(val) = reader.get(k)? {
                 return Ok(Some(val));
             }
         }

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -109,12 +109,16 @@ impl<WriterT: Blockstore> Blockstore for ManyCar<WriterT> {
         // Theoretically it should be easily parallelizable with `rayon`.
         // In practice, there is a massive performance loss when providing
         // more than a single reader.
+        if let Ok(Some(value)) = self.writer.get(k) {
+            return Ok(Some(value));
+        }
         for reader in self.read_only.read().iter() {
-            if let Some(val) = reader.get(k)? {
+            let opt = reader.get(k)?;
+            if let Some(val) = opt {
                 return Ok(Some(val));
             }
         }
-        self.writer.get(k)
+        Ok(None)
     }
 
     fn put_keyed(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -225,19 +225,21 @@ mod tests {
         assert!(many.heaviest_tipset().is_err());
     }
 
-    // #[test]
-    // fn many_car_idempotent() {
-    //     let many = ManyCar::new(MemoryDB::default())
-    //         .with_read_only(AnyCar::try_from(mainnet::DEFAULT_GENESIS).unwrap())
-    //         .with_read_only(AnyCar::try_from(mainnet::DEFAULT_GENESIS).unwrap());
-    //     assert_eq!(
-    //         many.heaviest_tipset().unwrap(),
-    //         AnyCar::try_from(mainnet::DEFAULT_GENESIS)
-    //             .unwrap()
-    //             .heaviest_tipset()
-    //             .unwrap()
-    //     );
-    // }
+    #[test]
+    fn many_car_idempotent() {
+        let many = ManyCar::new(MemoryDB::default())
+            .with_read_only(AnyCar::try_from(mainnet::DEFAULT_GENESIS).unwrap())
+            .unwrap()
+            .with_read_only(AnyCar::try_from(mainnet::DEFAULT_GENESIS).unwrap())
+            .unwrap();
+        assert_eq!(
+            many.heaviest_tipset().unwrap(),
+            AnyCar::try_from(mainnet::DEFAULT_GENESIS)
+                .unwrap()
+                .heaviest_tipset()
+                .unwrap()
+        );
+    }
 
     #[test]
     fn many_car_calibnet_heaviest() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Query ParityDB first
- Read-only CAR files are sorted by heaviest tipset

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

To exercise some load, I've imported 44 diff calibnet car files and done a simple export.

`forest-cli snapshot export -t 1395675 -d 900`

| branch | elapsed time |
| - | - |
| main | 92s |
| db-query-optim | 60s |

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
