### PR TITLE
feat: omit void (db) migrations

### DIFF
--- a/scripts/tests/calibnet_db_migration.sh
+++ b/scripts/tests/calibnet_db_migration.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-# This script tests the migration(s) from Forest 0.12.1 to the current version.
+# This script tests the migration(s) from Forest 0.12.0 to the current version.
 # As simple as it is, it will detect regressions in the migration process and breaking changes.
 
 source "$(dirname "$0")/harness.sh"
@@ -11,12 +11,12 @@ mkdir -p "${DATA_DIR}"
 
 chmod -R 777 "${DATA_DIR}"
 
-# Run Forest 0.12.1 with mounted db so that we can re-use it later.
+# Run Forest 0.12.0 with mounted db so that we can re-use it later.
 # NOTE: We aren't using '--auto-download-snapshot', because of a bug in
-# forest-0.12.1 that's related to `Content-Disposition` parsing.
-docker run --init --rm --name forest-0.12.1 \
+# forest-0.12.0 that's related to `Content-Disposition` parsing.
+docker run --init --rm --name forest-0.12.0 \
   --volume "${DATA_DIR}":/home/forest/.local/share/forest \
-  ghcr.io/chainsafe/forest:v0.12.1 \
+  ghcr.io/chainsafe/forest:v0.12.0 \
   --chain calibnet \
   --encrypt-keystore false \
   --import-snapshot=https://forest-archive.chainsafe.dev/latest/calibnet/ \
@@ -34,9 +34,9 @@ if [ ! -w "${DATA_DIR}/calibnet/paritydb" ]; then
   sudo chown -R "$(id -u):$(id -g)" "${DATA_DIR}/"
 fi
 
-# Note that for Forest 0.12.1, a seamless migration is not really possible given that there is no notion of versioning.
-# We **know** here that Forest was at 0.12.1 so we manually change the directory name to reflect that. This should not be required in the future.
-mv "${DATA_DIR}/calibnet/paritydb" "${DATA_DIR}/calibnet/0.12.1"
+# Note that for Forest 0.12.0, a seamless migration is not really possible given that there is no notion of versioning.
+# We **know** here that Forest was at 0.12.0 so we manually change the directory name to reflect that. This should not be required in the future.
+mv "${DATA_DIR}/calibnet/paritydb" "${DATA_DIR}/calibnet/0.12.0"
 
 CONFIG_FILE="${TMP_DIR}/config.toml"
 
@@ -60,8 +60,8 @@ export FULLNODE_API_INFO
 forest_wait_for_sync
 forest_check_db_stats
 
-# Assert there is no "0.12.1" directory in the database directory. This and a successful sync indicate that the database was successfully migrated.
-if [ -d "${DATA_DIR}/calibnet/0.12.1" ]; then
+# Assert there is no "0.12.0" directory in the database directory. This and a successful sync indicate that the database was successfully migrated.
+if [ -d "${DATA_DIR}/calibnet/0.12.0" ]; then
   echo "Database directory not migrated"
   exit 1
 fi


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to omit void migrations in the migration map definition by automatically generating void migrations when necessary. 

Changes introduced in this pull request:

- omit void (db) migrations

CI log https://github.com/ChainSafe/forest/actions/runs/8111423534/job/22170964108?pr=4017#step:6:126
```
2024-03-01T12:45:09.467017Z  INFO forest_filecoin::db::migration::db_migration: Migrating database from version 0.12.0 to 0.16.8
2024-03-01T12:45:09.467063Z  INFO forest_filecoin::db::migration::migration_map: Migrating database from version 0.12.0 to 0.12.1
2024-03-01T12:45:09.467104Z  INFO forest_filecoin::db::migration::void_migration: copying old database from /tmp/tmp.NlKDjKNEXj/data_dir/calibnet/0.12.0 to /tmp/tmp.NlKDjKNEXj/data_dir/calibnet/migration_0_12_0_0_12_1
2024-03-01T12:45:18.218939Z  INFO forest_filecoin::db::migration::migration_map: Database migration complete
2024-03-01T12:45:18.218954Z  INFO forest_filecoin::db::migration::migration_map: Migrating database from version 0.12.1 to 0.13.0
2024-03-01T12:45:18.218983Z  INFO forest_filecoin::db::migration::v0_12_1: copying old database from /tmp/tmp.NlKDjKNEXj/data_dir/calibnet/0.12.1 to /tmp/tmp.NlKDjKNEXj/data_dir/calibnet/migration_0_12_1_0_13_0
2024-03-01T12:45:36.026249Z  INFO forest_filecoin::db::migration::migration_map: Database migration complete
2024-03-01T12:45:36.026270Z  INFO forest_filecoin::db::migration::migration_map: Migrating database from version 0.13.0 to 0.15.2
2024-03-01T12:45:36.026305Z  INFO forest_filecoin::db::migration::void_migration: copying old database from /tmp/tmp.NlKDjKNEXj/data_dir/calibnet/0.13.0 to /tmp/tmp.NlKDjKNEXj/data_dir/calibnet/migration_0_13_0_0_15_2
2024-03-01T12:45:43.708409Z  INFO forest_filecoin::db::migration::migration_map: Database migration complete
2024-03-01T12:45:43.708430Z  INFO forest_filecoin::db::migration::migration_map: Migrating database from version 0.15.2 to 0.16.0
2024-03-01T12:45:45.479364Z  INFO forest_filecoin::db::migration::v0_16_0: migrating RollingDB partition "/tmp/tmp.NlKDjKNEXj/data_dir/calibnet/0.15.2/6322c08703504c1daa1185c2d7f42faa"
2024-03-01T12:45:45.484087Z  INFO forest_filecoin::db::migration::v0_16_0: migrating column GraphDagCborBlake2b256
2024-03-01T12:45:45.484374Z  INFO forest_filecoin::db::migration::v0_16_0: migrating column GraphFull
2024-03-01T12:45:45.484915Z  INFO forest_filecoin::db::migration::v0_16_0: migrating column Settings
2024-03-01T12:45:45.486199Z  INFO forest_filecoin::db::migration::v0_16_0: migrating RollingDB partition "/tmp/tmp.NlKDjKNEXj/data_dir/calibnet/0.15.2/167be629eb5a4a77b305e2855aad6e5e"
2024-03-01T12:45:49.484751Z  INFO forest_filecoin::db::migration::v0_16_0: migrating column GraphDagCborBlake2b256
2024-03-01T12:46:31.158215Z  INFO parity-db: Started reindex for i00-16    
2024-03-01T12:46:33.239904Z  INFO parity-db: Completed reindex i00-16 into i00-17    
2024-03-01T12:47:18.251700Z  INFO parity-db: Started reindex for i00-17    
2024-03-01T12:47:21.058666Z  INFO parity-db: Completed reindex i00-17 into i00-18    
2024-03-01T12:47:44.997438Z  INFO forest_filecoin::db::migration::v0_16_0: migrating column GraphFull
2024-03-01T12:47:46.373055Z  INFO forest_filecoin::db::migration::v0_16_0: migrating column Settings
2024-03-01T12:47:47.799667Z  INFO forest_filecoin::db::migration::migration_map: Database migration complete
2024-03-01T12:47:47.799687Z  INFO forest_filecoin::db::migration::migration_map: Migrating database from version 0.16.0 to 0.16.8
2024-03-01T12:47:47.799722Z  INFO forest_filecoin::db::migration::void_migration: copying old database from /tmp/tmp.NlKDjKNEXj/data_dir/calibnet/0.16.0 to /tmp/tmp.NlKDjKNEXj/data_dir/calibnet/migration_0_16_0_0_16_8
2024-03-01T12:47:55.569479Z  INFO forest_filecoin::db::migration::migration_map: Database migration complete
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
