### PR TITLE
[Fix] Implement Drop for UnorderedChainStream and handle send errors.

### DIFF
--- a/src/tool/subcommands/benchmark_cmd.rs
+++ b/src/tool/subcommands/benchmark_cmd.rs
@@ -185,7 +185,6 @@ async fn benchmark_unordered_graph_traversal(input: Vec<PathBuf>) -> anyhow::Res
     while let Some(block) = s.try_next().await? {
         sink.write_all(&block.data).await?
     }
-    s.join_workers().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- implemented `PinnedDrop` for `UnorderedChainStream` to make sure we cleanup automatically. 
- avoid worker panics when `UnorderedChainStream` is dropped, there is no need to panic when the receiver channel is closed.
- removed redundant `join_workers` method as we are cleaning up in `Drop`. 
- improved `into_seen` implementation to work properly with `Drop` and avoiding `Arc` nuances. 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #3991 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
