### PR TITLE
feat: make TipsetKey iterable

### DIFF
--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -57,6 +57,11 @@ impl TipsetKey {
     pub fn to_cids(&self) -> NonEmpty<Cid> {
         self.0.clone().into_cids()
     }
+
+    /// Returns an iterator of `CID`s.
+    pub fn iter(&self) -> impl Iterator<Item = Cid> + '_ {
+        self.0.iter()
+    }
 }
 
 impl From<NonEmpty<Cid>> for TipsetKey {

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -82,6 +82,26 @@ impl fmt::Display for TipsetKey {
     }
 }
 
+impl<'a> IntoIterator for &'a TipsetKey {
+    type Item = <&'a SmallCidNonEmptyVec as IntoIterator>::Item;
+
+    type IntoIter = <&'a SmallCidNonEmptyVec as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter()
+    }
+}
+
+impl IntoIterator for TipsetKey {
+    type Item = <SmallCidNonEmptyVec as IntoIterator>::Item;
+
+    type IntoIter = <SmallCidNonEmptyVec as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 /// An immutable set of blocks at the same height with the same parent set.
 /// Blocks in a tipset are canonically ordered by ticket size.
 ///

--- a/src/cid_collections/small_cid_vec.rs
+++ b/src/cid_collections/small_cid_vec.rs
@@ -32,6 +32,11 @@ impl SmallCidNonEmptyVec {
     pub fn into_cids(self) -> NonEmpty<Cid> {
         self.0.map(From::from)
     }
+
+    /// Returns an iterator of `CID`s.
+    pub fn iter(&self) -> impl Iterator<Item = Cid> + '_ {
+        self.0.iter().map(|cid| Cid::from(cid.clone()))
+    }
 }
 
 /// A [`MaybeCompactedCid`], with indirection to save space on the most common CID variant, at the cost

--- a/src/cid_collections/small_cid_vec.rs
+++ b/src/cid_collections/small_cid_vec.rs
@@ -39,6 +39,27 @@ impl SmallCidNonEmptyVec {
     }
 }
 
+impl<'a> IntoIterator for &'a SmallCidNonEmptyVec {
+    type Item = Cid;
+
+    type IntoIter = std::iter::Map<nonempty::Iter<'a, SmallCid>, fn(&SmallCid) -> Cid>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter().map(|cid| Cid::from(cid.clone()))
+    }
+}
+
+impl IntoIterator for SmallCidNonEmptyVec {
+    type Item = Cid;
+
+    type IntoIter =
+        std::iter::Map<<NonEmpty<SmallCid> as IntoIterator>::IntoIter, fn(SmallCid) -> Cid>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter().map(Cid::from)
+    }
+}
+
 /// A [`MaybeCompactedCid`], with indirection to save space on the most common CID variant, at the cost
 /// of an extra allocation on rare variants.
 ///
@@ -46,7 +67,7 @@ impl SmallCidNonEmptyVec {
 /// of [`MaybeCompactedCid`], so that the discriminant is not repeated.
 #[cfg_vis::cfg_vis(doc, pub)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-enum SmallCid {
+pub enum SmallCid {
     Inline(CidV1DagCborBlake2b256),
     Indirect(Box<Uncompactable>),
 }

--- a/src/ipld/util.rs
+++ b/src/ipld/util.rs
@@ -316,7 +316,7 @@ impl<DB: Blockstore, T: Iterator<Item = Tipset> + Unpin> Stream for ChainStream<
 
                         if block.epoch == 0 {
                             // The genesis block has some kind of dummy parent that needs to be emitted.
-                            for p in block.parents.iter() {
+                            for p in &block.parents {
                                 this.dfs.push_back(Emit(p));
                             }
                         }
@@ -553,7 +553,7 @@ impl<DB: Blockstore + Send + Sync + 'static, T: Iterator<Item = Tipset> + Unpin>
 
                         if block.epoch == 0 {
                             // The genesis block has some kind of dummy parent that needs to be emitted.
-                            for p in block.parents.iter() {
+                            for p in &block.parents {
                                 this.queue.push(p);
                             }
                         }

--- a/src/ipld/util.rs
+++ b/src/ipld/util.rs
@@ -316,7 +316,7 @@ impl<DB: Blockstore, T: Iterator<Item = Tipset> + Unpin> Stream for ChainStream<
 
                         if block.epoch == 0 {
                             // The genesis block has some kind of dummy parent that needs to be emitted.
-                            for p in block.parents.to_cids() {
+                            for p in block.parents.iter() {
                                 this.dfs.push_back(Emit(p));
                             }
                         }
@@ -553,7 +553,7 @@ impl<DB: Blockstore + Send + Sync + 'static, T: Iterator<Item = Tipset> + Unpin>
 
                         if block.epoch == 0 {
                             // The genesis block has some kind of dummy parent that needs to be emitted.
-                            for p in block.parents.to_cids() {
+                            for p in block.parents.iter() {
                                 this.queue.push(p);
                             }
                         }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Implement `fn TipsetKey::iter`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4024

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
