### PR TITLE
feat(cli): forest-cli net reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
   `forest-tool shed key-pair-from-private-key` commands. These facilate moving
   between Forest and Lotus without losing the peer-to-peer identity.
 
+- [#4052](https://github.com/ChainSafe/forest/pull/4052) Add
+  `forest-cli net reachability` command that prints information about
+  reachability from the internet.
+
 ### Changed
 
 ### Removed

--- a/src/cli/subcommands/net_cmd.rs
+++ b/src/cli/subcommands/net_cmd.rs
@@ -33,6 +33,8 @@ pub enum NetCommands {
         /// Peer ID to disconnect from
         id: String,
     },
+    /// Print information about reachability from the internet
+    Reachability,
 }
 
 impl NetCommands {
@@ -154,6 +156,18 @@ impl NetCommands {
             Self::Disconnect { id } => {
                 api.net_disconnect(id.to_owned()).await?;
                 println!("disconnect {id}: success");
+                Ok(())
+            }
+            Self::Reachability => {
+                let nat_status = api.net_auto_nat_status().await?;
+                println!("AutoNAT status:  {}", nat_status.reachability_as_str());
+                if let Some(public_addrs) = nat_status.public_addrs {
+                    if !public_addrs.is_empty() {
+                        // Format is compatible with Go code:
+                        // `fmt.Println("Public address:", []string{"foo", "bar"})`
+                        println!("Public address: [{}]", public_addrs.join(" "));
+                    }
+                }
                 Ok(())
             }
         }

--- a/src/rpc_api/mod.rs
+++ b/src/rpc_api/mod.rs
@@ -467,6 +467,18 @@ pub mod net_api {
     }
     lotus_json_with_self!(NatStatusResult);
 
+    impl NatStatusResult {
+        // See <https://github.com/libp2p/go-libp2p/blob/164adb40fef9c19774eb5fe6d92afb95c67ba83c/core/network/network.go#L93>
+        pub fn reachability_as_str(&self) -> &'static str {
+            match self.reachability {
+                0 => "Unknown",
+                1 => "Public",
+                2 => "Private",
+                _ => "(unrecognized)",
+            }
+        }
+    }
+
     impl From<libp2p::autonat::NatStatus> for NatStatusResult {
         fn from(nat: libp2p::autonat::NatStatus) -> Self {
             use libp2p::autonat::NatStatus;

--- a/src/rpc_client/net_ops.rs
+++ b/src/rpc_client/net_ops.rs
@@ -58,7 +58,11 @@ impl ApiInfo {
         RpcRequest::new(NET_AGENT_VERSION, (peer,))
     }
 
+    pub async fn net_auto_nat_status(&self) -> Result<NatStatusResult, JsonRpcError> {
+        self.call(Self::net_auto_nat_status_req()).await
+    }
+
     pub fn net_auto_nat_status_req() -> RpcRequest<NatStatusResult> {
-        RpcRequest::new(NET_AUTO_NAT_STATUS, ())
+        RpcRequest::new_v1(NET_AUTO_NAT_STATUS, ())
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Follow up of https://github.com/ChainSafe/forest/pull/4039

Changes introduced in this pull request:

- Add  `forest-cli net reachability` command (compatible with `lotus net reachability`) that prints information about reachability from the internet.

```console
➜  lotus git:(master) FULLNODE_API_INFO="/ip4/64.226.122.57/tcp/2345/http" lotus net reachability
2024-03-13T14:15:03.689+0800    WARN    cliutil util/apiinfo.go:94      API Token not set and requested, capabilities might be limited.
AutoNAT status:  Public
Public address: [/ip4/64.226.122.57/tcp/12345]

➜  forest git:(main) ✗  FULLNODE_API_INFO="/ip4/64.226.122.57/tcp/2345/http" cargo run --bin forest-cli -- net reachability
   Compiling forest-filecoin v0.17.0 (/home/me/git/forest)
    Finished dev [unoptimized] target(s) in 38.39s
     Running `target/debug/forest-cli net reachability`
AutoNAT status:  Public
Public address: [/ip4/64.226.122.57/tcp/12345]

➜  lotus git:(master) FULLNODE_API_INFO="/ip4/127.0.0.1/tcp/1234/http" lotus net reachability
2024-03-13T17:13:52.599+0800    WARN    cliutil util/apiinfo.go:94      API Token not set and requested, capabilities might be limited.
AutoNAT status:  Private

➜  forest git:(hm/net-reachability) FULLNODE_API_INFO="/ip4/127.0.0.1/tcp/1234/http" cargo run --bin forest-cli -- net r
eachability
    Finished dev [unoptimized] target(s) in 3.48s
     Running `target/debug/forest-cli net reachability`
AutoNAT status:  Private

➜  lotus git:(master) FULLNODE_API_INFO="/ip4/127.0.0.1/tcp/2345/http" lotus net reachability
2024-03-13T17:16:26.466+0800    WARN    cliutil util/apiinfo.go:94      API Token not set and requested, capabilities might be limited.
AutoNAT status:  Unknown

➜  forest git:(hm/net-reachability) FULLNODE_API_INFO="/ip4/127.0.0.1/tcp/2345/http" cargo run --bin forest-cli -- net r
eachability
    Finished dev [unoptimized] target(s) in 4.21s
     Running `target/debug/forest-cli net reachability`
AutoNAT status:  Unknown
```

Lotus code:
```go
var NetReachability = &cli.Command{
	Name:  "reachability",
	Usage: "Print information about reachability from the internet",
	Action: func(cctx *cli.Context) error {
		api, closer, err := GetAPI(cctx)
		if err != nil {
			return err
		}
		defer closer()

		ctx := ReqContext(cctx)

		i, err := api.NetAutoNatStatus(ctx)
		if err != nil {
			return err
		}

		fmt.Println("AutoNAT status: ", i.Reachability.String())
		if len(i.PublicAddrs) > 0 {
			fmt.Println("Public address:", i.PublicAddrs)
		}
		return nil
	},
}
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
