### PR TITLE
fix `forest-cli chain block` output

### DIFF
--- a/scripts/tests/calibnet_offline_rpc_check.sh
+++ b/scripts/tests/calibnet_offline_rpc_check.sh
@@ -40,7 +40,12 @@ done
 for port in "${PORTS[@]}"; do
   # Assert an old block is present, given that the old snapshot is used.
   # https://calibration.filfox.info/en/block/bafy2bzacecpjvcld56dazyukvj35uzwvlh3tb4ga2lvbgbiua3mgbqaz45hbm
-  FULLNODE_API_INFO="/ip4/127.0.0.1/tcp/$port/http" forest-cli chain block -c bafy2bzacecpjvcld56dazyukvj35uzwvlh3tb4ga2lvbgbiua3mgbqaz45hbm
+  temp_dir=$(mktemp -d)
+  FULLNODE_API_INFO="/ip4/127.0.0.1/tcp/$port/http" forest-cli chain block -c bafy2bzacecpjvcld56dazyukvj35uzwvlh3tb4ga2lvbgbiua3mgbqaz45hbm | jq . > "$temp_dir/block.json"
+
+  # assert block is as expected
+  parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+  diff "$parent_path/test_data/calibnet_block_3000.json" "$temp_dir/block.json"
 done
 
 # Compare the http endpoints

--- a/scripts/tests/test_data/calibnet_block_3000.json
+++ b/scripts/tests/test_data/calibnet_block_3000.json
@@ -1,0 +1,55 @@
+{
+  "Miner": "t01001",
+  "Ticket": {
+    "VRFProof": "tqvA2eKxv41idBKYyfn5s5NILa0ZbDCm0I966PxITW9v41zjaK+WBTlKt01HyJA6C547A1QnNmfl44RmU/ZzC6p7TJJeiB1ZSgbTu6oUmWoHokxN5w4wPJcqslfNCjcy"
+  },
+  "ElectionProof": {
+    "VRFProof": "lgQnCwE/R199jfPpK+/CXQyZwyyldgm9zATRG3KdD765ObLZsYLJEzJP7WspEhVxABhKbWqtR6iWuMqCfFYET+rQjv6q/7/HOnXxGm4NA+Vk/D6Py6B7dFpDJ0ynE1xA",
+    "WinCount": 1
+  },
+  "BeaconEntries": [
+    {
+      "Round": 2399511,
+      "Data": "gnEZiH4il5dkAhPmjF9s5xNYnFuLHnhSD2h+VnAh6j2PmNxZQKYqglWxAjr1TrUBEWvXCHqJX8Mlq0cHTQlGSMsyuvDiWVr7QBS7ianOvs5iZXbkq1MwSdySq6eBTkuo"
+    }
+  ],
+  "WinPoStProof": [
+    {
+      "PoStProof": 3,
+      "ProofBytes": "qZnqYHOeLxuKrw+zsgVq7RBoVZXuuLg/P4k2yRtGcCG5QPA7qq36WfCb8t9if9AkoXMCjRI/mV9GQyqDRyxn4ZCuA6Mco9js5Jh9+ZXgXIpD5aqk/DFzJAdAspI5MYT8Duk9xmKeN9w5j8RhkwqCgMhUruuvPBPbnGxOUKGMDMt6VZYBEj0BcmkHy1Tm7wG4rSv2eGRcCn9xNtgrJaJii8O4BO1GtbXAkvxLBgAJQqHUQ4Ci06bjC28hFa3DUx1Z"
+    }
+  ],
+  "Parents": [
+    {
+      "/": "bafy2bzaceboy6rk5lzoxhk2q2vmzq2yjmgtdzsaax4tret2iymumjcp4ohfjy"
+    },
+    {
+      "/": "bafy2bzaceaq5l57fo35ejowp6lxk3v3klrol35idwwon4ipqavcymf5vuqhyy"
+    },
+    {
+      "/": "bafy2bzacecf6vunv62ofnf2pms4ro7evx5vtzcpmyr5vqs2gixzerc4svtyu2"
+    }
+  ],
+  "ParentWeight": "56159550",
+  "Height": 3000,
+  "ParentStateRoot": {
+    "/": "bafy2bzacebjbt5nwgof7jaqwngr3yxmisdofqkuafsznxbau66wahznafipwm"
+  },
+  "ParentMessageReceipts": {
+    "/": "bafy2bzacedswlcz5ddgqnyo3sak3jmhmkxashisnlpq6ujgyhe4mlobzpnhs6"
+  },
+  "Messages": {
+    "/": "bafy2bzacecmda75ovposbdateg7eyhwij65zklgyijgcjwynlklmqazpwlhba"
+  },
+  "BLSAggregate": {
+    "Type": 2,
+    "Data": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  },
+  "Timestamp": 1667416380,
+  "BlockSig": {
+    "Type": 2,
+    "Data": "uJABIrNb5zlpbDCFpEW4nV0l77pYG/v2mC+XZYlx81JHC+81si+WjTXdSHU4fDRcCCfcBP798MvIfj6Faky2mCS1C6CHgEvpZCHQ1eXVBDxTGFHxu1ZEXiT98bsflEzl"
+  },
+  "ForkSignaling": 0,
+  "ParentBaseFee": "100"
+}

--- a/src/cli/subcommands/chain_cmd.rs
+++ b/src/cli/subcommands/chain_cmd.rs
@@ -59,7 +59,9 @@ pub enum ChainCommands {
 impl ChainCommands {
     pub async fn run(self, api: ApiInfo) -> anyhow::Result<()> {
         match self {
-            Self::Block { cid } => print_pretty_json(api.chain_get_block(cid).await?),
+            Self::Block { cid } => {
+                print_pretty_json(api.chain_get_block(cid).await?.into_lotus_json())
+            }
             Self::Genesis => print_pretty_json(LotusJson(api.chain_get_genesis().await?)),
             Self::Head => print_rpc_res_cids(api.chain_head().await?),
             Self::Message { cid } => {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes the output of the `forest-cli chain block` command, and ensures such regressions are caught in the future.

Previous output:
```
forest-cli chain block -c bafy2bzacedj4d4ceekbwcvyfokf5u5o6utbf7s4ovoltocdzdbrcdcfkll3q6                                                                                                                                                                                     14:05:00 [892/992]
[
  [
    0,
    234,
    7                                                                                                                                                                                                                                                                                                                             ],
  [
    [                                                                                                                                                                                                                                                                                                                                 184,
      66,
      224,
      126,
      53,                                                                                                                                                                                                                                                                                                                             83,
      121,
      228,                                                                                                                                                                                                                                                                                                                            250,
      102,
      93,
      200,
      133,                                                                                                                                                                                                                                                                                                                            125,
      51,
```
Current output:
```
❯ forest-cli chain block -c bafy2bzacecpjvcld56dazyukvj35uzwvlh3tb4ga2lvbgbiua3mgbqaz45hbm
{
  "Miner": "t01001",
  "Ticket": {
    "VRFProof": "tqvA2eKxv41idBKYyfn5s5NILa0ZbDCm0I966PxITW9v41zjaK+WBTlKt01HyJA6C547A1QnNmfl44RmU/ZzC6p7TJJeiB1ZSgbTu6oUmWoHokxN5w4wPJcqslfNCjcy"
  },
  "ElectionProof": {
    "VRFProof": "lgQnCwE/R199jfPpK+/CXQyZwyyldgm9zATRG3KdD765ObLZsYLJEzJP7WspEhVxABhKbWqtR6iWuMqCfFYET+rQjv6q/7/HOnXxGm4NA+Vk/D6Py6B7dFpDJ0ynE1xA",
    "WinCount": 1
  },
  "BeaconEntries": [
    {
      "Round": 2399511,
      "Data": "gnEZiH4il5dkAhPmjF9s5xNYnFuLHnhSD2h+VnAh6j2PmNxZQKYqglWxAjr1TrUBEWvXCHqJX8Mlq0cHTQlGSMsyuvDiWVr7QBS7ianOvs5iZXbkq1MwSdySq6eBTkuo"
    }
  ],
  "WinPoStProof": [
    {
      "PoStProof": 3,
      "ProofBytes": "qZnqYHOeLxuKrw+zsgVq7RBoVZXuuLg/P4k2yRtGcCG5QPA7qq36WfCb8t9if9AkoXMCjRI/mV9GQyqDRyxn4ZCuA6Mco9js5Jh9+ZXgXIpD5aqk/DFzJAdAspI5MYT8Duk9xmKeN9w5j8RhkwqCgMhUruuvPBPbnGxOUKGMDMt6VZYBEj0BcmkHy1Tm7wG4rSv2eGRcCn9xNtgrJaJii8O4BO1GtbXAkvxLBgAJQqHUQ4Ci06bjC28hFa3DUx1Z"
    }
  ],
  "Parents": [
    {
      "/": "bafy2bzaceboy6rk5lzoxhk2q2vmzq2yjmgtdzsaax4tret2iymumjcp4ohfjy"
    },
    {
      "/": "bafy2bzaceaq5l57fo35ejowp6lxk3v3klrol35idwwon4ipqavcymf5vuqhyy"
    },
    {
      "/": "bafy2bzacecf6vunv62ofnf2pms4ro7evx5vtzcpmyr5vqs2gixzerc4svtyu2"
    }
  ],
  "ParentWeight": "56159550",
  "Height": 3000,
  "ParentStateRoot": {
    "/": "bafy2bzacebjbt5nwgof7jaqwngr3yxmisdofqkuafsznxbau66wahznafipwm"
  },
  "ParentMessageReceipts": {
    "/": "bafy2bzacedswlcz5ddgqnyo3sak3jmhmkxashisnlpq6ujgyhe4mlobzpnhs6"
  },
  "Messages": {
    "/": "bafy2bzacecmda75ovposbdateg7eyhwij65zklgyijgcjwynlklmqazpwlhba"
  },
  "BLSAggregate": {
    "Type": 2,
    "Data": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
  },
  "Timestamp": 1667416380,
  "BlockSig": {
    "Type": 2,
    "Data": "uJABIrNb5zlpbDCFpEW4nV0l77pYG/v2mC+XZYlx81JHC+81si+WjTXdSHU4fDRcCCfcBP798MvIfj6Faky2mCS1C6CHgEvpZCHQ1eXVBDxTGFHxu1ZEXiT98bsflEzl"
  },
  "ForkSignaling": 0,
  "ParentBaseFee": "100"
}
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4030

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
