### PR TITLE
feat: trait RpcMethod for server, client, and schema

### DIFF
--- a/.config/forest.dic
+++ b/.config/forest.dic
@@ -46,6 +46,7 @@ GC
 GiB
 HAMT
 hasher
+implementor/SM
 IPFS
 IPLD
 JSON

--- a/src/rpc/chain_api.rs
+++ b/src/rpc/chain_api.rs
@@ -8,7 +8,10 @@ use crate::chain::{ChainStore, HeadChange};
 use crate::cid_collections::CidHashSet;
 use crate::lotus_json::LotusJson;
 use crate::message::ChainMessage;
-use crate::rpc::{error::JsonRpcError, reflect::RpcMethod};
+use crate::rpc::{
+    error::JsonRpcError,
+    reflect::{Ctx, RpcMethod},
+};
 use crate::rpc_api::data_types::{ApiHeadChange, ApiMessage, ApiReceipt};
 use crate::rpc_api::{
     chain_api::*,
@@ -268,14 +271,14 @@ pub async fn chain_get_block_messages<DB: Blockstore>(
 
 pub enum ChainGetPath {}
 
-impl<BS: Blockstore + Send + Sync> RpcMethod<2, Arc<RPCState<BS>>> for ChainGetPath {
+impl RpcMethod<2> for ChainGetPath {
     const NAME: &'static str = "Filecoin.ChainGetPath";
     const PARAM_NAMES: [&'static str; 2] = ["from", "to"];
     type Params = (LotusJson<TipsetKey>, LotusJson<TipsetKey>);
     type Ok = LotusJson<Vec<PathChange>>;
 
     async fn handle(
-        ctx: Arc<Arc<RPCState<BS>>>,
+        ctx: Ctx<impl Blockstore>,
         (LotusJson(from), LotusJson(to)): Self::Params,
     ) -> Result<Self::Ok, JsonRpcError> {
         impl_chain_get_path(&ctx.chain_store, &from, &to)

--- a/src/rpc/chain_api.rs
+++ b/src/rpc/chain_api.rs
@@ -8,7 +8,7 @@ use crate::chain::{ChainStore, HeadChange};
 use crate::cid_collections::CidHashSet;
 use crate::lotus_json::LotusJson;
 use crate::message::ChainMessage;
-use crate::rpc::error::JsonRpcError;
+use crate::rpc::{error::JsonRpcError, reflect::RpcMethod};
 use crate::rpc_api::data_types::{ApiHeadChange, ApiMessage, ApiReceipt};
 use crate::rpc_api::{
     chain_api::*,
@@ -266,6 +266,24 @@ pub async fn chain_get_block_messages<DB: Blockstore>(
     Ok(ret)
 }
 
+pub enum ChainGetPath {}
+
+impl<BS: Blockstore + Send + Sync> RpcMethod<2, Arc<RPCState<BS>>> for ChainGetPath {
+    const NAME: &'static str = "Filecoin.ChainGetPath";
+    const PARAM_NAMES: [&'static str; 2] = ["from", "to"];
+    type Params = (LotusJson<TipsetKey>, LotusJson<TipsetKey>);
+    type Ok = LotusJson<Vec<PathChange>>;
+
+    async fn handle(
+        ctx: Arc<Arc<RPCState<BS>>>,
+        (LotusJson(from), LotusJson(to)): Self::Params,
+    ) -> Result<Self::Ok, JsonRpcError> {
+        impl_chain_get_path(&ctx.chain_store, &from, &to)
+            .map(LotusJson)
+            .map_err(Into::into)
+    }
+}
+
 /// Find the path between two tipsets, as a series of [`PathChange`]s.
 ///
 /// ```text
@@ -283,16 +301,6 @@ pub async fn chain_get_block_messages<DB: Blockstore>(
 /// ```
 ///
 /// Exposes errors from the [`Blockstore`], and returns an error if there is no common ancestor.
-pub async fn chain_get_path(
-    ctx: Data<RPCState<impl Blockstore>>,
-    LotusJson(from): LotusJson<TipsetKey>,
-    LotusJson(to): LotusJson<TipsetKey>,
-) -> Result<LotusJson<Vec<PathChange>>, JsonRpcError> {
-    impl_chain_get_path(&ctx.chain_store, &from, &to)
-        .map(LotusJson)
-        .map_err(Into::into)
-}
-
 fn impl_chain_get_path(
     chain_store: &ChainStore<impl Blockstore>,
     from: &TipsetKey,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -51,7 +51,9 @@ use tokio::sync::RwLock;
 use tower::Service;
 use tracing::info;
 
+use self::chain_api::ChainGetPath;
 use self::reflect::openrpc_types::ParamStructure;
+use self::reflect::RpcMethodExt as _;
 
 const MAX_RESPONSE_BODY_SIZE: u32 = 16 * 1024 * 1024;
 
@@ -156,11 +158,8 @@ fn create_module<DB>(
 where
     DB: Blockstore + Send + Sync + 'static,
 {
-    let mut module = reflect::SelfDescribingModule::new(state, ParamStructure::ByPosition);
-    {
-        use chain_api::*;
-        module.serve(CHAIN_GET_PATH, ["from", "to"], chain_get_path)
-    };
+    let mut module = reflect::SelfDescribingRpcModule::new(state, ParamStructure::ByPosition);
+    ChainGetPath::register(&mut module);
     module.finish()
 }
 

--- a/src/rpc/reflect/mod.rs
+++ b/src/rpc/reflect/mod.rs
@@ -202,7 +202,7 @@ impl<const ARITY: usize, T> RpcMethodExt<ARITY> for T where T: RpcMethod<ARITY> 
 ///
 /// This should NOT be manually implemented.
 pub trait Params<const ARITY: usize> {
-    /// A [`Schema`] and [`Optional::optional`](`crate::util::Optional::optional`)
+    /// A [`Schema`] and [`Optional::optional`](`util::Optional::optional`)
     /// pair for argument, in-order.
     fn schemas(gen: &mut SchemaGenerator) -> [(Schema, bool); ARITY];
     /// Convert from raw request parameters, to the argument tuple required by

--- a/src/rpc/reflect/mod.rs
+++ b/src/rpc/reflect/mod.rs
@@ -61,7 +61,7 @@ type ModuleState<T> = Arc<RPCState<T>>;
 /// However, fixing it as [`Ctx<...>`] saves on complexity/confusion for implementors,
 /// at the expense of handler flexibility, which could come back to bite us.
 /// - All handlers accept [`RPCState`].
-/// - All `Ctx`s must be [`Send`] + [`Sync`] + `'static` due to bounds on [`RpcModule`].
+/// - All `Ctx`s must be `Send + Sync + 'static` due to bounds on [`RpcModule`].
 /// - Handlers don't specialize on top of the given bounds, but they MAY relax them.
 pub trait RpcMethod<const ARITY: usize> {
     /// Method name.
@@ -82,7 +82,7 @@ pub trait RpcMethod<const ARITY: usize> {
 /// Utility methods, defined as an extension trait to avoid having to specify
 /// `ARITY` in user code.
 pub trait RpcMethodExt<const ARITY: usize>: RpcMethod<ARITY> {
-    /// Convert from typed handler parameters to untyped JSON-RPC parameters.
+    /// Convert from typed handler parameters to un-typed JSON-RPC parameters.
     ///
     /// Exposes errors from [`Params::unparse`]
     fn build_params(
@@ -214,9 +214,9 @@ pub trait Params<const ARITY: usize> {
     ) -> Result<Self, Error>
     where
         Self: Sized;
-    /// Convert from an argument tuple to untyped JSON.
+    /// Convert from an argument tuple to un-typed JSON.
     ///
-    /// Exposes deserialization errors, or misimplementation of this trait.
+    /// Exposes de-serialization errors, or mis-implementation of this trait.
     fn unparse(&self) -> Result<[serde_json::Value; ARITY], serde_json::Error>
     where
         Self: Serialize,
@@ -235,6 +235,8 @@ pub trait Params<const ARITY: usize> {
     }
 }
 
+// TODO(aatifsyed): https://github.com/ChainSafe/forest/issues/4066
+#[allow(unused)]
 fn unexpected(v: &serde_json::Value) -> Unexpected<'_> {
     match v {
         serde_json::Value::Null => Unexpected::Unit,
@@ -323,6 +325,8 @@ impl<Ctx> SelfDescribingRpcModule<Ctx> {
     }
 }
 
+// TODO(aatifsyed): https://github.com/ChainSafe/forest/issues/4066
+#[allow(unused)]
 /// [`openrpc_types::ParamStructure`] describes accepted param format.
 /// This is an actual param format, used to decide how to construct arguments.
 pub enum ConcreteCallingConvention {

--- a/src/rpc/reflect/mod.rs
+++ b/src/rpc/reflect/mod.rs
@@ -9,12 +9,14 @@
 //! - The number of arguments ([arity](https://en.wikipedia.org/wiki/Arity)) and
 //!   names of those arguments for each RPC method.
 //!
-//! We have all this information in our handler functions, we just need to use it.
-//! - [`schemars::JsonSchema`] provides schema definitions, with our [`GenerateSchemas`]
-//!   trait acting as a shim.
-//! - [`Wrap`] defining arity and actually dispatching the function calls.
+//! As a secondary objective, we wish to provide an RPC client for our CLI, and
+//! internal tests against Lotus.
 //!
-//! [`SelfDescribingModule`] actually does the work to create the OpenRPC document.
+//! The [`RpcMethod`] trait encapsulates all the above at a single site.
+//! - [`schemars::JsonSchema`] provides schema definitions,
+//! - [`RpcMethod`] defining arity and actually dispatching the function calls.
+//!
+//! [`SelfDescribingRpcModule`] actually does the work to create the OpenRPC document.
 
 pub mod jsonrpc_types;
 pub mod openrpc_types;
@@ -22,39 +24,261 @@ pub mod openrpc_types;
 mod parser;
 mod util;
 
-use std::{
-    future::{ready, Future, Ready},
-    pin::Pin,
-    sync::Arc,
-    task::{ready, Context, Poll},
-};
+use self::{jsonrpc_types::RequestParameters, util::Optional as _};
+use super::error::JsonRpcError as Error;
 
 use futures::future::Either;
-use itertools::Itertools as _;
-use openrpc_types::{ContentDescriptor, Method, ParamStructure};
+use jsonrpsee::{MethodsError, RpcModule};
+use openrpc_types::{ContentDescriptor, Method, ParamListError, ParamStructure};
 use parser::Parser;
-use pin_project_lite::pin_project;
 use schemars::{
     gen::{SchemaGenerator, SchemaSettings},
     schema::Schema,
     JsonSchema,
 };
-use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde::Serialize;
+use serde::{
+    de::{DeserializeOwned, Error as _, Unexpected},
+    Deserialize,
+};
+use std::{future::Future, sync::Arc};
 
-use super::error::JsonRpcError;
-use util::Optional as _;
+/// A definition of an RPC method handler which can be registered with a
+/// [`SelfDescribingRpcModule`].
+pub trait RpcMethod<const ARITY: usize, Ctx> {
+    /// Method name.
+    const NAME: &'static str;
+    /// Name of each argument, MUST be unique.
+    const PARAM_NAMES: [&'static str; ARITY];
+    /// Types of each argument. [`Option`]-al arguments MUST follow mandatory ones.
+    type Params: Params<ARITY>;
+    /// Return value of this method.
+    type Ok;
+    /// Logic for this method.
+    fn handle(
+        ctx: Arc<Ctx>,
+        params: Self::Params,
+    ) -> impl Future<Output = Result<Self::Ok, Error>> + Send;
+}
 
-/// A wrapped [`jsonrpsee::server::RpcModule`] which generates an [OpenRPC](https://spec.open-rpc.org)
-/// schema for the methods.
-pub struct SelfDescribingModule<Ctx> {
+/// Utility methods, defined as an extension trait to avoid having to specify
+/// `ARITY` in user code.
+pub trait RpcMethodExt<const ARITY: usize, Ctx>: RpcMethod<ARITY, Ctx> {
+    /// Convert from typed handler parameters to untyped JSON-RPC parameters.
+    ///
+    /// Exposes errors from [`Params::unparse`]
+    fn build_params(
+        params: Self::Params,
+        calling_convention: ConcreteCallingConvention,
+    ) -> Result<RequestParameters, serde_json::Error>
+    where
+        Self::Params: Serialize,
+    {
+        let args = params.unparse()?;
+        match calling_convention {
+            ConcreteCallingConvention::ByPosition => {
+                Ok(RequestParameters::ByPosition(Vec::from(args)))
+            }
+            ConcreteCallingConvention::ByName => Ok(RequestParameters::ByName(
+                itertools::zip_eq(Self::PARAM_NAMES.into_iter().map(String::from), args).collect(),
+            )),
+        }
+    }
+    /// Generate a full `OpenRPC` method definition for this endpoint.
+    fn openrpc<'de>(
+        gen: &mut SchemaGenerator,
+        calling_convention: ParamStructure,
+    ) -> Result<Method, ParamListError>
+    where
+        Self::Ok: JsonSchema + Deserialize<'de>,
+    {
+        Ok(Method {
+            name: String::from(Self::NAME),
+            params: openrpc_types::Params::new(
+                itertools::zip_eq(Self::PARAM_NAMES, Self::Params::schemas(gen)).map(
+                    |(name, (schema, optional))| ContentDescriptor {
+                        name: String::from(name),
+                        schema,
+                        required: !optional,
+                    },
+                ),
+            )?,
+            param_structure: calling_convention,
+            result: Some(ContentDescriptor {
+                name: format!("{}::Result", Self::NAME),
+                schema: Self::Ok::json_schema(gen),
+                required: !Self::Ok::optional(),
+            }),
+        })
+    }
+    /// Register this method with an [`RpcModule`].
+    fn register_raw(
+        module: &mut RpcModule<Ctx>,
+        calling_convention: ParamStructure,
+    ) -> Result<&mut jsonrpsee::MethodCallback, jsonrpsee::core::RegisterMethodError>
+    where
+        Ctx: Send + Sync + 'static,
+        Self::Ok: Serialize + Clone + 'static,
+    {
+        module.register_async_method(Self::NAME, move |params, ctx| async move {
+            let raw = params
+                .as_str()
+                .map(serde_json::from_str)
+                .transpose()
+                .map_err(|e| Error::invalid_params(e, None))?;
+            let params = Self::Params::parse(raw, Self::PARAM_NAMES, calling_convention)?;
+            let ok = Self::handle(ctx, params).await?;
+            Result::<_, jsonrpsee::types::ErrorObjectOwned>::Ok(ok)
+        })
+    }
+    /// Register this method and generate a schema entry for it in a [`SelfDescribingRpcModule`].
+    fn register<'de>(module: &mut SelfDescribingRpcModule<Ctx>)
+    where
+        Ctx: Send + Sync + 'static,
+        Self::Ok: Serialize + Clone + 'static,
+        Self::Ok: JsonSchema + Deserialize<'de>,
+    {
+        Self::register_raw(&mut module.inner, module.calling_convention).unwrap();
+        module
+            .methods
+            .push(Self::openrpc(&mut module.schema_generator, module.calling_convention).unwrap());
+    }
+    /// Call this method on an [`RpcModule`].
+    fn call(
+        module: &RpcModule<Ctx>,
+        params: Self::Params,
+        calling_convention: ConcreteCallingConvention,
+    ) -> impl Future<Output = Result<Self::Ok, MethodsError>> + Send
+    where
+        Self::Params: Serialize,
+        Self::Ok: DeserializeOwned + Clone + Send,
+    {
+        macro_rules! tri {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(it) => it,
+                    Err(e) => return Either::Left(futures::future::ready(Err(e.into()))),
+                }
+            };
+        }
+        match tri!(Self::build_params(params, calling_convention)) {
+            RequestParameters::ByPosition(args) => {
+                let mut builder = jsonrpsee::core::params::ArrayParams::new();
+                for arg in args {
+                    tri!(builder.insert(arg))
+                }
+                Either::Right(Either::Left(module.call(Self::NAME, builder)))
+            }
+            RequestParameters::ByName(args) => {
+                let mut builder = jsonrpsee::core::params::ObjectParams::new();
+                for (name, value) in args {
+                    tri!(builder.insert(&name, value));
+                }
+                Either::Right(Either::Right(module.call(Self::NAME, builder)))
+            }
+        }
+    }
+}
+impl<const ARITY: usize, Ctx, T> RpcMethodExt<ARITY, Ctx> for T where T: RpcMethod<ARITY, Ctx> {}
+
+/// A tuple of `ARITY` arguments.
+///
+/// This should NOT be manually implemented.
+pub trait Params<const ARITY: usize> {
+    /// A [`Schema`] and [`Optional::optional`](`crate::util::Optional::optional`)
+    /// pair for argument, in-order.
+    fn schemas(gen: &mut SchemaGenerator) -> [(Schema, bool); ARITY];
+    /// Convert from raw request parameters, to the argument tuple required by
+    /// [`RpcMethod::handle`]
+    fn parse(
+        raw: Option<RequestParameters>,
+        names: [&str; ARITY],
+        calling_convention: ParamStructure,
+    ) -> Result<Self, Error>
+    where
+        Self: Sized;
+    /// Convert from an argument tuple to untyped JSON.
+    ///
+    /// Exposes deserialization errors, or misimplementation of this trait.
+    fn unparse(&self) -> Result<[serde_json::Value; ARITY], serde_json::Error>
+    where
+        Self: Serialize,
+    {
+        match serde_json::to_value(self) {
+            Ok(serde_json::Value::Array(args)) => match args.try_into() {
+                Ok(it) => Ok(it),
+                Err(_) => Err(serde_json::Error::custom("ARITY mismatch")),
+            },
+            Ok(it) => Err(serde_json::Error::invalid_type(
+                unexpected(&it),
+                &"a Vec with an item for each argument",
+            )),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+fn unexpected(v: &serde_json::Value) -> Unexpected<'_> {
+    match v {
+        serde_json::Value::Null => Unexpected::Unit,
+        serde_json::Value::Bool(it) => Unexpected::Bool(*it),
+        serde_json::Value::Number(it) => match (it.as_f64(), it.as_i64(), it.as_u64()) {
+            (None, None, None) => Unexpected::Other("Number"),
+            (Some(it), _, _) => Unexpected::Float(it),
+            (_, Some(it), _) => Unexpected::Signed(it),
+            (_, _, Some(it)) => Unexpected::Unsigned(it),
+        },
+        serde_json::Value::String(it) => Unexpected::Str(it),
+        serde_json::Value::Array(_) => Unexpected::Seq,
+        serde_json::Value::Object(_) => Unexpected::Map,
+    }
+}
+
+macro_rules! do_impls {
+    ($arity:literal $(, $arg:ident)* $(,)?) => {
+        const _: () = {
+            let _assert: [&str; $arity] = [$(stringify!($arg)),*];
+        };
+
+        impl<$($arg),*> Params<$arity> for ($($arg,)*)
+        where
+            $($arg: DeserializeOwned + Serialize + JsonSchema),*
+        {
+            fn parse(
+                raw: Option<RequestParameters>,
+                arg_names: [&str; $arity],
+                calling_convention: ParamStructure,
+            ) -> Result<Self, Error> {
+                let mut _parser = Parser::new(raw, &arg_names, calling_convention)?;
+                Ok(($(_parser.parse::<$arg>()?,)*))
+            }
+            fn schemas(_gen: &mut SchemaGenerator) -> [(Schema, bool); $arity] {
+                [$(($arg::json_schema(_gen), $arg::optional())),*]
+            }
+        }
+    };
+}
+
+do_impls!(0);
+do_impls!(1, T0);
+do_impls!(2, T0, T1);
+do_impls!(3, T0, T1, T2);
+do_impls!(4, T0, T1, T2, T3);
+do_impls!(5, T0, T1, T2, T3, T4);
+do_impls!(6, T0, T1, T2, T3, T4, T5);
+do_impls!(7, T0, T1, T2, T3, T4, T5, T6);
+do_impls!(8, T0, T1, T2, T3, T4, T5, T6, T7);
+do_impls!(9, T0, T1, T2, T3, T4, T5, T6, T7, T8);
+do_impls!(10, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9);
+
+pub struct SelfDescribingRpcModule<Ctx> {
     inner: jsonrpsee::server::RpcModule<Ctx>,
     schema_generator: SchemaGenerator,
     calling_convention: ParamStructure,
     methods: Vec<Method>,
 }
 
-impl<Ctx> SelfDescribingModule<Ctx> {
+impl<Ctx> SelfDescribingRpcModule<Ctx> {
     pub fn new(ctx: Ctx, calling_convention: ParamStructure) -> Self {
         Self {
             inner: jsonrpsee::server::RpcModule::new(ctx),
@@ -62,49 +286,6 @@ impl<Ctx> SelfDescribingModule<Ctx> {
             calling_convention,
             methods: vec![],
         }
-    }
-    /// Even if the calling convention is [`ParamStructure::ByPosition`], OpenRPC
-    /// requires each argument to have a unique name.
-    ///
-    /// # Panics
-    /// - if param names aren't unique
-    /// - if optional parameters follow mandatory params
-    pub fn serve<const ARITY: usize, F, Args, R>(
-        &mut self,
-        method_name: &'static str,
-        param_names: [&'static str; ARITY],
-        f: F,
-    ) -> &mut Self
-    where
-        F: Wrap<ARITY, Ctx, Args, R>,
-        Ctx: Send + Sync + 'static,
-        Args: GenerateSchemas,
-        R: JsonSchema + for<'de> Deserialize<'de>,
-    {
-        self.inner
-            .register_async_method(method_name, f.wrap(param_names, self.calling_convention))
-            .unwrap();
-        self.methods.push(Method {
-            name: String::from(method_name),
-            params: openrpc_types::Params::new(
-                Args::generate_schemas(&mut self.schema_generator)
-                    .into_iter()
-                    .zip_eq(param_names)
-                    .map(|((schema, optional), name)| ContentDescriptor {
-                        name: String::from(name),
-                        schema,
-                        required: !optional,
-                    }),
-            )
-            .unwrap(),
-            param_structure: self.calling_convention,
-            result: Some(ContentDescriptor {
-                name: format!("{}-result", method_name),
-                schema: R::json_schema(&mut self.schema_generator),
-                required: !R::optional(),
-            }),
-        });
-        self
     }
     pub fn finish(self) -> (jsonrpsee::server::RpcModule<Ctx>, openrpc_types::OpenRPC) {
         let Self {
@@ -125,145 +306,9 @@ impl<Ctx> SelfDescribingModule<Ctx> {
     }
 }
 
-/// Wrap a bare function with our argument parsing logic.
-/// Turns any `async fn foo(ctx, arg0...)` into a function that can be passed to [`jsonrpsee::server::RpcModule::register_async_method`].
-///
-/// This trait is NOT designed to implemented on anything except bare handler functions, as below.
-pub trait Wrap<const ARITY: usize, Ctx, Args, R> {
-    type Future: Future<Output = Result<serde_json::Value, JsonRpcError>> + Send;
-    fn wrap(
-        self,
-        param_names: [&'static str; ARITY],
-        calling_convention: ParamStructure,
-    ) -> impl Clone
-           + Send
-           + Sync
-           + 'static
-           + Fn(jsonrpsee::types::Params<'static>, Arc<Ctx>) -> Self::Future;
-}
-
-/// Return type-specific information for a function signature so that a [`ContentDescriptor`] can be created.
-pub trait GenerateSchemas {
-    fn generate_schemas(gen: &mut SchemaGenerator) -> Vec<(Schema, bool)>;
-}
-
-/// Implement [`Wrap`] and [`GenerateSchemas`] for various function arities.
-///
-/// See documentation on [`Wrap`] for more.
-macro_rules! do_impls {
-    ($arity:literal $(, $arg:ident)* $(,)?) => {
-        const _: () = {
-            let _assert: [&str; $arity] = [$(stringify!($arg)),*];
-        };
-
-        impl<F, $($arg,)* Ctx, Fut, R> Wrap<$arity, Ctx, ($($arg,)*), R> for F
-        where
-            F: Clone + Send + Sync + 'static + Fn(Arc<Ctx>, $($arg),*) -> Fut,
-            //                                    ^^^ Receives an Arc rather than a reference lest
-            //                                        we get the dreaded "one type is more general than the other"
-            Ctx: Send + Sync + 'static,
-            $(
-                $arg: for<'de> Deserialize<'de> + Clone,
-            )*
-            Fut: Future<Output = Result<R, JsonRpcError>> + Send + Sync + 'static,
-            R: Serialize,
-        {
-            type Future = Either<
-                Ready<Result<Value, JsonRpcError>>, // early exit when parsing
-                AndThenDeserializeResponse<Fut>,    // deferred handler, then deserializer
-            >;
-
-            fn wrap(
-                self,
-                param_names: [&'static str; $arity],
-                calling_convention: ParamStructure,
-            ) -> impl Clone
-                   + Send
-                   + Sync
-                   + 'static
-                   + Fn(jsonrpsee::types::Params<'static>, Arc<Ctx>) -> Self::Future {
-                move |params, ctx| {
-                    let params = match params.as_str().map(serde_json::from_str).transpose() {
-                        Ok(it) => it,
-                        Err(e) => {
-                            return Either::Left(ready(Err(
-                                JsonRpcError::invalid_params(e, None),
-                            )));
-                        }
-                    };
-                    #[allow(unused_variables, unused_mut)] // for the zero-argument case
-                    let mut parser = match Parser::new(params, &param_names, calling_convention) {
-                        Ok(it) => it,
-                        Err(e) => return Either::Left(ready(Err(e))),
-                    };
-
-                    Either::Right(AndThenDeserializeResponse {
-                        inner: self(
-                            ctx,
-                            $(  // parse out each argument
-                                match parser.parse::<$arg>() {
-                                    Ok(it) => it,
-                                    Err(e) => return Either::Left(ready(Err(e))),
-                                },
-                            )*
-                        ),
-                    })
-                }
-            }
-        }
-
-        #[automatically_derived]
-        impl<$($arg,)*> GenerateSchemas for ($($arg,)*)
-        where
-            $($arg: JsonSchema + for<'de> Deserialize<'de>,)*
-        {
-            fn generate_schemas(gen: &mut SchemaGenerator) -> Vec<(Schema, bool)> {
-                vec![
-                    $(($arg::json_schema(gen), $arg::optional())),*
-                ]
-            }
-        }
-
-    };
-}
-
-do_impls!(0);
-do_impls!(1, T0);
-do_impls!(2, T0, T1);
-do_impls!(3, T0, T1, T2);
-do_impls!(4, T0, T1, T2, T3);
-do_impls!(5, T0, T1, T2, T3, T4);
-do_impls!(6, T0, T1, T2, T3, T4, T5);
-do_impls!(7, T0, T1, T2, T3, T4, T5, T6);
-do_impls!(8, T0, T1, T2, T3, T4, T5, T6, T7);
-do_impls!(9, T0, T1, T2, T3, T4, T5, T6, T7, T8);
-do_impls!(10, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9);
-
-pin_project! {
-    pub struct AndThenDeserializeResponse<F> {
-        #[pin]
-        inner: F
-    }
-}
-
-impl<R, F> Future for AndThenDeserializeResponse<F>
-where
-    F: Future<Output = Result<R, JsonRpcError>>,
-    R: Serialize,
-{
-    type Output = Result<Value, JsonRpcError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(
-            serde_json::to_value(ready!(self.project().inner.poll(cx))?).map_err(|e| {
-                JsonRpcError::internal_error(
-                    "error deserializing return value for handler",
-                    json!({
-                        "type": std::any::type_name::<R>(),
-                        "error": e.to_string()
-                    }),
-                )
-            }),
-        )
-    }
+/// [`openrpc_types::ParamStructure`] describes accepted param format.
+/// This is an actual param format, used to decide how to construct arguments.
+pub enum ConcreteCallingConvention {
+    ByPosition,
+    ByName,
 }

--- a/src/rpc/snapshots/forest_filecoin__rpc__tests__openrpc.snap
+++ b/src/rpc/snapshots/forest_filecoin__rpc__tests__openrpc.snap
@@ -15,7 +15,7 @@ methods:
         required: true
     paramStructure: by-position
     result:
-      name: Filecoin.ChainGetPath-result
+      name: "Filecoin.ChainGetPath::Result"
       schema:
         type: array
         items:


### PR DESCRIPTION
## Summary of changes
Iteration on #4033.

This approach obviates the need to define client operations separately:
https://github.com/ChainSafe/forest/blob/d0b490e7889157c668c1e3f4f96416fb093cf1c9/src/rpc_client/chain_ops.rs

In the limit, `src/rpc_client` can be deleted.

## Obsoletes
- #4054, better to get this in first and _then_ start rewriting handlers.

## Tracking
- #4038 

## Follow up work
- #4032
- #4066 

## Change checklist

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
