### PR TITLE
fix(rpc): Filecoin.NetAutoNatStatus should be v0 API

### DIFF
--- a/src/rpc_client/net_ops.rs
+++ b/src/rpc_client/net_ops.rs
@@ -63,6 +63,6 @@ impl ApiInfo {
     }
 
     pub fn net_auto_nat_status_req() -> RpcRequest<NatStatusResult> {
-        RpcRequest::new_v1(NET_AUTO_NAT_STATUS, ())
+        RpcRequest::new(NET_AUTO_NAT_STATUS, ())
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

              `StateMinerAvailableBalance` is a v0 method. (When methods are available in both V0 and V1, we should use V0.)

_Originally posted by @lemmih in https://github.com/ChainSafe/forest/pull/4061#discussion_r1526028915_

Changes introduced in this pull request:

- call `/rpc/v0` endpoint for `Filecoin.NetAutoNatStatus`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

https://github.com/filecoin-project/lotus/blob/master/documentation/en/api-v0-methods.md#netautonatstatus

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
