### PR TITLE
refactor: remove duplicate JsonRpcError and Request objects

### DIFF
--- a/scripts/tests/calibnet_offline_rpc_check.sh
+++ b/scripts/tests/calibnet_offline_rpc_check.sh
@@ -48,8 +48,10 @@ for port in "${PORTS[@]}"; do
   diff "$parent_path/test_data/calibnet_block_3000.json" "$temp_dir/block.json"
 done
 
+# TODO(aatifsyed): https://github.com/ChainSafe/forest/pull/4096
+#                  `--filter` logic should be commonised
 # Compare the http endpoints
-$FOREST_TOOL_PATH api compare "$snapshot" --forest /ip4/127.0.0.1/tcp/8080/http --lotus /ip4/127.0.0.1/tcp/8081/http --n-tipsets 5
+$FOREST_TOOL_PATH api compare "$snapshot" --forest /ip4/127.0.0.1/tcp/8080/http --lotus /ip4/127.0.0.1/tcp/8081/http --n-tipsets 5 '--filter=!Filecoin.StateWaitMsg'
 
 # Compare the ws endpoints
-$FOREST_TOOL_PATH api compare "$snapshot" --forest /ip4/127.0.0.1/tcp/8080/ws --lotus /ip4/127.0.0.1/tcp/8081/ws --n-tipsets 5
+$FOREST_TOOL_PATH api compare "$snapshot" --forest /ip4/127.0.0.1/tcp/8080/ws --lotus /ip4/127.0.0.1/tcp/8081/ws --n-tipsets 5 '--filter=!Filecoin.StateWaitMsg'

--- a/src/cli/subcommands/auth_cmd.rs
+++ b/src/cli/subcommands/auth_cmd.rs
@@ -37,7 +37,7 @@ fn process_perms(perm: String) -> Result<Vec<String>, JsonRpcError> {
         "sign" => SIGN,
         "write" => WRITE,
         "read" => READ,
-        _ => return Err(JsonRpcError::INVALID_PARAMS),
+        _ => return Err(JsonRpcError::invalid_params("unknown permission", None)),
     }
     .iter()
     .map(ToString::to_string)

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -369,7 +369,6 @@ pub(super) async fn start(
                 shutdown_send,
             )
             .await
-            .map_err(|err| anyhow::anyhow!("{:?}", serde_json::to_string(&err)))
         });
     } else {
         debug!("RPC disabled.");

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -7,7 +7,6 @@ mod beacon_api;
 mod chain_api;
 mod channel;
 mod common_api;
-mod error;
 mod eth_api;
 mod gas_api;
 mod mpool_api;
@@ -17,6 +16,9 @@ mod reflect;
 mod state_api;
 mod sync_api;
 mod wallet_api;
+
+mod error;
+pub use error::JsonRpcError;
 
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -13,7 +13,6 @@ pub mod state_ops;
 pub mod sync_ops;
 pub mod wallet_ops;
 
-use std::borrow::Cow;
 use std::env;
 use std::fmt;
 use std::marker::PhantomData;
@@ -22,12 +21,14 @@ use std::time::Duration;
 
 use crate::libp2p::{Multiaddr, Protocol};
 use crate::lotus_json::HasLotusJson;
+pub use crate::rpc::JsonRpcError;
 use crate::utils::net::global_http_client;
 use jsonrpsee::{
     core::{client::ClientT, traits::ToRpcParams},
-    types::{params::TwoPointZero, Id, Request},
+    types::{Id, Request},
     ws_client::WsClientBuilder,
 };
+use serde::de::IntoDeserializer;
 use serde::Deserialize;
 use tracing::debug;
 
@@ -94,7 +95,7 @@ impl ApiInfo {
         req: RpcRequest<T>,
     ) -> Result<T, JsonRpcError> {
         let params = serde_json::value::to_raw_value(&req.params)
-            .map_err(|_| JsonRpcError::INVALID_PARAMS)?;
+            .map_err(|e| JsonRpcError::invalid_params(e, None))?;
         let rpc_req = Request::new(req.method_name.into(), Some(&params), Id::Number(0));
 
         let api_url = multiaddress_to_url(
@@ -116,37 +117,42 @@ impl ApiInfo {
         };
 
         let response = request.send().await?;
-        if response.status() == http0::StatusCode::NOT_FOUND {
-            return Err(JsonRpcError::METHOD_NOT_FOUND);
+        match response.status() {
+            http0::StatusCode::NOT_FOUND => {
+                Err(JsonRpcError::method_not_found("method_not_found", None))
+            }
+            http0::StatusCode::FORBIDDEN => Err(JsonRpcError::new(
+                response.status().as_u16().into(),
+                match &self.token {
+                    Some(_) => "Permission denied: Insufficient rights.",
+                    None => "Permission denied: Token required.",
+                },
+                None,
+            )),
+            other if !other.is_success() => Err(JsonRpcError::new(
+                other.as_u16().into(),
+                response.text().await?,
+                None,
+            )),
+            _ok => {
+                let bytes = response.bytes().await?;
+                let response = serde_json::from_slice::<
+                    jsonrpsee::types::Response<&serde_json::value::RawValue>,
+                >(&bytes)
+                .map_err(|e| JsonRpcError::parse_error(e, None))?;
+                debug!(?response);
+                match response.payload {
+                    jsonrpsee::types::ResponsePayload::Success(it) => {
+                        T::LotusJson::deserialize(it.into_deserializer())
+                            .map(T::from_lotus_json)
+                            .map_err(|e| JsonRpcError::parse_error(e, None))
+                    }
+                    jsonrpsee::types::ResponsePayload::Error(e) => {
+                        Err(JsonRpcError::parse_error(e, None))
+                    }
+                }
+            }
         }
-        if response.status() == http0::StatusCode::FORBIDDEN {
-            let msg = if self.token.is_none() {
-                "Permission denied: Token required."
-            } else {
-                "Permission denied: Insufficient rights."
-            };
-            return Err(JsonRpcError {
-                code: response.status().as_u16() as i64,
-                message: Cow::Borrowed(msg),
-            });
-        }
-        if !response.status().is_success() {
-            return Err(JsonRpcError {
-                code: response.status().as_u16() as i64,
-                message: Cow::Owned(response.text().await?),
-            });
-        }
-        let json = response.bytes().await?;
-        let rpc_res: JsonRpcResponse<T::LotusJson> =
-            serde_json::from_slice(&json).map_err(|_| JsonRpcError::PARSE_ERROR)?;
-
-        let resp = match rpc_res {
-            JsonRpcResponse::Result { result, .. } => Ok(HasLotusJson::from_lotus_json(result)),
-            JsonRpcResponse::Error { error, .. } => Err(error),
-        };
-
-        tracing::debug!("Response: {:?}", resp);
-        resp
     }
 
     pub async fn ws_call<T: HasLotusJson + std::fmt::Debug + Send>(
@@ -159,110 +165,26 @@ impl ApiInfo {
         let ws_client = WsClientBuilder::default()
             .request_timeout(req.timeout)
             .build(api_url.to_string())
-            .await?;
-        let response_lotus_json: T::LotusJson = ws_client.request(req.method_name, req).await?;
-
-        let resp = Ok(HasLotusJson::from_lotus_json(response_lotus_json));
-
-        tracing::debug!("Response: {:?}", resp);
-        resp
-    }
-}
-
-/// Error object in a response
-#[derive(Debug, Deserialize, PartialEq, Eq)]
-pub struct JsonRpcError {
-    pub code: i64,
-    pub message: Cow<'static, str>,
-}
-
-impl JsonRpcError {
-    // https://www.jsonrpc.org/specification#error_object
-    // -32700 	Parse error 	Invalid JSON was received by the server.
-    //                          An error occurred on the server while parsing the JSON text.
-    // -32600 	Invalid Request 	The JSON sent is not a valid Request object.
-    // -32601 	Method not found 	The method does not exist / is not available.
-    // -32602 	Invalid params 	Invalid method parameter(s).
-    // -32603 	Internal error 	Internal JSON-RPC error.
-    // -32000 to -32099 	Server error 	Reserved for implementation-defined server-errors.
-    pub const PARSE_ERROR: JsonRpcError = JsonRpcError {
-        code: -32700,
-        message: Cow::Borrowed(
-            "Invalid JSON was received by the server. \
-             An error occurred on the server while parsing the JSON text.",
-        ),
-    };
-    pub const INVALID_REQUEST: JsonRpcError = JsonRpcError {
-        code: -32600,
-        message: Cow::Borrowed("The JSON sent is not a valid Request object."),
-    };
-    pub const METHOD_NOT_FOUND: JsonRpcError = JsonRpcError {
-        code: -32601,
-        message: Cow::Borrowed("The method does not exist / is not available."),
-    };
-    pub const INVALID_PARAMS: JsonRpcError = JsonRpcError {
-        code: -32602,
-        message: Cow::Borrowed("Invalid method parameter(s)."),
-    };
-    pub const TIMED_OUT: JsonRpcError = JsonRpcError {
-        code: 0,
-        message: Cow::Borrowed("Operation timed out."),
-    };
-}
-
-impl std::fmt::Display for JsonRpcError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} (code={})", self.message, self.code)
-    }
-}
-
-impl std::error::Error for JsonRpcError {
-    fn description(&self) -> &str {
-        &self.message
+            .await
+            .map_err(|e| JsonRpcError::internal_error(e, None))?;
+        let response = ws_client
+            .request(req.method_name, req)
+            .await
+            .map(HasLotusJson::from_lotus_json)
+            .map_err(|e| JsonRpcError::internal_error(e, None))?;
+        debug!(?response);
+        Ok(response)
     }
 }
 
 impl From<reqwest::Error> for JsonRpcError {
-    fn from(reqwest_error: reqwest::Error) -> Self {
-        JsonRpcError {
-            code: reqwest_error
-                .status()
-                .map(|s| s.as_u16())
-                .unwrap_or_default() as i64,
-            message: Cow::Owned(reqwest_error.to_string()),
-        }
+    fn from(e: reqwest::Error) -> Self {
+        Self::new(
+            e.status().map(|it| it.as_u16()).unwrap_or_default().into(),
+            e,
+            None,
+        )
     }
-}
-
-impl From<jsonrpsee::core::client::Error> for JsonRpcError {
-    fn from(error: jsonrpsee::core::client::Error) -> Self {
-        use jsonrpsee::core::client::Error::*;
-
-        match error {
-            RequestTimeout => JsonRpcError::TIMED_OUT,
-            e => JsonRpcError {
-                code: 500,
-                message: Cow::Owned(e.to_string()),
-            },
-        }
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-pub enum JsonRpcResponse<'a, R> {
-    Result {
-        jsonrpc: TwoPointZero,
-        result: R,
-        #[serde(borrow)]
-        id: Id<'a>,
-    },
-    Error {
-        jsonrpc: TwoPointZero,
-        error: JsonRpcError,
-        #[serde(borrow)]
-        id: Id<'a>,
-    },
 }
 
 struct Url {

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -995,7 +995,7 @@ where
         },
     };
     crate::utils::io::terminal_cleanup();
-    result.map_err(|err| anyhow::anyhow!("{:?}", serde_json::to_string(&err)))
+    result
 }
 
 async fn run_tests(

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -38,6 +38,7 @@ use fil_actors_shared::v10::runtime::DomainSeparationTag;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use fvm_ipld_blockstore::Blockstore;
+use jsonrpsee::types::ErrorCode;
 use serde::de::DeserializeOwned;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
@@ -194,17 +195,16 @@ enum EndpointStatus {
 
 impl EndpointStatus {
     fn from_json_error(err: JsonRpcError) -> Self {
-        if err.code == JsonRpcError::INVALID_REQUEST.code {
-            EndpointStatus::InvalidRequest
-        } else if err.code == JsonRpcError::METHOD_NOT_FOUND.code {
-            EndpointStatus::MissingMethod
-        } else if err.code == JsonRpcError::PARSE_ERROR.code {
-            EndpointStatus::InvalidResponse
-        } else if err.code == 0 && err.message.contains("timed out") {
-            EndpointStatus::Timeout
-        } else {
-            tracing::debug!("{err}");
-            EndpointStatus::InternalServerError
+        match err.known_code() {
+            ErrorCode::ParseError => Self::InvalidResponse,
+            ErrorCode::OversizedRequest => Self::InvalidRequest,
+            ErrorCode::InvalidRequest => Self::InvalidRequest,
+            ErrorCode::MethodNotFound => Self::MissingMethod,
+            it if it.code() == 0 && it.message().contains("timed out") => Self::Timeout,
+            _ => {
+                tracing::debug!(?err);
+                Self::InternalServerError
+            }
         }
     }
 }

--- a/src/tool/subcommands/shed_cmd.rs
+++ b/src/tool/subcommands/shed_cmd.rs
@@ -60,7 +60,7 @@ impl ShedCommands {
                     multiaddr: host,
                     token: None,
                 };
-                let head = client.chain_head().await.context("couldn't get HEAD")?;
+                let head = client.chain_head().await?;
                 let end_height = match height {
                     Some(it) => it,
                     None => head


### PR DESCRIPTION
## Summary of changes
Changes introduced in this pull request:
- make `crate::rpc::error::JsonRpcError` public
- remove `crate::rpc_client::JsonRpcError` in favour of the above
- remove `crate::rpc_client::JsonRpcResponse` in favour of `jsonrpsee::types::Response`

Risks:
- Changes to output of API check commands.
  - I've tried to emulate the old behaviour where possible.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
