### PR TITLE
ci: mark `StateCall` as flaky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,6 @@
 - [#4080](https://github.com/ChainSafe/forest/pull/4080) Fix broken
   `StateVMCirculatingSupplyInternal` RPC method on calibnet.
 
-- [#4085](https://github.com/ChainSafe/forest/pull/4085) Fix discrepancies in
-  the `Filecoin.StateCall` RPC method.
-
 ## Forest 0.17.0 "Smaug"
 
 Mandatory release that includes:

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -5,6 +5,7 @@
 !Filecoin.ChainGetParentReceipts
 !Filecoin.MinerGetBaseInfo
 !Filecoin.StateAccountKey
+!Filecoin.StateCall
 !Filecoin.StateListMessages
 !Filecoin.StateSearchMsg
 !Filecoin.StateSearchMsgLimited


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `Filecoin.StateCall` is still flaky. Don't test it until fixed.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
