### PR TITLE
chore(toolchain): bump rust toolchain to 1.77.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,17 +490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.53",
-]
-
-[[package]]
 name = "async-signal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,7 +3192,6 @@ dependencies = [
  "assert_cmd",
  "async-compression",
  "async-fs 2.1.1",
- "async-recursion",
  "async-trait",
  "asynchronous-codec 0.6.2",
  "axum 0.7.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0"
 argon2 = "0.5"
 async-compression = { version = "0.4", features = ["tokio", "zstd"] }
 async-fs = "2"
-async-recursion = "1"
 async-trait = "0.1"
 asynchronous-codec = "0.6"
 axum = "0.7"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]

--- a/src/beacon/signatures/tests.rs
+++ b/src/beacon/signatures/tests.rs
@@ -22,7 +22,7 @@ mod quicknet {
 
     #[test]
     fn test_verify_messages_quicknet_batch_success() {
-        let messages = vec![message(2), message(3)];
+        let messages = [message(2), message(3)];
         let sig_2 = signature_2();
         let sig_3 = signature_3();
         let signatures = vec![&sig_2, &sig_3];
@@ -34,7 +34,7 @@ mod quicknet {
 
     #[test]
     fn test_verify_messages_quicknet_batch_failure() {
-        let messages = vec![message(1), message(3)];
+        let messages = [message(1), message(3)];
         let sig_2 = signature_2();
         let sig_3 = signature_3();
         let signatures = vec![&sig_2, &sig_3];
@@ -90,7 +90,7 @@ mod mainnet {
 
     #[test]
     fn test_verify_messages_mainnet_batch_success() {
-        let messages = vec![message(&signature_2(), 3), message(&signature_3(), 4)];
+        let messages = [message(&signature_2(), 3), message(&signature_3(), 4)];
         let signatures = vec![signature_3(), signature_4()];
         assert!(verify_messages_chained(
             &pk(),
@@ -101,7 +101,7 @@ mod mainnet {
 
     #[test]
     fn test_verify_messages_mainnet_batch_failure() {
-        let messages = vec![message(&signature_2(), 3), message(&signature_3(), 3)];
+        let messages = [message(&signature_2(), 3), message(&signature_3(), 3)];
         let signatures = vec![signature_3(), signature_4()];
         assert!(!verify_messages_chained(
             &pk(),

--- a/src/cli/subcommands/attach_cmd.rs
+++ b/src/cli/subcommands/attach_cmd.rs
@@ -406,6 +406,7 @@ impl AttachCommand {
                 .read(true)
                 .write(true)
                 .create(true)
+                .truncate(false)
                 .open(&path)?;
 
             // This is safe to call at this point

--- a/src/message_pool/msg_chain.rs
+++ b/src/message_pool/msg_chain.rs
@@ -254,7 +254,7 @@ impl Chains {
     pub(in crate::message_pool) fn drop_invalid(&mut self, key_vec: &mut Vec<NodeKey>) {
         let mut valid_keys = vec![];
         for k in key_vec.iter() {
-            if let true = self.map.get(*k).map(|n| n.valid).unwrap() {
+            if self.map.get(*k).map(|n| n.valid).unwrap() {
                 valid_keys.push(*k);
             } else {
                 self.map.remove(*k);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- bump rust toolchain to 1.77.0
- fix clippy warnings
- retire `async-recursion` crate

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

https://releases.rs/docs/1.77.0/

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
