### PR TITLE
Remove one level of Arc in Ctx

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -162,10 +162,7 @@ where
 
 fn create_module<DB>(
     state: Arc<RPCState<DB>>,
-) -> (
-    RpcModule<Arc<RPCState<DB>>>,
-    reflect::openrpc_types::OpenRPC,
-)
+) -> (RpcModule<RPCState<DB>>, reflect::openrpc_types::OpenRPC)
 where
     DB: Blockstore + Send + Sync + 'static,
 {
@@ -176,7 +173,7 @@ where
 
 #[deprecated = "methods should use `create_module`"]
 fn register_methods<DB>(
-    module: &mut RpcModule<Arc<RPCState<DB>>>,
+    module: &mut RpcModule<RPCState<DB>>,
     block_delay: u64,
     forest_version: &'static str,
     shutdown_send: Sender<()>,

--- a/src/rpc/reflect/mod.rs
+++ b/src/rpc/reflect/mod.rs
@@ -45,8 +45,6 @@ use serde::{
 use std::{future::Future, sync::Arc};
 
 /// Type to be used by [`RpcMethod::handle`].
-// TODO(aatifsyed): https://github.com/ChainSafe/forest/issues/4007
-//                  avoid double indirection
 pub type Ctx<T> = Arc<crate::rpc::RPCState<T>>;
 /// Type to be used by [`SelfDescribingRpcModule`] and [`RpcModule`].
 type ModuleState<T> = crate::rpc::RPCState<T>;
@@ -298,7 +296,7 @@ pub struct SelfDescribingRpcModule<Ctx> {
 impl<Ctx> SelfDescribingRpcModule<Ctx> {
     pub fn new(ctx: Arc<Ctx>, calling_convention: ParamStructure) -> Self {
         Self {
-            inner: jsonrpsee::server::RpcModule::from_arc(ctx.into()),
+            inner: jsonrpsee::server::RpcModule::from_arc(ctx),
             schema_generator: SchemaGenerator::new(SchemaSettings::openapi3()),
             calling_convention,
             methods: vec![],

--- a/src/rpc/reflect/mod.rs
+++ b/src/rpc/reflect/mod.rs
@@ -47,9 +47,9 @@ use std::{future::Future, sync::Arc};
 /// Type to be used by [`RpcMethod::handle`].
 // TODO(aatifsyed): https://github.com/ChainSafe/forest/issues/4007
 //                  avoid double indirection
-pub type Ctx<T> = Arc<Arc<crate::rpc::RPCState<T>>>;
+pub type Ctx<T> = Arc<crate::rpc::RPCState<T>>;
 /// Type to be used by [`SelfDescribingRpcModule`] and [`RpcModule`].
-type ModuleState<T> = Arc<crate::rpc::RPCState<T>>;
+type ModuleState<T> = crate::rpc::RPCState<T>;
 
 /// A definition of an RPC method handler which can be registered with a
 /// [`SelfDescribingRpcModule`].
@@ -296,9 +296,9 @@ pub struct SelfDescribingRpcModule<Ctx> {
 }
 
 impl<Ctx> SelfDescribingRpcModule<Ctx> {
-    pub fn new(ctx: Ctx, calling_convention: ParamStructure) -> Self {
+    pub fn new(ctx: Arc<Ctx>, calling_convention: ParamStructure) -> Self {
         Self {
-            inner: jsonrpsee::server::RpcModule::new(ctx),
+            inner: jsonrpsee::server::RpcModule::from_arc(ctx.into()),
             schema_generator: SchemaGenerator::new(SchemaSettings::openapi3()),
             calling_convention,
             methods: vec![],

--- a/src/rpc/sync_api.rs
+++ b/src/rpc/sync_api.rs
@@ -149,18 +149,16 @@ mod tests {
 
         let cid = r#"[{"/":"bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"}]"#;
 
-        match sync_check_bad(Params::new(Some(cid)), Arc::new(state.clone())).await {
+        match sync_check_bad(Params::new(Some(cid)), state.clone()).await {
             Ok(reason) => assert_eq!(reason, ""),
             Err(e) => std::panic::panic_any(e),
         }
 
         // Mark that block as bad manually and check again to verify
-        assert!(
-            sync_mark_bad(Params::new(Some(cid)), Arc::new(state.clone()))
-                .await
-                .is_ok()
-        );
-        match sync_check_bad(Params::new(Some(cid)), Arc::new(state.clone())).await {
+        assert!(sync_mark_bad(Params::new(Some(cid)), state.clone())
+            .await
+            .is_ok());
+        match sync_check_bad(Params::new(Some(cid)), state.clone()).await {
             Ok(reason) => assert_eq!(reason, "Marked bad manually through RPC API"),
             Err(e) => std::panic::panic_any(e),
         }
@@ -172,7 +170,7 @@ mod tests {
 
         let st_copy = state.sync_state.clone();
 
-        match sync_state(Arc::new(state.clone())).await {
+        match sync_state(state.clone()).await {
             Ok(ret) => assert_eq!(
                 ret.active_syncs,
                 nonempty![clone_state(st_copy.as_ref()).await]
@@ -184,7 +182,7 @@ mod tests {
         st_copy.write().set_stage(SyncStage::Messages);
         st_copy.write().set_epoch(4);
 
-        match sync_state(Arc::new(state.clone())).await {
+        match sync_state(state.clone()).await {
             Ok(ret) => {
                 assert_eq!(
                     ret.active_syncs,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Move to `RpcModule::from_arc` constructor to avoid double indirection

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #4007

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
