### PR TITLE
calibnet dragon fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 - [#4071](https://github.com/ChainSafe/forest/pull/4071) Add
   `forest-tool net ping` command that pings a peer via its multiaddress.
 
+- [#4119](https://github.com/ChainSafe/forest/pull/4119) Add support for NV22
+  fix for calibration network.
+
 ### Changed
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,9 +2716,9 @@ checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "fil_actor_account_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a441021b1b2b7e3828077daa0702bbbd41686e7873c6768e25371b02fbfd678"
+checksum = "028650dbb1544596ec2f78ec1e663191b2b44d87634f130819ead3e6ef0353cf"
 dependencies = [
  "frc42_macros",
  "fvm_ipld_encoding",
@@ -2732,9 +2732,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95adbc58ba47d68c519c00c635914820a073b4d38b0aa5413582cfc9bdd5c14"
+checksum = "210ace3e982f4bbbd6a3eca18a5b25e6f695d44344d44350e20e34ae7b1c9012"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
@@ -2747,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9948a90ec20c3126a91732098a2a09a0d6e5b9a85c936991371cabca7991a650"
+checksum = "d2ccd11bde82d189430b2e6ec2102f31ff919cabfad573a8cc6d55551b426522"
 dependencies = [
  "fil_actors_shared",
  "frc42_macros",
@@ -2767,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db9affa8c283fe53db5b8e07d72ce54c697dc3489f98c03cacfad4597df1a4d"
+checksum = "f7e058f4a7e9cde4226370c6905a97122d9ca620b4e4ddf7d25daa63ab2526b7"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -2787,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d96b047388eaf6f02c50b815129f9c5b5ffb9717deb15b369d938ef9ceb47a"
+checksum = "f55ffe39d3109583a8a6a5a00ade278de10cbd51be0317a859f60c3931fb84a1"
 dependencies = [
  "anyhow",
  "cid",
@@ -2808,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_interface"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d8057af082f4e9573016208509637ff485745e59c43dff8ad3ef77f96a9e67"
+checksum = "580d651f158da2b02bfe4908363e326e03d18a5033d738102af3019ebe3b63d5"
 dependencies = [
  "anyhow",
  "cid",
@@ -2846,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8405b80bc2921a6a8f099bc8f24661e4744a74fc00fc0c47a3bb57fc06913b"
+checksum = "178685710f049cbdee1abcc25859bfab94899002d0ebc2f3ff4a2b9c3a320eeb"
 dependencies = [
  "anyhow",
  "cid",
@@ -2871,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02ee73dedae17e282de63a75643af92d0905328529ac9175d55817445274a53"
+checksum = "e83454bd3c49afcd12ee7b1d5c01dd2cc1fd5269a9b0cf8dbacc32fe5e387076"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -2901,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b1a63b7066a3e64e5c0fb40c5c0f2c82ec80cf6e77048db88a3b5dba87a362"
+checksum = "ca96c6124d190900a6cc3cc44bab70780b2b2718bb441079bcda7c3c3cbdc4c5"
 dependencies = [
  "anyhow",
  "cid",
@@ -2924,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee623194a2327ed110e35dd3289df94412b90a3340aed54e67dfa8dead81064d"
+checksum = "f3d7d87f50606f088eff9e777b3d67798378700f539710822680b9bc0944088c"
 dependencies = [
  "anyhow",
  "cid",
@@ -2947,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04db01a721a1967affa412720ad19c9143210c4217c2608a14fdf0acf3199ed"
+checksum = "ae914722ee25fa68f5616a430d65958896f750ed2ba9160938d6029f8b86b285"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
@@ -2963,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da1bc83e3499519b522709d06812b9a124edd2f540d9f892cc44580ae5075c"
+checksum = "2bcfa44cb18581d6d4fb3a7dd7cc532021d102d481d6a80d10997867e8fb27ab"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -2980,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg_state"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8a0d1654587253bb0504d92f683817dd4c3810d1ec5018cd50461b2037695d"
+checksum = "cf716cdb4ca1943c5c1a1212007fdc487bb7419451980a34a197365b0548e645"
 dependencies = [
  "anyhow",
  "cid",
@@ -3000,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_shared"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efb5bc70862906a26da48b0b2541588082d0cd4680200d332be4e6dd438ee63"
+checksum = "45d580901129af61cd96a6b7530341c54a7c75b33e52676db4db215706941aaf"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,18 +51,18 @@ dialoguer = "0.11"
 digest = "0.10.5"
 directories = "5"
 ethereum-types = "0.14.1"
-fil_actor_account_state = { version = "10.0.0" }
-fil_actor_cron_state = { version = "10.0.0" }
-fil_actor_datacap_state = { version = "10.0.0" }
-fil_actor_init_state = { version = "10.0.0" }
-fil_actor_interface = { version = "10.0.0" }
-fil_actor_market_state = { version = "10.0.0" }
-fil_actor_miner_state = { version = "10.0.0" }
-fil_actor_power_state = { version = "10.0.0" }
-fil_actor_reward_state = { version = "10.0.0" }
-fil_actor_system_state = { version = "10.0.0" }
-fil_actor_verifreg_state = { version = "10.0.0" }
-fil_actors_shared = { version = "10.0.0", features = ["json"] }
+fil_actor_account_state = { version = "10.1.0" }
+fil_actor_cron_state = { version = "10.1.0" }
+fil_actor_datacap_state = { version = "10.1.0" }
+fil_actor_init_state = { version = "10.1.0" }
+fil_actor_interface = { version = "10.1.0" }
+fil_actor_market_state = { version = "10.1.0" }
+fil_actor_miner_state = { version = "10.1.0" }
+fil_actor_power_state = { version = "10.1.0" }
+fil_actor_reward_state = { version = "10.1.0" }
+fil_actor_system_state = { version = "10.1.0" }
+fil_actor_verifreg_state = { version = "10.1.0" }
+fil_actors_shared = { version = "10.1.0", features = ["json"] }
 filecoin-proofs-api = { version = "16.0", default-features = false }
 flume = "0.11"
 frc46_token = "10.0.0"

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -70,6 +70,7 @@ pub static ACTOR_BUNDLES: Lazy<Box<[ActorBundleInfo]>> = Lazy::new(|| {
         "bafy2bzacebl4w5ptfvuw6746w7ev562idkbf5ppq72e6zub22435ws2rukzru" @ "v12.0.0-rc.2" for "calibrationnet",
         "bafy2bzacednzb3pkrfnbfhmoqtb3bc6dgvxszpqklf3qcc7qzcage4ewzxsca" @ "v12.0.0" for "calibrationnet",
         "bafy2bzacea4firkyvt2zzdwqjrws5pyeluaesh6uaid246tommayr4337xpmi" @ "v13.0.0-rc.3" for "calibrationnet",
+        "bafy2bzacect4ktyujrwp6mjlsitnpvuw2pbuppz6w52sfljyo4agjevzm75qs" @ "v13.0.0" for "calibrationnet",
         "bafy2bzacectxvbk77ntedhztd6sszp2btrtvsmy7lp2ypnrk6yl74zb34t2cq" @ "v12.0.0" for "butterflynet",
         "bafy2bzacec75zk7ufzwx6tg5avls5fxdjx5asaqmd2bfqdvkqrkzoxgyflosu" @ "v13.0.0" for "butterflynet",
         "bafy2bzacedozk3jh2j4nobqotkbofodq4chbrabioxbfrygpldgoxs3zwgggk" @ "v9.0.3" for "devnet",

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -235,6 +235,17 @@ pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
                 ),
             },
         ),
+        (
+            Height::DragonFix,
+            HeightInfo {
+                // Wed Apr  3 11:00:00 AM UTC 2024
+                epoch: 1_493_854,
+                bundle: Some(
+                    Cid::try_from("bafy2bzacect4ktyujrwp6mjlsitnpvuw2pbuppz6w52sfljyo4agjevzm75qs")
+                        .unwrap(),
+                ),
+            },
+        ),
     ])
 });
 

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -127,6 +127,7 @@ pub enum Height {
     WatermelonFix,
     WatermelonFix2,
     Dragon,
+    DragonFix,
 }
 
 impl Default for Height {
@@ -163,6 +164,7 @@ impl From<Height> for NetworkVersion {
             Height::WatermelonFix => NetworkVersion::V21,
             Height::WatermelonFix2 => NetworkVersion::V21,
             Height::Dragon => NetworkVersion::V22,
+            Height::DragonFix => NetworkVersion::V22,
         }
     }
 }

--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -22,6 +22,7 @@ mod nv21;
 mod nv21fix;
 mod nv21fix2;
 mod nv22;
+mod nv22fix;
 mod type_migrations;
 
 type RunMigration<DB> = fn(&ChainConfig, &Arc<DB>, &Cid, ChainEpoch) -> anyhow::Result<Cid>;
@@ -55,6 +56,7 @@ where
                 (Height::WatermelonFix, nv21fix::run_migration::<DB>),
                 (Height::WatermelonFix2, nv21fix2::run_migration::<DB>),
                 (Height::Dragon, nv22::run_migration::<DB>),
+                (Height::DragonFix, nv22fix::run_migration::<DB>),
             ]
         }
         NetworkChain::Butterflynet => {

--- a/src/state_migration/nv22fix/migration.rs
+++ b/src/state_migration/nv22fix/migration.rs
@@ -1,0 +1,166 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+//
+//! This module contains the migration logic for the `NV22fix` upgrade.
+//! Corresponding
+use std::sync::Arc;
+
+use crate::networks::{ChainConfig, Height, NetworkChain};
+use crate::shim::{
+    address::Address,
+    clock::ChainEpoch,
+    machine::{BuiltinActor, BuiltinActorManifest},
+    state_tree::{StateTree, StateTreeVersion},
+};
+use crate::state_migration::common::PostMigrationCheck;
+use anyhow::{bail, Context};
+use cid::Cid;
+
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::CborStore;
+
+use super::{system, verifier::Verifier, SystemStateOld};
+use crate::state_migration::common::{migrators::nil_migrator, StateMigration};
+
+impl<BS: Blockstore> StateMigration<BS> {
+    pub fn add_nv22fix_migrations(
+        &mut self,
+        store: &Arc<BS>,
+        state: &Cid,
+        new_manifest: &BuiltinActorManifest,
+    ) -> anyhow::Result<()> {
+        let state_tree = StateTree::new_from_root(store.clone(), state)?;
+        let system_actor = state_tree
+            .get_actor(&Address::new_id(0))?
+            .context("failed to get system actor")?;
+
+        let system_actor_state = store
+            .get_cbor::<SystemStateOld>(&system_actor.state)?
+            .context("system actor state not found")?;
+
+        let current_manifest_data = system_actor_state.builtin_actors;
+
+        let current_manifest =
+            BuiltinActorManifest::load_v1_actor_list(store, &current_manifest_data)?;
+
+        for (name, code) in current_manifest.builtin_actors() {
+            let new_code = new_manifest.get(name)?;
+            self.add_migrator(code, nil_migrator(new_code))
+        }
+
+        self.add_migrator(
+            current_manifest.get_system(),
+            system::system_migrator(new_manifest),
+        );
+
+        Ok(())
+    }
+}
+
+struct PostMigrationVerifier {
+    state_pre: Cid,
+}
+
+impl<BS: Blockstore> PostMigrationCheck<BS> for PostMigrationVerifier {
+    fn post_migrate_check(&self, store: &BS, actors_out: &StateTree<BS>) -> anyhow::Result<()> {
+        let actors_in = StateTree::new_from_root(Arc::new(store), &self.state_pre)?;
+        let system_actor = actors_in
+            .get_actor(&Address::new_id(0))?
+            .context("failed to get system actor")?;
+
+        let system_actor_state = store
+            .get_cbor::<SystemStateOld>(&system_actor.state)?
+            .context("system actor state not found")?;
+
+        let current_manifest_data = system_actor_state.builtin_actors;
+
+        let current_manifest =
+            BuiltinActorManifest::load_v1_actor_list(store, &current_manifest_data)?;
+
+        actors_in.for_each(|address, actor_in| {
+            let actor_out = actors_out
+                .get_actor(&address)?
+                .context("failed to get actor from state tree")?;
+
+            if actor_in.sequence != actor_out.sequence {
+                bail!(
+                    "actor {address} sequence mismatch: pre-migration: {}, post-migration: {}",
+                    actor_in.sequence,
+                    actor_out.sequence
+                );
+            }
+
+            if actor_in.balance != actor_out.balance {
+                bail!(
+                    "actor {address} balance mismatch: pre-migration: {}, post-migration: {}",
+                    actor_in.balance,
+                    actor_out.balance
+                );
+            }
+
+            if actor_in.state != actor_out.state && actor_in.code != current_manifest.get_system() {
+                bail!(
+                    "actor {address} state mismatch: pre-migration: {}, post-migration: {}",
+                    actor_in.state,
+                    actor_out.state
+                );
+            }
+
+            if actor_in.code != current_manifest.get(BuiltinActor::VerifiedRegistry)?
+                && actor_in.code != actor_out.code
+            {
+                bail!(
+                    "actor {address} code mismatch: pre-migration: {}, post-migration: {}",
+                    actor_in.code,
+                    actor_out.code
+                );
+            }
+
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}
+
+/// Runs the migration for `NV22`. Returns the new state root.
+pub fn run_migration<DB>(
+    chain_config: &ChainConfig,
+    blockstore: &Arc<DB>,
+    state: &Cid,
+    epoch: ChainEpoch,
+) -> anyhow::Result<Cid>
+where
+    DB: Blockstore + Send + Sync,
+{
+    assert!(
+        chain_config.network == NetworkChain::Calibnet,
+        "NV22fix only supported on Calibnet"
+    );
+
+    let new_manifest_cid = chain_config
+        .height_infos
+        .get(&Height::DragonFix)
+        .context("no height info for network version NV22")?
+        .bundle
+        .as_ref()
+        .context("no bundle for network version NV22")?;
+
+    blockstore.get(new_manifest_cid)?.context(format!(
+        "manifest for network version NV22fix not found in blockstore: {new_manifest_cid}"
+    ))?;
+
+    // Add migration specification verification
+    let verifier = Arc::new(Verifier::default());
+
+    let new_manifest = BuiltinActorManifest::load_manifest(blockstore, new_manifest_cid)?;
+    let mut migration = StateMigration::<DB>::new(Some(verifier));
+    migration.add_nv22fix_migrations(blockstore, state, &new_manifest)?;
+    migration.add_post_migration_check(Arc::new(PostMigrationVerifier { state_pre: *state }));
+
+    let actors_in = StateTree::new_from_root(blockstore.clone(), state)?;
+    let actors_out = StateTree::new(blockstore.clone(), StateTreeVersion::V5)?;
+    let new_state = migration.migrate_state_tree(blockstore, epoch, actors_in, actors_out)?;
+
+    Ok(new_state)
+}

--- a/src/state_migration/nv22fix/mod.rs
+++ b/src/state_migration/nv22fix/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! This module contains the fix logic for the `NV22` calibration network fix.
+//! The corresponding Go implementation can be found here:
+//! <https://github.com/filecoin-project/lotus/pull/11776>.
+mod migration;
+
+/// Run migration for `NV22fix`. This should be the only exported method in this
+/// module.
+pub use migration::run_migration;
+
+use crate::{define_system_states, impl_system, impl_verifier};
+
+define_system_states!(
+    fil_actor_system_state::v13::State,
+    fil_actor_system_state::v13::State
+);
+
+impl_system!();
+impl_verifier!();


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:
- add NV22 fix upgrade,
- manually tested post-migration conformance with Lotus.

Forest:
```
2024-03-27T14:45:19.127400Z  INFO compute_tipset_state_blocking: forest_filecoin::state_migration: State migration at height DragonFix(epoch 1473980) was successful, Previous state: bafy2bzacea4gv5rrhavhsxfwvtd6xdbktcc34h75s4puu3bdjyzmn36gqt4w4, new state: bafy2bzaceby523wwqi5pdel7waavlkre55fb2ibvzelpkrx2igujcpdj2kq6g, new state actors: bafy2bzacebmbknorvnryliwnjeclqgukabceqccwxjkpsfdn66wzu2vqbkauy. Took: 0.5127817s.
```
Lotus:
```
2024-03-27T15:16:03.112+0100    WARN    statemgr        stmgr/forks.go:206      COMPLETED migration     {"height": "1473980", "from": "bafy2bzacea4gv5rrhavhsxfwvtd6xdbktcc34h75s4puu3bdjyzmn36gqt4w4", "to": "bafy2bzaceby523wwqi5pdel7waavlkre55fb2ibvzelpkrx2igujcpdj2kq6g", "duration": 4.202396948}
```

```
bafy2bzaceby523wwqi5pdel7waavlkre55fb2ibvzelpkrx2igujcpdj2kq6g ==
bafy2bzaceby523wwqi5pdel7waavlkre55fb2ibvzelpkrx2igujcpdj2kq6g
```
## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

See https://github.com/filecoin-project/lotus/pull/11776 for the corresponding PR on the Lotus side.

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
