### PR TITLE
fix(test): improve rpc test stability

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - |
         set -euxo pipefail
         forest-tool api serve $(ls /data/*.car.zst | tail -n 1) \
-          --chain calibnet --port ${FOREST_OFFLINE_RPC_PORT}
+          --chain calibnet --height=-20 --port ${FOREST_OFFLINE_RPC_PORT}
   lotus:
     depends_on:
       init:
@@ -91,8 +91,7 @@ services:
     command:
       - |
         set -euxo pipefail
-        lotus daemon --remove-existing-chain --halt-after-import --import-snapshot $(ls /data/*.car.zst | tail -n 1)
-        lotus daemon
+        lotus daemon --remove-existing-chain --import-snapshot $(ls /data/*.car.zst | tail -n 1)
   lotus-sync-wait:
     depends_on:
       lotus:
@@ -113,8 +112,11 @@ services:
         until lotus chain head; do
             sleep 5
         done
+        # `sethead` right after `sync wait` to ensure the head is not set in middle of a sync
+        lotus sync wait
         FULLNODE_API_INFO="$(cat /var/lib/lotus/token):/dns/lotus/tcp/${LOTUS_RPC_PORT}/http"
         lotus chain sethead --epoch $(($(ls /data/*.car.zst | tail -n 1 | grep -Eo '[0-9]+' | tail -n 1) - 20))
+        # wait for 30s to make sure the re-validation starts
         sleep 30
         lotus sync wait
   api-compare:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

There's some race condition in the current setup where `lotus chain sethead` does not work properly. 

Changes introduced in this pull request:

- run `lotus chain sethead` right after `lotus sync wait` to make sure it's not in middle of a sync so that it re-validates tipsets since the new head (to generate the missing message receipts for RPC tests)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
