### PR TITLE
feat: log inner error in additon to the context

### DIFF
--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -37,8 +37,9 @@ use crate::shim::{
 };
 use crate::state_manager::chain_rand::draw_randomness;
 use crate::state_migration::run_state_migrations;
+use crate::utils::error::Context2 as _;
 use ahash::{HashMap, HashMapExt};
-use anyhow::{bail, Context as _};
+use anyhow::bail;
 use bls_signatures::{PublicKey as BlsPublicKey, Serialize as _};
 use chain_rand::ChainRand;
 use cid::Cid;

--- a/src/utils/error/context2/implementation.rs
+++ b/src/utils/error/context2/implementation.rs
@@ -1,0 +1,42 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::Context2;
+use std::{convert::Infallible, fmt::Display};
+
+impl<T> Context2<T, Infallible> for Option<T> {
+    fn context<C>(self, context: C) -> anyhow::Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+    {
+        self.ok_or_else(|| anyhow::anyhow!("{context}"))
+    }
+
+    fn with_context<C, F>(self, context: F) -> anyhow::Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+        F: FnOnce() -> C,
+    {
+        self.ok_or_else(|| anyhow::anyhow!("{}", context()))
+    }
+}
+
+impl<T, E> Context2<T, E> for Result<T, E>
+where
+    E: Display,
+{
+    fn context<C>(self, context: C) -> anyhow::Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+    {
+        self.map_err(|e| anyhow::anyhow!("{context}: {e}"))
+    }
+
+    fn with_context<C, F>(self, context: F) -> anyhow::Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+        F: FnOnce() -> C,
+    {
+        self.map_err(|e| anyhow::anyhow!("{}: {e}", context()))
+    }
+}

--- a/src/utils/error/context2/mod.rs
+++ b/src/utils/error/context2/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::fmt::Display;
+
+mod implementation;
+
+pub trait Context2<T, E> {
+    /// Wrap the error value with additional context.
+    fn context<C>(self, context: C) -> anyhow::Result<T>
+    where
+        C: Display + Send + Sync + 'static;
+
+    /// Wrap the error value with additional context that is evaluated lazily
+    /// only once an error does occur.
+    fn with_context<C, F>(self, f: F) -> anyhow::Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+        F: FnOnce() -> C;
+}

--- a/src/utils/error/mod.rs
+++ b/src/utils/error/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+mod context2;
+pub use context2::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@
 pub mod cid;
 pub mod db;
 pub mod encoding;
+pub mod error;
 pub mod io;
 pub mod misc;
 pub mod monitoring;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

`anyhow::Context` provides a convenient way of wrapping the error with some context text, and the inner text is present in stack trace when the final error is unwrapped. However, In a long-running service like forest, most of the errors are logged with `tracing` instead of being unwrapped. In this case, unless the debug formatting(`"{error:?}"`) is specified, the inner errors which are quite helpful for troubleshooting in many cases are not present in the log text. To fix the issue, we could 
1. specify debug formatting
2. make a simple wrapper of `.map_err`.

This PR tries to implement the 2nd solution above.

Changes introduced in this pull request:

- Introduce `crate::error::Context2` as a drop-in replacement of `anyhow::Context`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
