### PR TITLE
refactor: migrate mpool_api to use trait RpcMethod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -569,7 +569,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1142,7 +1142,7 @@ checksum = "6be9c93793b60dac381af475b98634d4b451e28336e72218cad9a20176218dbc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "synstructure 0.13.1",
 ]
 
@@ -1237,7 +1237,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1456,7 +1456,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1468,7 +1468,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2004,7 +2004,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2063,7 +2063,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2085,7 +2085,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2145,7 +2145,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2203,7 +2203,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2214,7 +2214,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2336,7 +2336,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2486,7 +2486,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2635,7 +2635,7 @@ checksum = "ce8cd46a041ad005ab9c71263f9a0ff5b529eac0fe4cc9b4a20f4f0765d8cf4b"
 dependencies = [
  "execute-command-tokens",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3344,7 +3344,7 @@ dependencies = [
  "statrs",
  "strum",
  "strum_macros",
- "syn 2.0.57",
+ "syn 2.0.58",
  "tabled",
  "tap",
  "tar",
@@ -3579,7 +3579,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4109,7 +4109,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4145,9 +4145,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -4669,7 +4669,7 @@ checksum = "d2abdd3a62551e8337af119c5899e600ca0c88ec8f23a46c60ba216c803dcf1a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5676,7 +5676,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6307,9 +6307,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
 dependencies = [
  "async-io 1.13.0",
  "bytes",
@@ -6461,7 +6461,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6534,7 +6534,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6855,7 +6855,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6884,7 +6884,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7215,7 +7215,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7261,7 +7261,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7691,9 +7691,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "regress"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06f9a1f7cd8473611ba1a480cf35f9c5cffc2954336ba90a982fdb7e7d7f51e"
+checksum = "0eae2a1ebfecc58aff952ef8ccd364329abe627762f5bf09ff42eb9d98522479"
 dependencies = [
  "hashbrown 0.14.3",
  "memchr",
@@ -8240,7 +8240,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8295,7 +8295,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8367,7 +8367,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8577,7 +8577,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8866,9 +8866,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structmeta"
@@ -8879,7 +8879,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8890,7 +8890,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8912,7 +8912,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8934,9 +8934,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8975,7 +8975,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9102,7 +9102,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9276,7 +9276,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9862,7 +9862,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -9896,7 +9896,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10170,7 +10170,7 @@ checksum = "ca7af9bb3ee875c4907835e607a275d10b04d15623d3aebe01afe8fbd3f85050"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -10638,7 +10638,7 @@ checksum = "9e6936f0cce458098a201c245a11bef556c6a0181129c7034d10d76d1ec3a2b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "synstructure 0.13.1",
 ]
 
@@ -10659,7 +10659,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -10679,7 +10679,7 @@ checksum = "e6a647510471d372f2e6c2e6b7219e44d8c574d24fdc11c610a61455782f18c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "synstructure 0.13.1",
 ]
 
@@ -10700,7 +10700,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -10722,7 +10722,7 @@ checksum = "7b4e5997cbf58990550ef1f0e5124a05e47e1ebd33a84af25739be6031a62c20"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/src/rpc/auth_layer.rs
+++ b/src/rpc/auth_layer.rs
@@ -1,12 +1,14 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use super::RpcMethod as _;
 use crate::auth::{verify_token, JWT_IDENTIFIER};
 use crate::key_management::KeyStore;
 use crate::rpc::{
     auth_api, beacon_api, chain_api, common_api, eth_api, gas_api, mpool_api, net_api, node_api,
     state_api, sync_api, wallet_api, CANCEL_METHOD_NAME,
 };
+use ahash::{HashMap, HashMapExt as _};
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use hyper::header::{HeaderValue, AUTHORIZATION};
@@ -14,13 +16,11 @@ use hyper::HeaderMap;
 use jsonrpsee::server::middleware::rpc::RpcServiceT;
 use jsonrpsee::types::{error::ErrorCode, ErrorObject};
 use jsonrpsee::MethodResponse;
+use once_cell::sync::Lazy;
+use std::sync::Arc;
 use tokio::sync::RwLock;
 use tower::Layer;
 use tracing::debug;
-
-use ahash::{HashMap, HashMapExt as _};
-use once_cell::sync::Lazy;
-use std::sync::Arc;
 
 /// Access levels to be checked against JWT claims
 enum Access {
@@ -63,7 +63,7 @@ static ACCESS_MAP: Lazy<HashMap<&str, Access>> = Lazy::new(|| {
     access.insert(chain_api::CHAIN_GET_PARENT_RECEIPTS, Access::Read);
 
     // Message Pool API
-    access.insert(mpool_api::MPOOL_GET_NONCE, Access::Read);
+    access.insert(mpool_api::MpoolGetNonce::NAME, Access::Read);
     access.insert(mpool_api::MPOOL_PENDING, Access::Read);
     access.insert(mpool_api::MPOOL_PUSH, Access::Write);
     access.insert(mpool_api::MPOOL_PUSH_MESSAGE, Access::Sign);

--- a/src/rpc/auth_layer.rs
+++ b/src/rpc/auth_layer.rs
@@ -66,7 +66,7 @@ static ACCESS_MAP: Lazy<HashMap<&str, Access>> = Lazy::new(|| {
     access.insert(mpool_api::MpoolGetNonce::NAME, Access::Read);
     access.insert(mpool_api::MpoolPending::NAME, Access::Read);
     access.insert(mpool_api::MpoolPush::NAME, Access::Write);
-    access.insert(mpool_api::MPOOL_PUSH_MESSAGE, Access::Sign);
+    access.insert(mpool_api::MpoolPushMessage::NAME, Access::Sign);
 
     // Sync API
     access.insert(sync_api::SYNC_CHECK_BAD, Access::Read);

--- a/src/rpc/auth_layer.rs
+++ b/src/rpc/auth_layer.rs
@@ -65,7 +65,7 @@ static ACCESS_MAP: Lazy<HashMap<&str, Access>> = Lazy::new(|| {
     // Message Pool API
     access.insert(mpool_api::MpoolGetNonce::NAME, Access::Read);
     access.insert(mpool_api::MpoolPending::NAME, Access::Read);
-    access.insert(mpool_api::MPOOL_PUSH, Access::Write);
+    access.insert(mpool_api::MpoolPush::NAME, Access::Write);
     access.insert(mpool_api::MPOOL_PUSH_MESSAGE, Access::Sign);
 
     // Sync API

--- a/src/rpc/auth_layer.rs
+++ b/src/rpc/auth_layer.rs
@@ -64,7 +64,7 @@ static ACCESS_MAP: Lazy<HashMap<&str, Access>> = Lazy::new(|| {
 
     // Message Pool API
     access.insert(mpool_api::MpoolGetNonce::NAME, Access::Read);
-    access.insert(mpool_api::MPOOL_PENDING, Access::Read);
+    access.insert(mpool_api::MpoolPending::NAME, Access::Read);
     access.insert(mpool_api::MPOOL_PUSH, Access::Write);
     access.insert(mpool_api::MPOOL_PUSH_MESSAGE, Access::Sign);
 

--- a/src/rpc/chain_api.rs
+++ b/src/rpc/chain_api.rs
@@ -15,10 +15,7 @@ use crate::lotus_json::LotusJson;
 use crate::lotus_json::{assert_all_snapshots, assert_unchanged_via_json};
 use crate::message::ChainMessage;
 use crate::rpc::types::{ApiHeadChange, ApiMessage, ApiReceipt, ApiTipsetKey, BlockMessages};
-use crate::rpc::{
-    error::JsonRpcError,
-    reflect::{Ctx, RpcMethod},
-};
+use crate::rpc::{error::JsonRpcError, Ctx, RpcMethod};
 use crate::shim::clock::ChainEpoch;
 use crate::shim::message::Message;
 use crate::utils::io::VoidAsyncWriter;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -219,7 +219,6 @@ where
     module.register_async_method(CHAIN_GET_PARENT_MESSAGES, chain_get_parent_messages::<DB>)?;
     module.register_async_method(CHAIN_GET_PARENT_RECEIPTS, chain_get_parent_receipts::<DB>)?;
     // Message Pool API
-    module.register_async_method(MPOOL_PENDING, mpool_pending::<DB>)?;
     module.register_async_method(MPOOL_PUSH, mpool_push::<DB>)?;
     module.register_async_method(MPOOL_PUSH_MESSAGE, mpool_push_message::<DB>)?;
     // Sync API

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -164,7 +164,7 @@ where
 {
     let mut module = reflect::SelfDescribingRpcModule::new(state, ParamStructure::ByPosition);
     ChainGetPath::register(&mut module);
-    mpool_api::register(&mut module);
+    mpool_api::register_all(&mut module);
     module.finish()
 }
 
@@ -184,7 +184,6 @@ where
     use common_api::*;
     use eth_api::*;
     use gas_api::*;
-    use mpool_api::*;
     use net_api::*;
     use node_api::*;
     use sync_api::*;
@@ -218,8 +217,6 @@ where
     )?;
     module.register_async_method(CHAIN_GET_PARENT_MESSAGES, chain_get_parent_messages::<DB>)?;
     module.register_async_method(CHAIN_GET_PARENT_RECEIPTS, chain_get_parent_receipts::<DB>)?;
-    // Message Pool API
-    module.register_async_method(MPOOL_PUSH_MESSAGE, mpool_push_message::<DB>)?;
     // Sync API
     module.register_async_method(SYNC_CHECK_BAD, sync_check_bad::<DB>)?;
     module.register_async_method(SYNC_MARK_BAD, sync_mark_bad::<DB>)?;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -21,7 +21,7 @@ pub mod wallet_api;
 // Other RPC-specific modules
 pub use error::JsonRpcError;
 use reflect::Ctx;
-pub use reflect::RpcMethodExt;
+pub use reflect::{RpcMethod, RpcMethodExt};
 mod error;
 mod reflect;
 pub mod types;
@@ -164,6 +164,7 @@ where
 {
     let mut module = reflect::SelfDescribingRpcModule::new(state, ParamStructure::ByPosition);
     ChainGetPath::register(&mut module);
+    mpool_api::register(&mut module);
     module.finish()
 }
 
@@ -218,7 +219,6 @@ where
     module.register_async_method(CHAIN_GET_PARENT_MESSAGES, chain_get_parent_messages::<DB>)?;
     module.register_async_method(CHAIN_GET_PARENT_RECEIPTS, chain_get_parent_receipts::<DB>)?;
     // Message Pool API
-    module.register_async_method(MPOOL_GET_NONCE, mpool_get_nonce::<DB>)?;
     module.register_async_method(MPOOL_PENDING, mpool_pending::<DB>)?;
     module.register_async_method(MPOOL_PUSH, mpool_push::<DB>)?;
     module.register_async_method(MPOOL_PUSH_MESSAGE, mpool_push_message::<DB>)?;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -219,7 +219,6 @@ where
     module.register_async_method(CHAIN_GET_PARENT_MESSAGES, chain_get_parent_messages::<DB>)?;
     module.register_async_method(CHAIN_GET_PARENT_RECEIPTS, chain_get_parent_receipts::<DB>)?;
     // Message Pool API
-    module.register_async_method(MPOOL_PUSH, mpool_push::<DB>)?;
     module.register_async_method(MPOOL_PUSH_MESSAGE, mpool_push_message::<DB>)?;
     // Sync API
     module.register_async_method(SYNC_CHECK_BAD, sync_check_bad::<DB>)?;

--- a/src/rpc/mpool_api.rs
+++ b/src/rpc/mpool_api.rs
@@ -1,8 +1,5 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
-#![allow(clippy::unused_async)]
-
-use std::convert::TryFrom;
 
 use super::gas_api::estimate_message_gas;
 use super::RPCState;
@@ -15,8 +12,7 @@ use crate::shim::{
     address::{Address, Protocol},
     message::Message,
 };
-use ahash::{HashSet, HashSetExt};
-use anyhow::Result;
+use ahash::{HashSet, HashSetExt as _};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 

--- a/src/rpc/snapshots/forest_filecoin__rpc__tests__openrpc.snap
+++ b/src/rpc/snapshots/forest_filecoin__rpc__tests__openrpc.snap
@@ -22,6 +22,125 @@ methods:
           $ref: "#/components/schemas/PathChange_for_TipsetLotusJson"
         nullable: true
       required: true
+  - name: Filecoin.MpoolGetNonce
+    params:
+      - name: address
+        schema:
+          type: string
+        required: true
+    paramStructure: by-position
+    result:
+      name: "Filecoin.MpoolGetNonce::Result"
+      schema:
+        type: integer
+        format: uint64
+        minimum: 0
+      required: true
+  - name: Filecoin.MpoolPending
+    params:
+      - name: tsk
+        schema:
+          type: array
+          items:
+            $ref: "#/components/schemas/CidLotusJsonGeneric_for_64"
+          nullable: true
+        required: true
+    paramStructure: by-position
+    result:
+      name: "Filecoin.MpoolPending::Result"
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/SignedMessageLotusJson"
+        nullable: true
+      required: true
+  - name: Filecoin.MpoolPush
+    params:
+      - name: msg
+        schema:
+          type: object
+          required:
+            - Message
+            - Signature
+          properties:
+            CID:
+              $ref: "#/components/schemas/Nullable_CidLotusJsonGeneric_for_64"
+            Message:
+              $ref: "#/components/schemas/MessageLotusJson"
+            Signature:
+              $ref: "#/components/schemas/SignatureLotusJson"
+        required: true
+    paramStructure: by-position
+    result:
+      name: "Filecoin.MpoolPush::Result"
+      schema:
+        type: object
+        required:
+          - /
+        properties:
+          /:
+            $ref: "#/components/schemas/String"
+      required: true
+  - name: Filecoin.MpoolPushMessage
+    params:
+      - name: usmg
+        schema:
+          type: object
+          required:
+            - From
+            - GasFeeCap
+            - GasLimit
+            - GasPremium
+            - Method
+            - Nonce
+            - To
+            - Value
+            - Version
+          properties:
+            CID:
+              $ref: "#/components/schemas/Nullable_CidLotusJsonGeneric_for_64"
+            From:
+              $ref: "#/components/schemas/String"
+            GasFeeCap:
+              $ref: "#/components/schemas/String"
+            GasLimit:
+              $ref: "#/components/schemas/uint64"
+            GasPremium:
+              $ref: "#/components/schemas/String"
+            Method:
+              $ref: "#/components/schemas/uint64"
+            Nonce:
+              $ref: "#/components/schemas/uint64"
+            Params:
+              $ref: "#/components/schemas/Nullable_VecU8LotusJson"
+            To:
+              $ref: "#/components/schemas/String"
+            Value:
+              $ref: "#/components/schemas/String"
+            Version:
+              $ref: "#/components/schemas/uint64"
+        required: true
+      - name: spec
+        schema:
+          $ref: "#/components/schemas/MessageSendSpec"
+          nullable: true
+        required: false
+    paramStructure: by-position
+    result:
+      name: "Filecoin.MpoolPushMessage::Result"
+      schema:
+        type: object
+        required:
+          - Message
+          - Signature
+        properties:
+          CID:
+            $ref: "#/components/schemas/Nullable_CidLotusJsonGeneric_for_64"
+          Message:
+            $ref: "#/components/schemas/MessageLotusJson"
+          Signature:
+            $ref: "#/components/schemas/SignatureLotusJson"
+      required: true
 components:
   schemas:
     CidLotusJsonGeneric_for_64:
@@ -31,6 +150,54 @@ components:
       properties:
         /:
           $ref: "#/components/schemas/String"
+    MessageLotusJson:
+      type: object
+      required:
+        - From
+        - GasFeeCap
+        - GasLimit
+        - GasPremium
+        - Method
+        - Nonce
+        - To
+        - Value
+        - Version
+      properties:
+        CID:
+          $ref: "#/components/schemas/Nullable_CidLotusJsonGeneric_for_64"
+        From:
+          $ref: "#/components/schemas/String"
+        GasFeeCap:
+          $ref: "#/components/schemas/String"
+        GasLimit:
+          $ref: "#/components/schemas/uint64"
+        GasPremium:
+          $ref: "#/components/schemas/String"
+        Method:
+          $ref: "#/components/schemas/uint64"
+        Nonce:
+          $ref: "#/components/schemas/uint64"
+        Params:
+          $ref: "#/components/schemas/Nullable_VecU8LotusJson"
+        To:
+          $ref: "#/components/schemas/String"
+        Value:
+          $ref: "#/components/schemas/String"
+        Version:
+          $ref: "#/components/schemas/uint64"
+    MessageSendSpec:
+      type: object
+      required:
+        - MaxFee
+      properties:
+        MaxFee:
+          $ref: "#/components/schemas/String"
+    Nullable_CidLotusJsonGeneric_for_64:
+      $ref: "#/components/schemas/CidLotusJsonGeneric_for_64"
+      nullable: true
+    Nullable_VecU8LotusJson:
+      $ref: "#/components/schemas/VecU8LotusJson"
+      nullable: true
     PathChange_for_TipsetLotusJson:
       oneOf:
         - type: object
@@ -47,6 +214,39 @@ components:
             apply:
               $ref: "#/components/schemas/TipsetLotusJson"
           additionalProperties: false
+    SignatureLotusJson:
+      type: object
+      required:
+        - Data
+        - Type
+      properties:
+        Data:
+          $ref: "#/components/schemas/VecU8LotusJson2"
+        Type:
+          $ref: "#/components/schemas/SignatureTypeLotusJson"
+    SignatureType:
+      description: Signature variants for Filecoin signatures.
+      type: string
+      enum:
+        - Secp256k1
+        - Bls
+        - Delegated
+    SignatureTypeLotusJson:
+      anyOf:
+        - $ref: "#/components/schemas/SignatureType"
+        - $ref: "#/components/schemas/String"
+    SignedMessageLotusJson:
+      type: object
+      required:
+        - Message
+        - Signature
+      properties:
+        CID:
+          $ref: "#/components/schemas/Nullable_CidLotusJsonGeneric_for_64"
+        Message:
+          $ref: "#/components/schemas/MessageLotusJson"
+        Signature:
+          $ref: "#/components/schemas/SignatureLotusJson"
     String:
       type: string
     TipsetKeyLotusJson:
@@ -64,6 +264,14 @@ components:
           $ref: "#/components/schemas/TipsetKeyLotusJson"
         Height:
           $ref: "#/components/schemas/int64"
+    VecU8LotusJson:
+      $ref: "#/components/schemas/encoded binary"
+      nullable: true
+    VecU8LotusJson2:
+      $ref: "#/components/schemas/encoded binary"
+      nullable: true
+    encoded binary:
+      type: string
     "forest_filecoin::lotus_json::block_header::BlockHeaderLotusJson":
       type: array
       items:
@@ -77,3 +285,7 @@ components:
     int64:
       type: integer
       format: int64
+    uint64:
+      type: integer
+      format: uint64
+      minimum: 0

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -5,8 +5,6 @@
 //!
 //! If a type here is used by only one API, it should be relocated.
 
-use std::str::FromStr;
-
 use crate::beacon::BeaconEntry;
 use crate::blocks::{CachingBlockHeader, TipsetKey};
 use crate::chain_sync::SyncState;
@@ -43,8 +41,10 @@ use libipld_core::ipld::Ipld;
 use libp2p::PeerId;
 use nonempty::NonEmpty;
 use num_bigint::BigInt;
+use schemars::JsonSchema;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use std::str::FromStr;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
@@ -68,11 +68,10 @@ pub struct BlockMessages {
 
 lotus_json_with_self!(BlockMessages);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct MessageSendSpec {
-    #[serde(with = "crate::lotus_json")]
-    max_fee: TokenAmount,
+    max_fee: LotusJson<TokenAmount>,
 }
 
 lotus_json_with_self!(MessageSendSpec);

--- a/src/rpc_client/mpool_ops.rs
+++ b/src/rpc_client/mpool_ops.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::{
-    message::SignedMessage, rpc::mpool_api::*, rpc::types::MessageSendSpec, shim::address::Address,
-    shim::message::Message,
+    message::SignedMessage,
+    rpc::{mpool_api::*, types::MessageSendSpec, RpcMethod as _},
+    shim::{address::Address, message::Message},
 };
 use cid::Cid;
 
@@ -11,7 +12,7 @@ use super::{ApiInfo, JsonRpcError, RpcRequest};
 
 impl ApiInfo {
     pub fn mpool_get_nonce_req(addr: Address) -> RpcRequest<u64> {
-        RpcRequest::new(MPOOL_GET_NONCE, (addr,))
+        RpcRequest::new(MpoolGetNonce::NAME, (addr,))
     }
 
     pub async fn mpool_push_message(

--- a/src/rpc_client/mpool_ops.rs
+++ b/src/rpc_client/mpool_ops.rs
@@ -28,7 +28,7 @@ impl ApiInfo {
         message: Message,
         specs: Option<MessageSendSpec>,
     ) -> RpcRequest<SignedMessage> {
-        RpcRequest::new(MPOOL_PUSH_MESSAGE, (message, specs))
+        RpcRequest::new(MpoolPushMessage::NAME, (message, specs))
     }
 
     pub async fn mpool_pending(&self, cids: Vec<Cid>) -> Result<Vec<SignedMessage>, JsonRpcError> {

--- a/src/rpc_client/mpool_ops.rs
+++ b/src/rpc_client/mpool_ops.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     message::SignedMessage,
-    rpc::{mpool_api::*, types::MessageSendSpec, RpcMethod as _},
+    rpc::{mpool_api::*, types::MessageSendSpec, RpcMethod},
     shim::{address::Address, message::Message},
 };
 use cid::Cid;
@@ -36,6 +36,6 @@ impl ApiInfo {
     }
 
     pub fn mpool_pending_req(cids: Vec<Cid>) -> RpcRequest<Vec<SignedMessage>> {
-        RpcRequest::new(MPOOL_PENDING, (cids,))
+        RpcRequest::new(MpoolPending::NAME, (cids,))
     }
 }


### PR DESCRIPTION
## Summary of changes

I need a full API example to continue prototyping the client.
The mpool API is ideal for this:
- relatively small
- used in `forest-tool api compare`
- used in `forest-cli` subcommands

Changes introduced in this pull request:
- See title

## Other information and links
#4032 

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
