### PR TITLE
fix agent version cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
 ### Fixed
 
+- [#4145](https://github.com/ChainSafe/forest/pull/4145) Fix the
+  `forest-cli net peers --agent` command in case the agent is not available.
+
 ## Forest 0.17.1 "Villentretenmerth"
 
 This is a mandatory release that includes scheduled migration for the NV22

--- a/src/cli/subcommands/net_cmd.rs
+++ b/src/cli/subcommands/net_cmd.rs
@@ -71,7 +71,7 @@ impl NetCommands {
                     )
                     .await
                     .into_iter()
-                    .collect::<Result<Vec<_>, _>>()?;
+                    .map(|res| res.unwrap_or_else(|_| "<agent unknown>".to_owned()));
 
                     HashMap::from_iter(
                         addrs

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -30,7 +30,7 @@ use jsonrpsee::{
 };
 use serde::de::IntoDeserializer;
 use serde::Deserialize;
-use tracing::{debug, error};
+use tracing::debug;
 
 pub const API_INFO_KEY: &str = "FULLNODE_API_INFO";
 pub const DEFAULT_HOST: &str = "127.0.0.1";
@@ -158,10 +158,6 @@ impl ApiInfo {
                 }
             }
         };
-
-        if let Err(err) = &result {
-            error!("Failure: {}\n{request_log}", err.message());
-        }
 
         result
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fixes `forest-cli net agent --version`

Before:
```
❯ forest-cli net peers --agent
2024-04-04T13:23:22.785489Z ERROR forest_filecoin::rpc_client: Failure: ErrorObject { code: InternalError, message: "item not found", data: None }
JSON-RPC request URL: http://127.0.0.1:2345/rpc/v0, payload: {"jsonrpc":"2.0","id":0,"method":"Filecoin.NetAgentVersion","params":["12D3KooWJfKFjE7ZEEx9DQRETWnMe9iiDMYavWMgfbBe6456Cw2x"]}
2024-04-04T13:23:22.785552Z ERROR forest_filecoin::rpc_client: Failure: ErrorObject { code: InternalError, message: "item not found", data: None }
JSON-RPC request URL: http://127.0.0.1:2345/rpc/v0, payload: {"jsonrpc":"2.0","id":0,"method":"Filecoin.NetAgentVersion","params":["12D3KooWE46Q9NivpjELBV42VYNt7xS41vce9PNte2vEMbBg2LmA"]}
Error: JSON-RPC error:
        code: -32700
        message: ErrorObject { code: InternalError, message: "item not found", data: None }
```

After (but still with error logging in `call`)
```
2024-04-04T13:27:16.447605Z ERROR forest_filecoin::rpc_client: Failure: ErrorObject { code: InternalError, message: "item not found", data: None }
JSON-RPC request URL: http://127.0.0.1:2345/rpc/v0, payload: {"jsonrpc":"2.0","id":0,"method":"Filecoin.NetAgentVersion","params":["12D3KooWBtq3ra76pizZzP8GWJDrPk3kNyxdFE4MNBrmK8k7c1Yh"]}
2024-04-04T13:27:16.447695Z ERROR forest_filecoin::rpc_client: Failure: ErrorObject { code: InternalError, message: "item not found", data: None }
JSON-RPC request URL: http://127.0.0.1:2345/rpc/v0, payload: {"jsonrpc":"2.0","id":0,"method":"Filecoin.NetAgentVersion","params":["12D3KooWAaLcUY5BLpuq5NCGM4EnfdrPDHdM4PpsFtgqD3aERiyU"]}
2024-04-04T13:27:16.447735Z ERROR forest_filecoin::rpc_client: Failure: ErrorObject { code: InternalError, message: "item not found", data: None }
JSON-RPC request URL: http://127.0.0.1:2345/rpc/v0, payload: {"jsonrpc":"2.0","id":0,"method":"Filecoin.NetAgentVersion","params":["12D3KooWDeCxp4tFowcfVLpBuwA2BEpoeDLczrB8Zps6MNdfaq5o"]}
2024-04-04T13:27:16.447770Z ERROR forest_filecoin::rpc_client: Failure: ErrorObject { code: InternalError, message: "item not found", data: None }
JSON-RPC request URL: http://127.0.0.1:2345/rpc/v0, payload: {"jsonrpc":"2.0","id":0,"method":"Filecoin.NetAgentVersion","params":["12D3KooWLqikc8K1nKt1wfMqe4scPftExtoP37bmGxxUqdbTiP2Y"]}
2024-04-04T13:27:16.447780Z ERROR forest_filecoin::rpc_client: Failure: ErrorObject { code: InternalError, message: "item not found", data: None }
JSON-RPC request URL: http://127.0.0.1:2345/rpc/v0, payload: {"jsonrpc":"2.0","id":0,"method":"Filecoin.NetAgentVersion","params":["12D3KooWMMmu9YTxFhyR6VAHSxDJdZrWu6jaqAXppW2sRWVMpq9s"]}
12D3KooWD8nCWRtDRRkkKYasRAncoGedSC64UP8hEdM53cyx7oMz, [/ip4/183.60.90.197/tcp/41459/p2p/12D3KooWD8nCWRtDRRkkKYasRAncoGedSC64UP8hEdM53cyx7oMz], lotus-1.25.1+mainnet+oplian.1.5
12D3KooWFPfQbEVEXjTAMW1wYp6Ls2tEP8nwNmU1ow8pXQaqQRBf, [/ip4/80.81.16.129/tcp/63764/p2p/12D3KooWFPfQbEVEXjTAMW1wYp6Ls2tEP8nwNmU1ow8pXQaqQRBf], lotus-1.26.0+mainnet+git.0cdf58849
12D3KooWJvVU53DSyAcU57yczFFyD3vcS9fivEqje5tfahSSubAk, [/ip4/39.109.85.8/tcp/63759/p2p/12D3KooWJvVU53DSyAcU57yczFFyD3vcS9fivEqje5tfahSSubAk], lotus-1.25.0+mainnet+git.89129ac1a
12D3KooWDMg9rANGKkXPU6tgPXCUcGcYuca4sjgdBuvEf3wmBGE2, [/ip4/113.219.198.16/tcp/1413/p2p/12D3KooWDMg9rANGKkXPU6tgPXCUcGcYuca4sjgdBuvEf3wmBGE2], lotus-lianjing 1.26.1+mainnet+git.9dc9a5cf4.1711706469
12D3KooWJ9UnUbnrdMftReGUdP1hTystJSJrUb7GepFMb1FYEiCz, [/ip4/103.65.41.195/tcp/51243/p2p/12D3KooWJ9UnUbnrdMftReGUdP1hTystJSJrUb7GepFMb1FYEiCz], lotus-1.25.0+gzbt_cc+git.bd65eacd3.dirty
12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt, [/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt], lotus-1.25.1+main
```

So I also removed that logging part introduced in https://github.com/ChainSafe/forest/pull/4086. `forest-cli` should not be forced to have logs, and there must be a way to suppress them. Printing in the middle of a command is good for the daemon, not elsewhere. `call` callers (he he) should handle the error on their own if needed.

End result
```
12D3KooWArEmyNZ5YBZQGQ2o9YH1Rxr1TKMCA7sfwvpALhhcGxFy, [/ip4/36.189.234.218/tcp/64309/p2p/12D3KooWArEmyNZ5YBZQGQ2o9YH1Rxr1TKMCA7sfwvpALhhcGxFy], lotus-1.26.0+mainnet+git.f7ecfd2c8.dirty.1711975909
12D3KooWHQRSDFv4FvAjtU32shQ7znz7oRbLBryXzZ9NMK2feyyH, [/dns4/bootstrap-mainnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWHQRSDFv4FvAjtU32shQ7znz7oRbLBryXzZ9NMK2feyyH], lotus-1.26.1+mainnet+git.9dc9a5cf4
12D3KooWKKkCZbcigsWTEu1cgNetNbZJqeNtysRtFpq7DTqw3eqH, [/dns4/bootstrap-mainnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWKKkCZbcigsWTEu1cgNetNbZJqeNtysRtFpq7DTqw3eqH], forest-0.17.1+git.eca2bd1
12D3KooWBAfrhnyrabNrxgtLuNSwMQMGyCs2vZXLrSLnjBwgeBbi, [/ip4/39.109.85.8/udp/17041/quic-v1/p2p/12D3KooWBAfrhnyrabNrxgtLuNSwMQMGyCs2vZXLrSLnjBwgeBbi], lotus-1.25.0+mainnet+git.89129ac1a
12D3KooWHr98JrYaJMLmP2zoMy8CEUMFRoJuSbFB7EPiAacHpphr, [/ip4/103.90.153.246/tcp/50241/p2p/12D3KooWHr98JrYaJMLmP2zoMy8CEUMFRoJuSbFB7EPiAacHpphr], lotus-1.25.0+gzbt_cc+git.bd65eacd3.dirty
12D3KooWC6JxRhMvEdEEmn1qp2pjdaTumEgPG5Qr89iE41obaSzf, [/ip4/38.70.220.56/tcp/10201/p2p/12D3KooWC6JxRhMvEdEEmn1qp2pjdaTumEgPG5Qr89iE41obaSzf], boost-1.7.5+git.52f2aa6
12D3KooWJ2kwdmycf1nm64n5pqTXUhHHg8nT1NiHybYvLcH2RZHi, [/ip4/203.176.232.131/tcp/55019/p2p/12D3KooWJ2kwdmycf1nm64n5pqTXUhHHg8nT1NiHybYvLcH2RZHi], lotus-1.25.0+gzbt_cc+git.bd65eacd3.dirty
12D3KooWCNymcW3PNAHeMJBK9indSzH7Dd2m8YUaCnHC6v1Nm57s, [/ip4/113.29.246.210/tcp/18376/p2p/12D3KooWCNymcW3PNAHeMJBK9indSzH7Dd2m8YUaCnHC6v1Nm57s], boost-2.1.1+mainnet+git.e9d18ac
12D3KooWLdPyaQB3KbxKneokXX3KNgQzdKEzQZ6Jh3NTLCXEfM7m, [/ip4/61.155.145.144/tcp/3092/p2p/12D3KooWLdPyaQB3KbxKneokXX3KNgQzdKEzQZ6Jh3NTLCXEfM7m], <agent unknown>
12D3KooW9tMrPeMCwwb2SBCZaMKNDhG9Cyd4S5ViuRVCSE6gnsDB, [/ip4/58.22.103.100/tcp/51235/p2p/12D3KooW9tMrPeMCwwb2SBCZaMKNDhG9Cyd4S5ViuRVCSE6gnsDB], lotus-1.25.1+mainnet+git.40d9eb087.dirty
12D3KooWJff41MgwyHNtFPwgZ8uRoiGwzYTZVHxqHUrJbvkMFDcm, [/ip4/128.136.157.164/tcp/6084/p2p/12D3KooWJff41MgwyHNtFPwgZ8uRoiGwzYTZVHxqHUrJbvkMFDcm], lotus-1.24.1+mainnet+git.f1a115718
12D3KooWGnkd9GQKo3apkShQDaq1d6cKJJmsVe6KiQkacUk1T8oZ, [/dns4/bootstrap-mainnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWGnkd9GQKo3apkShQDaq1d6cKJJmsVe6KiQkacUk1T8oZ], lotus-1.26.1+mainnet+git.9dc9a5cf4
QmQu8C6deXwKvJP2D8B6QGyhngc3ZiDnFzEHBDx8yeBXST, [/dns4/bootstrap-venus.mainnet.filincubator.com/tcp/8888/p2p/QmQu8C6deXwKvJP2D8B6QGyhngc3ZiDnFzEHBDx8yeBXST], venus
12D3KooWPf9ZLeKB8g6Axn1xJWCvUUTwm8KJat3kkPx6Kn9DSAu7, [/ip4/220.195.127.252/tcp/12353/p2p/12D3KooWPf9ZLeKB8g6Axn1xJWCvUUTwm8KJat3kkPx6Kn9DSAu7], lotus-1.24.0+mainnet+git.7c093485c.dirty
12D3KooW9wdBZ1aCi4QMEeMMmXkTfVyJJE3BDrpUA4RmQmnv7Vmf, [/ip4/149.102.100.16/udp/29116/quic-v1/p2p/12D3KooW9wdBZ1aCi4QMEeMMmXkTfVyJJE3BDrpUA4RmQmnv7Vmf], lotus-1.25.3-dev+mainnet+git.b0bc4a963
12D3KooWQiYzpaYB1pXC7htBFfpEuN1XBp9YEddfyeRXx5Z2Vmyg, [/ip4/39.109.85.8/tcp/49752/p2p/12D3KooWQiYzpaYB1pXC7htBFfpEuN1XBp9YEddfyeRXx5Z2Vmyg], lotus-1.25.0+mainnet+git.89129ac1a
12D3KooWM6EzWmykHykwaY5c4Hqb3N5rvQxY5up4bEAzSonSEvHN, [/ip4/72.52.65.165/tcp/26101/p2p/12D3KooWM6EzWmykHykwaY5c4Hqb3N5rvQxY5up4bEAzSonSEvHN], boost-2.1.1+mainnet+git.e9d18ac
12D3KooWKGCcFVSAUXxe7YP62wiwsBvpCmMomnNauJCA67XbmHYj, [/ip4/45.141.104.43/tcp/11337/p2p/12D3KooWKGCcFVSAUXxe7YP62wiwsBvpCmMomnNauJCA67XbmHYj], boost-2.1.1-dukesoft+mainnet+git.2353e45
12D3KooWHXXUqMLAzmy4DNAxinZT7NUdfBZY3dZm8XbjMPpQ8J8w, [/ip4/46.19.166.56/tcp/1413/p2p/12D3KooWHXXUqMLAzmy4DNAxinZT7NUdfBZY3dZm8XbjMPpQ8J8w], lotus-lianjing 1.26.1+mainnet+git.9dc9a5cf4.1711706469
12D3KooWFsgceALC8TXftxMeWHW8iitXXEivVtehqzbkNVnkmz54, [/ip4/220.168.154.97/tcp/12002/p2p/12D3KooWFsgceALC8TXftxMeWHW8iitXXEivVtehqzbkNVnkmz54], <agent unknown>

```
## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
