### PR TITLE
fix(ci): bump lotus-devnet image to 1.26.1

### DIFF
--- a/scripts/devnet/.env
+++ b/scripts/devnet/.env
@@ -1,4 +1,4 @@
-LOTUS_IMAGE=ghcr.io/chainsafe/lotus-devnet:2024-03-22-9a508dc
+LOTUS_IMAGE=ghcr.io/chainsafe/lotus-devnet:2024-04-07-d6d22ca
 FOREST_DATA_DIR=/forest_data
 LOTUS_DATA_DIR=/lotus_data
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters

--- a/scripts/devnet/lotus.dockerfile
+++ b/scripts/devnet/lotus.dockerfile
@@ -1,11 +1,11 @@
 # Lotus binaries image, to be used in the local devnet with Forest.
-FROM golang:1.21.7-bullseye AS lotus-builder
+FROM golang:1.21-bullseye AS lotus-builder
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang ocl-icd-opencl-dev ocl-icd-libopencl1 jq libhwloc-dev 
 
 WORKDIR /lotus
 
-RUN git clone --depth 1 --branch v1.26.0 https://github.com/filecoin-project/lotus.git .
+RUN git clone --depth 1 --branch v1.26.1 https://github.com/filecoin-project/lotus.git .
 
 RUN CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__" \
     CGO_CFLAGS="-D__BLST_PORTABLE__" \


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- bump lotus-devnet image from `1.26.0` to `1.26.1`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
