### PR TITLE
chore(deps): bump reqwest to 0.12 and retire http 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "event-listener-strategy 0.5.1",
  "futures-core",
  "pin-project-lite",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a9249d1447a85f95810c620abea82e001fe58a31713fcce614caf52499f905"
+checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
 dependencies = [
  "futures-core",
  "memchr",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b3e585719c2358d2660232671ca8ca4ddb4be4ce8a1842d6c2dc8685303316"
+checksum = "5f98c37cf288e302c16ef6c8472aad1e034c6c84ce5ea7b8101c98eb4a802fee"
 dependencies = [
  "async-lock 3.3.0",
  "async-task",
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "1fd97381a8cc6493395a5afc4c691c1084b3768db713b73aa215217aa245d153"
 dependencies = [
  "jobserver",
  "libc",
@@ -1545,8 +1545,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
 dependencies = [
  "futures-core",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
  "tonic",
  "tracing-core",
 ]
@@ -1564,7 +1564,7 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "parking_lot",
- "prost-types 0.12.3",
+ "prost-types 0.12.4",
  "serde",
  "serde_json",
  "thread_local",
@@ -2578,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2603,7 +2603,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
 dependencies = [
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "pin-project-lite",
 ]
 
@@ -2716,9 +2716,9 @@ checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "fil_actor_account_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028650dbb1544596ec2f78ec1e663191b2b44d87634f130819ead3e6ef0353cf"
+checksum = "8702734e3c108219a00afc4d9036dcce01f1050e0ab3adb2f7e4aa9f37c56e73"
 dependencies = [
  "frc42_macros",
  "fvm_ipld_encoding",
@@ -2732,9 +2732,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210ace3e982f4bbbd6a3eca18a5b25e6f695d44344d44350e20e34ae7b1c9012"
+checksum = "610fb0f78ebc06393fcfe7f11bc77ba4694302f015ba5efb4614d85df4144614"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
@@ -2747,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ccd11bde82d189430b2e6ec2102f31ff919cabfad573a8cc6d55551b426522"
+checksum = "22f813ed6f52c509b44c2c7e6fee1448b58fe6ab75466c15a05a74186717f7e4"
 dependencies = [
  "fil_actors_shared",
  "frc42_macros",
@@ -2767,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e058f4a7e9cde4226370c6905a97122d9ca620b4e4ddf7d25daa63ab2526b7"
+checksum = "bee7f9fb16b100c239db59363699ddfc591227f1ddff09240db636cd00675433"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -2787,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55ffe39d3109583a8a6a5a00ade278de10cbd51be0317a859f60c3931fb84a1"
+checksum = "a498482d1b58a0afbc300997296f1ceb4145858981d3f7e98a96f459cfd43cb7"
 dependencies = [
  "anyhow",
  "cid",
@@ -2808,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_interface"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580d651f158da2b02bfe4908363e326e03d18a5033d738102af3019ebe3b63d5"
+checksum = "d510d15eb7efcde16d015d84b7833b231f9d4eb94f915077d6dab62070a02a72"
 dependencies = [
  "anyhow",
  "cid",
@@ -2846,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "178685710f049cbdee1abcc25859bfab94899002d0ebc2f3ff4a2b9c3a320eeb"
+checksum = "39438fd8aa63e776eac76286adc63cdfd3f241057c7de257570e71bcaddcc142"
 dependencies = [
  "anyhow",
  "cid",
@@ -2871,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83454bd3c49afcd12ee7b1d5c01dd2cc1fd5269a9b0cf8dbacc32fe5e387076"
+checksum = "76f68460e0a5eeff43f7824c194b58f0c3dcc37a428e0f0a53c34b4ea8012caf"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -2901,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca96c6124d190900a6cc3cc44bab70780b2b2718bb441079bcda7c3c3cbdc4c5"
+checksum = "fc8510f39a289a0c020ff8c862dbd0e95bf58c04a838619f7e2da56e6148165b"
 dependencies = [
  "anyhow",
  "cid",
@@ -2924,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d7d87f50606f088eff9e777b3d67798378700f539710822680b9bc0944088c"
+checksum = "4f82f8d64a2532c8b415e4eb427ec74ce73ec2a87534dadd91822782eeeb4a5b"
 dependencies = [
  "anyhow",
  "cid",
@@ -2947,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae914722ee25fa68f5616a430d65958896f750ed2ba9160938d6029f8b86b285"
+checksum = "923e5ca4d5775a3fe9d0ac1e4350adc854738986851a298b198938459abd5923"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
@@ -2963,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bcfa44cb18581d6d4fb3a7dd7cc532021d102d481d6a80d10997867e8fb27ab"
+checksum = "9e9f12ce8c07009d8892963692262a068184d446f7bafdd0deb0134e98e7a97f"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -2980,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg_state"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf716cdb4ca1943c5c1a1212007fdc487bb7419451980a34a197365b0548e645"
+checksum = "b4068c7f816220a8c5fb5b01bbe87f6f41266c80232211d5536636dfa3909071"
 dependencies = [
  "anyhow",
  "cid",
@@ -3000,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_shared"
-version = "10.1.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d580901129af61cd96a6b7530341c54a7c75b33e52676db4db215706941aaf"
+checksum = "188adedfc79e280e8a70af22c9ea71d381af59033598443b23cf7fcac7ec12ab"
 dependencies = [
  "anyhow",
  "cid",
@@ -3259,7 +3259,6 @@ dependencies = [
  "git-version",
  "group",
  "hex",
- "http 0.2.12",
  "http 1.1.0",
  "http-range-header",
  "human-repr",
@@ -3320,7 +3319,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-automata 0.4.6",
- "reqwest",
+ "reqwest 0.12.3",
  "rlimit",
  "rs-car-ipfs",
  "rustyline",
@@ -4054,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "a06fddc2749e0528d2813f95e050e87e52c8cbbae56223b9babf73b3e53b0cc6"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4164,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -4463,7 +4462,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -4487,6 +4486,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -4501,6 +4501,23 @@ dependencies = [
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "rustls 0.22.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -4522,6 +4539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -4529,6 +4547,9 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4906,7 +4927,7 @@ dependencies = [
  "socket2 0.5.6",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -7230,12 +7251,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
+ "prost-derive 0.12.4",
 ]
 
 [[package]]
@@ -7253,12 +7274,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -7275,11 +7296,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
 dependencies = [
- "prost 0.12.3",
+ "prost 0.12.4",
 ]
 
 [[package]]
@@ -7720,7 +7741,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -7737,6 +7758,47 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.25.4",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.22.3",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tokio-rustls 0.25.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -7744,8 +7806,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
- "winreg",
+ "webpki-roots 0.26.1",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -7980,7 +8042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -7997,11 +8059,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "rustls-pki-types",
 ]
 
@@ -8034,9 +8096,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "rustyline"
@@ -9434,7 +9496,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.3",
+ "prost 0.12.4",
  "tokio",
  "tokio-stream",
  "tower",
@@ -9561,7 +9623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49bbc87d08020d7c2a9f4bb0b7d10da5381d3867f8ae57fcc54621b34567e963"
 dependencies = [
  "loki-api",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "snap",
@@ -10200,6 +10262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10211,9 +10282,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "win-sys"
@@ -10481,6 +10552,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ git-version = "0.3"
 group = "0.13"
 hex = { version = "0.4", features = ["serde"] }
 http = "1.0"
-http0 = { package = "http", version = "0.2" }
 human-repr = "1.0"
 human_bytes = "0.4"
 humantime = "2.1.0"
@@ -155,7 +154,7 @@ rand_distr = "0.4"
 raw_sync_2 = "0.1"
 rayon = "1.8"
 regex = "1.10"
-reqwest = { version = "0.11", default-features = false, features = [
+reqwest = { version = "0.12", default-features = false, features = [
   "stream",
   "rustls-tls",
   "json",

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -145,7 +145,7 @@ pub async fn generate_actor_bundle(output: &Path) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use http0::StatusCode;
+    use http::StatusCode;
     use reqwest::Response;
     use std::time::Duration;
 

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -117,16 +117,16 @@ impl ApiInfo {
             .timeout(req.timeout)
             .json(&rpc_req);
         let request = match self.token.as_ref() {
-            Some(token) => request.header(http0::header::AUTHORIZATION, token),
+            Some(token) => request.header(http::header::AUTHORIZATION, token),
             _ => request,
         };
 
         let response = request.send().await?;
         let result = match response.status() {
-            http0::StatusCode::NOT_FOUND => {
+            http::StatusCode::NOT_FOUND => {
                 Err(JsonRpcError::method_not_found("method_not_found", None))
             }
-            http0::StatusCode::FORBIDDEN => Err(JsonRpcError::new(
+            http::StatusCode::FORBIDDEN => Err(JsonRpcError::new(
                 response.status().as_u16().into(),
                 match &self.token {
                     Some(_) => "Permission denied: Insufficient rights.",

--- a/src/utils/reqwest_resume/mod.rs
+++ b/src/utils/reqwest_resume/mod.rs
@@ -72,8 +72,8 @@ impl RequestBuilder {
         };
         let accept_byte_ranges = response
             .headers()
-            .get(http0::header::ACCEPT_RANGES)
-            .map(http0::HeaderValue::as_bytes)
+            .get(http::header::ACCEPT_RANGES)
+            .map(http::HeaderValue::as_bytes)
             == Some(b"bytes");
         let resp = Response {
             client,
@@ -138,10 +138,10 @@ impl Stream for Decoder {
                         break Poll::Ready(Some(Err(err)));
                     }
                     let builder = self.client.request(self.method.clone(), self.url.clone());
-                    let mut headers = http0::HeaderMap::new();
-                    let value = http0::HeaderValue::from_str(&std::format!("bytes={}-", self.pos))
+                    let mut headers = http::HeaderMap::new();
+                    let value = http::HeaderValue::from_str(&std::format!("bytes={}-", self.pos))
                         .expect("unreachable");
-                    headers.insert(http0::header::RANGE, value);
+                    headers.insert(http::header::RANGE, value);
                     let builder = builder.headers(headers);
                     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
                     self.decoder = Box::pin(

--- a/src/utils/reqwest_resume/tests.rs
+++ b/src/utils/reqwest_resume/tests.rs
@@ -116,6 +116,6 @@ async fn test_non_resumable_get() {
     assert_eq!(RANDOM_BYTES[0..data.len()], data);
     let item = stream.next().await.unwrap();
     let err = item.unwrap_err();
-    assert!(err.is_body());
+    assert!(err.is_decode(), "{err}");
     assert!(stream.next().await.is_none());
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- bump reqwest to 0.12
- retire http 0.2

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
