### PR TITLE
fix: drand verification logic and block validation logic

### DIFF
--- a/src/beacon/tests/drand.rs
+++ b/src/beacon/tests/drand.rs
@@ -88,6 +88,17 @@ async fn ask_and_verify_mainnet_beacon_entry_success() {
     assert!(beacon.verify_entries(&[e2, e3], &e1).unwrap());
 }
 
+// For issue description, see <https://github.com/ChainSafe/forest/pull/4163>
+#[tokio::test]
+async fn ask_and_verify_mainnet_beacon_entry_success_issue_4163() {
+    let beacon = new_beacon_mainnet();
+
+    let e1 = beacon.entry(3907446).await.unwrap();
+    let e2 = beacon.entry(3907447).await.unwrap();
+    let e3 = beacon.entry(3907447).await.unwrap();
+    assert!(beacon.verify_entries(&[e2, e3], &e1).unwrap());
+}
+
 #[tokio::test]
 async fn ask_and_verify_mainnet_beacon_entry_fail() {
     let beacon = new_beacon_mainnet();

--- a/src/beacon/tests/drand.rs
+++ b/src/beacon/tests/drand.rs
@@ -88,7 +88,9 @@ async fn ask_and_verify_mainnet_beacon_entry_success() {
     assert!(beacon.verify_entries(&[e2, e3], &e1).unwrap());
 }
 
-// For issue description, see <https://github.com/ChainSafe/forest/pull/4163>
+// This is a regression test for cases when a block header contains
+// duplicate beacon entries.
+// For details, see <https://github.com/ChainSafe/forest/pull/4163>
 #[tokio::test]
 async fn ask_and_verify_mainnet_beacon_entry_success_issue_4163() {
     let beacon = new_beacon_mainnet();

--- a/src/fil_cns/mod.rs
+++ b/src/fil_cns/mod.rs
@@ -22,6 +22,8 @@ pub enum FilecoinConsensusError {
     BlockWithoutElectionProof,
     #[error("Block without ticket")]
     BlockWithoutTicket,
+    #[error("Block height {current} not greater than parent height {parent}")]
+    BlockHeightNotGreaterThanParentHeight { current: i64, parent: i64 },
     #[error("Block had the wrong timestamp: {0} != {1}")]
     UnequalBlockTimestamps(u64, u64),
     #[error("Tipset without ticket to verify")]

--- a/src/fil_cns/validation.rs
+++ b/src/fil_cns/validation.rs
@@ -82,7 +82,7 @@ pub(in crate::fil_cns) async fn validate_block<DB: Blockstore + Sync + Send + 's
 
     let prev_beacon = chain_store
         .chain_index
-        .latest_beacon_entry(&base_tipset)
+        .latest_beacon_entry(base_tipset.clone())
         .map(Arc::new)
         .map_err(to_errs)?;
 
@@ -127,19 +127,17 @@ pub(in crate::fil_cns) async fn validate_block<DB: Blockstore + Sync + Send + 's
 
     // Beacon values check
     if std::env::var(IGNORE_DRAND_VAR) != Ok("1".to_owned()) {
-        let v_block = Arc::clone(&block);
-        let parent_epoch = base_tipset.epoch();
-        let v_prev_beacon = Arc::clone(&prev_beacon);
-        validations.push(tokio::task::spawn(async move {
-            v_block
-                .header()
-                .validate_block_drand(
-                    win_p_nv,
-                    beacon_schedule.as_ref(),
-                    parent_epoch,
-                    &v_prev_beacon,
-                )
-                .map_err(|e| FilecoinConsensusError::BeaconValidation(e.to_string()))
+        validations.push(tokio::task::spawn({
+            let block = Arc::clone(&block);
+            let parent_epoch = base_tipset.epoch();
+            let prev_beacon = Arc::clone(&prev_beacon);
+            let nv = state_manager.get_network_version(header.epoch);
+            async move {
+                block
+                    .header()
+                    .validate_block_drand(nv, beacon_schedule.as_ref(), parent_epoch, &prev_beacon)
+                    .map_err(|e| FilecoinConsensusError::BeaconValidation(e.to_string()))
+            }
         }));
     }
 
@@ -197,10 +195,18 @@ fn block_timestamp_checks(
     base_tipset: &Tipset,
     chain_config: &ChainConfig,
 ) -> Result<(), FilecoinConsensusError> {
+    if header.epoch <= base_tipset.epoch() {
+        return Err(
+            FilecoinConsensusError::BlockHeightNotGreaterThanParentHeight {
+                current: header.epoch,
+                parent: base_tipset.epoch(),
+            },
+        );
+    }
     // Timestamp checks
     let block_delay = chain_config.block_delay_secs;
-    let nulls = (header.epoch - (base_tipset.epoch() + 1)) as u64;
-    let target_timestamp = base_tipset.min_timestamp() + block_delay as u64 * (nulls + 1);
+    let nulls = header.epoch - (base_tipset.epoch() + 1);
+    let target_timestamp = base_tipset.min_timestamp() + block_delay as u64 * (nulls + 1) as u64;
     if target_timestamp != header.timestamp {
         return Err(FilecoinConsensusError::UnequalBlockTimestamps(
             header.timestamp,

--- a/src/state_manager/chain_rand.rs
+++ b/src/state_manager/chain_rand.rs
@@ -114,7 +114,7 @@ where
         lookback: bool,
     ) -> anyhow::Result<[u8; 32]> {
         let rand_ts: Arc<Tipset> = self.get_beacon_randomness_tipset(round, lookback)?;
-        let be = self.chain_index.latest_beacon_entry(&rand_ts)?;
+        let be = self.chain_index.latest_beacon_entry(rand_ts)?;
         Ok(digest(be.signature()))
     }
 

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -1172,7 +1172,7 @@ where
         let prev_beacon = self
             .chain_store()
             .chain_index
-            .latest_beacon_entry(&tipset)?;
+            .latest_beacon_entry(tipset.clone())?;
 
         let entries: Vec<BeaconEntry> = beacon_schedule
             .beacon_entries_for_block(


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to fix a bug in chained drand verification caught by https://github.com/ChainSafe/forest/pull/4146

[Full CI log](https://productionresultssa10.blob.core.windows.net/actions-results/684fb0a5-cd58-48e6-ad8f-8591e1ea7687/workflow-job-run-db13e6aa-cabf-50ef-864b-9f917373f735/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-04-09T09%3A35%3A13Z&sig=dsRUhA9Vm7Ai09vBJg8G9%2FlTgLArJfRZAXAK9IJrwao%3D&sp=r&spr=https&sr=b&st=2024-04-09T09%3A25%3A08Z&sv=2021-12-02)

Basically, when blocks of a certain height are not mined (in this case, height 18 is missing)
In lotus miner log, we see
```
mined new block	{"cid": "bafy2bzaced3zy2fcdpyfqha4zaqrv5s5bjgjpvdwhmg3ltnp2ha5etkvl222s", "height": 17
...
mined new block	{"cid": "bafy2bzacedicxuinvpb4yihvxgc73bfnyttvkzopp4x3nji3pxbu5x4pbrkp4", "height": 19
drand in minedBlock	{"entries": [3907447, 3907447]}
```

The brand beacon entries field in the block header contains duplicate records.

In lotus log, we see
```
drand verification	{"chained": true, "prev": 3907446, "entries": []}
block validation	{"took": 0.007159428, "height": "17", "age": 72.804504077}
...
drand verification	{"chained": true, "prev": 3907446, "entries": [3907447, 3907447]}
block validation	{"took": 0.006184122, "height": "19", "age": 69.471819394}
```

And in forest log, we see
```
forest_filecoin::chain_sync::tipset_syncer: Validating tipset: EPOCH = 19, N blocks = 1
forest_filecoin::blocks::header: beacon network at 19: Mainnet, is_chained: true
forest_filecoin::beacon::drand: drand verification: network=Mainnet, prev=3907446, entries(2)=3907447,3907447
forest_filecoin::beacon::signatures: acc.finalverify(None) failed
```

This PR tries to fix beacon verification logic in this case by duplicating the beacon entries by their epochs

In lotus code, `verify(3907446, 3907447)` succeeds, and `verify(3907447, 3907447)` hits the cache and succeeds without running verification
```go
        // Verify the beacon entries themselves
	for i, e := range h.BeaconEntries {
		if err := currBeacon.VerifyEntry(e, prevEntry.Data); err != nil {
			return xerrors.Errorf("beacon entry %d (%d - %x (%d)) was invalid: %w", i, e.Round, e.Data, len(e.Data), err)
		}
		prevEntry = e
	}

func (db *DrandBeacon) VerifyEntry(entry types.BeaconEntry, prevEntrySig []byte) error {
	if be := db.getCachedValue(entry.Round); be != nil {
		if !bytes.Equal(entry.Data, be.Data) {
			return xerrors.New("invalid beacon value, does not match cached good value")
		}
		// return no error if the value is in the cache already
		return nil
	}
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
