### PR TITLE
self-host proof parameters

### DIFF
--- a/.config/forest.dic
+++ b/.config/forest.dic
@@ -22,6 +22,7 @@ CBOR
 CID/SM
 CIDs
 CLI
+Cloudflare
 clonable
 codebase
 codec
@@ -75,6 +76,7 @@ parsable
 PoC
 pointer/SM
 PoSt
+R2
 RPC
 schema/SM
 schemas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 
 ### Changed
 
+- [#4170](https://github.com/ChainSafe/forest/pull/4170) Change the default
+  Filecoin proof parameters source to ChainSafe's hosted Cloudflare R2 bucket.
+  IPFS gateway can still be enforced via `FOREST_PROOFS_ONLY_IPFS_GATEWAY=1`.
+
 ### Removed
 
 ### Fixed

--- a/documentation/src/environment_variables.md
+++ b/documentation/src/environment_variables.md
@@ -4,13 +4,14 @@ Besides CLI options and the configuration values in the configuration file,
 there are some environment variables that control the behaviour of a `forest`
 process.
 
-| Environment variable       | Value                            | Default | Description                                                               |
-| -------------------------- | -------------------------------- | ------- | ------------------------------------------------------------------------- |
-| FOREST_KEYSTORE_PHRASE     | any text                         | empty   | The passphrase for the encrypted keystore                                 |
-| FOREST_CAR_LOADER_FILE_IO  | 1 or true                        | false   | Load CAR files with `RandomAccessFile` instead of `Mmap`                  |
-| FOREST_DB_DEV_MODE         | [see here](#-forest_db_dev_mode) | current | The database to use in development mode                                   |
-| FOREST_ACTOR_BUNDLE_PATH   | file path                        | empty   | Path to the local actor bundle, download from remote servers when not set |
-| FIL_PROOFS_PARAMETER_CACHE | dir path                         | empty   | Path to folder that caches fil proof parameter files                      |
+| Environment variable            | Value                            | Default | Description                                                               |
+| ------------------------------- | -------------------------------- | ------- | ------------------------------------------------------------------------- |
+| FOREST_KEYSTORE_PHRASE          | any text                         | empty   | The passphrase for the encrypted keystore                                 |
+| FOREST_CAR_LOADER_FILE_IO       | 1 or true                        | false   | Load CAR files with `RandomAccessFile` instead of `Mmap`                  |
+| FOREST_DB_DEV_MODE              | [see here](#-forest_db_dev_mode) | current | The database to use in development mode                                   |
+| FOREST_ACTOR_BUNDLE_PATH        | file path                        | empty   | Path to the local actor bundle, download from remote servers when not set |
+| FIL_PROOFS_PARAMETER_CACHE      | dir path                         | empty   | Path to folder that caches fil proof parameter files                      |
+| FOREST_PROOFS_ONLY_IPFS_GATEWAY | 1 or true                        | false   | Use only IPFS gateway for proofs parameters download                      |
 
 ### FOREST_DB_DEV_MODE
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- by default, use self-hosted proof parameters. In case of errors (or if forced by an environmental variable), fall back to the IPFS gateway. This should resolve numerous issues with the slow download and knocking out our GH jobs.

Even in good conditions, it's faster:
```
❯ export FOREST_PROOFS_ONLY_IPFS_GATEWAY=1
❯ time forest-tool fetch-params --keys
________________________________________________________
Executed in   11.83 secs      fish           external
   usr time  620.09 millis    0.00 micros  620.09 millis
   sys time  338.11 millis  276.00 micros  337.83 millis
```


```
❯ export FOREST_PROOFS_ONLY_IPFS_GATEWAY=0
❯ time forest-tool fetch-params --keys
________________________________________________________
Executed in    4.59 secs      fish           external
   usr time  399.09 millis  217.00 micros  398.87 millis
   sys time  244.08 millis   48.00 micros  244.03 millis

```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
