### PR TITLE
disable flaky MpoolGetNonce

### DIFF
--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -2,6 +2,8 @@
 # They should be considered bugged, and not used until the root cause is resolved.
 !Filecoin.ChainGetPath
 !Filecoin.MinerGetBaseInfo
+# Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619017774/job/23623141130?pr=4170
+!Filecoin.MpoolGetNonce
 !Filecoin.StateCall
 !Filecoin.StateListMessages
 !Filecoin.StateSectorGetInfo

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -2,6 +2,8 @@
 # They should be considered bugged, and not used until the root cause is resolved.
 !Filecoin.ChainGetPath
 !Filecoin.MinerGetBaseInfo
+# Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619314467/job/23624081698
+!Filecoin.MpoolGetNonce
 !Filecoin.StateCall
 !Filecoin.StateListMessages
 !Filecoin.StateSectorGetInfo


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- no mercy for flaky methods
- it failed in https://github.com/ChainSafe/forest/actions/runs/8619017774/job/23623141130?pr=4170 (and I recall some other PR).

```
  | Filecoin.EthSyncing                             | Valid  | Valid               |
  | Filecoin.MpoolGetNonce (12)                     | Valid  | InternalServerError |
  | Filecoin.MpoolGetNonce (8)                      | Valid  | Valid               |
  | Filecoin.MpoolPending                           | Valid  | Valid               |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
