### PR TITLE
wibble: remove references to `Arc`s when possible

### DIFF
--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -691,7 +691,7 @@ where
     /// Blocking version of `compute_tipset_state`
     #[tracing::instrument(skip_all)]
     pub fn compute_tipset_state_blocking(
-        self: &Arc<Self>,
+        self: &Self,
         tipset: Arc<Tipset>,
         callback: Option<impl FnMut(&MessageCallbackCtx) -> anyhow::Result<()> + Send + 'static>,
         enable_tracing: VMTrace,
@@ -1053,11 +1053,7 @@ where
     }
 
     /// Retrieves miner info.
-    pub fn miner_info(
-        self: &Arc<Self>,
-        addr: &Address,
-        ts: &Arc<Tipset>,
-    ) -> Result<MinerInfo, Error> {
+    pub fn miner_info(self: &Self, addr: &Address, ts: &Tipset) -> Result<MinerInfo, Error> {
         let actor = self
             .get_actor(addr, *ts.parent_state())?
             .ok_or_else(|| Error::State("Miner actor not found".to_string()))?;
@@ -1065,17 +1061,15 @@ where
 
         Ok(state.info(self.blockstore())?)
     }
+
     /// Retrieves miner faults.
-    pub fn miner_faults(
-        self: &Arc<Self>,
-        addr: &Address,
-        ts: &Arc<Tipset>,
-    ) -> Result<BitField, Error> {
+    pub fn miner_faults(self: &Self, addr: &Address, ts: &Arc<Tipset>) -> Result<BitField, Error> {
         self.all_partition_sectors(addr, ts, |partition| partition.faulty_sectors().clone())
     }
+
     /// Retrieves miner recoveries.
     pub fn miner_recoveries(
-        self: &Arc<Self>,
+        self: &Self,
         addr: &Address,
         ts: &Arc<Tipset>,
     ) -> Result<BitField, Error> {
@@ -1083,7 +1077,7 @@ where
     }
 
     fn all_partition_sectors(
-        self: &Arc<Self>,
+        self: &Self,
         addr: &Address,
         ts: &Arc<Tipset>,
         get_sector: impl Fn(Partition<'_>) -> BitField,
@@ -1111,11 +1105,7 @@ where
     }
 
     /// Retrieves miner power.
-    pub fn miner_power(
-        self: &Arc<Self>,
-        addr: &Address,
-        ts: &Arc<Tipset>,
-    ) -> Result<MinerPower, Error> {
+    pub fn miner_power(self: &Self, addr: &Address, ts: &Tipset) -> Result<MinerPower, Error> {
         if let Some((miner_power, total_power)) = self.get_power(ts.parent_state(), Some(addr))? {
             return Ok(MinerPower {
                 miner_power,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Replace `&Arc<Self>` with `&Self`.
- A reference to an `Arc` is nearly always a wart, but not all can be removed without refactoring.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Part of #4176

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
