### PR TITLE
`--no-healthcheck`, no shorthands and test necromancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,16 +27,23 @@
 
 ### Breaking
 
+- [#4184](https://github.com/ChainSafe/forest/pull/4184) Removed short form
+  flags from `forest` binary.
+
 ### Added
 
 - [#4084](https://github.com/ChainSafe/forest/pull/4084) Add support for the
   `Filecoin.StateDealProviderCollateralBounds` RPC method.
+
 - [#3949](https://github.com/ChainSafe/forest/issues/3949) Added healthcheck
   endpoints `/healthz`, `/readyz`, and `/livez`. By default, the healthcheck
   endpoint is enabled on port 2346.
 
 - [#4166](https://github.com/ChainSafe/forest/issues/4166) Add support for the
   `Filecoin.Web3ClientVersion` RPC method.
+
+- [#4184](https://github.com/ChainSafe/forest/pull/4184) Added
+  `--no-healthcheck` flag to `forest` to disable the healthcheck endpoint.
 
 ### Changed
 

--- a/src/cli_shared/cli/client.rs
+++ b/src/cli_shared/cli/client.rs
@@ -43,6 +43,7 @@ pub struct Client {
     pub genesis_file: Option<String>,
     pub enable_rpc: bool,
     pub enable_metrics_endpoint: bool,
+    pub enable_health_check: bool,
     /// If this is true, then we do not validate the imported snapshot.
     /// Otherwise, we validate and compute the states.
     pub snapshot: bool,
@@ -86,6 +87,7 @@ impl Default for Client {
             genesis_file: None,
             enable_rpc: true,
             enable_metrics_endpoint: true,
+            enable_health_check: true,
             snapshot_path: None,
             snapshot: false,
             consume_snapshot: false,

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -40,16 +40,16 @@ OPTIONS:
 #[derive(Default, Debug, Parser)]
 pub struct CliOpts {
     /// A TOML file containing relevant configurations
-    #[arg(short, long)]
+    #[arg(long)]
     pub config: Option<PathBuf>,
     /// The genesis CAR file
-    #[arg(short, long)]
+    #[arg(long)]
     pub genesis: Option<String>,
     /// Allow RPC to be active or not (default: true)
-    #[arg(short, long)]
+    #[arg(long)]
     pub rpc: Option<bool>,
     /// Disable Metrics endpoint
-    #[arg(short, long)]
+    #[arg(long)]
     pub no_metrics: bool,
     /// Address used for metrics collection server. By defaults binds on
     /// localhost on port 6116.
@@ -58,6 +58,9 @@ pub struct CliOpts {
     /// Address used for RPC. By defaults binds on localhost on port 2345.
     #[arg(long)]
     pub rpc_address: Option<SocketAddr>,
+    /// Disable healthcheck endpoints
+    #[arg(long)]
+    pub no_healthcheck: bool,
     /// Address used for healthcheck server. By defaults binds on localhost on port 2346.
     #[arg(long)]
     pub healthcheck_address: Option<SocketAddr>,
@@ -65,7 +68,7 @@ pub struct CliOpts {
     #[arg(long)]
     pub p2p_listen_address: Option<Vec<Multiaddr>>,
     /// Allow Kademlia (default: true)
-    #[arg(short, long)]
+    #[arg(long)]
     pub kademlia: Option<bool>,
     /// Allow MDNS (default: false)
     #[arg(long)]
@@ -173,8 +176,13 @@ impl CliOpts {
             cfg.client.enable_rpc = false;
         }
 
-        if let Some(healthcheck_address) = self.healthcheck_address {
-            cfg.client.healthcheck_address = healthcheck_address;
+        if self.no_healthcheck {
+            cfg.client.enable_health_check = false;
+        } else {
+            cfg.client.enable_health_check = true;
+            if let Some(healthcheck_address) = self.healthcheck_address {
+                cfg.client.healthcheck_address = healthcheck_address;
+            }
         }
 
         if self.no_metrics {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -336,7 +336,7 @@ pub(super) async fn start(
     let sync_state = chain_muxer.sync_state_cloned();
     services.spawn(async { Err(anyhow::anyhow!("{}", chain_muxer.await)) });
 
-    {
+    if config.client.enable_health_check {
         let forest_state = crate::health::ForestState {
             config: config.clone(),
             chain_config: chain_config.clone(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,10 +24,9 @@ pub trait CommonArgs {
 
 impl CommonArgs for Command {
     fn common_args(&mut self) -> &mut Self {
-        self.arg("--rpc-address")
-            .arg("127.0.0.1:0")
-            .arg("--metrics-address")
-            .arg("127.0.0.1:0")
+        self.arg("--rpc")
+            .arg("false")
+            .arg("--no-metrics")
             .arg("--exit-after-init")
             .arg("--skip-load-actors")
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -27,6 +27,7 @@ impl CommonArgs for Command {
         self.arg("--rpc")
             .arg("false")
             .arg("--no-metrics")
+            .arg("--no-healthcheck")
             .arg("--exit-after-init")
             .arg("--skip-load-actors")
     }

--- a/tests/import_snapshot_tests.rs
+++ b/tests/import_snapshot_tests.rs
@@ -5,26 +5,23 @@ pub mod common;
 
 use crate::common::{create_tmp_config, daemon, CommonEnv};
 
-// Ignored because it's flaky.
 #[test]
-#[ignore]
 fn importing_bad_snapshot_should_fail() {
     let (config_file, data_dir) = create_tmp_config();
     let temp_file = data_dir.path().join("bad-snapshot.car");
     std::fs::write(&temp_file, "bad-snapshot").unwrap();
     daemon()
         .common_env()
-        .arg("--rpc-address")
-        .arg("127.0.0.1:0")
-        .arg("--metrics-address")
-        .arg("127.0.0.1:0")
+        .arg("--rpc")
+        .arg("false")
+        .arg("--no-metrics")
         .arg("--config")
         .arg(config_file)
         .arg("--encrypt-keystore")
         .arg("false")
+        .arg("--skip-load-actors")
         .arg("--import-snapshot")
         .arg(temp_file)
-        .arg("--halt-after-import")
         .assert()
         .failure();
 }

--- a/tests/import_snapshot_tests.rs
+++ b/tests/import_snapshot_tests.rs
@@ -15,6 +15,7 @@ fn importing_bad_snapshot_should_fail() {
         .arg("--rpc")
         .arg("false")
         .arg("--no-metrics")
+        .arg("--no-healthcheck")
         .arg("--config")
         .arg(config_file)
         .arg("--encrypt-keystore")


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- re-enabled `importing_bad_snapshot_should_fail` - I was not able to reproduce the failure, if it happens again let's investigate it.
- simplified common conditions for tests, so that no servers are started by default (might help with some flakiness)
- added a flag to disable healthcheck
- :warning: Breaking change. Removed shorthand flags from `forest`. They were not helpful; someone seeing `forest -n` might have been surprised it runs Forest with disabled metrics.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/3449

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
