### PR TITLE
add debugging tooling for api-compare

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
       - FULLNODE_API_INFO=/dns/forest/tcp/${FOREST_RPC_PORT}/http
+      - RUST_LOG=info,forest_filecoin::rpc=debug
     entrypoint: [ "/bin/bash", "-c" ]
     command:
       - |
@@ -63,6 +64,7 @@ services:
       - api-tests
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
+      - RUST_LOG=info,forest_filecoin::rpc=debug
     entrypoint: [ "/bin/bash", "-c" ]
     command:
       - |
@@ -130,6 +132,8 @@ services:
       - ./filter-list:/data/filter-list
     networks:
       - api-tests
+    environment:
+      - RUST_LOG=info,forest_filecoin::tool::subcommands=debug
     entrypoint: [ "/bin/bash", "-c" ]
     command:
       - |
@@ -151,6 +155,8 @@ services:
       - ./filter-list-offline:/data/filter-list-offline
     networks:
       - api-tests
+    environment:
+      - RUST_LOG=info,forest_filecoin::tool::subcommands=debug
     entrypoint: [ "/bin/bash", "-c" ]
     command:
       - |

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -215,7 +215,8 @@ struct TestDump {
 
 impl std::fmt::Display for TestDump {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Request: {:?}", self.request)?;
+        writeln!(f, "Request dump: {:?}", self.request)?;
+        writeln!(f, "Request params JSON: {}", self.request.params)?;
         if let (Some(forest_response), Some(lotus_response)) =
             (&self.forest_response, &self.lotus_response)
         {

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -40,6 +40,7 @@ use fvm_shared2::piece::PaddedPieceSize;
 use itertools::Itertools as _;
 use jsonrpsee::types::ErrorCode;
 use serde::de::DeserializeOwned;
+use similar::{ChangeTag, TextDiff};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
@@ -204,6 +205,54 @@ impl EndpointStatus {
         }
     }
 }
+
+/// Data about a failed test. Used for debugging.
+struct TestDump {
+    request: RpcRequest,
+    forest_response: Option<String>,
+    lotus_response: Option<String>,
+}
+
+impl std::fmt::Display for TestDump {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Request: {:?}", self.request)?;
+        if let (Some(forest_response), Some(lotus_response)) =
+            (&self.forest_response, &self.lotus_response)
+        {
+            let diff = TextDiff::from_lines(forest_response, lotus_response);
+            let mut print_diff = Vec::new();
+            for change in diff.iter_all_changes() {
+                let sign = match change.tag() {
+                    ChangeTag::Delete => "-",
+                    ChangeTag::Insert => "+",
+                    ChangeTag::Equal => " ",
+                };
+                print_diff.push(format!("{sign}{change}"));
+            }
+            writeln!(f, "Forest response: {}", forest_response)?;
+            writeln!(f, "Lotus response: {}", lotus_response)?;
+            writeln!(f, "Diff: {}", print_diff.join("\n"))?;
+        } else {
+            if let Some(forest_response) = &self.forest_response {
+                writeln!(f, "Forest response: {}", forest_response)?;
+            }
+            if let Some(lotus_response) = &self.lotus_response {
+                writeln!(f, "Lotus response: {}", lotus_response)?;
+            }
+        };
+        Ok(())
+    }
+}
+
+struct TestResult {
+    /// Forest result after calling the RPC method.
+    forest_status: EndpointStatus,
+    /// Lotus result after calling the RPC method.
+    lotus_status: EndpointStatus,
+    /// Optional data dump if either status was invalid.
+    test_dump: Option<TestDump>,
+}
+
 struct RpcTest {
     request: RpcRequest,
     check_syntax: Arc<dyn Fn(serde_json::Value) -> bool + Send + Sync>,
@@ -302,15 +351,23 @@ impl RpcTest {
         self
     }
 
-    async fn run(
-        &self,
-        forest_api: &ApiInfo,
-        lotus_api: &ApiInfo,
-    ) -> (EndpointStatus, EndpointStatus) {
+    async fn run(&self, forest_api: &ApiInfo, lotus_api: &ApiInfo) -> TestResult {
         let forest_resp = forest_api.call(self.request.clone()).await;
         let lotus_resp = lotus_api.call(self.request.clone()).await;
 
-        match (forest_resp, lotus_resp) {
+        let forest_json_str = if let Ok(forest_resp) = forest_resp.as_ref() {
+            serde_json::to_string_pretty(forest_resp).ok()
+        } else {
+            None
+        };
+
+        let lotus_json_str = if let Ok(lotus_resp) = lotus_resp.as_ref() {
+            serde_json::to_string_pretty(lotus_resp).ok()
+        } else {
+            None
+        };
+
+        let (forest_status, lotus_status) = match (forest_resp, lotus_resp) {
             (Ok(forest), Ok(lotus))
                 if (self.check_syntax)(forest.clone()) && (self.check_syntax)(lotus.clone()) =>
             {
@@ -320,10 +377,6 @@ impl RpcTest {
                     EndpointStatus::InvalidResponse
                 };
                 (forest_status, EndpointStatus::Valid)
-            }
-            (Err(forest_err), Err(lotus_err)) if forest_err == lotus_err => {
-                // Both Forest and Lotus have the same error, consider it as valid
-                (EndpointStatus::Valid, EndpointStatus::Valid)
             }
             (forest_resp, lotus_resp) => {
                 let forest_status =
@@ -344,6 +397,24 @@ impl RpcTest {
                     });
 
                 (forest_status, lotus_status)
+            }
+        };
+
+        if forest_status == EndpointStatus::Valid && lotus_status == EndpointStatus::Valid {
+            TestResult {
+                forest_status,
+                lotus_status,
+                test_dump: None,
+            }
+        } else {
+            TestResult {
+                forest_status,
+                lotus_status,
+                test_dump: Some(TestDump {
+                    request: self.request.clone(),
+                    forest_response: forest_json_str,
+                    lotus_response: lotus_json_str,
+                }),
             }
         }
     }
@@ -1079,9 +1150,9 @@ async fn run_tests(
         let forest = forest.clone();
         let lotus = lotus.clone();
         let future = tokio::spawn(async move {
-            let (forest_status, lotus_status) = test.run(&forest, &lotus).await;
+            let test_result = test.run(&forest, &lotus).await;
             drop(permit); // Release the permit after test execution
-            (test.request.method_name, forest_status, lotus_status)
+            (test.request.method_name, test_result)
         });
 
         futures.push(future);
@@ -1089,7 +1160,10 @@ async fn run_tests(
 
     let mut success_results = HashMap::default();
     let mut failed_results = HashMap::default();
-    while let Some(Ok((method_name, forest_status, lotus_status))) = futures.next().await {
+    let mut fail_details = Vec::new();
+    while let Some(Ok((method_name, test_result))) = futures.next().await {
+        let forest_status = test_result.forest_status;
+        let lotus_status = test_result.lotus_status;
         let result_entry = (method_name, forest_status, lotus_status);
         if (forest_status == EndpointStatus::Valid && lotus_status == EndpointStatus::Valid)
             || (forest_status == EndpointStatus::Timeout && lotus_status == EndpointStatus::Timeout)
@@ -1099,6 +1173,9 @@ async fn run_tests(
                 .and_modify(|v| *v += 1)
                 .or_insert(1u32);
         } else {
+            if let Some(test_result) = test_result.test_dump {
+                fail_details.push(test_result);
+            }
             failed_results
                 .entry(result_entry)
                 .and_modify(|v| *v += 1)
@@ -1109,12 +1186,19 @@ async fn run_tests(
             break;
         }
     }
+    print_error_details(&fail_details);
     print_test_results(&success_results, &failed_results);
 
     if failed_results.is_empty() {
         Ok(())
     } else {
         Err(anyhow::Error::msg("Some tests failed"))
+    }
+}
+
+fn print_error_details(fail_details: &[TestDump]) {
+    for dump in fail_details {
+        println!("{dump}")
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- add basic debugging capabilities to `api compare`, so that we're not completely blind when encountering an error in, e.g., CI.
- I expect one RPC endpoint to fail here, so https://github.com/ChainSafe/forest/pull/4201 is a blocker.

```
api-compare-1          | Request: RpcRequest { method_name: "Filecoin.BeaconGetEntry", params: Array [Number(10101)], result_type: PhantomData<serde_json::value::Value>, api_version: V0, timeout: 60s }
api-compare-1          | Forest response: {
api-compare-1          |   "Data": "jrcsjrAwyZTEj+SJbhlQgB/o3dcqWY30AMCHiQ1KyQLfFqs2AQPLroE4WJl4Y05eDZSn6t5dGidL09Lz1FS8xL6yhhaMygPKnRhSaC0QISbi57+gtmf4OVWarqvyhJ20",
api-compare-1          |   "Round": 2406587
api-compare-1          | }
api-compare-1          | Lotus response: {
api-compare-1          |   "Data": "q4Ld1oDM4YtLFvAb8ovBzrh0GJTeiWqNj1CMDSs2RDeS1Jjp83aO7+rJcB9NO3QWE7fvPT++jjT1fJKyto4xkRkLIiTgtYxORj0KmfcmFRrv4uI3H5bub/Ak111wzf55",
api-compare-1          |   "Round": 2406612
api-compare-1          | }
api-compare-1          | Diff:  {
api-compare-1          |
api-compare-1          | -  "Data": "jrcsjrAwyZTEj+SJbhlQgB/o3dcqWY30AMCHiQ1KyQLfFqs2AQPLroE4WJl4Y05eDZSn6t5dGidL09Lz1FS8xL6yhhaMygPKnRhSaC0QISbi57+gtmf4OVWarqvyhJ20",
api-compare-1          |
api-compare-1          | -  "Round": 2406587
api-compare-1          |
api-compare-1          | +  "Data": "q4Ld1oDM4YtLFvAb8ovBzrh0GJTeiWqNj1CMDSs2RDeS1Jjp83aO7+rJcB9NO3QWE7fvPT++jjT1fJKyto4xkRkLIiTgtYxORj0KmfcmFRrv4uI3H5bub/Ak111wzf55",
api-compare-1          |
api-compare-1          | +  "Round": 2406612
api-compare-1          |
api-compare-1          |  }
api-compare-1          |
api-compare-1          |
api-compare-1          | | RPC Method                                      | Forest          | Lotus |
api-compare-1          | |-------------------------------------------------|-----------------|-------|
api-compare-1          | | Filecoin.BeaconGetEntry                         | InvalidResponse | Valid |
api-compare-1          | | Filecoin.ChainGetBlock                          | Valid           | Valid |
api-compare-1          | | Filecoin.ChainGetBlockMessages (27)             | Valid           | Valid |
api-compare-1          | | Filecoin.ChainGetGenesis                        | Valid           | Valid |
api-compare-1          | | Filecoin.ChainGetMessage (52)                   | Valid           | Valid |
api-compare-1          | | Filecoin.ChainGetMessagesInTipset (10)          | Valid           | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
