### PR TITLE
increase RPC max req/resp size

### DIFF
--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -22,7 +22,7 @@ use serde::de::DeserializeOwned;
 use tracing::{debug, Instrument, Level};
 use url::Url;
 
-use super::ApiVersion;
+use super::{ApiVersion, MAX_REQUEST_BODY_SIZE, MAX_RESPONSE_BODY_SIZE};
 
 /// A JSON-RPC client that can dispatch either a [`crate::rpc_client::RpcRequest`]
 /// or a [`crate::rpc::RpcMethod`] to a single URL.
@@ -174,12 +174,16 @@ impl UrlClient {
                 jsonrpsee::ws_client::WsClientBuilder::new()
                     .set_headers(headers)
                     .request_timeout(timeout)
+                    .max_request_size(MAX_REQUEST_BODY_SIZE)
+                    .max_response_size(MAX_RESPONSE_BODY_SIZE)
                     .build(&url)
                     .await?,
             ),
             "http" | "https" => OneClientInner::Https(
                 jsonrpsee::http_client::HttpClientBuilder::new()
                     .set_headers(headers)
+                    .max_request_size(MAX_REQUEST_BODY_SIZE)
+                    .max_response_size(MAX_RESPONSE_BODY_SIZE)
                     .request_timeout(timeout)
                     .build(&url)?,
             ),

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -87,7 +87,8 @@ use tracing::info;
 
 use self::reflect::openrpc_types::ParamStructure;
 
-const MAX_RESPONSE_BODY_SIZE: u32 = 16 * 1024 * 1024;
+const MAX_REQUEST_BODY_SIZE: u32 = 64 * 1024 * 1024;
+const MAX_RESPONSE_BODY_SIZE: u32 = MAX_REQUEST_BODY_SIZE;
 
 /// This is where you store persistent data, or at least access to stateful
 /// data.
@@ -141,6 +142,7 @@ where
         stop_handle: stop_handle.clone(),
         svc_builder: Server::builder()
             // Default size (10 MiB) is not enough for methods like `Filecoin.StateMinerActiveSectors`
+            .max_request_body_size(MAX_REQUEST_BODY_SIZE)
             .max_response_body_size(MAX_RESPONSE_BODY_SIZE)
             .to_service_builder(),
         keystore,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Some tests were failing on client-side; payload size was too large for the default 10 MiB. Likely, in the future, this should be configurable, though a sane default is more important.
- merge before https://github.com/ChainSafe/forest/pull/4199

```
2024-04-15T15:30:45.109455Z DEBUG forest_filecoin::tool::subcommands::api_cmd: err=ServerError { inner: ErrorObject { code: InternalError, message: "The HTTP message was too big", data: None } }
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
