### PR TITLE
fix: api compare test failures

### DIFF
--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -513,6 +513,7 @@ mod lotus_json {
 
     use super::TipsetKey;
 
+    #[derive(Clone)]
     pub struct TipsetLotusJson(Tipset);
 
     impl JsonSchema for TipsetLotusJson {

--- a/src/cli/subcommands/attach_cmd.rs
+++ b/src/cli/subcommands/attach_cmd.rs
@@ -258,11 +258,7 @@ async fn send_message(params: SendMessageParams, api: ApiInfo) -> anyhow::Result
         Address::from_str(&to)?,
         humantoken::parse(&value)?, // Convert forest_shim::TokenAmount to TokenAmount3
     );
-    Ok(
-        MpoolPushMessage::call(&rpc::Client::from(api), (message.into(), None))
-            .await?
-            .into_inner(),
-    )
+    Ok(MpoolPushMessage::call(&rpc::Client::from(api), (message.into(), None)).await?)
 }
 
 type SleepParams = (u64,);
@@ -279,14 +275,14 @@ async fn sleep_tipsets(epochs: ChainEpochDelta, api: ApiInfo) -> anyhow::Result<
     let mut epoch = None;
     loop {
         let state = SyncState::call(&client, ()).await?;
-        if state.active_syncs.as_ref().first().stage() == SyncStage::Complete {
+        if state.active_syncs.first().stage() == SyncStage::Complete {
             if let Some(prev) = epoch {
-                let curr = state.active_syncs.as_ref().first().epoch();
+                let curr = state.active_syncs.first().epoch();
                 if (curr - prev) >= epochs {
                     return Ok(());
                 }
             } else {
-                epoch = Some(state.active_syncs.as_ref().first().epoch());
+                epoch = Some(state.active_syncs.first().epoch());
             }
         }
         time::sleep(time::Duration::from_secs(1)).await;

--- a/src/cli/subcommands/auth_cmd.rs
+++ b/src/cli/subcommands/auth_cmd.rs
@@ -55,18 +55,14 @@ impl AuthCommands {
                 let perm: String = perm.parse()?;
                 let perms = process_perms(perm)?;
                 let token_exp = Duration::from_std(expire_in.into())?;
-                let res = AuthNew::call(&client, (AuthNewParams { perms, token_exp },))
-                    .await?
-                    .into_inner();
+                let res = AuthNew::call(&client, (AuthNewParams { perms, token_exp },)).await?;
                 print_rpc_res_bytes(res)
             }
             Self::ApiInfo { perm, expire_in } => {
                 let perm: String = perm.parse()?;
                 let perms = process_perms(perm)?;
                 let token_exp = Duration::from_std(expire_in.into())?;
-                let token = AuthNew::call(&client, (AuthNewParams { perms, token_exp },))
-                    .await?
-                    .into_inner();
+                let token = AuthNew::call(&client, (AuthNewParams { perms, token_exp },)).await?;
                 let new_api = api.set_token(Some(String::from_utf8(token)?));
                 println!("FULLNODE_API_INFO=\"{}\"", new_api);
                 Ok(())

--- a/src/cli/subcommands/info_cmd.rs
+++ b/src/cli/subcommands/info_cmd.rs
@@ -159,16 +159,13 @@ impl InfoCommand {
             StartTime::call(&client, ()),
             WalletDefaultAddress::call(&client, ()),
         )?;
-        let default_wallet_address = default_wallet_address.into_inner();
 
         let cur_duration: Duration = SystemTime::now().duration_since(UNIX_EPOCH)?;
         let blocks_per_tipset_last_finality =
             node_status.chain_status.blocks_per_tipset_last_finality;
 
         let default_wallet_address_balance = if let Some(def_addr) = default_wallet_address {
-            let balance = WalletBalance::call(&client, (def_addr.into(),))
-                .await?
-                .into_inner();
+            let balance = WalletBalance::call(&client, (def_addr.into(),)).await?;
             Some(balance)
         } else {
             None
@@ -177,7 +174,7 @@ impl InfoCommand {
         let node_status_info = NodeStatusInfo::new(
             cur_duration,
             blocks_per_tipset_last_finality,
-            &head.into_inner(),
+            &head,
             start_time,
             network,
             default_wallet_address,

--- a/src/cli/subcommands/mpool_cmd.rs
+++ b/src/cli/subcommands/mpool_cmd.rs
@@ -214,12 +214,11 @@ impl MpoolCommands {
                 to,
                 from,
             } => {
-                let messages = MpoolPending::call(&client, (LotusJson(ApiTipsetKey(None)),))
-                    .await?
-                    .into_inner();
+                let messages =
+                    MpoolPending::call(&client, (LotusJson(ApiTipsetKey(None)),)).await?;
 
                 let local_addrs = if local {
-                    let response = WalletList::call(&client, ()).await?.into_inner();
+                    let response = WalletList::call(&client, ()).await?;
                     Some(HashSet::from_iter(response))
                 } else {
                     None
@@ -244,18 +243,17 @@ impl MpoolCommands {
                 basefee_lookback,
                 local,
             } => {
-                let tipset = ChainHead::call(&client, ()).await?.into_inner();
+                let tipset = ChainHead::call(&client, ()).await?;
                 let curr_base_fee = tipset.block_headers().first().parent_base_fee.to_owned();
 
                 let atto_str = ChainGetMinBaseFee::call(&client, (basefee_lookback,)).await?;
                 let min_base_fee = TokenAmount::from_atto(atto_str.parse::<BigInt>()?);
 
-                let messages = MpoolPending::call(&client, (LotusJson(ApiTipsetKey(None)),))
-                    .await?
-                    .into_inner();
+                let messages =
+                    MpoolPending::call(&client, (LotusJson(ApiTipsetKey(None)),)).await?;
 
                 let local_addrs = if local {
-                    let response = WalletList::call(&client, ()).await?.into_inner();
+                    let response = WalletList::call(&client, ()).await?;
                     Some(HashSet::from_iter(response))
                 } else {
                     None

--- a/src/cli/subcommands/net_cmd.rs
+++ b/src/cli/subcommands/net_cmd.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::libp2p::{Multiaddr, Protocol};
-use crate::lotus_json::LotusJson;
 use crate::rpc::{self, net::AddrInfo, prelude::*};
 use ahash::{HashMap, HashSet};
 use cid::multibase;
@@ -62,7 +61,7 @@ impl NetCommands {
                 Ok(())
             }
             Self::Peers { agent } => {
-                let LotusJson(addrs) = NetPeers::call(&client, ()).await?;
+                let addrs = NetPeers::call(&client, ()).await?;
                 let peer_to_agents: HashMap<String, String> = if agent {
                     let agents = futures::future::join_all(
                         addrs

--- a/src/cli/subcommands/net_cmd.rs
+++ b/src/cli/subcommands/net_cmd.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::libp2p::{Multiaddr, Protocol};
+use crate::lotus_json::LotusJson;
 use crate::rpc::{self, net::AddrInfo, prelude::*};
 use ahash::{HashMap, HashSet};
 use cid::multibase;
@@ -61,7 +62,7 @@ impl NetCommands {
                 Ok(())
             }
             Self::Peers { agent } => {
-                let addrs = NetPeers::call(&client, ()).await?;
+                let LotusJson(addrs) = NetPeers::call(&client, ()).await?;
                 let peer_to_agents: HashMap<String, String> = if agent {
                     let agents = futures::future::join_all(
                         addrs

--- a/src/cli/subcommands/send_cmd.rs
+++ b/src/cli/subcommands/send_cmd.rs
@@ -42,7 +42,6 @@ impl SendCommand {
         } else {
             WalletDefaultAddress::call(&client, ())
                 .await?
-                .into_inner()
                 .context("No default wallet address selected. Please set a default address.")?
         };
 
@@ -58,9 +57,7 @@ impl SendCommand {
             ..Default::default()
         };
 
-        let signed_msg = MpoolPushMessage::call(&client, (message.into(), None))
-            .await?
-            .into_inner();
+        let signed_msg = MpoolPushMessage::call(&client, (message.into(), None)).await?;
 
         println!("{}", signed_msg.cid().unwrap());
 

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -49,16 +49,15 @@ impl SnapshotCommands {
                 tipset,
                 depth,
             } => {
-                let chain_head = ChainHead::call(&client, ()).await?.into_inner();
+                let chain_head = ChainHead::call(&client, ()).await?;
 
                 let epoch = tipset.unwrap_or(chain_head.epoch());
 
                 let raw_network_name = api.state_network_name().await?;
                 let chain_name = crate::daemon::get_actual_chain_name(&raw_network_name);
 
-                let tipset = ChainGetTipSetByHeight::call(&client, (epoch, Default::default()))
-                    .await?
-                    .into_inner();
+                let tipset =
+                    ChainGetTipSetByHeight::call(&client, (epoch, Default::default())).await?;
 
                 let output_path = match output_path.is_dir() {
                     true => output_path.join(snapshot::filename(

--- a/src/cli/subcommands/sync_cmd.rs
+++ b/src/cli/subcommands/sync_cmd.rs
@@ -48,7 +48,7 @@ impl SyncCommands {
 
                 for _ in ticker {
                     let resp = SyncState::call(&client, ()).await?;
-                    let active_syncs = resp.active_syncs.as_ref();
+                    let active_syncs = resp.active_syncs;
                     let state = active_syncs
                         .iter()
                         .rev()
@@ -99,7 +99,7 @@ impl SyncCommands {
             }
             Self::Status => {
                 let resp = SyncState::call(&client, ()).await?;
-                let state = resp.active_syncs.as_ref().first();
+                let state = resp.active_syncs.first();
 
                 let base = state.base();
                 let elapsed_time = state.get_elapsed_time();

--- a/src/lotus_json/beacon_entry.rs
+++ b/src/lotus_json/beacon_entry.rs
@@ -5,7 +5,7 @@ use crate::beacon::BeaconEntry;
 
 use super::*;
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct BeaconEntryLotusJson {
     round: LotusJson<u64>,

--- a/src/lotus_json/block_header.rs
+++ b/src/lotus_json/block_header.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::blocks::{CachingBlockHeader, RawBlockHeader};
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct BlockHeaderLotusJson {
     miner: LotusJson<Address>,

--- a/src/lotus_json/cid.rs
+++ b/src/lotus_json/cid.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CidLotusJsonGeneric<const S: usize> {
     #[serde(rename = "/")]
     slash: Stringify<::cid::CidGeneric<S>>,

--- a/src/lotus_json/key_info.rs
+++ b/src/lotus_json/key_info.rs
@@ -4,7 +4,7 @@ use super::*;
 
 use crate::{key_management::KeyInfo, shim::crypto::SignatureType};
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct KeyInfoLotusJson {
     r#type: LotusJson<SignatureType>,

--- a/src/lotus_json/message.rs
+++ b/src/lotus_json/message.rs
@@ -7,7 +7,7 @@ use crate::shim::{address::Address, econ::TokenAmount, message::Message};
 use ::cid::Cid;
 use fvm_ipld_encoding::RawBytes;
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct MessageLotusJson {
     version: LotusJson<u64>,

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -132,6 +132,7 @@ use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializ
 #[cfg(test)]
 use serde_json::json;
 use std::{fmt::Display, str::FromStr};
+use uuid::Uuid;
 #[cfg(test)]
 use {pretty_assertions::assert_eq, quickcheck::quickcheck};
 
@@ -416,9 +417,6 @@ impl<T> LotusJson<T> {
     pub fn into_inner(self) -> T {
         self.0
     }
-    pub fn as_ref(&self) -> &T {
-        &self.0
-    }
 }
 
 impl<T> LotusJson<Option<T>> {
@@ -446,6 +444,12 @@ impl<T> JsonSchema for Stringify<T> {
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
         String::json_schema(gen)
+    }
+}
+
+impl<T: Clone> Clone for Stringify<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 
@@ -482,6 +486,7 @@ lotus_json_with_self!(
     bool,
     DeadlineInfo,
     PaddedPieceSize,
+    Uuid,
 );
 
 #[derive(Default, Debug, Serialize, Deserialize)]

--- a/src/lotus_json/signature.rs
+++ b/src/lotus_json/signature.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::shim::crypto::{Signature, SignatureType};
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct SignatureLotusJson {
     r#type: LotusJson<SignatureType>,

--- a/src/lotus_json/signed_message.rs
+++ b/src/lotus_json/signed_message.rs
@@ -7,7 +7,7 @@ use ::cid::Cid;
 
 use super::*;
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct SignedMessageLotusJson {
     message: LotusJson<Message>,

--- a/src/lotus_json/token_amount.rs
+++ b/src/lotus_json/token_amount.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::shim::econ::TokenAmount;
 use num::BigInt;
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)] // name the field for clarity
 pub struct TokenAmountLotusJson {
     attos: LotusJson<BigInt>,

--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -29,6 +29,12 @@ where
     }
 }
 
+impl<T: Clone> Clone for VecLotusJson<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 #[test]
 fn shapshots() {
     assert_one_snapshot(json!([{"/": "baeaaaaa"}]), vec![::cid::Cid::default()]);

--- a/src/lotus_json/vec_u8.rs
+++ b/src/lotus_json/vec_u8.rs
@@ -6,10 +6,10 @@ use super::*;
 // This code looks odd so we can
 // - use #[serde(with = "...")]
 // - de/ser empty vecs as null
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct VecU8LotusJson(Option<Inner>);
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 struct Inner(#[serde(with = "base64_standard")] Vec<u8>);
 
 impl JsonSchema for Inner {

--- a/src/rpc/methods/auth.rs
+++ b/src/rpc/methods/auth.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::auth::*;
-use crate::lotus_json::LotusJson;
 use crate::rpc::{ApiVersion, Ctx, RpcMethod, ServerError};
 use anyhow::Result;
 use chrono::Duration;
@@ -26,7 +25,7 @@ impl RpcMethod<1> for AuthNew {
     const PARAM_NAMES: [&'static str; 1] = ["params"];
     const API_VERSION: ApiVersion = ApiVersion::V0;
     type Params = (AuthNewParams,);
-    type Ok = LotusJson<Vec<u8>>;
+    type Ok = Vec<u8>;
     async fn handle(
         ctx: Ctx<impl Blockstore>,
         (params,): Self::Params,
@@ -34,7 +33,7 @@ impl RpcMethod<1> for AuthNew {
         let ks = ctx.keystore.read().await;
         let ki = ks.get(JWT_IDENTIFIER)?;
         let token = create_token(params.perms, ki.private_key(), params.token_exp)?;
-        Ok(LotusJson(token.as_bytes().to_vec()))
+        Ok(token.as_bytes().to_vec())
     }
 }
 

--- a/src/rpc/methods/beacon.rs
+++ b/src/rpc/methods/beacon.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::rpc::{ApiVersion, Ctx, RpcMethod, ServerError};
-use crate::{beacon::BeaconEntry, lotus_json::LotusJson, shim::clock::ChainEpoch};
+use crate::{beacon::BeaconEntry, shim::clock::ChainEpoch};
 use anyhow::Result;
 use fvm_ipld_blockstore::Blockstore;
 
@@ -23,7 +23,7 @@ impl RpcMethod<1> for BeaconGetEntry {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (ChainEpoch,);
-    type Ok = LotusJson<BeaconEntry>;
+    type Ok = BeaconEntry;
 
     async fn handle(
         ctx: Ctx<impl Blockstore>,
@@ -33,6 +33,6 @@ impl RpcMethod<1> for BeaconGetEntry {
         let rr =
             beacon.max_beacon_round_for_epoch(ctx.state_manager.get_network_version(first), first);
         let e = beacon.entry(rr).await?;
-        Ok(e.into())
+        Ok(e)
     }
 }

--- a/src/rpc/methods/common.rs
+++ b/src/rpc/methods/common.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use crate::lotus_json::lotus_json_with_self;
 use crate::rpc::error::ServerError;
 use crate::rpc::{ApiVersion, Ctx, RpcMethod};
 use fvm_ipld_blockstore::Blockstore;
@@ -94,6 +95,7 @@ pub struct PublicVersion {
     pub api_version: ShiftingVersion,
     pub block_delay: u32,
 }
+lotus_json_with_self!(PublicVersion);
 
 /// Integer based value on version information. Highest order bits for Major,
 /// Mid order for Minor and lowest for Patch.

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -325,7 +325,6 @@ pub async fn eth_syncing<DB: Blockstore + Sync + Send + 'static>(
     let crate::rpc::sync::RPCSyncState { active_syncs } =
         crate::rpc::sync::SyncState::handle(data.clone(), ()).await?;
     match active_syncs
-        .into_inner()
         .into_iter()
         .rev()
         .find_or_first(|ss| ss.stage() != SyncStage::Idle)

--- a/src/rpc/methods/mpool.rs
+++ b/src/rpc/methods/mpool.rs
@@ -53,7 +53,7 @@ impl RpcMethod<1> for MpoolPending {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<ApiTipsetKey>,);
-    type Ok = LotusJson<Vec<SignedMessage>>;
+    type Ok = Vec<SignedMessage>;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
@@ -72,7 +72,7 @@ impl RpcMethod<1> for MpoolPending {
         }
 
         if mpts.epoch() > ts.epoch() {
-            return Ok(pending.into_iter().collect::<Vec<_>>().into());
+            return Ok(pending.into_iter().collect::<Vec<_>>());
         }
 
         loop {
@@ -116,7 +116,7 @@ impl RpcMethod<1> for MpoolPending {
                 .chain_index
                 .load_required_tipset(ts.parents())?;
         }
-        Ok(pending.into_iter().collect::<Vec<_>>().into())
+        Ok(pending.into_iter().collect::<Vec<_>>())
     }
 }
 
@@ -128,7 +128,7 @@ impl RpcMethod<2> for MpoolSelect {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<ApiTipsetKey>, f64);
-    type Ok = LotusJson<Vec<SignedMessage>>;
+    type Ok = Vec<SignedMessage>;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
@@ -139,7 +139,7 @@ impl RpcMethod<2> for MpoolSelect {
             .chain_store()
             .load_required_tipset_or_heaviest(&tsk)?;
 
-        Ok(LotusJson(ctx.mpool.select_messages(&ts, tq)?))
+        Ok(ctx.mpool.select_messages(&ts, tq)?)
     }
 }
 
@@ -151,14 +151,14 @@ impl RpcMethod<1> for MpoolPush {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<SignedMessage>,);
-    type Ok = LotusJson<Cid>;
+    type Ok = Cid;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (LotusJson(msg),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let cid = ctx.mpool.as_ref().push(msg).await?;
-        Ok(cid.into())
+        Ok(cid)
     }
 }
 
@@ -170,7 +170,7 @@ impl RpcMethod<2> for MpoolPushMessage {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<Message>, Option<MessageSendSpec>);
-    type Ok = LotusJson<SignedMessage>;
+    type Ok = SignedMessage;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
@@ -218,6 +218,6 @@ impl RpcMethod<2> for MpoolPushMessage {
 
         ctx.mpool.as_ref().push(smsg.clone()).await?;
 
-        Ok(smsg.into())
+        Ok(smsg)
     }
 }

--- a/src/rpc/methods/net.rs
+++ b/src/rpc/methods/net.rs
@@ -5,14 +5,13 @@ use std::any::Any;
 use std::str::FromStr;
 
 use crate::libp2p::{NetRPCMethods, NetworkMessage, PeerId};
-use crate::lotus_json::{lotus_json_with_self, LotusJson};
+use crate::lotus_json::lotus_json_with_self;
 use crate::rpc::{ApiVersion, ServerError};
 use crate::rpc::{Ctx, RpcMethod};
 use anyhow::Result;
 use cid::multibase;
 use futures::channel::oneshot;
 use fvm_ipld_blockstore::Blockstore;
-use itertools::Itertools as _;
 use libp2p::Multiaddr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -64,7 +63,7 @@ impl RpcMethod<0> for NetPeers {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = ();
-    type Ok = LotusJson<Vec<AddrInfo>>;
+    type Ok = Vec<AddrInfo>;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
         let (tx, rx) = oneshot::channel();
@@ -81,9 +80,9 @@ impl RpcMethod<0> for NetPeers {
                 id: id.to_string(),
                 addrs,
             })
-            .collect_vec();
+            .collect();
 
-        Ok(connections.into())
+        Ok(connections)
     }
 }
 
@@ -264,6 +263,7 @@ pub struct NetInfoResult {
     pub num_pending_outgoing: u32,
     pub num_established: u32,
 }
+lotus_json_with_self!(NetInfoResult);
 
 impl From<libp2p::swarm::NetworkInfo> for NetInfoResult {
     fn from(i: libp2p::swarm::NetworkInfo) -> Self {
@@ -285,6 +285,7 @@ pub struct NatStatusResult {
     pub reachability: i32,
     pub public_addrs: Option<Vec<String>>,
 }
+lotus_json_with_self!(NatStatusResult);
 
 impl NatStatusResult {
     // See <https://github.com/libp2p/go-libp2p/blob/164adb40fef9c19774eb5fe6d92afb95c67ba83c/core/network/network.go#L93>

--- a/src/rpc/methods/node.rs
+++ b/src/rpc/methods/node.rs
@@ -3,7 +3,10 @@
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::rpc::{ApiVersion, Ctx, RpcMethod, ServerError};
+use crate::{
+    lotus_json::lotus_json_with_self,
+    rpc::{ApiVersion, Ctx, RpcMethod, ServerError},
+};
 use fvm_ipld_blockstore::Blockstore;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -77,18 +80,21 @@ pub struct NodeSyncStatus {
     pub epoch: u64,
     pub behind: u64,
 }
+lotus_json_with_self!(NodeSyncStatus);
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 pub struct NodePeerStatus {
     pub peers_to_publish_msgs: u32,
     pub peers_to_publish_blocks: u32,
 }
+lotus_json_with_self!(NodePeerStatus);
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 pub struct NodeChainStatus {
     pub blocks_per_tipset_last_100: f64,
     pub blocks_per_tipset_last_finality: f64,
 }
+lotus_json_with_self!(NodeChainStatus);
 
 #[derive(Debug, Deserialize, Default, Serialize, Clone, JsonSchema)]
 pub struct NodeStatusResult {
@@ -96,3 +102,4 @@ pub struct NodeStatusResult {
     pub peer_status: NodePeerStatus,
     pub chain_status: NodeChainStatus,
 }
+lotus_json_with_self!(NodeStatusResult);

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1230,7 +1230,7 @@ impl RpcMethod<1> for StateGetBeaconEntry {
     const API_VERSION: ApiVersion = ApiVersion::V1;
 
     type Params = (LotusJson<ChainEpoch>,);
-    type Ok = LotusJson<BeaconEntry>;
+    type Ok = BeaconEntry;
 
     async fn handle(
         ctx: Ctx<impl Blockstore>,
@@ -1254,7 +1254,7 @@ impl RpcMethod<1> for StateGetBeaconEntry {
         let network_version = ctx.state_manager.get_network_version(epoch);
         let round = beacon.max_beacon_round_for_epoch(network_version, epoch);
         let entry = beacon.entry(round).await?;
-        Ok(LotusJson(entry))
+        Ok(entry)
     }
 }
 

--- a/src/rpc/methods/sync.rs
+++ b/src/rpc/methods/sync.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::lotus_json::LotusJson;
+use crate::lotus_json::{lotus_json_with_self, LotusJson};
 use crate::rpc::{ApiVersion, Ctx, RpcMethod, ServerError};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
@@ -64,7 +64,7 @@ impl RpcMethod<0> for SyncState {
     type Ok = RPCSyncState;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
-        let active_syncs = LotusJson(nonempty![ctx.sync_state.as_ref().read().clone()]);
+        let active_syncs = nonempty![ctx.sync_state.as_ref().read().clone()];
         Ok(RPCSyncState { active_syncs })
     }
 }
@@ -73,8 +73,10 @@ impl RpcMethod<0> for SyncState {
 #[serde(rename_all = "PascalCase")]
 pub struct RPCSyncState {
     #[schemars(with = "LotusJson<Vec<crate::chain_sync::SyncState>>")]
-    pub active_syncs: LotusJson<NonEmpty<crate::chain_sync::SyncState>>,
+    #[serde(with = "crate::lotus_json")]
+    pub active_syncs: NonEmpty<crate::chain_sync::SyncState>,
 }
+lotus_json_with_self!(RPCSyncState);
 
 #[cfg(test)]
 mod tests {
@@ -205,10 +207,7 @@ mod tests {
         let st_copy = ctx.sync_state.clone();
 
         let ret = SyncState::handle(ctx.clone(), ()).await.unwrap();
-        assert_eq!(
-            ret.active_syncs,
-            nonempty![st_copy.as_ref().read().clone()].into()
-        );
+        assert_eq!(ret.active_syncs, nonempty![st_copy.as_ref().read().clone()]);
 
         // update cloned state
         st_copy.write().set_stage(SyncStage::Messages);
@@ -216,9 +215,6 @@ mod tests {
 
         let ret = SyncState::handle(ctx.clone(), ()).await.unwrap();
 
-        assert_eq!(
-            ret.active_syncs,
-            nonempty![st_copy.as_ref().read().clone()].into()
-        );
+        assert_eq!(ret.active_syncs, nonempty![st_copy.as_ref().read().clone()]);
     }
 }

--- a/src/rpc/methods/wallet.rs
+++ b/src/rpc/methods/wallet.rs
@@ -40,7 +40,7 @@ impl RpcMethod<1> for WalletBalance {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<Address>,);
-    type Ok = LotusJson<TokenAmount>;
+    type Ok = TokenAmount;
 
     async fn handle(
         ctx: Ctx<impl Blockstore>,
@@ -49,12 +49,12 @@ impl RpcMethod<1> for WalletBalance {
         let heaviest_ts = ctx.state_manager.chain_store().heaviest_tipset();
         let cid = heaviest_ts.parent_state();
 
-        Ok(LotusJson(
+        Ok(
             StateTree::new_from_root(ctx.state_manager.blockstore_owned(), cid)?
                 .get_actor(&address)?
                 .map(|it| it.balance.clone().into())
                 .unwrap_or_default(),
-        ))
+        )
     }
 }
 
@@ -65,11 +65,11 @@ impl RpcMethod<0> for WalletDefaultAddress {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = ();
-    type Ok = LotusJson<Option<Address>>;
+    type Ok = Option<Address>;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
         let keystore = ctx.keystore.read().await;
-        Ok(LotusJson(crate::key_management::get_default(&keystore)?))
+        Ok(crate::key_management::get_default(&keystore)?)
     }
 }
 
@@ -80,16 +80,15 @@ impl RpcMethod<1> for WalletExport {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<Address>,);
-    type Ok = LotusJson<KeyInfo>;
+    type Ok = KeyInfo;
 
     async fn handle(
         ctx: Ctx<impl Blockstore>,
         (LotusJson(address),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let keystore = ctx.keystore.read().await;
-
         let key_info = crate::key_management::export_key_info(&address, &keystore)?;
-        Ok(key_info.into())
+        Ok(key_info)
     }
 }
 
@@ -118,7 +117,7 @@ impl RpcMethod<1> for WalletImport {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<KeyInfo>,);
-    type Ok = LotusJson<Address>;
+    type Ok = Address;
 
     async fn handle(
         ctx: Ctx<impl Blockstore>,
@@ -130,7 +129,7 @@ impl RpcMethod<1> for WalletImport {
 
         let mut keystore = ctx.keystore.write().await;
         keystore.put(&addr, key.key_info)?;
-        Ok(LotusJson(key.address))
+        Ok(key.address)
     }
 }
 
@@ -141,11 +140,11 @@ impl RpcMethod<0> for WalletList {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = ();
-    type Ok = LotusJson<Vec<Address>>;
+    type Ok = Vec<Address>;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
         let keystore = ctx.keystore.read().await;
-        Ok(crate::key_management::list_addrs(&keystore)?.into())
+        Ok(crate::key_management::list_addrs(&keystore)?)
     }
 }
 
@@ -156,7 +155,7 @@ impl RpcMethod<1> for WalletNew {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<SignatureType>,);
-    type Ok = LotusJson<Address>;
+    type Ok = Address;
 
     async fn handle(
         ctx: Ctx<impl Blockstore>,
@@ -172,7 +171,7 @@ impl RpcMethod<1> for WalletNew {
             keystore.put("default", key.key_info)?
         }
 
-        Ok(key.address.into())
+        Ok(key.address)
     }
 }
 
@@ -205,7 +204,7 @@ impl RpcMethod<2> for WalletSign {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (LotusJson<Address>, LotusJson<Vec<u8>>);
-    type Ok = LotusJson<Signature>;
+    type Ok = Signature;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
@@ -231,7 +230,7 @@ impl RpcMethod<2> for WalletSign {
             &BASE64_STANDARD.decode(message)?,
         )?;
 
-        Ok(sig.into())
+        Ok(sig)
     }
 }
 
@@ -242,10 +241,10 @@ impl RpcMethod<1> for WalletValidateAddress {
     const API_VERSION: ApiVersion = ApiVersion::V0;
 
     type Params = (String,);
-    type Ok = LotusJson<Address>;
+    type Ok = Address;
 
     async fn handle(_: Ctx<impl Any>, (s,): Self::Params) -> Result<Self::Ok, ServerError> {
-        Ok(LotusJson(s.parse()?))
+        Ok(s.parse()?)
     }
 }
 

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -338,10 +338,6 @@ impl RpcTest {
     fn identity<T: PartialEq + HasLotusJson>(request: RpcRequest<T>) -> RpcTest {
         Self::validate(request, |forest, lotus| forest == lotus)
     }
-    /// See [Self::identity], and note on this `impl` block.
-    fn identity_raw<T: PartialEq + DeserializeOwned>(request: RpcRequest<T>) -> Self {
-        Self::validate_raw(request, |l, r| l == r)
-    }
 
     fn with_timeout(mut self, timeout: Duration) -> Self {
         self.request.set_timeout(timeout);
@@ -424,9 +420,9 @@ impl RpcTest {
 
 fn common_tests() -> Vec<RpcTest> {
     vec![
-        RpcTest::basic_raw(Version::request(()).unwrap()),
-        RpcTest::basic_raw(StartTime::request(()).unwrap()),
-        RpcTest::basic_raw(Session::request(()).unwrap()),
+        RpcTest::basic(Version::request(()).unwrap()),
+        RpcTest::basic(StartTime::request(()).unwrap()),
+        RpcTest::basic(Session::request(()).unwrap()),
     ]
 }
 
@@ -437,15 +433,15 @@ fn auth_tests() -> Vec<RpcTest> {
 }
 
 fn beacon_tests() -> Vec<RpcTest> {
-    vec![RpcTest::identity_raw(
+    vec![RpcTest::identity(
         BeaconGetEntry::request((10101,)).unwrap(),
     )]
 }
 
 fn chain_tests() -> Vec<RpcTest> {
     vec![
-        RpcTest::basic_raw(ChainHead::request(()).unwrap()),
-        RpcTest::identity_raw(ChainGetGenesis::request(()).unwrap()),
+        RpcTest::basic(ChainHead::request(()).unwrap()),
+        RpcTest::identity(ChainGetGenesis::request(()).unwrap()),
     ]
 }
 
@@ -453,21 +449,21 @@ fn chain_tests_with_tipset(shared_tipset: &Tipset) -> Vec<RpcTest> {
     let shared_block_cid = (*shared_tipset.min_ticket_block().cid()).into();
 
     vec![
-        RpcTest::identity_raw(ChainReadObj::request((shared_block_cid,)).unwrap()),
-        RpcTest::identity_raw(ChainHasObj::request((shared_block_cid,)).unwrap()),
-        RpcTest::identity_raw(ChainGetBlock::request((shared_block_cid,)).unwrap()),
-        RpcTest::identity_raw(
+        RpcTest::identity(ChainReadObj::request((shared_block_cid,)).unwrap()),
+        RpcTest::identity(ChainHasObj::request((shared_block_cid,)).unwrap()),
+        RpcTest::identity(ChainGetBlock::request((shared_block_cid,)).unwrap()),
+        RpcTest::identity(
             ChainGetTipSetAfterHeight::request((shared_tipset.epoch(), Default::default()))
                 .unwrap(),
         ),
-        RpcTest::identity_raw(
+        RpcTest::identity(
             ChainGetTipSetAfterHeight::request((shared_tipset.epoch(), Default::default()))
                 .unwrap(),
         ),
-        RpcTest::identity_raw(
+        RpcTest::identity(
             ChainGetTipSet::request((LotusJson(shared_tipset.key().clone().into()),)).unwrap(),
         ),
-        RpcTest::identity_raw(
+        RpcTest::identity(
             ChainGetPath::request((
                 shared_tipset.key().clone().into(),
                 shared_tipset.parents().clone().into(),
@@ -479,8 +475,8 @@ fn chain_tests_with_tipset(shared_tipset: &Tipset) -> Vec<RpcTest> {
 
 fn mpool_tests() -> Vec<RpcTest> {
     vec![
-        RpcTest::basic_raw(MpoolPending::request((LotusJson(ApiTipsetKey(None)),)).unwrap()),
-        RpcTest::basic_raw(MpoolSelect::request((LotusJson(ApiTipsetKey(None)), 0.9_f64)).unwrap()),
+        RpcTest::basic(MpoolPending::request((LotusJson(ApiTipsetKey(None)),)).unwrap()),
+        RpcTest::basic(MpoolSelect::request((LotusJson(ApiTipsetKey(None)), 0.9_f64)).unwrap()),
     ]
 }
 
@@ -498,14 +494,14 @@ fn net_tests() -> Vec<RpcTest> {
     // More net commands should be tested. Tracking issue:
     // https://github.com/ChainSafe/forest/issues/3639
     vec![
-        RpcTest::basic_raw(NetAddrsListen::request(()).unwrap()),
-        RpcTest::basic_raw(NetPeers::request(()).unwrap()),
-        RpcTest::identity_raw(NetListening::request(()).unwrap()),
-        RpcTest::basic_raw(NetAgentVersion::request((peer_id,)).unwrap()),
-        RpcTest::basic_raw(NetInfo::request(()).unwrap())
+        RpcTest::basic(NetAddrsListen::request(()).unwrap()),
+        RpcTest::basic(NetPeers::request(()).unwrap()),
+        RpcTest::identity(NetListening::request(()).unwrap()),
+        RpcTest::basic(NetAgentVersion::request((peer_id,)).unwrap()),
+        RpcTest::basic(NetInfo::request(()).unwrap())
             .ignore("Not implemented in Lotus. Why do we even have this method?"),
-        RpcTest::basic_raw(NetAutoNatStatus::request(()).unwrap()),
-        RpcTest::identity_raw(NetVersion::request(()).unwrap()),
+        RpcTest::basic(NetAutoNatStatus::request(()).unwrap()),
+        RpcTest::identity(NetVersion::request(()).unwrap()),
     ]
 }
 
@@ -519,8 +515,8 @@ fn node_tests() -> Vec<RpcTest> {
 
 fn state_tests() -> Vec<RpcTest> {
     vec![
-        RpcTest::identity_raw(StateGetBeaconEntry::request((0.into(),)).unwrap()),
-        RpcTest::identity_raw(StateGetBeaconEntry::request((1.into(),)).unwrap()),
+        RpcTest::identity(StateGetBeaconEntry::request((0.into(),)).unwrap()),
+        RpcTest::identity(StateGetBeaconEntry::request((1.into(),)).unwrap()),
     ]
 }
 
@@ -594,9 +590,7 @@ fn state_tests_with_tipset(shared_tipset: &Tipset) -> Vec<RpcTest> {
             Address::new_id(18101), // msig address id
             shared_tipset.key().into(),
         )),
-        RpcTest::identity_raw(
-            StateGetBeaconEntry::request((shared_tipset.epoch().into(),)).unwrap(),
-        ),
+        RpcTest::identity(StateGetBeaconEntry::request((shared_tipset.epoch().into(),)).unwrap()),
     ]
 }
 
@@ -615,9 +609,9 @@ fn wallet_tests() -> Vec<RpcTest> {
     };
 
     vec![
-        RpcTest::identity_raw(WalletBalance::request((known_wallet.into(),)).unwrap()),
-        RpcTest::identity_raw(WalletValidateAddress::request((known_wallet.to_string(),)).unwrap()),
-        RpcTest::identity_raw(
+        RpcTest::identity(WalletBalance::request((known_wallet.into(),)).unwrap()),
+        RpcTest::identity(WalletValidateAddress::request((known_wallet.to_string(),)).unwrap()),
+        RpcTest::identity(
             WalletVerify::request((known_wallet.into(), text.into(), signature.into())).unwrap(),
         ),
         // These methods require write access in Lotus. Not sure why.
@@ -677,7 +671,7 @@ fn gas_tests_with_tipset(shared_tipset: &Tipset) -> Vec<RpcTest> {
     // is inherently non-deterministic but I'm fairly sure we're compensated for
     // everything. If not, this test will be flaky. Instead of disabling it, we
     // should relax the verification requirement.
-    vec![RpcTest::identity_raw(
+    vec![RpcTest::identity(
         GasEstimateGasLimit::request((message.into(), LotusJson(shared_tipset.key().into())))
             .unwrap(),
     )]
@@ -714,7 +708,7 @@ fn snapshot_tests(store: Arc<ManyCar>, n_tipsets: usize) -> anyhow::Result<Vec<R
     )));
 
     for tipset in shared_tipset.clone().chain(&store).take(n_tipsets) {
-        tests.push(RpcTest::identity_raw(ChainGetMessagesInTipset::request((
+        tests.push(RpcTest::identity(ChainGetMessagesInTipset::request((
             tipset.key().clone().into(),
         ))?));
         tests.push(RpcTest::identity(
@@ -724,15 +718,15 @@ fn snapshot_tests(store: Arc<ManyCar>, n_tipsets: usize) -> anyhow::Result<Vec<R
                 tipset.key().into(),
             ),
         ));
-        tests.push(RpcTest::identity_raw(ChainTipSetWeight::request((
-            LotusJson(tipset.key().into()),
-        ))?));
+        tests.push(RpcTest::identity(ChainTipSetWeight::request((LotusJson(
+            tipset.key().into(),
+        ),))?));
         for block in tipset.block_headers() {
             let block_cid = (*block.cid()).into();
             tests.extend([
-                RpcTest::identity_raw(ChainGetBlockMessages::request((block_cid,))?),
-                RpcTest::identity_raw(ChainGetParentMessages::request((block_cid,))?),
-                RpcTest::identity_raw(ChainGetParentReceipts::request((block_cid,))?),
+                RpcTest::identity(ChainGetBlockMessages::request((block_cid,))?),
+                RpcTest::identity(ChainGetParentMessages::request((block_cid,))?),
+                RpcTest::identity(ChainGetParentReceipts::request((block_cid,))?),
             ]);
             tests.push(RpcTest::identity(ApiInfo::state_miner_active_sectors_req(
                 block.miner_address,
@@ -741,7 +735,7 @@ fn snapshot_tests(store: Arc<ManyCar>, n_tipsets: usize) -> anyhow::Result<Vec<R
             for sector in
                 StateSectorPreCommitInfo::get_sectors(&store, &block.miner_address, &tipset)?
             {
-                tests.push(RpcTest::identity_raw(StateSectorPreCommitInfo::request((
+                tests.push(RpcTest::identity(StateSectorPreCommitInfo::request((
                     block.miner_address.into(),
                     sector.into(),
                     LotusJson(tipset.key().into()),
@@ -750,7 +744,7 @@ fn snapshot_tests(store: Arc<ManyCar>, n_tipsets: usize) -> anyhow::Result<Vec<R
 
             let (bls_messages, secp_messages) = crate::chain::store::block_messages(&store, block)?;
             for msg in bls_messages.into_iter().unique() {
-                tests.push(RpcTest::identity_raw(ChainGetMessage::request((msg
+                tests.push(RpcTest::identity(ChainGetMessage::request((msg
                     .cid()?
                     .into(),))?));
                 tests.push(RpcTest::identity(ApiInfo::state_account_key_req(
@@ -791,7 +785,7 @@ fn snapshot_tests(store: Arc<ManyCar>, n_tipsets: usize) -> anyhow::Result<Vec<R
                 ));
             }
             for msg in secp_messages.into_iter().unique() {
-                tests.push(RpcTest::identity_raw(ChainGetMessage::request((msg
+                tests.push(RpcTest::identity(ChainGetMessage::request((msg
                     .cid()?
                     .into(),))?));
                 tests.push(RpcTest::identity(ApiInfo::state_account_key_req(

--- a/src/tool/subcommands/shed_cmd.rs
+++ b/src/tool/subcommands/shed_cmd.rs
@@ -59,7 +59,7 @@ impl ShedCommands {
         match self {
             ShedCommands::SummarizeTipsets { height, ancestors } => {
                 let client = rpc::Client::from(ApiInfo::from_env()?);
-                let head = ChainHead::call(&client, ()).await?.into_inner();
+                let head = ChainHead::call(&client, ()).await?;
                 let end_height = match height {
                     Some(it) => it,
                     None => head
@@ -80,7 +80,7 @@ impl ShedCommands {
                                 LotusJson(ApiTipsetKey(Some(head.key().clone()))),
                             ),
                         )
-                        .map_ok(|LotusJson(tipset)| {
+                        .map_ok(|tipset| {
                             let cids = tipset.block_headers().iter().map(|it| *it.cid());
                             (tipset.epoch(), cids.collect::<Vec<_>>())
                         })

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -85,7 +85,7 @@ impl WalletBackend {
         if let Some(keystore) = &self.local {
             Ok(crate::key_management::list_addrs(keystore)?)
         } else {
-            Ok(WalletList::call(&self.remote, ()).await?.into_inner())
+            Ok(WalletList::call(&self.remote, ()).await?)
         }
     }
 
@@ -93,9 +93,7 @@ impl WalletBackend {
         if let Some(keystore) = &self.local {
             Ok(crate::key_management::export_key_info(&address, keystore)?)
         } else {
-            Ok(WalletExport::call(&self.remote, (address.into(),))
-                .await?
-                .into_inner())
+            Ok(WalletExport::call(&self.remote, (address.into(),)).await?)
         }
     }
 
@@ -109,7 +107,6 @@ impl WalletBackend {
         } else {
             Ok(WalletImport::call(&self.remote, (key_info.into(),))
                 .await?
-                .into_inner()
                 .to_string())
         }
     }
@@ -145,7 +142,6 @@ impl WalletBackend {
         } else {
             Ok(WalletNew::call(&self.remote, (signature_type.into(),))
                 .await?
-                .into_inner()
                 .to_string())
         }
     }
@@ -156,7 +152,6 @@ impl WalletBackend {
         } else {
             Ok(WalletDefaultAddress::call(&self.remote, ())
                 .await?
-                .into_inner()
                 .map(|it| it.to_string()))
         }
     }
@@ -185,8 +180,7 @@ impl WalletBackend {
         } else {
             Ok(
                 WalletSign::call(&self.remote, (address.into(), message.into_bytes().into()))
-                    .await?
-                    .into_inner(),
+                    .await?,
             )
         }
     }
@@ -328,9 +322,7 @@ impl WalletCommands {
             Self::Balance { address } => {
                 let StrictAddress(address) = StrictAddress::from_str(&address)
                     .with_context(|| format!("Invalid address: {address}"))?;
-                let balance = WalletBalance::call(&backend.remote, (address.into(),))
-                    .await?
-                    .into_inner();
+                let balance = WalletBalance::call(&backend.remote, (address.into(),)).await?;
                 println!("{balance}");
                 Ok(())
             }
@@ -417,9 +409,7 @@ impl WalletCommands {
                     };
 
                     let balance_token_amount =
-                        WalletBalance::call(&backend.remote, (address.into(),))
-                            .await?
-                            .into_inner();
+                        WalletBalance::call(&backend.remote, (address.into(),)).await?;
 
                     let balance_string = match (no_round, no_abbrev) {
                         // no_round, absolute
@@ -454,9 +444,7 @@ impl WalletCommands {
                 Ok(())
             }
             Self::ValidateAddress { address } => {
-                let response = WalletValidateAddress::call(&backend.remote, (address,))
-                    .await?
-                    .into_inner();
+                let response = WalletValidateAddress::call(&backend.remote, (address,)).await?;
                 println!("{response}");
                 Ok(())
             }
@@ -535,9 +523,7 @@ impl WalletCommands {
                     MpoolPush::call(&backend.remote, (LotusJson(smsg.clone()),)).await?;
                     smsg
                 } else {
-                    MpoolPushMessage::call(&backend.remote, (LotusJson(message), None))
-                        .await?
-                        .into_inner()
+                    MpoolPushMessage::call(&backend.remote, (LotusJson(message), None)).await?
                 };
 
                 println!("{}", signed_msg.cid().unwrap());


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to fix [CI test failures](https://github.com/ChainSafe/forest/actions/runs/8725844010/job/23940006136?pr=4218)

```
Forest response: []
Lotus response: null
Diff: -[]

+null
```

The root cause is, the framework accepts any serializable Ok types whose raw JSON formats differ from their lotus JSON 
 formats. (Vec<T> in this case, vec![] should serialize into null instead of [])  Constrain `Ok: HasLotusJson` to avoid this kind of bug.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
