### PR TITLE
rpc tests on demand

### DIFF
--- a/.github/workflows/rpc_test_repeat.yml
+++ b/.github/workflows/rpc_test_repeat.yml
@@ -1,0 +1,46 @@
+name: RPC tests on repeat
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Forest image to use'
+        required: false
+        default: 'ghcr.io/chainsafe/forest:edge-fat'
+        type: string
+
+  schedule:
+    # Run every day at midnight
+    - cron: 0 0 * * *
+
+env:
+  SHELL_IMAGE: busybox
+  SCRIPT_TIMEOUT_MINUTES: 30
+
+jobs:
+  calibnet-rpc-checks:
+    strategy:
+      fail-fast: false
+      matrix:
+        # GH Actions do not support running jobs in a loop.
+        # This is a workaround to run the same job 100 times.
+        x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        y: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    name: Calibnet RPC checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run api compare tests
+        shell: bash
+        run: |
+          IMAGE=${{ github.event.inputs.image }}
+          if [ -z "$IMAGE" ]; then
+            IMAGE="ghcr.io/chainsafe/forest:edge-fat"
+          fi
+          echo "FROM $IMAGE" > Dockerfile-RPC
+          export FOREST_DOCKERFILE_OVERRIDE=Dockerfile-RPC
+          ./scripts/tests/api_compare/setup.sh
+        timeout-minutes: '${{ fromJSON(env.SCRIPT_TIMEOUT_MINUTES) }}'
+      - name: Dump docker logs
+        if: always()
+        uses: jwalton/gh-docker-logs@v2


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- introduces a cron/on-demand workflow to spawn 100 parallel RPC tests in order to flush out  flakiness from the Forest's RPC world.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
