### PR TITLE
fix: constrain print_pretty_json with T: HasLotusJson to avoid breakage

### DIFF
--- a/src/cli/subcommands/chain_cmd.rs
+++ b/src/cli/subcommands/chain_cmd.rs
@@ -10,7 +10,7 @@ use cid::Cid;
 use clap::Subcommand;
 use nonempty::NonEmpty;
 
-use super::{print_pretty_json, print_rpc_res_cids};
+use super::{print_pretty_lotus_json, print_rpc_res_cids};
 
 #[derive(Debug, Subcommand)]
 pub enum ChainCommands {
@@ -60,17 +60,21 @@ impl ChainCommands {
     pub async fn run(self, client: rpc::Client) -> anyhow::Result<()> {
         match self {
             Self::Block { cid } => {
-                print_pretty_json(ChainGetBlock::call(&client, (cid.into(),)).await?)
+                print_pretty_lotus_json(ChainGetBlock::call(&client, (cid.into(),)).await?)
             }
-            Self::Genesis => print_pretty_json(ChainGetGenesis::call_raw(&client, ()).await?),
+            Self::Genesis => print_pretty_lotus_json(ChainGetGenesis::call(&client, ()).await?),
             Self::Head => print_rpc_res_cids(ChainHead::call(&client, ()).await?),
             Self::Message { cid } => {
                 let bytes = ChainReadObj::call(&client, (cid.into(),)).await?;
                 match fvm_ipld_encoding::from_slice::<ChainMessage>(&bytes)? {
-                    ChainMessage::Unsigned(m) => print_pretty_json(LotusJson(m)),
+                    ChainMessage::Unsigned(m) => print_pretty_lotus_json(m),
                     ChainMessage::Signed(m) => {
                         let cid = m.cid()?;
-                        print_pretty_json(m.into_lotus_json().with_cid(cid))
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&m.into_lotus_json().with_cid(cid))?
+                        );
+                        Ok(())
                     }
                 }
             }

--- a/src/cli/subcommands/mod.rs
+++ b/src/cli/subcommands/mod.rs
@@ -21,12 +21,11 @@ mod sync_cmd;
 
 use std::io::Write;
 
-use crate::blocks::Tipset;
 pub(crate) use crate::cli_shared::cli::Config;
 use crate::cli_shared::cli::HELP_MESSAGE;
 use crate::utils::version::FOREST_VERSION_STRING;
+use crate::{blocks::Tipset, lotus_json::HasLotusJson};
 use clap::Parser;
-use serde::Serialize;
 use tracing::error;
 
 pub(super) use self::{
@@ -111,8 +110,8 @@ pub fn cli_error_and_die(msg: impl AsRef<str>, code: i32) -> ! {
 }
 
 /// Prints a pretty HTTP JSON-RPC response result
-pub(super) fn print_pretty_json<T: Serialize>(obj: T) -> anyhow::Result<()> {
-    println!("{}", serde_json::to_string_pretty(&obj)?);
+pub(super) fn print_pretty_lotus_json<T: HasLotusJson>(obj: T) -> anyhow::Result<()> {
+    println!("{}", serde_json::to_string_pretty(&obj.into_lotus_json())?);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- constrain `print_pretty_json` with `T: HasLotusJson` to avoid breakage of the output format
- rename `print_pretty_json` to `print_pretty_lotus_json` to avoid confusion

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
