### PR TITLE
handle bearer token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   Forest-specific RPC methods to `Forest`; `Filecoin.NetInfo` and
   `Filecoin.StateFetchRoot` to `Forest.NetInfo` and `Forest.StateFetchRoot`.
 
+- [#4262](https://github.com/ChainSafe/forest/pull/4262) Added `Bearer` prefix
+  to the `Authorization` header in the Forest RPC API. This is a
+  partially-breaking change - new Forest RPC clients will not work with old
+  Forest nodes. This change is necessary to align with the Lotus RPC API.
+
 ### Added
 
 - [#4246](https://github.com/ChainSafe/forest/pull/4246) Add support for the

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -155,14 +155,13 @@ impl UrlClient {
     async fn new(url: Url, token: impl Into<Option<String>>) -> Result<Self, ClientError> {
         let timeout = Duration::MAX; // we handle timeouts ourselves.
         let headers = match token.into() {
-            Some(it) => HeaderMap::from_iter([(
+            Some(token) => HeaderMap::from_iter([(
                 header::AUTHORIZATION,
-                match HeaderValue::try_from(it) {
-                    Ok(it) => it,
+                match HeaderValue::try_from(format!("Bearer {token}")) {
+                    Ok(token) => token,
                     Err(e) => {
                         return Err(ClientError::Custom(format!(
-                            "Invalid authorization token: {}",
-                            e
+                            "Invalid authorization token: {e}",
                         )))
                     }
                 },


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- align JWT usage with Lotus (and in general JSON Web Token specification) - header values shall include the `Bearer` prefix. This is necessary, e.g., for the `api compare` to support sending `write` tokens to Lotus, see [Go JSON-RPC authorization handling](https://github.com/filecoin-project/go-jsonrpc/blob/17a35772b24f59ceee25cc8d8177a2b255a659ac/auth/handler.go#L29-L33).
- Added some tests to untested code.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
