### PR TITLE
Decrease `request_timeout` in builders to avoid panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@
 - [#4177](https://github.com/ChainSafe/forest/pull/4177) Fixed a bug where the
   environment variable `IPFS_GATEWAY` was not used to change the IPFS gateway.
 
+- [#4267](https://github.com/ChainSafe/forest/pull/4267) Fixed potential panics
+  in `forest-tool api compare`.
+
 ## Forest 0.17.2 "Dovakhin"
 
 This is a **mandatory** release for all mainnet node operators. It changes the

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -18,6 +18,7 @@ use jsonrpsee::core::client::ClientT as _;
 use jsonrpsee::core::params::{ArrayParams, ObjectParams};
 use jsonrpsee::core::ClientError;
 use serde::de::DeserializeOwned;
+use std::time::Duration;
 use tracing::{debug, Instrument, Level};
 use url::Url;
 
@@ -152,6 +153,7 @@ impl Debug for UrlClient {
 
 impl UrlClient {
     async fn new(url: Url, token: impl Into<Option<String>>) -> Result<Self, ClientError> {
+        const ONE_DAY: Duration = Duration::from_secs(24 * 3600); // we handle timeouts ourselves.
         let headers = match token.into() {
             Some(token) => HeaderMap::from_iter([(
                 header::AUTHORIZATION,
@@ -172,6 +174,7 @@ impl UrlClient {
                     .set_headers(headers)
                     .max_request_size(MAX_REQUEST_BODY_SIZE)
                     .max_response_size(MAX_RESPONSE_BODY_SIZE)
+                    .request_timeout(ONE_DAY)
                     .build(&url)
                     .await?,
             ),
@@ -180,6 +183,7 @@ impl UrlClient {
                     .set_headers(headers)
                     .max_request_size(MAX_REQUEST_BODY_SIZE)
                     .max_response_size(MAX_RESPONSE_BODY_SIZE)
+                    .request_timeout(ONE_DAY)
                     .build(&url)?,
             ),
             it => {

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -12,13 +12,13 @@
 //! - Support per-request timeouts.
 
 use std::fmt::{self, Debug};
+use std::time::Duration;
 
 use http02::{header, HeaderMap, HeaderValue};
 use jsonrpsee::core::client::ClientT as _;
 use jsonrpsee::core::params::{ArrayParams, ObjectParams};
 use jsonrpsee::core::ClientError;
 use serde::de::DeserializeOwned;
-use std::time::Duration;
 use tracing::{debug, Instrument, Level};
 use url::Url;
 

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -12,7 +12,6 @@
 //! - Support per-request timeouts.
 
 use std::fmt::{self, Debug};
-use std::time::Duration;
 
 use http02::{header, HeaderMap, HeaderValue};
 use jsonrpsee::core::client::ClientT as _;
@@ -153,7 +152,6 @@ impl Debug for UrlClient {
 
 impl UrlClient {
     async fn new(url: Url, token: impl Into<Option<String>>) -> Result<Self, ClientError> {
-        let timeout = Duration::MAX; // we handle timeouts ourselves.
         let headers = match token.into() {
             Some(token) => HeaderMap::from_iter([(
                 header::AUTHORIZATION,
@@ -172,7 +170,6 @@ impl UrlClient {
             "ws" | "wss" => OneClientInner::Ws(
                 jsonrpsee::ws_client::WsClientBuilder::new()
                     .set_headers(headers)
-                    .request_timeout(timeout)
                     .max_request_size(MAX_REQUEST_BODY_SIZE)
                     .max_response_size(MAX_RESPONSE_BODY_SIZE)
                     .build(&url)
@@ -183,7 +180,6 @@ impl UrlClient {
                     .set_headers(headers)
                     .max_request_size(MAX_REQUEST_BODY_SIZE)
                     .max_response_size(MAX_RESPONSE_BODY_SIZE)
-                    .request_timeout(timeout)
                     .build(&url)?,
             ),
             it => {


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:

- Decrease `request_timeout` value in `WsClientBuilder` and `HttpClientBuilder` to avoid panics (see logs below)

Rational:

We don't need to handle timeouts at the `jsonrpsee` client level since we shim our own timeouts during the call, but setting it to some max value seems unsafe.

Setting a 10s timeout and simulating a slow endpoint in forest daemon:

```console
$ FOREST_RPC_DEFAULT_TIMEOUT=10 ./forest-tool api compare --lotus /ip4/127.0.0.1/tcp/1234/ws --forest /ip4/127.0.0.1/tcp/2345/ws forest_snapshot_calibnet_2024-04-19_height_1539740.forest.car.zst --filter EthChainId
Request dump: RpcRequest { method_name: "Filecoin.EthChainId", params: Null, result_type: PhantomData<serde_json::value::Value>, api_version: V1, timeout: 10s }
Request params JSON: null
Lotus response: "0x4cb2f"

| RPC Method          | Forest              | Lotus |
|---------------------|---------------------|-------|
| Filecoin.EthChainId | InternalServerError | Valid |
Error: Some tests failed
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

```
$ RUST_BACKTRACE=1 ./forest-tool api compare --lotus /ip4/127.0.0.1/tcp/1234/ws --forest /ip4/127.0.0.1/tcp/2345/ws forest_snapshot_calibnet_2024-04-19_height_1539740.forest.car.zst --filter EthChainId
thread 'tokio-runtime-worker' panicked at library/std/src/time.rs:417:33:
overflow when adding duration to instant
```

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
