### PR TITLE
chore: use `fn get_required_*` to avoid uninformative `<Option as anyhow::Context>::context` calls

### DIFF
--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -17,6 +17,7 @@ use crate::shim::clock::ChainEpoch;
 use crate::shim::error::ExitCode;
 use crate::shim::executor::Receipt;
 use crate::shim::message::Message;
+use crate::utils::db::CborStoreExt as _;
 use crate::utils::io::VoidAsyncWriter;
 use anyhow::{Context as _, Result};
 use cid::Cid;
@@ -306,11 +307,7 @@ impl RpcMethod<1> for ChainGetBlockMessages {
         ctx: Ctx<impl Blockstore>,
         (cid,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let blk: CachingBlockHeader = ctx
-            .state_manager
-            .blockstore()
-            .get_cbor(&cid)?
-            .context("can't find block with that cid")?;
+        let blk: CachingBlockHeader = ctx.state_manager.blockstore().get_cbor_required(&cid)?;
         let blk_msgs = &blk.messages;
         let (unsigned_cids, signed_cids) =
             crate::chain::read_msg_cids(ctx.state_manager.blockstore(), blk_msgs)?;
@@ -507,11 +504,7 @@ impl RpcMethod<1> for ChainGetBlock {
         ctx: Ctx<impl Blockstore>,
         (cid,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let blk: CachingBlockHeader = ctx
-            .state_manager
-            .blockstore()
-            .get_cbor(&cid)?
-            .context("can't find BlockHeader with that cid")?;
+        let blk: CachingBlockHeader = ctx.state_manager.blockstore().get_cbor_required(&cid)?;
         Ok(blk)
     }
 }

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -20,7 +20,7 @@ use crate::shim::fvm_shared_latest::MethodNum;
 use crate::shim::message::Message;
 use crate::shim::{clock::ChainEpoch, state_tree::StateTree};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use bytes::{Buf, BytesMut};
 use cbor4ii::core::{dec::Decode, utils::SliceReader, Value};
 use cid::{
@@ -782,9 +782,7 @@ impl RpcMethod<2> for EthGetBalance {
         let ts = tipset_by_block_number_or_hash(&ctx.chain_store, block_param)?;
         let state =
             StateTree::new_from_root(ctx.state_manager.blockstore_owned(), ts.parent_state())?;
-        let actor = state
-            .get_actor(&fil_addr)?
-            .context("Failed to retrieve actor")?;
+        let actor = state.get_required_actor(&fil_addr)?;
         Ok(BigInt(actor.balance.atto().clone()))
     }
 }

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -18,7 +18,10 @@ use crate::shim::{
 use crate::state_manager::chain_rand::ChainRand;
 use crate::state_manager::circulating_supply::GenesisInfo;
 use crate::state_manager::MarketBalance;
-use crate::utils::db::car_stream::{CarBlock, CarWriter};
+use crate::utils::db::{
+    car_stream::{CarBlock, CarWriter},
+    BlockstoreExt as _,
+};
 use crate::{
     beacon::BeaconEntry,
     rpc::{types::*, ApiVersion, Ctx, Permission, RpcMethod, ServerError},
@@ -729,8 +732,7 @@ impl RpcMethod<3> for StateMinerInitialPledgeCollateral {
 
         let actor = ctx
             .state_manager
-            .get_actor(&Address::MARKET_ACTOR, state)?
-            .context("Market actor address could not be resolved")?;
+            .get_required_actor(&Address::MARKET_ACTOR, state)?;
         let market_state = market::State::load(ctx.store(), actor.code, actor.state)?;
         let (w, vw) = market_state.verify_deals_for_activation(
             ctx.store(),
@@ -744,16 +746,14 @@ impl RpcMethod<3> for StateMinerInitialPledgeCollateral {
 
         let actor = ctx
             .state_manager
-            .get_actor(&Address::POWER_ACTOR, state)?
-            .context("Power actor address could not be resolved")?;
+            .get_required_actor(&Address::POWER_ACTOR, state)?;
         let power_state = power::State::load(ctx.store(), actor.code, actor.state)?;
         let power_smoothed = power_state.total_power_smoothed();
         let pledge_collateral = power_state.total_locked();
 
         let actor = ctx
             .state_manager
-            .get_actor(&Address::REWARD_ACTOR, state)?
-            .context("Reward actor address could not be resolved")?;
+            .get_required_actor(&Address::REWARD_ACTOR, state)?;
         let reward_state = reward::State::load(ctx.store(), actor.code, actor.state)?;
         let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config());
         let circ_supply = genesis_info.get_vm_circulating_supply_detailed(
@@ -1240,11 +1240,7 @@ impl RpcMethod<2> for StateReadState {
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
-        let blk = ctx
-            .state_manager
-            .blockstore()
-            .get(&actor.state)?
-            .context("Failed to get block from blockstore")?;
+        let blk = ctx.state_manager.blockstore().get_required(&actor.state)?;
         let state = *fvm_ipld_encoding::from_slice::<NonEmpty<Cid>>(&blk)?.first();
         Ok(ApiActorState {
             balance: actor.balance.clone().into(),

--- a/src/state_manager/circulating_supply.rs
+++ b/src/state_manager/circulating_supply.rs
@@ -267,9 +267,7 @@ fn get_fil_vested(genesis_info: &GenesisInfo, height: ChainEpoch) -> TokenAmount
 }
 
 fn get_fil_mined<DB: Blockstore>(state_tree: &StateTree<DB>) -> Result<TokenAmount, anyhow::Error> {
-    let actor = state_tree
-        .get_actor(&Address::REWARD_ACTOR)?
-        .context("Reward actor address could not be resolved")?;
+    let actor = state_tree.get_required_actor(&Address::REWARD_ACTOR)?;
     let state = reward::State::load(state_tree.store(), actor.code, actor.state)?;
 
     Ok(state.into_total_storage_power_reward().into())

--- a/src/state_migration/common/macros/verifier.rs
+++ b/src/state_migration/common/macros/verifier.rs
@@ -10,11 +10,9 @@ macro_rules! impl_verifier {
         pub(super) mod verifier {
             use $crate::cid_collections::CidHashMap;
             use $crate::shim::{address::Address, machine::BuiltinActorManifest, state_tree::StateTree};
-            use ::fvm_ipld_blockstore::Blockstore;
-            use ::fvm_ipld_encoding::CborStore as _;
             use $crate::state_migration::common::{verifier::ActorMigrationVerifier, Migrator};
-            use ::anyhow::Context as _;
-
+            use $crate::utils::db::CborStoreExt as _;
+            use ::fvm_ipld_blockstore::Blockstore;
             use super::*;
 
             #[derive(Default)]
@@ -28,12 +26,9 @@ macro_rules! impl_verifier {
                     actors_in: &StateTree<BS>,
                 ) -> anyhow::Result<()> {
                     let system_actor = actors_in
-                        .get_actor(&Address::SYSTEM_ACTOR)?
-                        .context("system actor not found")?;
-
+                        .get_required_actor(&Address::SYSTEM_ACTOR)?;
                     let system_actor_state = store
-                        .get_cbor::<SystemStateOld>(&system_actor.state)?
-                        .context("system actor state not found")?;
+                        .get_cbor_required::<SystemStateOld>(&system_actor.state)?;
                     let manifest =
                         BuiltinActorManifest::load_v1_actor_list(&store, &system_actor_state.builtin_actors)?;
                     let manifest_actors_count = manifest.builtin_actors().len();

--- a/src/state_migration/nv18/eth_account.rs
+++ b/src/state_migration/nv18/eth_account.rs
@@ -1,31 +1,26 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use super::SystemStateNew;
 use crate::shim::{
     address::Address,
     machine::{BuiltinActor, BuiltinActorManifest},
     state_tree::{ActorState, StateTree},
 };
+use crate::state_migration::common::PostMigrator;
+use crate::utils::db::CborStoreExt as _;
 use anyhow::anyhow;
-use anyhow::Context as _;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
-
-use crate::state_migration::common::PostMigrator;
-
-use super::SystemStateNew;
 
 pub struct EthAccountPostMigrator;
 
 impl<BS: Blockstore> PostMigrator<BS> for EthAccountPostMigrator {
     /// Creates the Ethereum Account actor in the state tree.
     fn post_migrate_state(&self, store: &BS, actors_out: &mut StateTree<BS>) -> anyhow::Result<()> {
-        let init_actor = actors_out
-            .get_actor(&Address::INIT_ACTOR)?
-            .context("Couldn't get init actor state")?;
-        let init_state: fil_actor_init_state::v10::State = store
-            .get_cbor(&init_actor.state)?
-            .context("Couldn't get statev10")?;
+        let init_actor = actors_out.get_required_actor(&Address::INIT_ACTOR)?;
+        let init_state: fil_actor_init_state::v10::State =
+            store.get_cbor_required(&init_actor.state)?;
 
         let eth_zero_addr =
             Address::new_delegated(Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR.id()?, &[0; 20])?;

--- a/src/state_migration/nv19/power.rs
+++ b/src/state_migration/nv19/power.rs
@@ -6,8 +6,7 @@
 
 use crate::shim::sector::convert_window_post_proof_v1_to_v1p1;
 use crate::state_migration::common::{ActorMigration, ActorMigrationInput, ActorMigrationOutput};
-use crate::utils::db::CborStoreExt;
-use anyhow::Context as _;
+use crate::utils::db::CborStoreExt as _;
 use cid::Cid;
 use fil_actor_power_state::{
     v10::{Claim as ClaimV10, State as StateV10},
@@ -17,7 +16,6 @@ use fil_actors_shared::v11::{
     builtin::HAMT_BIT_WIDTH, make_empty_map, make_map_with_root_and_bitwidth,
 };
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
 use std::sync::Arc;
 
 pub struct PowerMigrator(Cid);
@@ -35,9 +33,7 @@ impl<BS: Blockstore> ActorMigration<BS> for PowerMigrator {
         store: &BS,
         input: ActorMigrationInput,
     ) -> anyhow::Result<Option<ActorMigrationOutput>> {
-        let in_state: StateV10 = store
-            .get_cbor(&input.head)?
-            .context("Power actor: could not read v10 state")?;
+        let in_state: StateV10 = store.get_cbor_required(&input.head)?;
 
         let in_claims = make_map_with_root_and_bitwidth(&in_state.claims, &store, HAMT_BIT_WIDTH)?;
 

--- a/src/state_migration/nv21fix/migration.rs
+++ b/src/state_migration/nv21fix/migration.rs
@@ -11,10 +11,10 @@ use crate::shim::{
     state_tree::{StateTree, StateTreeVersion},
 };
 use crate::state_migration::common::PostMigrationCheck;
+use crate::utils::db::CborStoreExt as _;
 use anyhow::{bail, Context};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
 
 use super::{system, verifier::Verifier, SystemStateOld};
 use crate::state_migration::common::{migrators::nil_migrator, StateMigration};
@@ -27,13 +27,9 @@ impl<BS: Blockstore> StateMigration<BS> {
         new_manifest: &BuiltinActorManifest,
     ) -> anyhow::Result<()> {
         let state_tree = StateTree::new_from_root(store.clone(), state)?;
-        let system_actor = state_tree
-            .get_actor(&Address::new_id(0))?
-            .context("failed to get system actor")?;
+        let system_actor = state_tree.get_required_actor(&Address::new_id(0))?;
 
-        let system_actor_state = store
-            .get_cbor::<SystemStateOld>(&system_actor.state)?
-            .context("system actor state not found")?;
+        let system_actor_state = store.get_cbor_required::<SystemStateOld>(&system_actor.state)?;
 
         let current_manifest_data = system_actor_state.builtin_actors;
 
@@ -61,13 +57,9 @@ struct PostMigrationVerifier {
 impl<BS: Blockstore> PostMigrationCheck<BS> for PostMigrationVerifier {
     fn post_migrate_check(&self, store: &BS, actors_out: &StateTree<BS>) -> anyhow::Result<()> {
         let actors_in = StateTree::new_from_root(Arc::new(store), &self.state_pre)?;
-        let system_actor = actors_in
-            .get_actor(&Address::new_id(0))?
-            .context("failed to get system actor")?;
+        let system_actor = actors_in.get_required_actor(&Address::new_id(0))?;
 
-        let system_actor_state = store
-            .get_cbor::<SystemStateOld>(&system_actor.state)?
-            .context("system actor state not found")?;
+        let system_actor_state = store.get_cbor_required::<SystemStateOld>(&system_actor.state)?;
 
         let current_manifest_data = system_actor_state.builtin_actors;
 
@@ -75,9 +67,7 @@ impl<BS: Blockstore> PostMigrationCheck<BS> for PostMigrationVerifier {
             BuiltinActorManifest::load_v1_actor_list(store, &current_manifest_data)?;
 
         actors_in.for_each(|address, actor_in| {
-            let actor_out = actors_out
-                .get_actor(&address)?
-                .context("failed to get actor from state tree")?;
+            let actor_out = actors_out.get_required_actor(&address)?;
 
             if actor_in.sequence != actor_out.sequence {
                 bail!(

--- a/src/state_migration/nv21fix2/migration.rs
+++ b/src/state_migration/nv21fix2/migration.rs
@@ -11,10 +11,10 @@ use crate::shim::{
     state_tree::{StateTree, StateTreeVersion},
 };
 use crate::state_migration::common::PostMigrationCheck;
+use crate::utils::db::CborStoreExt as _;
 use anyhow::{bail, Context};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
 
 use super::{system, verifier::Verifier, SystemStateOld};
 use crate::state_migration::common::{migrators::nil_migrator, StateMigration};
@@ -27,13 +27,9 @@ impl<BS: Blockstore> StateMigration<BS> {
         new_manifest: &BuiltinActorManifest,
     ) -> anyhow::Result<()> {
         let state_tree = StateTree::new_from_root(store.clone(), state)?;
-        let system_actor = state_tree
-            .get_actor(&Address::new_id(0))?
-            .context("failed to get system actor")?;
+        let system_actor = state_tree.get_required_actor(&Address::new_id(0))?;
 
-        let system_actor_state = store
-            .get_cbor::<SystemStateOld>(&system_actor.state)?
-            .context("system actor state not found")?;
+        let system_actor_state = store.get_cbor_required::<SystemStateOld>(&system_actor.state)?;
 
         let current_manifest_data = system_actor_state.builtin_actors;
 
@@ -61,13 +57,9 @@ struct PostMigrationVerifier {
 impl<BS: Blockstore> PostMigrationCheck<BS> for PostMigrationVerifier {
     fn post_migrate_check(&self, store: &BS, actors_out: &StateTree<BS>) -> anyhow::Result<()> {
         let actors_in = StateTree::new_from_root(Arc::new(store), &self.state_pre)?;
-        let system_actor = actors_in
-            .get_actor(&Address::new_id(0))?
-            .context("failed to get system actor")?;
+        let system_actor = actors_in.get_required_actor(&Address::new_id(0))?;
 
-        let system_actor_state = store
-            .get_cbor::<SystemStateOld>(&system_actor.state)?
-            .context("system actor state not found")?;
+        let system_actor_state = store.get_cbor_required::<SystemStateOld>(&system_actor.state)?;
 
         let current_manifest_data = system_actor_state.builtin_actors;
 
@@ -75,9 +67,7 @@ impl<BS: Blockstore> PostMigrationCheck<BS> for PostMigrationVerifier {
             BuiltinActorManifest::load_v1_actor_list(store, &current_manifest_data)?;
 
         actors_in.for_each(|address, actor_in| {
-            let actor_out = actors_out
-                .get_actor(&address)?
-                .context("failed to get actor from state tree")?;
+            let actor_out = actors_out.get_required_actor(&address)?;
 
             if actor_in.sequence != actor_out.sequence {
                 bail!(

--- a/src/state_migration/nv22/market.rs
+++ b/src/state_migration/nv22/market.rs
@@ -21,7 +21,6 @@ use fil_actor_market_state::v13::{
 use fil_actors_shared::v12::Array as ArrayOld;
 use fil_actors_shared::v13::Array as ArrayNew;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
 use fvm_shared4::clock::ChainEpoch;
 
 use crate::state_migration::common::{ActorMigration, ActorMigrationInput, ActorMigrationOutput};
@@ -51,9 +50,7 @@ impl<BS: Blockstore> ActorMigration<BS> for MarketMigrator {
         store: &BS,
         input: ActorMigrationInput,
     ) -> anyhow::Result<Option<ActorMigrationOutput>> {
-        let in_state: MarketStateOld = store
-            .get_cbor(&input.head)?
-            .context("failed to load state")?;
+        let in_state: MarketStateOld = store.get_cbor_required(&input.head)?;
 
         let (provider_sectors, new_states) =
             self.migrate_provider_sectors_and_states(store, &in_state.states, &in_state.proposals)?;

--- a/src/state_migration/nv22/miner.rs
+++ b/src/state_migration/nv22/miner.rs
@@ -12,13 +12,12 @@
 //! > requires reading all sector metadata from the miner actor.
 
 use crate::state_migration::common::{ActorMigration, ActorMigrationInput, ActorMigrationOutput};
+use crate::utils::db::CborStoreExt as _;
 use ahash::HashMap;
-use anyhow::Context;
 use cid::Cid;
 use fil_actor_miner_state::v12::State as MinerStateOld;
 use fil_actors_shared::v12::Array as ArrayOld;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
 use fvm_shared4::clock::ChainEpoch;
 use fvm_shared4::deal::DealID;
 use fvm_shared4::sector::{SectorID, SectorNumber};
@@ -57,9 +56,7 @@ impl<BS: Blockstore> ActorMigration<BS> for MinerMigrator {
         input: ActorMigrationInput,
     ) -> anyhow::Result<Option<ActorMigrationOutput>> {
         let miner_id = input.address.id()?;
-        let in_state: MinerStateOld = store
-            .get_cbor(&input.head)?
-            .context("Miner actor: could not read v12 state")?;
+        let in_state: MinerStateOld = store.get_cbor_required(&input.head)?;
 
         let in_sectors = ArrayOld::<fil_actor_miner_state::v12::SectorOnChainInfo, BS>::load(
             &in_state.sectors,

--- a/src/state_migration/type_migrations/miner/state_v10_to_v11.rs
+++ b/src/state_migration/type_migrations/miner/state_v10_to_v11.rs
@@ -2,22 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::shim::sector::convert_window_post_proof_v1_to_v1p1;
-use crate::utils::db::CborStoreExt;
-use anyhow::Context as _;
+use crate::state_migration::common::{TypeMigration, TypeMigrator};
+use crate::utils::db::CborStoreExt as _;
 use fil_actor_miner_state::{
     v10::{MinerInfo as MinerInfoV10, State as MinerStateV10},
     v11::{MinerInfo as MinerInfoV11, State as MinerStateV11},
 };
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
-
-use crate::state_migration::common::{TypeMigration, TypeMigrator};
 
 impl TypeMigration<MinerStateV10, MinerStateV11> for TypeMigrator {
     fn migrate_type(from: MinerStateV10, store: &impl Blockstore) -> anyhow::Result<MinerStateV11> {
-        let in_info: MinerInfoV10 = store
-            .get_cbor(&from.info)?
-            .context("Miner info: could not read v10 state")?;
+        let in_info: MinerInfoV10 = store.get_cbor_required(&from.info)?;
 
         let out_proof_type = convert_window_post_proof_v1_to_v1p1(in_info.window_post_proof_type)
             .map_err(|e| anyhow::anyhow!(e))?;

--- a/src/state_migration/type_migrations/miner/state_v8_to_v9.rs
+++ b/src/state_migration/type_migrations/miner/state_v8_to_v9.rs
@@ -2,21 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::utils::db::CborStoreExt;
-use anyhow::Context as _;
 use fil_actor_miner_state::{
     v8::{MinerInfo as MinerInfoV8, State as MinerStateV8},
     v9::{MinerInfo as MinerInfoV9, State as MinerStateV9},
 };
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::CborStore;
 
 use super::super::super::common::{TypeMigration, TypeMigrator};
 
 impl TypeMigration<MinerStateV8, MinerStateV9> for TypeMigrator {
     fn migrate_type(from: MinerStateV8, store: &impl Blockstore) -> anyhow::Result<MinerStateV9> {
-        let in_info: MinerInfoV8 = store
-            .get_cbor(&from.info)?
-            .context("Miner info: could not read v8 state")?;
+        let in_info: MinerInfoV8 = store.get_cbor_required(&from.info)?;
 
         let out_info: MinerInfoV9 = TypeMigrator::migrate_type(in_info, store)?;
 

--- a/src/statediff/resolve.rs
+++ b/src/statediff/resolve.rs
@@ -1,7 +1,7 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use anyhow::Context as _;
+use crate::utils::db::CborStoreExt as _;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
@@ -17,12 +17,8 @@ pub fn resolve_cids_recursive<BS>(
 where
     BS: Blockstore,
 {
-    let mut ipld = bs
-        .get_cbor(cid)?
-        .context("Cid does not exist in blockstore")?;
-
+    let mut ipld = bs.get_cbor_required(cid)?;
     resolve_ipld(bs, &mut ipld, depth)?;
-
     Ok(ipld)
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- simplify `CborStore::get_cbor(params)?.context(params)?` with `CborStore::get_cbor_required(params)?`
- simplify `StateManager::get_actor(params)?.context(params)?` with `StateManager::get_required_actor(params)?`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
