### PR TITLE
move `MinerGetBaseInfo` to miner module

### DIFF
--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -51,7 +51,6 @@ use tokio::task::JoinSet;
 
 macro_rules! for_each_method {
     ($callback:ident) => {
-        $callback!(crate::rpc::state::MinerGetBaseInfo);
         $callback!(crate::rpc::state::StateCall);
         $callback!(crate::rpc::state::StateGetBeaconEntry);
         $callback!(crate::rpc::state::StateListMessages);
@@ -100,32 +99,6 @@ pub(crate) use for_each_method;
 
 const INITIAL_PLEDGE_NUM: u64 = 110;
 const INITIAL_PLEDGE_DEN: u64 = 100;
-
-pub enum MinerGetBaseInfo {}
-impl RpcMethod<3> for MinerGetBaseInfo {
-    const NAME: &'static str = "Filecoin.MinerGetBaseInfo";
-    const PARAM_NAMES: [&'static str; 3] = ["address", "epoch", "tsk"];
-    const API_VERSION: ApiVersion = ApiVersion::V0;
-    const PERMISSION: Permission = Permission::Read;
-
-    type Params = (Address, i64, ApiTipsetKey);
-    type Ok = Option<MiningBaseInfo>;
-
-    async fn handle(
-        ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
-        (address, epoch, ApiTipsetKey(tsk)): Self::Params,
-    ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
-
-        Ok(ctx
-            .state_manager
-            .miner_get_base_info(ctx.state_manager.beacon_schedule(), ts, address, epoch)
-            .await?)
-    }
-}
 
 pub enum StateCall {}
 impl RpcMethod<2> for StateCall {

--- a/src/rpc/methods/state/types.rs
+++ b/src/rpc/methods/state/types.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::beacon::BeaconEntry;
 use crate::lotus_json::{lotus_json_with_self, LotusJson};
 use crate::shim::{
     address::Address,
@@ -9,7 +8,6 @@ use crate::shim::{
     error::ExitCode,
     executor::Receipt,
     message::Message,
-    sector::{SectorInfo, StoragePower},
     state_tree::{ActorID, ActorState},
 };
 use cid::Cid;
@@ -163,34 +161,6 @@ impl PartialEq for GasTrace {
             && self.storage_gas == other.storage_gas
     }
 }
-
-#[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "PascalCase")]
-pub struct MiningBaseInfo {
-    #[serde(with = "crate::lotus_json")]
-    #[schemars(with = "LotusJson<StoragePower>")]
-    pub miner_power: StoragePower,
-    #[serde(with = "crate::lotus_json")]
-    #[schemars(with = "LotusJson<StoragePower>")]
-    pub network_power: StoragePower,
-    #[serde(with = "crate::lotus_json")]
-    #[schemars(with = "LotusJson<Vec<SectorInfo>>")]
-    pub sectors: Vec<SectorInfo>,
-    #[serde(with = "crate::lotus_json")]
-    #[schemars(with = "LotusJson<Address>")]
-    pub worker_key: Address,
-    #[schemars(with = "u64")]
-    pub sector_size: fvm_shared2::sector::SectorSize,
-    #[serde(with = "crate::lotus_json")]
-    #[schemars(with = "LotusJson<BeaconEntry>")]
-    pub prev_beacon_entry: BeaconEntry,
-    #[serde(with = "crate::lotus_json")]
-    #[schemars(with = "LotusJson<Vec<BeaconEntry>>")]
-    pub beacon_entries: Vec<BeaconEntry>,
-    pub eligible_for_mining: bool,
-}
-
-lotus_json_with_self!(MiningBaseInfo);
 
 #[derive(PartialEq, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "PascalCase")]

--- a/src/rpc/types/mod.rs
+++ b/src/rpc/types/mod.rs
@@ -15,6 +15,7 @@ mod tsk_impl;
 #[cfg(test)]
 mod tests;
 
+use crate::beacon::BeaconEntry;
 use crate::blocks::TipsetKey;
 use crate::libp2p::Multihash;
 use crate::lotus_json::{lotus_json_with_self, HasLotusJson, LotusJson};
@@ -26,7 +27,7 @@ use crate::shim::{
     executor::Receipt,
     fvm_shared_latest::MethodNum,
     message::Message,
-    sector::{RegisteredSealProof, SectorNumber},
+    sector::{RegisteredSealProof, SectorInfo, SectorNumber, StoragePower},
 };
 use cid::Cid;
 use fil_actor_interface::market::AllocationID;
@@ -535,3 +536,31 @@ pub struct DealCollateralBounds {
 }
 
 lotus_json_with_self!(DealCollateralBounds);
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "PascalCase")]
+pub struct MiningBaseInfo {
+    #[serde(with = "crate::lotus_json")]
+    #[schemars(with = "LotusJson<StoragePower>")]
+    pub miner_power: StoragePower,
+    #[serde(with = "crate::lotus_json")]
+    #[schemars(with = "LotusJson<StoragePower>")]
+    pub network_power: StoragePower,
+    #[serde(with = "crate::lotus_json")]
+    #[schemars(with = "LotusJson<Vec<SectorInfo>>")]
+    pub sectors: Vec<SectorInfo>,
+    #[serde(with = "crate::lotus_json")]
+    #[schemars(with = "LotusJson<Address>")]
+    pub worker_key: Address,
+    #[schemars(with = "u64")]
+    pub sector_size: fvm_shared2::sector::SectorSize,
+    #[serde(with = "crate::lotus_json")]
+    #[schemars(with = "LotusJson<BeaconEntry>")]
+    pub prev_beacon_entry: BeaconEntry,
+    #[serde(with = "crate::lotus_json")]
+    #[schemars(with = "LotusJson<Vec<BeaconEntry>>")]
+    pub beacon_entries: Vec<BeaconEntry>,
+    pub eligible_for_mining: bool,
+}
+
+lotus_json_with_self!(MiningBaseInfo);

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -25,7 +25,8 @@ use crate::lotus_json::{lotus_json_with_self, LotusJson};
 use crate::message::{ChainMessage, Message as MessageTrait};
 use crate::metrics::HistogramTimerExt;
 use crate::networks::ChainConfig;
-use crate::rpc::state::{ApiInvocResult, InvocResult, MessageGasCost, MiningBaseInfo};
+use crate::rpc::state::{ApiInvocResult, InvocResult, MessageGasCost};
+use crate::rpc::types::MiningBaseInfo;
 use crate::shim::{
     address::{Address, Payload, Protocol},
     clock::ChainEpoch,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `MinerGetBaseInfo` was incorrectly in the `state` module, though it should be in the `miner` https://github.com/filecoin-project/lotus/blob/082a9159ced1f6bd7e8fa77064a51d209324b693/documentation/en/api-v0-methods.md#miner

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
