### PR TITLE
refactor: schema names should be `Tipset`, not `TipsetLotusJson`

### DIFF
--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -515,41 +515,25 @@ mod lotus_json {
     use crate::blocks::{CachingBlockHeader, Tipset};
     use crate::lotus_json::*;
     use nunny::Vec as NonEmpty;
-    use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use schemars::JsonSchema;
+    use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
     use super::TipsetKey;
 
-    #[derive(Clone)]
-    pub struct TipsetLotusJson(Tipset);
+    #[derive(Clone, JsonSchema)]
+    #[schemars(rename = "Tipset")]
+    pub struct TipsetLotusJson(#[schemars(with = "TipsetLotusJsonInner")] Tipset);
 
-    impl JsonSchema for TipsetLotusJson {
-        fn schema_name() -> String {
-            String::from("TipsetLotusJson")
-        }
-        fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-            // can't impl JsonSchema for NonEmpty...
-            #[derive(JsonSchema)]
-            #[serde(rename_all = "PascalCase")]
-            #[allow(unused)]
-            struct Helper {
-                cids: LotusJson<TipsetKey>,
-                blocks: LotusJson<Vec<CachingBlockHeader>>,
-                height: LotusJson<i64>,
-            }
-            Helper::json_schema(gen)
-        }
-    }
-
-    // NOTE: keep this in sync with JsonSchema implementation above
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[schemars(rename = "Tipset")]
     #[serde(rename_all = "PascalCase")]
     struct TipsetLotusJsonInner {
         #[serde(with = "crate::lotus_json")]
+        #[schemars(with = "LotusJson<TipsetKey>")]
         cids: TipsetKey,
         #[serde(with = "crate::lotus_json")]
+        #[schemars(with = "LotusJson<NonEmpty<CachingBlockHeader>>")]
         blocks: NonEmpty<CachingBlockHeader>,
-        #[serde(with = "crate::lotus_json")]
         height: i64,
     }
 
@@ -564,10 +548,7 @@ mod lotus_json {
                 height: _ignored1,
             } = Deserialize::deserialize(deserializer)?;
 
-            Ok(Self(Tipset {
-                headers: blocks,
-                key: Default::default(),
-            }))
+            Ok(Self(Tipset::new(blocks).map_err(D::Error::custom)?))
         }
     }
 

--- a/src/lotus_json/actor_state.rs
+++ b/src/lotus_json/actor_state.rs
@@ -7,6 +7,7 @@ use ::cid::Cid;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "ActorState")]
 pub struct ActorStateLotusJson {
     #[schemars(with = "LotusJson<Cid>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/address.rs
+++ b/src/lotus_json/address.rs
@@ -2,11 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;
-
 use crate::shim::address::Address;
 
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(rename = "Address")]
+pub struct AddressLotusJson(
+    #[schemars(with = "String")]
+    #[serde(with = "crate::lotus_json::stringify")]
+    Address,
+);
+
 impl HasLotusJson for Address {
-    type LotusJson = Stringify<Address>;
+    type LotusJson = AddressLotusJson;
 
     #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
@@ -14,10 +21,10 @@ impl HasLotusJson for Address {
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        self.into()
+        AddressLotusJson(self)
     }
 
-    fn from_lotus_json(Stringify(address): Self::LotusJson) -> Self {
+    fn from_lotus_json(AddressLotusJson(address): Self::LotusJson) -> Self {
         address
     }
 }

--- a/src/lotus_json/beacon_entry.rs
+++ b/src/lotus_json/beacon_entry.rs
@@ -7,6 +7,7 @@ use super::*;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "BeaconEntry")]
 pub struct BeaconEntryLotusJson {
     round: u64,
     #[schemars(with = "LotusJson<Vec<u8>>")]
@@ -24,10 +25,7 @@ impl HasLotusJson for BeaconEntry {
 
     fn into_lotus_json(self) -> Self::LotusJson {
         let (round, data) = self.into_parts();
-        Self::LotusJson {
-            round,
-            data,
-        }
+        Self::LotusJson { round, data }
     }
 
     fn from_lotus_json(lotus_json: Self::LotusJson) -> Self {

--- a/src/lotus_json/big_int.rs
+++ b/src/lotus_json/big_int.rs
@@ -5,8 +5,16 @@ use super::*;
 
 use num::BigInt;
 
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(rename = "BigInt")]
+pub struct BigIntLotusJson(
+    #[schemars(with = "String")]
+    #[serde(with = "crate::lotus_json::stringify")]
+    BigInt,
+);
+
 impl HasLotusJson for BigInt {
-    type LotusJson = Stringify<BigInt>;
+    type LotusJson = BigIntLotusJson;
 
     #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
@@ -14,10 +22,10 @@ impl HasLotusJson for BigInt {
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        self.into()
+        BigIntLotusJson(self)
     }
 
-    fn from_lotus_json(Stringify(big_int): Self::LotusJson) -> Self {
+    fn from_lotus_json(BigIntLotusJson(big_int): Self::LotusJson) -> Self {
         big_int
     }
 }

--- a/src/lotus_json/bit_field.rs
+++ b/src/lotus_json/bit_field.rs
@@ -6,6 +6,7 @@ use super::*;
 use fil_actors_shared::fvm_ipld_bitfield::{json::BitFieldJson, BitField};
 
 #[derive(Serialize, Deserialize, JsonSchema)]
+#[schemars(rename = "BitField")]
 pub struct BitFieldLotusJson(#[schemars(with = "Option<Vec<u8>>")] pub BitFieldJson);
 
 impl Clone for BitFieldLotusJson {

--- a/src/lotus_json/block_header.rs
+++ b/src/lotus_json/block_header.rs
@@ -18,6 +18,7 @@ use crate::blocks::{CachingBlockHeader, RawBlockHeader};
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "BlockHeader")]
 pub struct BlockHeaderLotusJson {
     #[schemars(with = "LotusJson<Address>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/cid.rs
+++ b/src/lotus_json/cid.rs
@@ -6,8 +6,9 @@ use super::*;
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(rename = "Cid")]
 pub struct CidLotusJsonGeneric<const S: usize> {
-    #[serde(rename = "/")]
-    slash: Stringify<::cid::CidGeneric<S>>,
+    #[schemars(with = "String")]
+    #[serde(rename = "/", with = "crate::lotus_json::stringify")]
+    slash: ::cid::CidGeneric<S>,
 }
 
 impl<const S: usize> HasLotusJson for ::cid::CidGeneric<S> {
@@ -19,12 +20,12 @@ impl<const S: usize> HasLotusJson for ::cid::CidGeneric<S> {
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        Self::LotusJson { slash: self.into() }
+        Self::LotusJson { slash: self }
     }
 
     fn from_lotus_json(lotus_json: Self::LotusJson) -> Self {
         let Self::LotusJson { slash } = lotus_json;
-        slash.into_inner()
+        slash
     }
 }
 

--- a/src/lotus_json/cid.rs
+++ b/src/lotus_json/cid.rs
@@ -4,6 +4,7 @@
 use super::*;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(rename = "Cid")]
 pub struct CidLotusJsonGeneric<const S: usize> {
     #[serde(rename = "/")]
     slash: Stringify<::cid::CidGeneric<S>>,

--- a/src/lotus_json/claim.rs
+++ b/src/lotus_json/claim.rs
@@ -7,6 +7,7 @@ use super::*;
 
 #[derive(Default, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "Claim")]
 pub struct ClaimLotusJson {
     #[schemars(with = "LotusJson<num::BigInt>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/election_proof.rs
+++ b/src/lotus_json/election_proof.rs
@@ -7,6 +7,7 @@ use super::*;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "ElectionProof")]
 pub struct ElectionProofLotusJson {
     #[schemars(with = "LotusJson<VRFProof>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/gossip_block.rs
+++ b/src/lotus_json/gossip_block.rs
@@ -8,6 +8,7 @@ use ::cid::Cid;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "GossipBlock")]
 pub struct GossipBlockLotusJson {
     #[schemars(with = "LotusJson<CachingBlockHeader>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/ipld.rs
+++ b/src/lotus_json/ipld.rs
@@ -31,6 +31,7 @@ use libipld::{ipld, Ipld};
 use serde::de;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
+#[schemars(rename = "Ipld")]
 pub struct IpldLotusJson(
     #[serde(with = "self")]
     #[schemars(with = "serde_json::Value")] // opt-out of JsonSchema for now

--- a/src/lotus_json/key_info.rs
+++ b/src/lotus_json/key_info.rs
@@ -6,6 +6,7 @@ use crate::{key_management::KeyInfo, shim::crypto::SignatureType};
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "KeyInfo")]
 pub struct KeyInfoLotusJson {
     #[schemars(with = "LotusJson<SignatureType>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/message.rs
+++ b/src/lotus_json/message.rs
@@ -9,6 +9,7 @@ use fvm_ipld_encoding::RawBytes;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "Message")]
 pub struct MessageLotusJson {
     version: u64,
     #[schemars(with = "LotusJson<Address>")]

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -467,33 +467,6 @@ impl<T> LotusJson<T> {
     }
 }
 
-/// A struct that is (de) serialized through its [`Display`] and [`FromStr`] implementations.
-#[derive(Serialize, Deserialize, From, Default)]
-#[serde(bound = "T: Display + FromStr, T::Err: Display")]
-pub struct Stringify<T>(#[serde(with = "stringify")] pub T);
-
-impl<T> Stringify<T> {
-    pub fn into_inner(self) -> T {
-        self.0
-    }
-}
-
-impl<T> JsonSchema for Stringify<T> {
-    fn schema_name() -> String {
-        String::schema_name()
-    }
-
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        String::json_schema(gen)
-    }
-}
-
-impl<T: Clone> Clone for Stringify<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
 macro_rules! lotus_json_with_self {
     ($($domain_ty:ty),* $(,)?) => {
         $(

--- a/src/lotus_json/po_st_proof.rs
+++ b/src/lotus_json/po_st_proof.rs
@@ -8,6 +8,7 @@ use super::*;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "PoStProof")]
 pub struct PoStProofLotusJson {
     #[schemars(with = "LotusJson<RegisteredPoStProof>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/receipt.rs
+++ b/src/lotus_json/receipt.rs
@@ -9,6 +9,7 @@ use crate::shim::executor::Receipt;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "Receipt")]
 pub struct ReceiptLotusJson {
     exit_code: u32,
     #[schemars(with = "LotusJson<RawBytes>")]

--- a/src/lotus_json/sector_info.rs
+++ b/src/lotus_json/sector_info.rs
@@ -7,6 +7,7 @@ use ::cid::Cid;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "SectorInfo")]
 pub struct SectorInfoLotusJson {
     #[schemars(with = "LotusJson<RegisteredSealProof>")]
     #[serde(with = "crate::lotus_json")]
@@ -57,10 +58,6 @@ impl HasLotusJson for SectorInfo {
             sector_number,
             sealed_c_i_d,
         } = lotus_json;
-        Self::new(
-            seal_proof.into(),
-            sector_number,
-            sealed_c_i_d,
-        )
+        Self::new(seal_proof.into(), sector_number, sealed_c_i_d)
     }
 }

--- a/src/lotus_json/signature.rs
+++ b/src/lotus_json/signature.rs
@@ -6,6 +6,7 @@ use crate::shim::crypto::{Signature, SignatureType};
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "Signature")]
 pub struct SignatureLotusJson {
     #[schemars(with = "LotusJson<SignatureType>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/signature_type.rs
+++ b/src/lotus_json/signature_type.rs
@@ -13,9 +13,14 @@ use crate::shim::crypto::SignatureType;
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)] // try an int, then a string
+#[schemars(rename = "SignatureType")]
 pub enum SignatureTypeLotusJson {
     Integer(SignatureType),
-    String(Stringify<SignatureType>),
+    String(
+        #[serde(with = "crate::lotus_json::stringify")]
+        #[schemars(with = "String")]
+        SignatureType,
+    ),
 }
 
 impl HasLotusJson for SignatureType {
@@ -32,8 +37,7 @@ impl HasLotusJson for SignatureType {
 
     fn from_lotus_json(lotus_json: Self::LotusJson) -> Self {
         match lotus_json {
-            SignatureTypeLotusJson::Integer(inner)
-            | SignatureTypeLotusJson::String(Stringify(inner)) => inner,
+            SignatureTypeLotusJson::Integer(inner) | SignatureTypeLotusJson::String(inner) => inner,
         }
     }
 }

--- a/src/lotus_json/signed_message.rs
+++ b/src/lotus_json/signed_message.rs
@@ -9,6 +9,7 @@ use super::*;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "SignedMessage")]
 pub struct SignedMessageLotusJson {
     #[schemars(with = "LotusJson<Message>")]
     #[serde(with = "crate::lotus_json")]
@@ -82,9 +83,6 @@ impl HasLotusJson for SignedMessage {
             signature,
             cid: _ignored, // See notes on Message
         } = lotus_json;
-        Self {
-            message,
-            signature,
-        }
+        Self { message, signature }
     }
 }

--- a/src/lotus_json/sync_stage.rs
+++ b/src/lotus_json/sync_stage.rs
@@ -4,8 +4,16 @@ use super::*;
 
 use crate::chain_sync::SyncStage;
 
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(rename = "SyncStage")]
+pub struct SyncStageLotusJson(
+    #[schemars(with = "String")]
+    #[serde(with = "crate::lotus_json::stringify")]
+    SyncStage,
+);
+
 impl HasLotusJson for SyncStage {
-    type LotusJson = Stringify<SyncStage>;
+    type LotusJson = SyncStageLotusJson;
 
     #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
@@ -13,10 +21,10 @@ impl HasLotusJson for SyncStage {
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        self.into()
+        SyncStageLotusJson(self)
     }
 
-    fn from_lotus_json(Stringify(sync_stage): Self::LotusJson) -> Self {
+    fn from_lotus_json(SyncStageLotusJson(sync_stage): Self::LotusJson) -> Self {
         sync_stage
     }
 }

--- a/src/lotus_json/ticket.rs
+++ b/src/lotus_json/ticket.rs
@@ -7,6 +7,7 @@ use super::*;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
+#[schemars(rename = "Ticket")]
 pub struct TicketLotusJson {
     #[schemars(with = "LotusJson<VRFProof>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/token_amount.rs
+++ b/src/lotus_json/token_amount.rs
@@ -7,6 +7,7 @@ use num::BigInt;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)] // name the field for clarity
+#[schemars(rename = "TokenAmount")]
 pub struct TokenAmountLotusJson {
     #[schemars(with = "LotusJson<BigInt>")]
     #[serde(with = "crate::lotus_json")]

--- a/src/lotus_json/vec_u8.rs
+++ b/src/lotus_json/vec_u8.rs
@@ -7,6 +7,7 @@ use super::*;
 // - use #[serde(with = "...")]
 // - de/ser empty vecs as null
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(rename = "Base64String")]
 pub struct VecU8LotusJson(Option<Inner>);
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -488,8 +488,6 @@ mod structured {
         called_at: CalledAt,
         duration: Duration,
     ) -> anyhow::Result<serde_json::Value> {
-        use crate::lotus_json::Stringify;
-
         let is_explicit = matches!(called_at.apply_kind(), fvm3::executor::ApplyKind::Explicit);
 
         let chain_message_cid = chain_message.cid()?;
@@ -502,7 +500,7 @@ mod structured {
             "Error": apply_ret.failure_info().unwrap_or_default(),
             "GasCost": {
                 "Message": is_explicit.then_some(unsigned_message_cid.into_lotus_json()),
-                "GasUsed": is_explicit.then_some(Stringify(apply_ret.msg_receipt().gas_used())).unwrap_or_default(),
+                "GasUsed": is_explicit.then_some(apply_ret.msg_receipt().gas_used().to_string()).unwrap_or(String::from("0")),
                 "BaseFeeBurn": apply_ret.base_fee_burn().into_lotus_json(),
                 "OverEstimationBurn": apply_ret.over_estimation_burn().into_lotus_json(),
                 "MinerPenalty": apply_ret.penalty().into_lotus_json(),


### PR DESCRIPTION
This should make generated names better, see #4295 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
