### PR TITLE
fix: double base64 decoding in `Filecoin.WalletSign`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@
 - [#4267](https://github.com/ChainSafe/forest/pull/4267) Fixed potential panics
   in `forest-tool api compare`.
 
+- [#4297](https://github.com/ChainSafe/forest/pull/4297) Fixed double decoding
+  of message in the `Filecoin.WalletSign` RPC method.
+
 ## Forest 0.17.2 "Dovakhin"
 
 This is a **mandatory** release for all mainnet node operators. It changes the

--- a/scripts/tests/api_compare/.env
+++ b/scripts/tests/api_compare/.env
@@ -11,4 +11,5 @@ CHAIN=calibnet
 # The process is too lengthy to create the miner on the fly (needs to send FIL to the miner, wait for confirmations, etc)
 # It's fine to use this miner for testing purposes, e.g., signing messages in tests.
 MINER_ADDRESS=t0111551 # t2nfplhzpyeck5dcc4fokj5ar6nbs3mhbdmq6xu3q
+MINER_WORKER_ADDRESS=t3sw466j35hqjbch5x7tcr7ona6idsgzypoturfci2ajqsfrrwhp7ty3ythtd7x646adaidnvxpdr5b2ftcciq
 MINER_WORKER_KEY=7b2254797065223a22626c73222c22507269766174654b6579223a225a6c4c784f55666d666f44332b577a2f386175482f6b2f456f4b674443365365584256563447714c4c6d6b3d227d

--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -183,7 +183,8 @@ services:
           --lotus $$LOTUS_API_INFO \
           --n-tipsets 10 \
           --filter-file /data/filter-list \
-          --miner-address ${MINER_ADDRESS}
+          --miner-address ${MINER_ADDRESS} \
+          --worker-address ${MINER_WORKER_ADDRESS}
   api-compare-offline:
     depends_on:
       lotus-sync-wait:

--- a/src/rpc/methods/wallet.rs
+++ b/src/rpc/methods/wallet.rs
@@ -11,7 +11,6 @@ use crate::shim::{
     econ::TokenAmount,
     state_tree::StateTree,
 };
-use base64::{prelude::BASE64_STANDARD, Engine};
 use fvm_ipld_blockstore::Blockstore;
 
 macro_rules! for_each_method {
@@ -235,7 +234,7 @@ impl RpcMethod<2> for WalletSign {
         let sig = crate::key_management::sign(
             *key.key_info.key_type(),
             key.key_info.private_key(),
-            &BASE64_STANDARD.decode(message)?,
+            &message,
         )?;
 
         Ok(sig)

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -120,6 +120,9 @@ pub enum ApiCommands {
         /// Miner address to use for miner tests. Miner worker key must be in the key-store.
         #[arg(long)]
         miner_address: Option<Address>,
+        /// Worker address to use where key is applicable. Worker key must be in the key-store.
+        #[arg(long)]
+        worker_address: Option<Address>,
     },
 }
 
@@ -133,6 +136,7 @@ struct ApiTestFlags {
     run_ignored: RunIgnored,
     max_concurrent_requests: usize,
     miner_address: Option<Address>,
+    worker_address: Option<Address>,
 }
 
 impl ApiCommands {
@@ -159,6 +163,7 @@ impl ApiCommands {
                 run_ignored,
                 max_concurrent_requests,
                 miner_address,
+                worker_address,
             } => {
                 let config = ApiTestFlags {
                     filter,
@@ -168,6 +173,7 @@ impl ApiCommands {
                     run_ignored,
                     max_concurrent_requests,
                     miner_address,
+                    worker_address,
                 };
 
                 compare_apis(
@@ -922,7 +928,7 @@ fn state_tests_with_tipset<DB: Blockstore>(
     Ok(tests)
 }
 
-fn wallet_tests() -> Vec<RpcTest> {
+fn wallet_tests(config: &ApiTestFlags) -> Vec<RpcTest> {
     // This address has been funded by the calibnet faucet and the private keys
     // has been discarded. It should always have a non-zero balance.
     let known_wallet = Address::from_str("t1c4dkec3qhrnrsa4mccy7qntkyq2hhsma4sq7lui").unwrap();
@@ -936,15 +942,26 @@ fn wallet_tests() -> Vec<RpcTest> {
         _ => panic!("Invalid signature (must be bls or secp256k1)"),
     };
 
-    vec![
+    let mut tests = vec![
         RpcTest::identity(WalletBalance::request((known_wallet,)).unwrap()),
         RpcTest::identity(WalletValidateAddress::request((known_wallet.to_string(),)).unwrap()),
         RpcTest::identity(WalletVerify::request((known_wallet, text, signature)).unwrap()),
-        // These methods require write access in Lotus. Not sure why.
-        // RpcTest::basic(ApiInfo::wallet_default_address_req()),
-        // RpcTest::basic(ApiInfo::wallet_list_req()),
-        // RpcTest::basic(ApiInfo::wallet_has_req(known_wallet.to_string())),
-    ]
+    ];
+
+    // If a worker address is provided, we can test wallet methods requiring
+    // a shared key.
+    if let Some(worker_address) = config.worker_address {
+        use base64::{prelude::BASE64_STANDARD, Engine};
+        let msg =
+            BASE64_STANDARD.encode("Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn".as_bytes());
+        tests.push(RpcTest::identity(
+            WalletSign::request((worker_address, msg.into())).unwrap(),
+        ));
+        tests.push(RpcTest::identity(
+            WalletSign::request((worker_address, Vec::new())).unwrap(),
+        ));
+    }
+    tests
 }
 
 fn eth_tests() -> Vec<RpcTest> {
@@ -1121,7 +1138,7 @@ async fn compare_apis(
     tests.extend(mpool_tests());
     tests.extend(net_tests());
     tests.extend(node_tests());
-    tests.extend(wallet_tests());
+    tests.extend(wallet_tests(&config));
     tests.extend(eth_tests());
     tests.extend(state_tests());
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- exposed worker address as part of the `api-compare`,
- fixed `Filecoin.WalletSign` endpoint and introduce a conformance test

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
