### PR TITLE
fix(ci): snapshot parity tests: use larger timeout wating for lotus daemon

### DIFF
--- a/.github/workflows/lotus-api-bump.yml
+++ b/.github/workflows/lotus-api-bump.yml
@@ -17,6 +17,7 @@ jobs:
           NETWORK=calibnet
           TAG=$(curl --silent https://api.github.com/repos/filecoin-project/lotus/releases | jq -r 'first | .tag_name')
           sed -i "s/\(LOTUS_IMAGE=.*\):.*/\1:$TAG-$NETWORK/" ./scripts/tests/api_compare/.env
+          sed -i "s/\(LOTUS_IMAGE=.*\):.*/\1:$TAG-$NETWORK/" ./scripts/tests/snapshot_parity/.env
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/scripts/tests/snapshot_parity/.env
+++ b/scripts/tests/snapshot_parity/.env
@@ -1,4 +1,4 @@
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.26.3-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.27.0-rc2-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/scripts/tests/snapshot_parity/docker-compose.yml
+++ b/scripts/tests/snapshot_parity/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - |
         set -euxo pipefail
         lotus daemon --remove-existing-chain --import-snapshot $(ls /data/*.car.zst | tail -n 1) &
-        lotus wait-api --timeout 10m
+        lotus wait-api --timeout 20m
         lotus sync wait
         lotus chain export --tipset @$(ls /data/*.car.zst | tail -n 1 | grep -Eo '[0-9]+' | tail -n 1) --recent-stateroots ${EXPORT_EPOCHS} --skip-old-msgs /data/exported/lotus.car
         kill -KILL $!


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to mitigate CI failures in snapshot parity test we've seen recently.
```
ERROR: timed out waiting for api to come online
```
https://github.com/ChainSafe/forest/actions/runs/9003120109/job/24733303342#step:7:757
https://github.com/ChainSafe/forest/actions/runs/9005049877/job/24739698942#step:7:774

Changes introduced in this pull request:

- change `lotus wait-api --timeout 10m` to `lotus wait-api --timeout 20m`
- bump lotus docker image version

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
