### PR TITLE
fix(ci): snapshot parity test: fetch param files on init and drop CI cache

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -376,20 +376,6 @@ jobs:
       # We use a custom Dockerfile for CI to speed up the build process.
       FOREST_DOCKERFILE_OVERRIDE: scripts/devnet/forest_ci.dockerfile
     steps:
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: '${{ env.FIL_PROOFS_PARAMETER_CACHE }}'
-          key: proof-params-keys
-      - name: Load cache into volume
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: |
-          docker volume create api_compare_filecoin-proofs
-          docker run --rm \
-            -v api_compare_filecoin-proofs:/proofs \
-            -v $FIL_PROOFS_PARAMETER_CACHE:/cache \
-            $SHELL_IMAGE \
-            sh -c "cp /cache/* /proofs"
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
@@ -400,15 +386,6 @@ jobs:
       - name: Dump docker logs
         if: always()
         uses: jwalton/gh-docker-logs@v2
-      - name: Prepare cache folder for uploading
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          docker run --rm \
-            -v api_compare_filecoin-proofs:/proofs \
-            -v $FIL_PROOFS_PARAMETER_CACHE:/cache \
-            $SHELL_IMAGE \
-            sh -c "cp /proofs/* /cache"
-          sudo chmod -R 755 $FIL_PROOFS_PARAMETER_CACHE
   snapshot-parity-checks:
     needs:
       - build-ubuntu

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -421,20 +421,6 @@ jobs:
       # We use a custom Dockerfile for CI to speed up the build process.
       FOREST_DOCKERFILE_OVERRIDE: scripts/devnet/forest_ci.dockerfile
     steps:
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: '${{ env.FIL_PROOFS_PARAMETER_CACHE }}'
-          key: proof-params-keys
-      - name: Load cache into volume
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: |
-          docker volume create snapshot_parity_filecoin-proofs
-          docker run --rm \
-            -v snapshot_parity_filecoin-proofs:/proofs \
-            -v $FIL_PROOFS_PARAMETER_CACHE:/cache \
-            $SHELL_IMAGE \
-            sh -c "cp /cache/* /proofs"
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
@@ -445,12 +431,3 @@ jobs:
       - name: Dump docker logs
         if: always()
         uses: jwalton/gh-docker-logs@v2
-      - name: Prepare cache folder for uploading
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          docker run --rm \
-            -v snapshot_parity_filecoin-proofs:/proofs \
-            -v $FIL_PROOFS_PARAMETER_CACHE:/cache \
-            $SHELL_IMAGE \
-            sh -c "cp /proofs/* /cache"
-          sudo chmod -R 755 $FIL_PROOFS_PARAMETER_CACHE

--- a/scripts/tests/api_compare/aria2-Dockerfile
+++ b/scripts/tests/api_compare/aria2-Dockerfile
@@ -1,7 +1,0 @@
-FROM ubuntu:focal
-
-RUN apt-get update
-
-RUN apt-get install -y aria2
-
-CMD aria2c

--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -3,9 +3,11 @@
 services:
   init: 
     build:
-      dockerfile: aria2-Dockerfile
+      context: ../../../.
+      dockerfile: ${FOREST_DOCKERFILE_OVERRIDE:-Dockerfile}
     volumes:
       - node-data:/data
+      - filecoin-proofs:${FIL_PROOFS_PARAMETER_CACHE}
     networks:
       - api-tests
     environment:
@@ -14,11 +16,13 @@ services:
     command:
       - |
         set -euxo pipefail
+        # fetch parameter files
+        forest-tool fetch-params --keys
         # if there are some files in the data directory, then we don't need to fetch the snapshot
         if [ "$$(ls -A /data/*.car.zst)" ]; then
           echo "Snapshot already fetched"
         else
-          aria2c -d /data -x5 https://forest-archive.chainsafe.dev/latest/calibnet/
+          forest-tool snapshot fetch --chain calibnet -d /data
         fi
   forest:
     depends_on:

--- a/scripts/tests/snapshot_parity/docker-compose.yml
+++ b/scripts/tests/snapshot_parity/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       dockerfile: ${FOREST_DOCKERFILE_OVERRIDE:-Dockerfile}
     volumes:
       - node-data:/data
+      - filecoin-proofs:${FIL_PROOFS_PARAMETER_CACHE}
     networks:
       - snapshot-parity-tests
     environment:
@@ -16,6 +17,8 @@ services:
     command:
       - |
         set -euxo pipefail
+        # fetch parameter files
+        forest-tool fetch-params --keys
         # if there are some files in the data directory, then we don't need to fetch the snapshot
         if [ "$$(ls -A /data/*.car.zst)" ]; then
           echo "Snapshot already fetched"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

The cache step does not work properly on buildjet build agents and is causing timeout in lotus

https://github.com/ChainSafe/forest/actions/runs/9029022947/job/24810699319#step:2:42
```
/usr/bin/tar: ../../../../../var: Cannot mkdir: Permission denied
/usr/bin/tar: ../../../../../var/tmp/filecoin-proof-parameters: Cannot mkdir: No such file or directory
```

Changes introduced in this pull request:

- drop CI cache
- run `forest-tool fetch-params --keys` in `docker-compose` `init` service

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
