### PR TITLE
fix: api-compare compose init permissions

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
     entrypoint: [ "/bin/bash", "-c" ]
+    user: 0:0
     command:
       - |
         set -euxo pipefail


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- it might be docker version or host specific, but I get:
```
init-1                  | 2024-05-13T10:51:14.286993Z  INFO retry: forest::snapshot: downloading snapshot url=https://forest-archive.chainsafe.dev/archive/calibnet/latest/forest_snapshot_calibnet_2024-05-13_height_1608973.forest.car.zst destination=/data/forest_snapshot_calibnet_2024-05-13_height_1608973.forest.car.zst
init-1                  | 2024-05-13T10:51:14.287014Z  INFO retry: forest_filecoin::utils::net: Downloading file: https://forest-archive.chainsafe.dev/archive/calibnet/latest/forest_snapshot_calibnet_2024-05-13_height_1608973.forest.car.zst
init-1                  | 2024-05-13T10:51:14.568006Z ERROR retry: forest_filecoin::utils: retrying operation after couldn't create destination file
init-1                  |
init-1                  | Caused by:
init-1                  |     Permission denied (os error 13)
init-1                  | 2024-05-13T10:51:14.768781Z ERROR forest_filecoin::cli_shared::cli: Failed fetching the snapshot: retry limit exceeded
init-1 exited with code 1
service "init" didn't complete successfully: exit 1
```

it wasn't an error because the custom container ran with a `root` user.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
