### PR TITLE
fix(ci): rust build issues in lotus devnet dockerfile

### DIFF
--- a/scripts/devnet/lotus.dockerfile
+++ b/scripts/devnet/lotus.dockerfile
@@ -1,14 +1,22 @@
 # Lotus binaries image, to be used in the local devnet with Forest.
 FROM golang:1.21-bullseye AS lotus-builder
 
-RUN apt-get update && apt-get install -y ca-certificates build-essential clang ocl-icd-opencl-dev ocl-icd-libopencl1 jq libhwloc-dev 
+RUN apt-get update && apt-get install -y curl ca-certificates build-essential clang ocl-icd-opencl-dev ocl-icd-libopencl1 jq libhwloc-dev 
 
 WORKDIR /lotus
 
+# Install rust toolchain for rebuilding `filecoin-ffi`
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --profile minimal
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 RUN git clone --depth 1 --branch v1.26.1 https://github.com/filecoin-project/lotus.git .
 
+# https://github.com/Filecoin-project/filecoin-ffi?tab=readme-ov-file#building-from-source
 RUN CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__" \
     CGO_CFLAGS="-D__BLST_PORTABLE__" \
+    FFI_USE_BLST_PORTABLE="1" \
+    FFI_USE_GPU="0" \
     make 2k && strip lotus*
 
 FROM ubuntu:22.04


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

When we build a custom lotus branch that references an unpublished version of `filecoin-ffi`(like in #4321), a prebuilt `libfilcrypto` cannot be downloaded and `filecoin-ffi` needs to be rebuilt from source code.

Changes introduced in this pull request:

- Install rust toolchain (for building `filecoin-ffi`)
- Set `FFI_USE_BLST_PORTABLE="1"`
- Set `FFI_USE_GPU="0"`
- (See https://github.com/Filecoin-project/filecoin-ffi?tab=readme-ov-file#building-from-source)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
