### PR TITLE
fix: set tipset sample size to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@
 - [#4297](https://github.com/ChainSafe/forest/pull/4297) Fixed double decoding
   of message in the `Filecoin.WalletSign` RPC method.
 
+- [#4328](https://github.com/ChainSafe/forest/pull/4328) Fix issues when
+  connecting to a network with fewer than 5 peers.
+
 ## Forest 0.17.2 "Dovakhin"
 
 This is a **mandatory** release for all mainnet node operators. It changes the

--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -44,7 +44,7 @@ use crate::chain_sync::{
 // Sync the messages for one or many tipsets @ a time
 // Lotus uses a window size of 8: https://github.com/filecoin-project/lotus/blob/c1d22d8b3298fdce573107413729be608e72187d/chain/sync.go#L56
 const DEFAULT_REQUEST_WINDOW: usize = 8;
-const DEFAULT_TIPSET_SAMPLE_SIZE: usize = 5;
+const DEFAULT_TIPSET_SAMPLE_SIZE: usize = 1;
 const DEFAULT_RECENT_STATE_ROOTS: i64 = 2000;
 
 pub(in crate::chain_sync) type WorkerState = Arc<RwLock<SyncState>>;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Forest would sample tipset HEADs from 5 peers before fully joining a network. This obviously doesn't work if there are fewer than 5 peers available. This PR temporarily sets the sample size to 1. The chain muxer is scheduled to be completely re-written soon.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
