### PR TITLE
fix: handle optional parameters

### DIFF
--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -438,7 +438,7 @@ where
 
 /// A domain struct that is (de) serialized through its lotus JSON representation.
 #[derive(Debug, Deserialize, From, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[serde(bound = "T: HasLotusJson")]
+#[serde(bound = "T: HasLotusJson", transparent)]
 pub struct LotusJson<T>(#[serde(with = "self")] pub T);
 
 impl<T: Clone> Clone for LotusJson<T> {


### PR DESCRIPTION
`LotusJson<Option<T>>` is handled as an optional argument 