### PR TITLE
feat: FIP-0065 Ignore built-in market locked balance

### DIFF
--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -758,7 +758,7 @@ impl RpcMethod<3> for StateMinerInitialPledgeCollateral {
             .state_manager
             .get_required_actor(&Address::REWARD_ACTOR, state)?;
         let reward_state = reward::State::load(ctx.store(), actor.code, actor.state)?;
-        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config());
+        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config().clone());
         let circ_supply = genesis_info.get_vm_circulating_supply_detailed(
             ts.epoch(),
             &Arc::new(ctx.store()),
@@ -1273,7 +1273,7 @@ impl RpcMethod<1> for StateCirculatingSupply {
         let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
         let height = ts.epoch();
         let root = ts.parent_state();
-        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config());
+        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config().clone());
         let supply = genesis_info.get_state_circulating_supply(
             height,
             &ctx.state_manager.blockstore_owned(),
@@ -1320,7 +1320,7 @@ impl RpcMethod<1> for StateVMCirculatingSupplyInternal {
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config());
+        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config().clone());
         Ok(genesis_info.get_vm_circulating_supply_detailed(
             ts.epoch(),
             &ctx.state_manager.blockstore_owned(),
@@ -1461,7 +1461,7 @@ impl RpcMethod<3> for StateDealProviderCollateralBounds {
         let power_state = power::State::load(store, power_actor.code, power_actor.state)?;
         let reward_state = reward::State::load(store, reward_actor.code, reward_actor.state)?;
 
-        let genesis_info = GenesisInfo::from_chain_config(state_manager.chain_config());
+        let genesis_info = GenesisInfo::from_chain_config(state_manager.chain_config().clone());
 
         let supply = genesis_info.get_vm_circulating_supply(
             ts.epoch(),

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -423,7 +423,7 @@ where
         // TODO(elmattic): https://github.com/ChainSafe/forest/issues/3733
 
         let height = tipset.epoch();
-        let genesis_info = GenesisInfo::from_chain_config(self.chain_config());
+        let genesis_info = GenesisInfo::from_chain_config(self.chain_config().clone());
         let mut vm = VM::new(
             ExecutionContext {
                 heaviest_tipset: Arc::clone(tipset),
@@ -509,7 +509,7 @@ where
         // Since we're simulating a future message, pretend we're applying it in the
         // "next" tipset
         let epoch = ts.epoch() + 1;
-        let genesis_info = GenesisInfo::from_chain_config(self.chain_config());
+        let genesis_info = GenesisInfo::from_chain_config(self.chain_config().clone());
         // FVM requires a stack size of 64MiB. The alternative is to use `ThreadedExecutor` from
         // FVM, but that introduces some constraints, and possible deadlocks.
         let (ret, _) = stacker::grow(64 << 20, || -> ApplyResult {
@@ -1542,7 +1542,7 @@ where
         beacon,
     );
 
-    let genesis_info = GenesisInfo::from_chain_config(&chain_config);
+    let genesis_info = GenesisInfo::from_chain_config(chain_config.clone());
     let create_vm = |state_root: Cid, epoch, timestamp| {
         let circulating_supply =
             genesis_info.get_vm_circulating_supply(epoch, &chain_index.db, &state_root)?;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- implemented FIP-0065 Ignore built-in market locked balance in circulating supply calculation.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

Looking more closely into the networks, I assessed that it needs some rework to facilitate further changes, see more in https://github.com/ChainSafe/forest/issues/4347

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
