### PR TITLE
fix(p2p): max concurrent streams in request_response protocol

### DIFF
--- a/src/libp2p/chain_exchange/behaviour.rs
+++ b/src/libp2p/chain_exchange/behaviour.rs
@@ -25,6 +25,16 @@ pub struct ChainExchangeBehaviour {
 }
 
 impl ChainExchangeBehaviour {
+    pub fn new(cfg: request_response::Config) -> Self {
+        Self {
+            inner: InnerBehaviour::new(
+                [(CHAIN_EXCHANGE_PROTOCOL_NAME, ProtocolSupport::Full)],
+                cfg,
+            ),
+            response_channels: Default::default(),
+        }
+    }
+
     pub fn send_request(
         &mut self,
         peer: &PeerId,
@@ -78,18 +88,6 @@ impl ChainExchangeBehaviour {
         metrics::NETWORK_CONTAINER_CAPACITIES
             .get_or_create(&metrics::values::CHAIN_EXCHANGE_REQUEST_TABLE)
             .set(self.response_channels.capacity() as _);
-    }
-}
-
-impl Default for ChainExchangeBehaviour {
-    fn default() -> Self {
-        Self {
-            inner: InnerBehaviour::new(
-                [(CHAIN_EXCHANGE_PROTOCOL_NAME, ProtocolSupport::Full)],
-                Default::default(),
-            ),
-            response_channels: Default::default(),
-        }
     }
 }
 

--- a/src/libp2p/hello/behaviour.rs
+++ b/src/libp2p/hello/behaviour.rs
@@ -20,6 +20,13 @@ pub struct HelloBehaviour {
 }
 
 impl HelloBehaviour {
+    pub fn new(cfg: request_response::Config) -> Self {
+        Self {
+            inner: InnerBehaviour::new([(HELLO_PROTOCOL_NAME, ProtocolSupport::Full)], cfg),
+            response_channels: Default::default(),
+        }
+    }
+
     pub fn send_request(
         &mut self,
         peer: &PeerId,
@@ -63,18 +70,6 @@ impl HelloBehaviour {
         metrics::NETWORK_CONTAINER_CAPACITIES
             .get_or_create(&metrics::values::HELLO_REQUEST_TABLE)
             .set(self.response_channels.capacity() as _);
-    }
-}
-
-impl Default for HelloBehaviour {
-    fn default() -> Self {
-        Self {
-            inner: InnerBehaviour::new(
-                [(HELLO_PROTOCOL_NAME, ProtocolSupport::Full)],
-                Default::default(),
-            ),
-            response_channels: Default::default(),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to fix the below errors when running `forest --chain mainnet --encrypt-keystore false --save-token /tmp/forest_token --stateless --target-peer-count=5000`

```
2024-05-27T07:46:02.738459Z  WARN libp2p_request_response::handler: Dropping outbound stream because we are at capacity
...
```

The error occurs when the target peer count is large thus the default `max_concurrent_streams`(100) become insufficient

Changes introduced in this pull request:

- set `max_concurrent_streams` to `target_peer_count  * 10`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
