### PR TITLE
fix(p2p): ban peers that don't support hello and chain exchange

### DIFF
--- a/src/chain_sync/network_context.rs
+++ b/src/chain_sync/network_context.rs
@@ -402,10 +402,16 @@ where
             Ok(Ok(Err(e))) => {
                 // Internal libp2p error, score failure for peer and potentially disconnect
                 match e {
-                    RequestResponseError::ConnectionClosed
-                    | RequestResponseError::DialFailure
-                    | RequestResponseError::UnsupportedProtocols => {
-                        peer_manager.mark_peer_bad(peer_id);
+                    RequestResponseError::UnsupportedProtocols => {
+                        peer_manager
+                            .ban_peer_with_default_duration(
+                                peer_id,
+                                "ChainExchange protocol unsupported",
+                            )
+                            .await;
+                    }
+                    RequestResponseError::ConnectionClosed | RequestResponseError::DialFailure => {
+                        peer_manager.mark_peer_bad(peer_id, format!("chain exchange error {e:?}"));
                     }
                     // Ignore dropping peer on timeout for now. Can't be confident yet that the
                     // specified timeout is adequate time.

--- a/src/libp2p/peer_manager.rs
+++ b/src/libp2p/peer_manager.rs
@@ -263,7 +263,7 @@ impl PeerManager {
         }
     }
 
-    /// Bans a peer with the default duration(1h)
+    /// Bans a peer with the default duration(`1h`)
     pub async fn ban_peer_with_default_duration(&self, peer: PeerId, reason: impl Into<String>) {
         const BAN_PEER_DURATION: Duration = Duration::from_secs(60 * 60); //1h
         self.ban_peer(peer, reason, Some(BAN_PEER_DURATION)).await


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

(Part of https://github.com/ChainSafe/forest/issues/4346 investigation)

In the previous logic, we mark peers bad when they don't support `Hello` and `ChainExchange` protocols, but it does not make sense to hold connections to those peers and broadcast their addresses via `Kademlia` in the network.

Changes introduced in this pull request:

- Ban peers that don't support `Hello` and `ChainExchange` protocols

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
