### PR TITLE
fix(log): demote log levels on peer banning

### DIFF
--- a/scripts/devnet/docker-compose.yml
+++ b/scripts/devnet/docker-compose.yml
@@ -176,7 +176,7 @@ services:
       - ./forest_config.toml.tpl:/forest/forest_config.toml.tpl
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
-      - RUST_LOG=info,forest_filecoin::blocks::header=debug
+      - RUST_LOG=info,forest_filecoin::blocks::header=trace
       - FOREST_GENESIS_NETWORK_VERSION=${GENESIS_NETWORK_VERSION}
       - FOREST_SHARK_HEIGHT=${SHARK_HEIGHT}
       - FOREST_HYGGE_HEIGHT=${HYGGE_HEIGHT}

--- a/src/blocks/header.rs
+++ b/src/blocks/header.rs
@@ -126,7 +126,7 @@ impl RawBlockHeader {
         let (cb_epoch, curr_beacon) = b_schedule
             .beacon_for_epoch(self.epoch)
             .map_err(|e| Error::Validation(e.to_string()))?;
-        tracing::debug!(
+        tracing::trace!(
             "beacon network at {}: {:?}, is_chained: {}",
             self.epoch,
             curr_beacon.network(),

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -26,7 +26,7 @@ use nunny::vec as nonempty;
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::broadcast::{self, Sender as Publisher};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use super::{
     index::{ChainIndex, ResolveNullTipset},
@@ -228,7 +228,7 @@ where
     pub fn is_block_validated(&self, cid: &Cid) -> bool {
         let validated = self.validated_blocks.lock().contains(cid);
         if validated {
-            debug!("Block {cid} was previously validated");
+            trace!("Block {cid} was previously validated");
         }
         validated
     }

--- a/src/chain_sync/network_context.rs
+++ b/src/chain_sync/network_context.rs
@@ -156,7 +156,7 @@ where
             .last()
             .ok_or_else(|| "tipsets cannot be empty".to_owned())?;
         let tsk = head.key();
-        tracing::debug!(
+        tracing::trace!(
             "ChainExchange message sync tipsets: epoch: {}, len: {}",
             head.epoch(),
             tipsets.len()
@@ -344,7 +344,7 @@ where
                     .get_ok_validated(validate)
                     .await
                     .ok_or_else(make_failure_message)?;
-                debug!("Succeed: handle_chain_exchange_request");
+                trace!("Succeed: handle_chain_exchange_request");
                 v
             }
         };
@@ -367,7 +367,7 @@ where
         peer_id: PeerId,
         request: ChainExchangeRequest,
     ) -> Result<ChainExchangeResponse, String> {
-        debug!("Sending ChainExchange Request to {peer_id}");
+        trace!("Sending ChainExchange Request to {peer_id}");
 
         let req_pre_time = SystemTime::now();
 
@@ -396,7 +396,7 @@ where
             Ok(Ok(Ok(bs_res))) => {
                 // Successful response
                 peer_manager.log_success(peer_id, res_duration);
-                debug!("Succeeded: ChainExchange Request to {peer_id}");
+                trace!("Succeeded: ChainExchange Request to {peer_id}");
                 Ok(bs_res)
             }
             Ok(Ok(Err(e))) => {

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -779,14 +779,14 @@ async fn sync_tipset_range<DB: Blockstore + Sync + Send + 'static>(
     // At this point the head is synced and it can be set in the store as the
     // heaviest
     debug!(
-        "Tipset range successfully verified: EPOCH = [{}, {}], HEAD_KEY = {:?}",
+        "Tipset range successfully verified: EPOCH = [{}, {}], HEAD_KEY = {}",
         proposed_head.epoch(),
         current_head.epoch(),
         proposed_head.key()
     );
     if let Err(why) = chain_store.put_tipset(&proposed_head) {
         error!(
-            "Putting tipset range head [EPOCH = {}, KEYS = {:?}] in the store failed: {}",
+            "Putting tipset range head [EPOCH = {}, KEYS = {}] in the store failed: {}",
             proposed_head.epoch(),
             proposed_head.key(),
             why
@@ -1130,7 +1130,7 @@ async fn validate_tipset<DB: Blockstore + Send + Sync + 'static>(
         "Validating tipset: EPOCH = {epoch}, N blocks = {}",
         blocks.len()
     );
-    debug!("Tipset keys: {full_tipset_key}");
+    trace!("Tipset keys: {full_tipset_key}");
 
     for b in blocks {
         let validation_fn = tokio::task::spawn(validate_block(state_manager.clone(), Arc::new(b)));

--- a/src/libp2p/peer_manager.rs
+++ b/src/libp2p/peer_manager.rs
@@ -179,7 +179,7 @@ impl PeerManager {
     /// Logs a success for the given peer, and updates the average request
     /// duration.
     pub fn log_success(&self, peer: PeerId, dur: Duration) {
-        debug!("logging success for {:?}", peer);
+        trace!("logging success for {peer}");
         let mut peers = self.peers.write();
         // Attempt to remove the peer and decrement bad peer count
         if peers.bad_peers.remove(&peer) {
@@ -197,7 +197,7 @@ impl PeerManager {
     /// Logs a failure for the given peer, and updates the average request
     /// duration.
     pub fn log_failure(&self, peer: PeerId, dur: Duration) {
-        debug!("logging failure for {:?}", peer);
+        trace!("logging failure for {peer}");
         let mut peers = self.peers.write();
         if !peers.bad_peers.contains(&peer) {
             metrics::PEER_FAILURE_TOTAL.inc();
@@ -221,7 +221,7 @@ impl PeerManager {
 
         // Add peer to bad peer set
         let reason = reason.into();
-        tracing::warn!(%peer_id, %reason, "marked peer bad");
+        tracing::debug!(%peer_id, %reason, "marked peer bad");
         if peers.bad_peers.insert(peer_id) {
             metrics::BAD_PEERS.inc();
         }
@@ -232,7 +232,7 @@ impl PeerManager {
     /// Remove peer from managed set, does not mark as bad
     pub fn remove_peer(&self, peer_id: &PeerId) -> bool {
         let mut peers = self.peers.write();
-        debug!("removed peer {}", peer_id);
+        trace!("removed peer {peer_id}");
         let removed = remove_peer(&mut peers, peer_id);
         if removed {
             metrics::FULL_PEERS.dec();
@@ -309,9 +309,8 @@ impl PeerManager {
 }
 
 fn remove_peer(peers: &mut PeerSets, peer_id: &PeerId) -> bool {
-    debug!(
-        "removing peer {:?}, remaining chain exchange peers: {}",
-        peer_id,
+    trace!(
+        "removing peer {peer_id}, remaining chain exchange peers: {}",
         peers.full_peers.len()
     );
 

--- a/src/libp2p/ping.rs
+++ b/src/libp2p/ping.rs
@@ -33,7 +33,7 @@ pub async fn p2p_ping(addr: Multiaddr) -> Result<Duration, ping::Failure> {
                 conn_established_in = Some(established_in);
             }
             Ok(e) => {
-                tracing::debug!("{e:?}");
+                tracing::trace!("{e:?}");
             }
             Err(_e) => {
                 return conn_established_in.ok_or(ping::Failure::Timeout);

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -346,13 +346,13 @@ where
                 },
                 interval_event = interval.next() => if interval_event.is_some() {
                     // Print peer count on an interval.
-                    debug!("Peers connected: {}", swarm_stream.get_mut().behaviour_mut().peers().len());
+                    trace!("Peers connected: {}", swarm_stream.get_mut().behaviour_mut().peers().len());
                 },
                 cs_pair_opt = cx_response_rx_stream.next() => {
                     if let Some((_request_id, channel, cx_response)) = cs_pair_opt {
                         let behaviour = swarm_stream.get_mut().behaviour_mut();
                         if let Err(e) = behaviour.chain_exchange.send_response(channel, cx_response) {
-                            warn!("Error sending chain exchange response: {e:?}");
+                            debug!("Error sending chain exchange response: {e:?}");
                         }
                     }
                 },
@@ -410,12 +410,12 @@ fn handle_peer_ops(
         Ban(peer, reason) => {
             // Do not ban bootstrap nodes
             if !bootstrap_peers.contains_key(&peer) {
-                warn!(%peer, %reason, "Banning peer");
+                debug!(%peer, %reason, "Banning peer");
                 swarm.behaviour_mut().blocked_peers.block_peer(peer);
             }
         }
         Unban(peer) => {
-            info!(%peer, "Unbanning peer");
+            debug!(%peer, "Unbanning peer");
             swarm.behaviour_mut().blocked_peers.unblock_peer(peer);
         }
     }
@@ -580,11 +580,11 @@ async fn handle_discovery_event(
 ) {
     match discovery_out {
         DiscoveryEvent::PeerConnected(peer_id) => {
-            debug!("Peer connected, {:?}", peer_id);
+            trace!("Peer connected, {peer_id}");
             emit_event(network_sender_out, NetworkEvent::PeerConnected(peer_id)).await;
         }
         DiscoveryEvent::PeerDisconnected(peer_id) => {
-            debug!("Peer disconnected, {:?}", peer_id);
+            trace!("Peer disconnected, {peer_id}");
             emit_event(network_sender_out, NetworkEvent::PeerDisconnected(peer_id)).await;
         }
         DiscoveryEvent::Discovery(_) => {}

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -71,7 +71,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::RangeInclusive;
 use std::{num::NonZeroUsize, sync::Arc};
 use tokio::sync::{broadcast::error::RecvError, Mutex as TokioMutex, RwLock};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{error, info, instrument, trace, warn};
 pub use utils::is_valid_for_sending;
 
 const DEFAULT_TIPSET_CACHE_SIZE: NonZeroUsize = nonzero!(1024usize);
@@ -395,7 +395,7 @@ where
                 let ts_state = self
                     .compute_tipset_state(Arc::clone(tipset), NO_CALLBACK, VMTrace::NotTraced)
                     .await?;
-                debug!("Completed tipset state calculation {:?}", tipset.cids());
+                trace!("Completed tipset state calculation {:?}", tipset.cids());
                 Ok(ts_state)
             })
             .await


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As [discussed on slack](https://chainsafeio.slack.com/archives/C0144LHN732/p1717501294343469)

Changes introduced in this pull request:

- demote log levels on peer banning from `warn` to `debug`
- demote verbose debug logs to trace to make output more readable when `RUST_LOG=forest_filecoin=debug`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
