### PR TITLE
Fix Filecoin.StateCall RPC

### DIFF
--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -4,4 +4,3 @@
 !Filecoin.MinerGetBaseInfo
 # Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619017774/job/23623141130?pr=4170
 !Filecoin.MpoolGetNonce
-!Filecoin.StateCall

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -4,7 +4,6 @@
 !Filecoin.MinerGetBaseInfo
 # Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619314467/job/23624081698
 !Filecoin.MpoolGetNonce
-!Filecoin.StateCall
 !Filecoin.EthSyncing
 !Filecoin.NetAddrsListen
 !Filecoin.NetAgentVersion

--- a/src/lotus_json/actor_state.rs
+++ b/src/lotus_json/actor_state.rs
@@ -23,7 +23,8 @@ pub struct ActorStateLotusJson {
     #[serde(
         with = "crate::lotus_json",
         skip_serializing_if = "Option::is_none",
-        default
+        default,
+        rename = "Address"
     )]
     delegated_address: Option<Address>,
 }

--- a/src/rpc/methods/state/types.rs
+++ b/src/rpc/methods/state/types.rs
@@ -86,7 +86,7 @@ pub struct ExecutionTrace {
     pub msg_rct: ReturnTrace,
     pub invoked_actor: Option<ActorTrace>,
     pub gas_charges: Vec<GasTrace>,
-    pub subcalls: Vec<ExecutionTrace>,
+    pub subcalls: Option<Vec<ExecutionTrace>>,
 }
 
 lotus_json_with_self!(ExecutionTrace);

--- a/src/rpc/methods/state/types.rs
+++ b/src/rpc/methods/state/types.rs
@@ -86,6 +86,8 @@ pub struct ExecutionTrace {
     pub msg_rct: ReturnTrace,
     pub invoked_actor: Option<ActorTrace>,
     pub gas_charges: Vec<GasTrace>,
+    #[serde(with = "crate::lotus_json")]
+    #[schemars(with = "LotusJson<Option<Vec<ExecutionTrace>>>")]
     pub subcalls: Option<Vec<ExecutionTrace>>,
 }
 

--- a/src/rpc/methods/state/types.rs
+++ b/src/rpc/methods/state/types.rs
@@ -87,8 +87,8 @@ pub struct ExecutionTrace {
     pub invoked_actor: Option<ActorTrace>,
     pub gas_charges: Vec<GasTrace>,
     #[serde(with = "crate::lotus_json")]
-    #[schemars(with = "LotusJson<Option<Vec<ExecutionTrace>>>")]
-    pub subcalls: Option<Vec<ExecutionTrace>>,
+    #[schemars(with = "LotusJson<Vec<ExecutionTrace>>")]
+    pub subcalls: Vec<ExecutionTrace>,
 }
 
 lotus_json_with_self!(ExecutionTrace);

--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -244,7 +244,10 @@ mod test {
 
 /// Parsed tree of [`fvm4::trace::ExecutionEvent`]s
 pub mod structured {
-    use crate::{rpc::state::{ActorTrace, ExecutionTrace, GasTrace, MessageTrace, ReturnTrace}, shim::kernel::ErrorNumber};
+    use crate::{
+        rpc::state::{ActorTrace, ExecutionTrace, GasTrace, MessageTrace, ReturnTrace},
+        shim::kernel::ErrorNumber,
+    };
     use std::collections::VecDeque;
 
     use crate::shim::{
@@ -454,19 +457,17 @@ pub mod structured {
                 r#return: RawBytes::default(),
                 return_codec: 0,
             },
-            CallTreeReturn::Error(syscall_error) => {
-                match syscall_error.number {
-                    ErrorNumber::InsufficientFunds => ReturnTrace {
-                        exit_code: ExitCode::from(6),
-                        r#return: RawBytes::default(),
-                        return_codec: 0,
-                    },
-                    _ => ReturnTrace {
-                        exit_code: ExitCode::from(0),
-                        r#return: RawBytes::default(),
-                        return_codec: 0,
-                    }
-                }
+            CallTreeReturn::Error(syscall_error) => match syscall_error.number {
+                ErrorNumber::InsufficientFunds => ReturnTrace {
+                    exit_code: ExitCode::from(6),
+                    r#return: RawBytes::default(),
+                    return_codec: 0,
+                },
+                _ => ReturnTrace {
+                    exit_code: ExitCode::from(0),
+                    r#return: RawBytes::default(),
+                    return_codec: 0,
+                },
             },
         }
     }

--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -414,7 +414,7 @@ pub mod structured {
                         msg: to_message_trace(call),
                         msg_rct: to_return_trace(ret),
                         gas_charges,
-                        subcalls,
+                        subcalls: Some(subcalls),
                         invoked_actor: actor_trace,
                     });
                 }

--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -244,7 +244,7 @@ mod test {
 
 /// Parsed tree of [`fvm4::trace::ExecutionEvent`]s
 pub mod structured {
-    use crate::rpc::state::{ActorTrace, ExecutionTrace, GasTrace, MessageTrace, ReturnTrace};
+    use crate::{rpc::state::{ActorTrace, ExecutionTrace, GasTrace, MessageTrace, ReturnTrace}, shim::kernel::ErrorNumber};
     use std::collections::VecDeque;
 
     use crate::shim::{
@@ -454,10 +454,19 @@ pub mod structured {
                 r#return: RawBytes::default(),
                 return_codec: 0,
             },
-            CallTreeReturn::Error(_syscall_error) => ReturnTrace {
-                exit_code: ExitCode::from(0),
-                r#return: RawBytes::default(),
-                return_codec: 0,
+            CallTreeReturn::Error(syscall_error) => {
+                match syscall_error.number {
+                    ErrorNumber::InsufficientFunds => ReturnTrace {
+                        exit_code: ExitCode::from(6),
+                        r#return: RawBytes::default(),
+                        return_codec: 0,
+                    },
+                    _ => ReturnTrace {
+                        exit_code: ExitCode::from(0),
+                        r#return: RawBytes::default(),
+                        return_codec: 0,
+                    }
+                }
             },
         }
     }

--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -417,7 +417,7 @@ pub mod structured {
                         msg: to_message_trace(call),
                         msg_rct: to_return_trace(ret),
                         gas_charges,
-                        subcalls: Some(subcalls),
+                        subcalls,
                         invoked_actor: actor_trace,
                     });
                 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fix `Filecoin.StateCall` RPC and re-enable in rpc check
```
forest-tool api compare forest_snapshot_calibnet_2024-05-09_height_1597332.forest.car.zst --filter StateCall
| RPC Method              | Forest | Lotus |
|-------------------------|--------|-------|
| Filecoin.StateCall (27) | Valid  | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Contributes to #4164 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation,
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
