### PR TITLE
Fix Filecoin.ChainGetPath RPC

### DIFF
--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -1,6 +1,5 @@
 # This list contains potentially broken methods (or tests) that are ignored.
 # They should be considered bugged, and not used until the root cause is resolved.
-!Filecoin.ChainGetPath
 !Filecoin.MinerGetBaseInfo
 # Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619017774/job/23623141130?pr=4170
 !Filecoin.MpoolGetNonce

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -1,6 +1,5 @@
 # This list contains potentially broken methods (or tests) that are ignored.
 # They should be considered bugged, and not used until the root cause is resolved.
-!Filecoin.ChainGetPath
 !Filecoin.MinerGetBaseInfo
 # Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619314467/job/23624081698
 !Filecoin.MpoolGetNonce

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -749,7 +749,7 @@ pub struct ApiHeadChange {
 lotus_json_with_self!(ApiHeadChange);
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[serde(tag = "Type", content = "Val", rename_all = "snake_case")]
 pub enum PathChange<T = Arc<Tipset>> {
     Revert(T),
     Apply(T),

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -762,7 +762,8 @@ impl HasLotusJson for PathChange {
         use serde_json::json;
         vec![(
             json!({
-                "revert": {
+                "Type": "revert",
+                "Val": {
                     "Blocks": [
                         {
                             "BeaconEntries": null,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fix `Filecoin.ChainGetPath` RPC and re-enable in rpc check
```
forest-tool api compare forest_snapshot_calibnet_2024-05-09_height_1597332.forest.car.zst --filter ChainGetPath
| RPC Method                 | Forest | Lotus |
|----------------------------|--------|-------|
| Filecoin.ChainGetPath (10) | Valid  | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Contributes to https://github.com/ChainSafe/forest/issues/4164

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation,
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
