### PR TITLE
fix: use &T instead of &Arc<T> in parameter types when possible

### DIFF
--- a/src/health/endpoints.rs
+++ b/src/health/endpoints.rs
@@ -82,7 +82,7 @@ pub(crate) async fn healthz(
     }
 }
 
-fn check_sync_state_complete(state: &Arc<ForestState>, acc: &mut MessageAccumulator) -> bool {
+fn check_sync_state_complete(state: &ForestState, acc: &mut MessageAccumulator) -> bool {
     // Forest must be in sync with the network
     if state.sync_state.read().stage() == SyncStage::Complete {
         acc.push_ok("sync complete");
@@ -93,7 +93,7 @@ fn check_sync_state_complete(state: &Arc<ForestState>, acc: &mut MessageAccumula
     }
 }
 
-fn check_sync_state_not_error(state: &Arc<ForestState>, acc: &mut MessageAccumulator) -> bool {
+fn check_sync_state_not_error(state: &ForestState, acc: &mut MessageAccumulator) -> bool {
     // Forest must be in sync with the network
     if state.sync_state.read().stage() != SyncStage::Error {
         acc.push_ok("sync ok");
@@ -107,7 +107,7 @@ fn check_sync_state_not_error(state: &Arc<ForestState>, acc: &mut MessageAccumul
 /// Checks if the current epoch of the node is not too far behind the network.
 /// Making the threshold too strict can cause the node to repeatedly report as not ready, especially
 /// in case of forking.
-fn check_epoch_up_to_date(state: &Arc<ForestState>, acc: &mut MessageAccumulator) -> bool {
+fn check_epoch_up_to_date(state: &ForestState, acc: &mut MessageAccumulator) -> bool {
     const MAX_EPOCH_DIFF: i64 = 5;
 
     let now_epoch = calculate_expected_epoch(
@@ -126,7 +126,7 @@ fn check_epoch_up_to_date(state: &Arc<ForestState>, acc: &mut MessageAccumulator
     }
 }
 
-async fn check_rpc_server_running(state: &Arc<ForestState>, acc: &mut MessageAccumulator) -> bool {
+async fn check_rpc_server_running(state: &ForestState, acc: &mut MessageAccumulator) -> bool {
     if !state.config.client.enable_rpc {
         acc.push_ok("rpc server disabled");
         true
@@ -142,7 +142,7 @@ async fn check_rpc_server_running(state: &Arc<ForestState>, acc: &mut MessageAcc
     }
 }
 
-fn check_peers_connected(state: &Arc<ForestState>, acc: &mut MessageAccumulator) -> bool {
+fn check_peers_connected(state: &ForestState, acc: &mut MessageAccumulator) -> bool {
     // At least 1 peer is connected
     if state.peer_manager.peer_count() > 0 {
         acc.push_ok("peers connected");

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -647,7 +647,7 @@ async fn handle_gossip_event(
 async fn handle_hello_event(
     hello: &mut HelloBehaviour,
     event: request_response::Event<HelloRequest, HelloResponse, HelloResponse>,
-    peer_manager: &Arc<PeerManager>,
+    peer_manager: &PeerManager,
     genesis_cid: &Cid,
     network_sender_out: &Sender<NetworkEvent>,
 ) {
@@ -743,7 +743,7 @@ async fn handle_hello_event(
     }
 }
 
-async fn handle_ping_event(ping_event: ping::Event, peer_manager: &Arc<PeerManager>) {
+async fn handle_ping_event(ping_event: ping::Event, peer_manager: &PeerManager) {
     match ping_event.result {
         Ok(rtt) => {
             trace!(

--- a/src/message_pool/msgpool/mod.rs
+++ b/src/message_pool/msgpool/mod.rs
@@ -60,7 +60,7 @@ async fn republish_pending_messages<T>(
     cur_tipset: &Mutex<Arc<Tipset>>,
     republished: &SyncRwLock<HashSet<Cid>>,
     local_addrs: &SyncRwLock<Vec<Address>>,
-    chain_config: &Arc<ChainConfig>,
+    chain_config: &ChainConfig,
 ) -> Result<(), Error>
 where
     T: Provider,

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -683,7 +683,7 @@ impl RpcMethod<2> for EthGetBalance {
 }
 
 fn tipset_by_block_number_or_hash<DB: Blockstore>(
-    chain: &Arc<ChainStore<DB>>,
+    chain: &ChainStore<DB>,
     block_param: BlockNumberOrHash,
 ) -> anyhow::Result<Arc<Tipset>> {
     let head = chain.heaviest_tipset();

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -2096,7 +2096,7 @@ impl RpcMethod<0> for StateGetNetworkParams {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let config = ctx.state_manager.chain_config();
+        let config = ctx.state_manager.chain_config().as_ref();
         let policy = &config.policy;
 
         // This is the correct implementation, but for conformance with Lotus,
@@ -2191,9 +2191,9 @@ pub struct ForkUpgradeParams {
     // upgrade_aussie_height: ChainEpoch,
 }
 
-impl TryFrom<&Arc<ChainConfig>> for ForkUpgradeParams {
+impl TryFrom<&ChainConfig> for ForkUpgradeParams {
     type Error = anyhow::Error;
-    fn try_from(config: &Arc<ChainConfig>) -> anyhow::Result<Self> {
+    fn try_from(config: &ChainConfig) -> anyhow::Result<Self> {
         let height_infos = &config.height_infos;
         let get_height = |height| -> anyhow::Result<ChainEpoch> {
             let height = height_infos

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -370,7 +370,7 @@ where
     pub fn get_all_sectors(
         self: &Arc<Self>,
         addr: &Address,
-        ts: &Arc<Tipset>,
+        ts: &Tipset,
     ) -> anyhow::Result<Vec<SectorOnChainInfo>> {
         let actor = self
             .get_actor(addr, *ts.parent_state())?
@@ -1064,19 +1064,19 @@ where
     }
 
     /// Retrieves miner faults.
-    pub fn miner_faults(&self, addr: &Address, ts: &Arc<Tipset>) -> Result<BitField, Error> {
+    pub fn miner_faults(&self, addr: &Address, ts: &Tipset) -> Result<BitField, Error> {
         self.all_partition_sectors(addr, ts, |partition| partition.faulty_sectors().clone())
     }
 
     /// Retrieves miner recoveries.
-    pub fn miner_recoveries(&self, addr: &Address, ts: &Arc<Tipset>) -> Result<BitField, Error> {
+    pub fn miner_recoveries(&self, addr: &Address, ts: &Tipset) -> Result<BitField, Error> {
         self.all_partition_sectors(addr, ts, |partition| partition.recovering_sectors().clone())
     }
 
     fn all_partition_sectors(
         &self,
         addr: &Address,
-        ts: &Arc<Tipset>,
+        ts: &Tipset,
         get_sector: impl Fn(Partition<'_>) -> BitField,
     ) -> Result<BitField, Error> {
         let actor = self

--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -30,7 +30,7 @@ type RunMigration<DB> = fn(&ChainConfig, &Arc<DB>, &Cid, ChainEpoch) -> anyhow::
 /// Run state migrations
 pub fn run_state_migrations<DB>(
     epoch: ChainEpoch,
-    chain_config: &Arc<ChainConfig>,
+    chain_config: &ChainConfig,
     db: &Arc<DB>,
     parent_state: &Cid,
 ) -> anyhow::Result<Option<Cid>>


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR demotes some `&Arc<T>` parameter types to `&T` when possible

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
