### PR TITLE
Add support for Eth mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,7 +2944,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forest-filecoin"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "anes 0.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forest-filecoin"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 repository = "https://github.com/ChainSafe/forest"
 edition = "2021"

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -34,7 +34,7 @@ pub async fn export<D: Digest>(
     // Stream stateroots in range (stateroot_lookup_limit+1)..=tipset.epoch(). Also
     // stream all block headers until genesis.
     let blocks = par_buffer(
-        // Queue 1k blocks. This is enuogh to saturate the compressor and blocks
+        // Queue 1k blocks. This is enough to saturate the compressor and blocks
         // are small enough that keeping 1k in memory isn't a problem. Average
         // block size is between 1kb and 2kb.
         1024,

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -184,9 +184,10 @@ where
         Ok(tsk)
     }
 
-    /// Writes the `Hash` to `Cid` mapping to the blockstore for `EthAPI` queries.
-    pub fn put_mapping(&self, k: &eth::Hash, v: &Cid) -> Result<(), Error> {
-        self.eth_mappings.write_obj(k, v)?;
+    /// Writes with timestamp the `Hash` to `Cid` mapping to the blockstore for `EthAPI` queries.
+    pub fn put_mapping(&self, k: eth::Hash, v: Cid) -> Result<(), Error> {
+        let timestamp = chrono::Utc::now().timestamp() as u64;
+        self.eth_mappings.write_obj(&k, &(v, timestamp))?;
 
         Ok(())
     }

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -10,6 +10,7 @@ use crate::interpreter::VMTrace;
 use crate::libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
 use crate::message::{ChainMessage, Message as MessageTrait, SignedMessage};
 use crate::networks::ChainConfig;
+use crate::rpc::eth;
 use crate::shim::clock::ChainEpoch;
 use crate::shim::{
     address::Address, econ::TokenAmount, executor::Receipt, message::Message,
@@ -34,7 +35,7 @@ use super::{
     Error,
 };
 use crate::db::setting_keys::HEAD_KEY;
-use crate::db::{SettingsStore, SettingsStoreExt};
+use crate::db::{EthMappingsStore, EthMappingsStoreExt, SettingsStore, SettingsStoreExt};
 
 // A cap on the size of the future_sink
 const SINK_CAP: usize = 200;
@@ -73,6 +74,9 @@ pub struct ChainStore<DB> {
 
     /// validated blocks
     validated_blocks: Mutex<HashSet<Cid>>,
+
+    /// Ethereum mappings store
+    eth_mappings: Arc<dyn EthMappingsStore + Sync + Send>,
 }
 
 impl<DB> BitswapStoreRead for ChainStore<DB>
@@ -106,6 +110,7 @@ where
     pub fn new(
         db: Arc<DB>,
         settings: Arc<dyn SettingsStore + Sync + Send>,
+        eth_mappings: Arc<dyn EthMappingsStore + Sync + Send>,
         chain_config: Arc<ChainConfig>,
         genesis_block_header: CachingBlockHeader,
     ) -> anyhow::Result<Self> {
@@ -130,6 +135,7 @@ where
             settings,
             genesis_block_header,
             validated_blocks,
+            eth_mappings,
         };
 
         Ok(cs)
@@ -155,9 +161,33 @@ where
     pub fn put_tipset(&self, ts: &Tipset) -> Result<(), Error> {
         persist_objects(self.blockstore(), ts.block_headers().iter())?;
 
+        self.put_tipset_key(ts.key())?;
+
         // Expand tipset to include other compatible blocks at the epoch.
         let expanded = self.expand_tipset(ts.min_ticket_block().clone())?;
         self.update_heaviest(Arc::new(expanded))?;
+        Ok(())
+    }
+
+    /// Writes the `TipsetKey` to the blockstore for `EthAPI` queries.
+    pub fn put_tipset_key(&self, tsk: &TipsetKey) -> Result<(), Error> {
+        let hash = tsk.cid()?.into();
+        self.eth_mappings.write_obj(&hash, tsk)?;
+
+        Ok(())
+    }
+
+    /// Reads the `TipsetKey` from the blockstore for `EthAPI` queries.
+    pub fn get_tipset_key(&self, hash: &eth::Hash) -> Result<Option<TipsetKey>, Error> {
+        let tsk = self.eth_mappings.read_obj(hash)?;
+
+        Ok(tsk)
+    }
+
+    /// Writes the `Hash` to `Cid` mapping to the blockstore for `EthAPI` queries.
+    pub fn put_mapping(&self, k: &eth::Hash, v: &Cid) -> Result<(), Error> {
+        self.eth_mappings.write_obj(k, v)?;
+
         Ok(())
     }
 
@@ -548,7 +578,8 @@ mod tests {
             message_receipts: Cid::new_v1(DAG_CBOR, Identity.digest(&[])),
             ..Default::default()
         });
-        let cs = ChainStore::new(db.clone(), db, chain_config, gen_block.clone()).unwrap();
+        let cs =
+            ChainStore::new(db.clone(), db.clone(), db, chain_config, gen_block.clone()).unwrap();
 
         assert_eq!(cs.genesis_block_header(), &gen_block);
     }
@@ -562,7 +593,7 @@ mod tests {
             ..Default::default()
         });
 
-        let cs = ChainStore::new(db.clone(), db, chain_config, gen_block).unwrap();
+        let cs = ChainStore::new(db.clone(), db.clone(), db, chain_config, gen_block).unwrap();
 
         let cid = Cid::new_v1(DAG_CBOR, Blake2b256.digest(&[1, 2, 3]));
         assert!(!cs.is_block_validated(&cid));

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -158,6 +158,8 @@ where
 {
     let mut delegated_messages = vec![];
 
+    info!("Populating column EthMappings");
+
     for ts in head_ts
         .clone()
         .chain(&state_manager.chain_store().blockstore())

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -28,6 +28,12 @@ use tracing::{debug, info};
 use url::Url;
 use walkdir::WalkDir;
 
+#[cfg(doc)]
+use crate::rpc::eth::Hash;
+
+#[cfg(doc)]
+use crate::blocks::TipsetKey;
+
 pub fn load_all_forest_cars<T>(store: &ManyCar<T>, forest_car_db_dir: &Path) -> anyhow::Result<()> {
     if !forest_car_db_dir.is_dir() {
         fs::create_dir_all(forest_car_db_dir)?;
@@ -149,6 +155,12 @@ async fn transcode_into_forest_car(from: &Path, to: &Path) -> anyhow::Result<()>
     Ok(())
 }
 
+/// For the need for Ethereum RPC API, a new column in parity-db has been introduced to handle
+/// mapping of:
+/// - [`Hash`] to [`TipsetKey`].
+/// - [`Hash`] to delegated message [`Cid`].
+///
+/// This function traverses the chain store and populates the column.
 pub fn populate_eth_mappings<DB>(
     state_manager: &StateManager<DB>,
     head_ts: &Tipset,
@@ -185,6 +197,7 @@ where
     Ok(())
 }
 
+/// Filter [`SignedMessage`]'s to keep only delegated ones and the most recent ones, then write them to the chain store.
 fn process_signed_messages<DB>(
     state_manager: &StateManager<DB>,
     messages: &[SignedMessage],

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -201,7 +201,7 @@ where
 fn process_signed_messages<DB>(
     state_manager: &StateManager<DB>,
     messages: &[SignedMessage],
-) -> anyhow::Result<usize>
+) -> anyhow::Result<()>
 where
     DB: fvm_ipld_blockstore::Blockstore,
 {
@@ -226,10 +226,10 @@ where
     let filtered = filter_lowest_index(eth_txs);
 
     // write back
-    for (k, v) in filtered.iter() {
+    for (k, v) in filtered.into_iter() {
         state_manager.chain_store().put_mapping(k, v)?;
     }
-    Ok(filtered.len())
+    Ok(())
 }
 
 fn filter_lowest_index(values: Vec<(eth::Hash, Cid, usize)>) -> Vec<(eth::Hash, Cid)> {

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -192,7 +192,7 @@ where
         }
         state_manager.chain_store().put_tipset_key(ts.key())?;
     }
-    let _ = process_signed_messages(state_manager, &delegated_messages)?;
+    process_signed_messages(state_manager, &delegated_messages)?;
 
     Ok(())
 }

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -157,8 +157,8 @@ async fn transcode_into_forest_car(from: &Path, to: &Path) -> anyhow::Result<()>
 
 /// For the need for Ethereum RPC API, a new column in parity-db has been introduced to handle
 /// mapping of:
-/// - [`Hash`] to [`TipsetKey`].
-/// - [`Hash`] to delegated message [`Cid`].
+/// - [`struct@Hash`] to [`TipsetKey`].
+/// - [`struct@Hash`] to delegated message [`Cid`].
 ///
 /// This function traverses the chain store and populates the column.
 pub fn populate_eth_mappings<DB>(

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -9,8 +9,9 @@
 //! A single z-frame cache is shared between all read-only stores.
 
 use super::{AnyCar, ZstdFrameCache};
-use crate::db::{MemoryDB, SettingsStore};
+use crate::db::{EthMappingsStore, MemoryDB, SettingsStore};
 use crate::libp2p_bitswap::BitswapStoreReadWrite;
+use crate::rpc::eth;
 use crate::shim::clock::ChainEpoch;
 use crate::utils::io::EitherMmapOrRandomAccessFile;
 use crate::{blocks::Tipset, libp2p_bitswap::BitswapStoreRead};
@@ -201,6 +202,20 @@ impl<WriterT: SettingsStore> SettingsStore for ManyCar<WriterT> {
 
     fn setting_keys(&self) -> anyhow::Result<Vec<String>> {
         SettingsStore::setting_keys(self.writer())
+    }
+}
+
+impl<WriterT: EthMappingsStore> EthMappingsStore for ManyCar<WriterT> {
+    fn read_bin(&self, key: &eth::Hash) -> anyhow::Result<Option<Vec<u8>>> {
+        EthMappingsStore::read_bin(self.writer(), key)
+    }
+
+    fn write_bin(&self, key: &eth::Hash, value: &[u8]) -> anyhow::Result<()> {
+        EthMappingsStore::write_bin(self.writer(), key, value)
+    }
+
+    fn exists(&self, key: &eth::Hash) -> anyhow::Result<bool> {
+        EthMappingsStore::exists(self.writer(), key)
     }
 }
 

--- a/src/db/gc/mod.rs
+++ b/src/db/gc/mod.rs
@@ -279,7 +279,14 @@ mod test {
             let gen_block: CachingBlockHeader = mock_block(1, 1);
             db.put_cbor_default(&gen_block).unwrap();
             let store = Arc::new(
-                ChainStore::new(db.clone(), db.clone(), Arc::new(config), gen_block).unwrap(),
+                ChainStore::new(
+                    db.clone(),
+                    db.clone(),
+                    db.clone(),
+                    Arc::new(config),
+                    gen_block,
+                )
+                .unwrap(),
             );
 
             GCTester { db, store }

--- a/src/db/migration/db_migration.rs
+++ b/src/db/migration/db_migration.rs
@@ -117,15 +117,15 @@ mod tests {
         let mut config = Config::default();
         temp_dir.path().clone_into(&mut config.client.data_dir);
 
-        let db_dir = temp_dir.path().join("0.1.0");
-        std::fs::create_dir(&db_dir).unwrap();
+        let db_dir = temp_dir.path().join("mainnet/0.1.0");
+        std::fs::create_dir_all(&db_dir).unwrap();
         let db_migration = DbMigration::new(&config);
 
         std::env::set_var(FOREST_DB_DEV_MODE, "latest");
         assert!(!db_migration.is_migration_required().unwrap());
 
         std::fs::remove_dir(db_dir).unwrap();
-        std::fs::create_dir(temp_dir.path().join("cthulhu")).unwrap();
+        std::fs::create_dir_all(temp_dir.path().join("mainnet/cthulhu")).unwrap();
 
         std::env::set_var(FOREST_DB_DEV_MODE, "cthulhu");
         assert!(!db_migration.is_migration_required().unwrap());
@@ -137,8 +137,8 @@ mod tests {
         let mut config = Config::default();
         temp_dir.path().clone_into(&mut config.client.data_dir);
 
-        let db_dir = temp_dir.path().join("0.1.0");
-        std::fs::create_dir(db_dir).unwrap();
+        let db_dir = temp_dir.path().join("mainnet/0.1.0");
+        std::fs::create_dir_all(db_dir).unwrap();
         let db_migration = DbMigration::new(&config);
 
         std::env::set_var(FOREST_DB_DEV_MODE, "current");

--- a/src/db/migration/db_migration.rs
+++ b/src/db/migration/db_migration.rs
@@ -6,36 +6,44 @@ use std::path::PathBuf;
 use tracing::info;
 
 use crate::{
+    cli_shared::chain_path,
     db::{
         db_mode::{get_latest_versioned_database, DbMode},
         migration::migration_map::create_migration_chain,
     },
     utils::version::FOREST_VERSION,
+    Config,
 };
 
 /// Governs the database migration process. This is the entry point for the migration process.
 pub struct DbMigration {
-    /// Root of the chain data directory. This is where all the databases are stored.
-    chain_data_path: PathBuf,
+    /// Forest configuration used.
+    config: Config,
 }
 
 impl DbMigration {
-    pub fn new(chain_data_path: PathBuf) -> Self {
-        Self { chain_data_path }
+    pub fn new(config: &Config) -> Self {
+        Self {
+            config: config.clone(),
+        }
+    }
+
+    pub fn chain_data_path(&self) -> PathBuf {
+        chain_path(&self.config)
     }
 
     /// Verifies if a migration is needed for the current Forest process.
     /// Note that migration can possibly happen only if the DB is in `current` mode.
     pub fn is_migration_required(&self) -> anyhow::Result<bool> {
         // No chain data means that this is a fresh instance. No migration required.
-        if !self.chain_data_path.exists() {
+        if !self.chain_data_path().exists() {
             return Ok(false);
         }
 
         // migration is required only if the DB is in `current` mode and the current db version is
         // smaller than the current binary version
         if let DbMode::Current = DbMode::read() {
-            let current_db = get_latest_versioned_database(&self.chain_data_path)?
+            let current_db = get_latest_versioned_database(&self.chain_data_path())?
                 .unwrap_or_else(|| FOREST_VERSION.clone());
             Ok(current_db < *FOREST_VERSION)
         } else {
@@ -54,7 +62,7 @@ impl DbMigration {
             return Ok(());
         }
 
-        let latest_db_version = get_latest_versioned_database(&self.chain_data_path)?
+        let latest_db_version = get_latest_versioned_database(&self.chain_data_path())?
             .unwrap_or_else(|| FOREST_VERSION.clone());
 
         info!(
@@ -67,7 +75,7 @@ impl DbMigration {
         let migrations = create_migration_chain(&latest_db_version, target_db_version)?;
 
         for migration in migrations {
-            migration.migrate(&self.chain_data_path)?;
+            migration.migrate(&self.chain_data_path(), &self.config)?;
         }
 
         info!(
@@ -88,24 +96,30 @@ mod tests {
     #[test]
     fn test_migration_not_required_no_chain_path() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let db_migration = DbMigration::new(temp_dir.path().join("azathoth"));
+        let mut config = Config::default();
+        config.client.data_dir = temp_dir.path().join("azathoth");
+        let db_migration = DbMigration::new(&config);
         assert!(!db_migration.is_migration_required().unwrap());
     }
 
     #[test]
     fn test_migration_not_required_no_databases() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let db_migration = DbMigration::new(temp_dir.path().to_owned());
+        let mut config = Config::default();
+        temp_dir.path().clone_into(&mut config.client.data_dir);
+        let db_migration = DbMigration::new(&config);
         assert!(!db_migration.is_migration_required().unwrap());
     }
 
     #[test]
     fn test_migration_not_required_under_non_current_mode() {
         let temp_dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        temp_dir.path().clone_into(&mut config.client.data_dir);
 
         let db_dir = temp_dir.path().join("0.1.0");
         std::fs::create_dir(&db_dir).unwrap();
-        let db_migration = DbMigration::new(temp_dir.path().to_owned());
+        let db_migration = DbMigration::new(&config);
 
         std::env::set_var(FOREST_DB_DEV_MODE, "latest");
         assert!(!db_migration.is_migration_required().unwrap());
@@ -120,10 +134,12 @@ mod tests {
     #[test]
     fn test_migration_required_current_mode() {
         let temp_dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        temp_dir.path().clone_into(&mut config.client.data_dir);
 
         let db_dir = temp_dir.path().join("0.1.0");
         std::fs::create_dir(db_dir).unwrap();
-        let db_migration = DbMigration::new(temp_dir.path().to_owned());
+        let db_migration = DbMigration::new(&config);
 
         std::env::set_var(FOREST_DB_DEV_MODE, "current");
         assert!(db_migration.is_migration_required().unwrap());

--- a/src/db/migration/migration_map.rs
+++ b/src/db/migration/migration_map.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use multimap::MultiMap;
 use once_cell::sync::Lazy;
 use semver::Version;
-use tracing::info;
+use tracing::{debug, info};
 
 use super::v0_12_1::Migration0_12_1_0_13_0;
 use super::void_migration::MigrationVoid;
@@ -100,7 +100,7 @@ impl Migration {
         self.post_checks(chain_data_path)?;
 
         let new_db = chain_data_path.join(format!("{}", self.to));
-        info!(
+        debug!(
             "Renaming database {} to {}",
             migrated_db.display(),
             new_db.display()
@@ -108,7 +108,7 @@ impl Migration {
         std::fs::rename(migrated_db, new_db)?;
 
         let old_db = chain_data_path.join(format!("{}", self.from));
-        info!("Deleting database {}", old_db.display());
+        debug!("Deleting database {}", old_db.display());
         std::fs::remove_dir_all(old_db)?;
 
         info!("Database migration complete");

--- a/src/db/migration/mod.rs
+++ b/src/db/migration/mod.rs
@@ -5,6 +5,7 @@ mod db_migration;
 mod migration_map;
 mod v0_12_1;
 mod v0_16_0;
+mod v0_19_0;
 mod void_migration;
 
 pub use db_migration::DbMigration;

--- a/src/db/migration/v0_12_1.rs
+++ b/src/db/migration/v0_12_1.rs
@@ -9,6 +9,7 @@
 //! coming from the rolling database and ParityDb.
 
 use crate::db::migration::migration_map::temporary_db_name;
+use crate::Config;
 use fs_extra::dir::CopyOptions;
 use semver::Version;
 use std::path::{Path, PathBuf};
@@ -29,7 +30,7 @@ impl MigrationOperation for Migration0_12_1_0_13_0 {
         Ok(())
     }
 
-    fn migrate(&self, chain_data_path: &Path) -> anyhow::Result<PathBuf> {
+    fn migrate(&self, chain_data_path: &Path, _config: &Config) -> anyhow::Result<PathBuf> {
         let source_db = chain_data_path.join(self.from.to_string());
 
         let temp_db_path = chain_data_path.join(temporary_db_name(&self.from, &self.to));

--- a/src/db/migration/v0_16_0.rs
+++ b/src/db/migration/v0_16_0.rs
@@ -8,6 +8,7 @@
 use crate::db::db_engine::Db;
 use crate::db::migration::migration_map::temporary_db_name;
 use crate::db::migration::v0_16_0::paritydb_0_15_1::{DbColumn, ParityDb};
+use crate::Config;
 use anyhow::Context;
 use cid::multihash::Code::Blake2b256;
 use cid::multihash::MultihashDigest;
@@ -40,7 +41,7 @@ impl MigrationOperation for Migration0_15_2_0_16_0 {
         Ok(())
     }
 
-    fn migrate(&self, chain_data_path: &Path) -> anyhow::Result<PathBuf> {
+    fn migrate(&self, chain_data_path: &Path, _config: &Config) -> anyhow::Result<PathBuf> {
         let source_db = chain_data_path.join(self.from.to_string());
 
         let db_paths: Vec<PathBuf> = source_db

--- a/src/db/migration/v0_19_0.rs
+++ b/src/db/migration/v0_19_0.rs
@@ -1,0 +1,335 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Migration logic for 0.18.0 to 0.19.0 version.
+//! For the need for Ethereum RPC API, a new column in parity-db has been introduced to handle
+//! mapping of values such as, `Hash` to `TipsetKey` and `Hash` to message `Cid`.
+
+use crate::chain::ChainStore;
+use crate::cli_shared::chain_path;
+use crate::daemon::db_util::{load_all_forest_cars, populate_eth_mappings};
+use crate::db::car::ManyCar;
+use crate::db::db_engine::{open_db, Db};
+use crate::db::migration::migration_map::temporary_db_name;
+use crate::db::migration::v0_19_0::paritydb_0_18_0::{DbColumn, ParityDb};
+use crate::genesis::read_genesis_header;
+use crate::networks::ChainConfig;
+use crate::state_manager::StateManager;
+use crate::Config;
+use anyhow::Context;
+use cid::multihash::Code::Blake2b256;
+use cid::multihash::MultihashDigest;
+use cid::Cid;
+use fs_extra::dir::CopyOptions;
+use fvm_ipld_encoding::DAG_CBOR;
+use semver::Version;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use strum::IntoEnumIterator;
+use tracing::info;
+
+use super::migration_map::MigrationOperation;
+
+pub(super) struct Migration0_18_0_0_19_0 {
+    from: Version,
+    to: Version,
+}
+
+/// Migrates the database from version 0.18.0 to 0.19.0
+impl MigrationOperation for Migration0_18_0_0_19_0 {
+    fn new(from: Version, to: Version) -> Self
+    where
+        Self: Sized,
+    {
+        Self { from, to }
+    }
+
+    fn pre_checks(&self, _chain_data_path: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate(&self, chain_data_path: &Path, config: &Config) -> anyhow::Result<PathBuf> {
+        let source_db = chain_data_path.join(self.from.to_string());
+
+        let temp_db_path = chain_data_path.join(temporary_db_name(&self.from, &self.to));
+        if temp_db_path.exists() {
+            info!(
+                "Removing old temporary database {temp_db_path}",
+                temp_db_path = temp_db_path.display()
+            );
+            std::fs::remove_dir_all(&temp_db_path)?;
+        }
+
+        let old_car_db_path = source_db.join("car_db");
+        let new_car_db_path = temp_db_path.join("car_db");
+
+        // Make sure `car_db` dir exists as it might not be the case when migrating
+        // from older versions.
+        if old_car_db_path.is_dir() {
+            info!(
+                "Copying snapshot from {source_db} to {temp_db_path}",
+                source_db = old_car_db_path.display(),
+                temp_db_path = new_car_db_path.display()
+            );
+
+            fs_extra::copy_items(
+                &[old_car_db_path.as_path()],
+                new_car_db_path,
+                &CopyOptions::default().copy_inside(true),
+            )?;
+        }
+
+        let db = ParityDb::open(source_db)?;
+
+        // open the new database to migrate data from the old one.
+        let new_db = paritydb_0_19_0::ParityDb::open(&temp_db_path)?;
+
+        for col in DbColumn::iter() {
+            info!("Migrating column {}", col);
+            let mut res = anyhow::Ok(());
+            if col == DbColumn::GraphDagCborBlake2b256 {
+                db.db.iter_column_while(col as u8, |val| {
+                    let hash = Blake2b256.digest(&val.value);
+                    let cid = Cid::new_v1(DAG_CBOR, hash);
+                    res = new_db
+                        .db
+                        .commit_changes([Db::set_operation(col as u8, cid.to_bytes(), val.value)])
+                        .context("failed to commit");
+
+                    if res.is_err() {
+                        return false;
+                    }
+
+                    true
+                })?;
+                res?;
+            } else {
+                let mut iter = db.db.iter(col as u8)?;
+                while let Some((key, value)) = iter.next()? {
+                    new_db
+                        .db
+                        .commit_changes([Db::set_operation(col as u8, key, value)])
+                        .context("failed to commit")?;
+                }
+            }
+        }
+
+        drop(new_db);
+
+        // open the new database to populate the Ethereum mappings
+        info!("Populating column EthMappings");
+        let handle = tokio::runtime::Handle::current();
+        futures::executor::block_on(async {
+            let mut cloned_config = config.clone();
+            let mut data_dir: PathBuf = chain_data_path.into();
+            data_dir.pop();
+            cloned_config.client.data_dir = data_dir;
+            let db_name = temporary_db_name(&self.from, &self.to);
+            handle
+                .spawn(create_state_manager_and_populate(cloned_config, db_name))
+                .await
+                .expect("Task spawned panicked")
+        })?;
+
+        Ok(temp_db_path)
+    }
+
+    fn post_checks(&self, chain_data_path: &Path) -> anyhow::Result<()> {
+        let temp_db_name = temporary_db_name(&self.from, &self.to);
+        if !chain_data_path.join(&temp_db_name).exists() {
+            anyhow::bail!(
+                "migration database {} does not exist",
+                chain_data_path.join(temp_db_name).display()
+            );
+        }
+        Ok(())
+    }
+}
+
+async fn create_state_manager_and_populate(config: Config, db_name: String) -> anyhow::Result<()> {
+    let chain_data_path = chain_path(&config);
+    let db_root_dir = chain_data_path.join(db_name);
+    let db_writer = Arc::new(open_db(db_root_dir.clone(), config.db_config().clone())?);
+    let db = Arc::new(ManyCar::new(db_writer.clone()));
+    let forest_car_db_dir = db_root_dir.join("car_db");
+    load_all_forest_cars(&db, &forest_car_db_dir)?;
+
+    let chain_config = Arc::new(ChainConfig::from_chain(&config.chain));
+
+    let genesis_header = read_genesis_header(
+        config.client.genesis_file.as_ref(),
+        chain_config.genesis_bytes(&db).await?.as_deref(),
+        &db,
+    )
+    .await?;
+
+    let chain_store = Arc::new(ChainStore::new(
+        Arc::clone(&db),
+        db.writer().clone(),
+        db.writer().clone(),
+        chain_config.clone(),
+        genesis_header.clone(),
+    )?);
+
+    let state_manager = StateManager::new(
+        Arc::clone(&chain_store),
+        Arc::clone(&chain_config),
+        Arc::new(config.sync.clone()),
+    )?;
+
+    populate_eth_mappings(&state_manager, &chain_store.heaviest_tipset())?;
+
+    Ok(())
+}
+
+/// Database settings from Forest `v0.18.0`
+mod paritydb_0_18_0 {
+    use parity_db::{CompressionType, Db, Options};
+    use std::path::PathBuf;
+    use strum::{Display, EnumIter, IntoEnumIterator};
+
+    #[derive(Copy, Clone, Debug, PartialEq, EnumIter, Display)]
+    #[repr(u8)]
+    pub(super) enum DbColumn {
+        GraphDagCborBlake2b256,
+        GraphFull,
+        Settings,
+    }
+
+    impl DbColumn {
+        fn create_column_options(compression: CompressionType) -> Vec<parity_db::ColumnOptions> {
+            DbColumn::iter()
+                .map(|col| {
+                    match col {
+                        DbColumn::GraphDagCborBlake2b256 => parity_db::ColumnOptions {
+                            preimage: true,
+                            compression,
+                            ..Default::default()
+                        },
+                        DbColumn::GraphFull => parity_db::ColumnOptions {
+                            preimage: true,
+                            // This is needed for key retrieval.
+                            btree_index: true,
+                            compression,
+                            ..Default::default()
+                        },
+                        DbColumn::Settings => parity_db::ColumnOptions {
+                            // explicitly disable preimage for settings column
+                            // othewise we are not able to overwrite entries
+                            preimage: false,
+                            // This is needed for key retrieval.
+                            btree_index: true,
+                            compression,
+                            ..Default::default()
+                        },
+                    }
+                })
+                .collect()
+        }
+    }
+
+    pub(super) struct ParityDb {
+        pub db: parity_db::Db,
+    }
+
+    impl ParityDb {
+        pub(super) fn to_options(path: PathBuf) -> Options {
+            Options {
+                path,
+                sync_wal: true,
+                sync_data: true,
+                stats: false,
+                salt: None,
+                columns: DbColumn::create_column_options(CompressionType::Lz4),
+                compression_threshold: [(0, 128)].into_iter().collect(),
+            }
+        }
+
+        pub(super) fn open(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
+            let opts = Self::to_options(path.into());
+            Ok(Self {
+                db: Db::open_or_create(&opts)?,
+            })
+        }
+    }
+}
+
+/// Database settings from Forest `v0.19.0`
+mod paritydb_0_19_0 {
+    use parity_db::{CompressionType, Db, Options};
+    use std::path::PathBuf;
+    use strum::{Display, EnumIter, IntoEnumIterator};
+
+    #[derive(Copy, Clone, Debug, PartialEq, EnumIter, Display)]
+    #[repr(u8)]
+    pub(super) enum DbColumn {
+        GraphDagCborBlake2b256,
+        GraphFull,
+        Settings,
+        EthMappings,
+    }
+
+    impl DbColumn {
+        fn create_column_options(compression: CompressionType) -> Vec<parity_db::ColumnOptions> {
+            DbColumn::iter()
+                .map(|col| {
+                    match col {
+                        DbColumn::GraphDagCborBlake2b256 => parity_db::ColumnOptions {
+                            preimage: true,
+                            compression,
+                            ..Default::default()
+                        },
+                        DbColumn::GraphFull => parity_db::ColumnOptions {
+                            preimage: true,
+                            // This is needed for key retrieval.
+                            btree_index: true,
+                            compression,
+                            ..Default::default()
+                        },
+                        DbColumn::Settings => parity_db::ColumnOptions {
+                            // explicitly disable preimage for settings column
+                            // othewise we are not able to overwrite entries
+                            preimage: false,
+                            // This is needed for key retrieval.
+                            btree_index: true,
+                            compression,
+                            ..Default::default()
+                        },
+                        DbColumn::EthMappings => parity_db::ColumnOptions {
+                            preimage: false,
+                            // This is needed for key retrieval.
+                            btree_index: true,
+                            compression,
+                            ..Default::default()
+                        },
+                    }
+                })
+                .collect()
+        }
+    }
+
+    pub(super) struct ParityDb {
+        pub db: parity_db::Db,
+    }
+
+    impl ParityDb {
+        pub(super) fn to_options(path: PathBuf) -> Options {
+            Options {
+                path,
+                sync_wal: true,
+                sync_data: true,
+                stats: false,
+                salt: None,
+                columns: DbColumn::create_column_options(CompressionType::Lz4),
+                compression_threshold: [(0, 128)].into_iter().collect(),
+            }
+        }
+
+        pub(super) fn open(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
+            let opts = Self::to_options(path.into());
+            Ok(Self {
+                db: Db::open_or_create(&opts)?,
+            })
+        }
+    }
+}

--- a/src/db/migration/v0_19_0.rs
+++ b/src/db/migration/v0_19_0.rs
@@ -117,7 +117,6 @@ impl MigrationOperation for Migration0_18_0_0_19_0 {
         drop(new_db);
 
         // open the new database to populate the Ethereum mappings
-        info!("Populating column EthMappings");
         let handle = tokio::runtime::Handle::current();
         futures::executor::block_on(async {
             let mut cloned_config = config.clone();

--- a/src/db/migration/v0_19_0.rs
+++ b/src/db/migration/v0_19_0.rs
@@ -296,7 +296,8 @@ mod paritydb_0_19_0 {
                         },
                         DbColumn::EthMappings => parity_db::ColumnOptions {
                             preimage: false,
-                            btree_index: false,
+                            // This is needed for key iteration.
+                            btree_index: true,
                             compression,
                             ..Default::default()
                         },

--- a/src/db/migration/v0_19_0.rs
+++ b/src/db/migration/v0_19_0.rs
@@ -296,8 +296,7 @@ mod paritydb_0_19_0 {
                         },
                         DbColumn::EthMappings => parity_db::ColumnOptions {
                             preimage: false,
-                            // This is needed for key iteration.
-                            btree_index: true,
+                            btree_index: false,
                             compression,
                             ..Default::default()
                         },

--- a/src/db/migration/v0_19_0.rs
+++ b/src/db/migration/v0_19_0.rs
@@ -296,8 +296,7 @@ mod paritydb_0_19_0 {
                         },
                         DbColumn::EthMappings => parity_db::ColumnOptions {
                             preimage: false,
-                            // This is needed for key retrieval.
-                            btree_index: true,
+                            btree_index: false,
                             compression,
                             ..Default::default()
                         },

--- a/src/db/migration/void_migration.rs
+++ b/src/db/migration/void_migration.rs
@@ -4,6 +4,7 @@
 //! Migration logic from any version that requires no migration logic.
 
 use crate::db::migration::migration_map::temporary_db_name;
+use crate::Config;
 use fs_extra::dir::CopyOptions;
 use semver::Version;
 use std::path::{Path, PathBuf};
@@ -21,7 +22,7 @@ impl MigrationOperation for MigrationVoid {
         Ok(())
     }
 
-    fn migrate(&self, chain_data_path: &Path) -> anyhow::Result<PathBuf> {
+    fn migrate(&self, chain_data_path: &Path, _config: &Config) -> anyhow::Result<PathBuf> {
         let source_db = chain_data_path.join(self.from.to_string());
 
         let temp_db_path = chain_data_path.join(temporary_db_name(&self.from, &self.to));
@@ -88,7 +89,7 @@ mod test {
 
         let path = chain_data_path.path();
         migration.pre_checks(path).unwrap();
-        let temp_db_path = migration.migrate(path).unwrap();
+        let temp_db_path = migration.migrate(path, &Config::default()).unwrap();
         migration.post_checks(path).unwrap();
 
         // check that the temporary database directory exists and contains the file with the

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -77,8 +77,7 @@ impl DbColumn {
                     },
                     DbColumn::EthMappings => parity_db::ColumnOptions {
                         preimage: false,
-                        // This is needed for key retrieval.
-                        btree_index: true,
+                        btree_index: false,
                         compression,
                         ..Default::default()
                     },

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -6,10 +6,14 @@ use std::path::PathBuf;
 
 use super::SettingsStore;
 
+use super::EthMappingsStore;
+
 use crate::db::{
     parity_db_config::ParityDbConfig, truncated_hash, DBStatistics, GarbageCollectable,
 };
 use crate::libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
+
+use crate::rpc::eth;
 
 use anyhow::{anyhow, Context as _};
 use cid::multihash::Code::Blake2b256;
@@ -41,6 +45,8 @@ enum DbColumn {
     GraphFull,
     /// Column for storing Forest-specific settings.
     Settings,
+    /// Column for storing Ethereum mappings.
+    EthMappings,
 }
 
 impl DbColumn {
@@ -63,6 +69,13 @@ impl DbColumn {
                     DbColumn::Settings => parity_db::ColumnOptions {
                         // explicitly disable preimage for settings column
                         // othewise we are not able to overwrite entries
+                        preimage: false,
+                        // This is needed for key retrieval.
+                        btree_index: true,
+                        compression,
+                        ..Default::default()
+                    },
+                    DbColumn::EthMappings => parity_db::ColumnOptions {
                         preimage: false,
                         // This is needed for key retrieval.
                         btree_index: true,
@@ -166,6 +179,23 @@ impl SettingsStore for ParityDb {
     }
 }
 
+impl EthMappingsStore for ParityDb {
+    fn read_bin(&self, key: &eth::Hash) -> anyhow::Result<Option<Vec<u8>>> {
+        self.read_from_column(key.0.as_bytes(), DbColumn::EthMappings)
+    }
+
+    fn write_bin(&self, key: &eth::Hash, value: &[u8]) -> anyhow::Result<()> {
+        self.write_to_column(key.0.as_bytes(), value, DbColumn::EthMappings)
+    }
+
+    fn exists(&self, key: &eth::Hash) -> anyhow::Result<bool> {
+        self.db
+            .get_size(DbColumn::EthMappings as u8, key.0.as_bytes())
+            .map(|size| size.is_some())
+            .context("error checking if key exists")
+    }
+}
+
 impl Blockstore for ParityDb {
     fn get(&self, k: &Cid) -> anyhow::Result<Option<Vec<u8>>> {
         let column = Self::choose_column(k);
@@ -173,7 +203,7 @@ impl Blockstore for ParityDb {
             DbColumn::GraphDagCborBlake2b256 | DbColumn::GraphFull => {
                 self.read_from_column(k.to_bytes(), column)
             }
-            DbColumn::Settings => panic!("invalid column for IPLD data"),
+            DbColumn::Settings | DbColumn::EthMappings => panic!("invalid column for IPLD data"),
         }
     }
 
@@ -185,7 +215,7 @@ impl Blockstore for ParityDb {
             DbColumn::GraphDagCborBlake2b256 | DbColumn::GraphFull => {
                 self.write_to_column(k.to_bytes(), block, column)
             }
-            DbColumn::Settings => panic!("invalid column for IPLD data"),
+            DbColumn::Settings | DbColumn::EthMappings => panic!("invalid column for IPLD data"),
         }
     }
 
@@ -393,6 +423,7 @@ mod test {
                 DbColumn::GraphDagCborBlake2b256 => DbColumn::GraphFull,
                 DbColumn::GraphFull => DbColumn::GraphDagCborBlake2b256,
                 DbColumn::Settings => panic!("invalid column for IPLD data"),
+                DbColumn::EthMappings => panic!("invalid column for IPLD data"),
             };
             let actual = db.read_from_column(cid.to_bytes(), other_column).unwrap();
             assert!(actual.is_none());

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -77,8 +77,7 @@ impl DbColumn {
                     },
                     DbColumn::EthMappings => parity_db::ColumnOptions {
                         preimage: false,
-                        // This is needed for key iteration.
-                        btree_index: true,
+                        btree_index: false,
                         compression,
                         ..Default::default()
                     },

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -77,7 +77,8 @@ impl DbColumn {
                     },
                     DbColumn::EthMappings => parity_db::ColumnOptions {
                         preimage: false,
-                        btree_index: false,
+                        // This is needed for key iteration.
+                        btree_index: true,
                         compression,
                         ..Default::default()
                     },

--- a/src/libp2p/chain_exchange/provider.rs
+++ b/src/libp2p/chain_exchange/provider.rs
@@ -175,7 +175,14 @@ mod tests {
         });
 
         let response = make_chain_exchange_response(
-            &ChainStore::new(db.clone(), db, Arc::new(ChainConfig::default()), gen_block).unwrap(),
+            &ChainStore::new(
+                db.clone(),
+                db.clone(),
+                db,
+                Arc::new(ChainConfig::default()),
+                gen_block,
+            )
+            .unwrap(),
             &ChainExchangeRequest {
                 start: cids,
                 request_len: 2,

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -960,6 +960,7 @@ mod tests {
             ChainStore::new(
                 db,
                 Arc::new(MemoryDB::default()),
+                Arc::new(MemoryDB::default()),
                 Arc::new(ChainConfig::calibnet()),
                 genesis_block_header,
             )

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -5,7 +5,7 @@ pub mod types;
 
 use self::types::*;
 use super::gas;
-use crate::blocks::{Tipset, TipsetKey};
+use crate::blocks::Tipset;
 use crate::chain::{index::ResolveNullTipset, ChainStore};
 use crate::chain_sync::SyncStage;
 use crate::cid_collections::CidHashSet;
@@ -23,20 +23,17 @@ use crate::shim::fvm_shared_latest::MethodNum;
 use crate::shim::message::Message;
 use crate::shim::{clock::ChainEpoch, state_tree::StateTree};
 use crate::utils::db::BlockstoreExt as _;
+use anyhow::Context;
 use anyhow::{bail, Result};
 use bytes::{Buf, BytesMut};
 use cbor4ii::core::{dec::Decode, utils::SliceReader, Value};
-use cid::{
-    multihash::{self, MultihashDigest},
-    Cid,
-};
+use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{RawBytes, CBOR, DAG_CBOR, IPLD_RAW};
 use itertools::Itertools;
 use keccak_hash::keccak;
 use num_bigint::{self, Sign};
 use num_traits::{Signed as _, Zero as _};
-use nunny::vec as nonempty;
 use rlp::RlpStream;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -144,16 +141,10 @@ pub struct Int64(
 
 lotus_json_with_self!(Int64);
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Default, Clone, JsonSchema)]
+#[derive(PartialEq, Eq, Hash, Debug, Deserialize, Serialize, Default, Clone, JsonSchema)]
 pub struct Hash(#[schemars(with = "String")] pub ethereum_types::H256);
 
 impl Hash {
-    // Should ONLY be used for blocks and Filecoin messages. Eth transactions expect a different hashing scheme.
-    pub fn to_cid(&self) -> cid::Cid {
-        let mh = multihash::Code::Blake2b256.digest(self.0.as_bytes());
-        Cid::new_v1(fvm_ipld_encoding::DAG_CBOR, mh)
-    }
-
     pub fn empty_uncles() -> Self {
         Self(ethereum_types::H256::from_str(EMPTY_UNCLES).unwrap())
     }
@@ -221,8 +212,14 @@ impl BlockNumberOrHash {
     pub fn from_block_number(number: i64) -> Self {
         Self::BlockNumber(number)
     }
+
+    pub fn from_block_hash(hash: Hash) -> Self {
+        Self::BlockHash(hash, false)
+    }
 }
 
+// TODO(elmattic): https://github.com/ChainSafe/forest/issues/4359
+//                 implement EIP-1898
 // TODO(aatifsyed): https://github.com/ChainSafe/forest/issues/4032
 //                  this shouldn't exist
 impl HasLotusJson for BlockNumberOrHash {
@@ -248,6 +245,10 @@ impl HasLotusJson for BlockNumberOrHash {
             "latest" => return Self::PredefinedBlock(Predefined::Latest),
             _ => (),
         };
+
+        if let Ok(hash) = Hash::from_str(&lotus_json) {
+            return Self::BlockHash(hash, false);
+        }
 
         #[allow(clippy::indexing_slicing)]
         if lotus_json.len() > 2 && &lotus_json[..2] == "0x" {
@@ -709,7 +710,9 @@ fn tipset_by_block_number_or_hash<DB: Blockstore>(
             Ok(ts)
         }
         BlockNumberOrHash::BlockHash(hash, require_canonical) => {
-            let tsk = TipsetKey::from(nonempty![hash.to_cid()]);
+            let tsk = chain
+                .get_tipset_key(&hash)?
+                .with_context(|| format!("cannot find tipset with hash {}", &hash))?;
             let ts = chain.chain_index.load_required_tipset(&tsk)?;
             // verify that the tipset is in the canonical chain
             if require_canonical {
@@ -837,7 +840,7 @@ fn recover_sig(sig: &Signature) -> Result<(BigInt, BigInt, BigInt)> {
 /// - `block_hash`
 /// - `block_number`
 /// - `transaction_index`
-fn eth_tx_from_signed_eth_message(smsg: &SignedMessage, chain_id: u32) -> Result<Tx> {
+pub fn eth_tx_from_signed_eth_message(smsg: &SignedMessage, chain_id: u32) -> Result<Tx> {
     // The from address is always an f410f address, never an ID or other address.
     let from = smsg.message().from;
     if !is_eth_address(&from) {

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -212,10 +212,6 @@ impl BlockNumberOrHash {
     pub fn from_block_number(number: i64) -> Self {
         Self::BlockNumber(number)
     }
-
-    pub fn from_block_hash(hash: Hash) -> Self {
-        Self::BlockHash(hash, false)
-    }
 }
 
 // TODO(elmattic): https://github.com/ChainSafe/forest/issues/4359

--- a/src/rpc/methods/sync.rs
+++ b/src/rpc/methods/sync.rs
@@ -177,7 +177,14 @@ mod tests {
         });
 
         let cs_arc = Arc::new(
-            ChainStore::new(db.clone(), db, chain_config.clone(), genesis_header).unwrap(),
+            ChainStore::new(
+                db.clone(),
+                db.clone(),
+                db,
+                chain_config.clone(),
+                genesis_header,
+            )
+            .unwrap(),
         );
 
         let state_manager =

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -5,7 +5,7 @@ use crate::blocks::{ElectionProof, Ticket, Tipset};
 use crate::chain::ChainStore;
 use crate::chain_sync::{SyncConfig, SyncStage};
 use crate::cli_shared::snapshot::TrustedVendor;
-use crate::daemon::db_util::download_to;
+use crate::daemon::db_util::{download_to, populate_eth_mappings};
 use crate::db::{car::ManyCar, MemoryDB};
 use crate::genesis::{get_network_name_from_genesis, read_genesis_header};
 use crate::key_management::{KeyStore, KeyStoreConfig};
@@ -1296,6 +1296,7 @@ async fn start_offline_server(
     let chain_store = Arc::new(ChainStore::new(
         db.clone(),
         db.clone(),
+        db.clone(),
         chain_config.clone(),
         genesis_header.clone(),
     )?);
@@ -1309,6 +1310,8 @@ async fn start_offline_server(
     state_manager
         .chain_store()
         .set_heaviest_tipset(head_ts.clone())?;
+
+    populate_eth_mappings(&state_manager, &head_ts)?;
 
     let beacon = Arc::new(
         state_manager


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Introduce a new ParityDB namespace for storing Ethereum mappings such as `Hash` to `TipsetKey` and `Hash` to message `Cid`.
  This is required by methods like:
  - EthGetBlockByHash
  - EthGetBlockTransactionCountByHash
  - EthGetMessageCidByTransactionHash
- Increment Forest version to `0.19.0`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
