### PR TITLE
fix(log): suppress WARN log in quinn_udp

### DIFF
--- a/src/cli_shared/logger/mod.rs
+++ b/src/cli_shared/logger/mod.rs
@@ -150,6 +150,7 @@ fn default_env_filter() -> EnvFilter {
         "rpc=error",
         "storage_proofs_core=warn",
         "tracing_loki=off",
+        "quinn_udp=error",
     ];
     EnvFilter::try_new(default_directives.join(",")).unwrap()
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- suppress `WARN` log in `quinn_udp` (dep of libp2p)

```
2024-06-07T12:42:55.026568Z  WARN quinn_udp: sendmsg error: Os { code: 101, kind: NetworkUnreachable, message: "Network is unreachable" }, Transmit: { destination: [2600:1700:bb60:8420::b]:52093, src_ip: None, enc: Some(Ect0), len: 1200, segment_size: None }
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
