### PR TITLE
chore: bump rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]

--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -369,7 +369,7 @@ where
         stateless_mode: bool,
     ) -> Result<Option<(FullTipset, PeerId)>, ChainMuxerError> {
         let (tipset, source) = match event {
-            NetworkEvent::HelloRequestInbound { .. } => {
+            NetworkEvent::HelloRequestInbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::HELLO_REQUEST_INBOUND)
                     .inc();
@@ -396,13 +396,13 @@ where
                 };
                 (tipset, source)
             }
-            NetworkEvent::HelloRequestOutbound { .. } => {
+            NetworkEvent::HelloRequestOutbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::HELLO_REQUEST_OUTBOUND)
                     .inc();
                 return Ok(None);
             }
-            NetworkEvent::HelloResponseInbound { .. } => {
+            NetworkEvent::HelloResponseInbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::HELLO_RESPONSE_INBOUND)
                     .inc();
@@ -455,25 +455,25 @@ where
                     return Ok(None);
                 }
             },
-            NetworkEvent::ChainExchangeRequestOutbound { .. } => {
+            NetworkEvent::ChainExchangeRequestOutbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::CHAIN_EXCHANGE_REQUEST_OUTBOUND)
                     .inc();
                 return Ok(None);
             }
-            NetworkEvent::ChainExchangeResponseInbound { .. } => {
+            NetworkEvent::ChainExchangeResponseInbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::CHAIN_EXCHANGE_RESPONSE_INBOUND)
                     .inc();
                 return Ok(None);
             }
-            NetworkEvent::ChainExchangeRequestInbound { .. } => {
+            NetworkEvent::ChainExchangeRequestInbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::CHAIN_EXCHANGE_REQUEST_INBOUND)
                     .inc();
                 return Ok(None);
             }
-            NetworkEvent::ChainExchangeResponseOutbound { .. } => {
+            NetworkEvent::ChainExchangeResponseOutbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::CHAIN_EXCHANGE_RESPONSE_OUTBOUND)
                     .inc();

--- a/src/libp2p/discovery.rs
+++ b/src/libp2p/discovery.rs
@@ -80,7 +80,7 @@ impl<'a> DiscoveryConfig<'a> {
             local_peer_id: local_public_key.to_peer_id(),
             local_public_key,
             user_defined: Vec::new(),
-            target_peer_count: std::u64::MAX,
+            target_peer_count: u64::MAX,
             enable_mdns: false,
             enable_kademlia: true,
             network_name,

--- a/src/libp2p/rpc/mod.rs
+++ b/src/libp2p/rpc/mod.rs
@@ -36,23 +36,28 @@ impl<P, RQ, RS> Default for CborRequestResponse<P, RQ, RS> {
 ///
 /// This type mirrors the internal libp2p type, but this avoids having to expose
 /// that internal type.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RequestResponseError {
     /// The request could not be sent because a dialing attempt failed.
+    #[error("DialFailure")]
     DialFailure,
     /// The request timed out before a response was received.
     ///
     /// It is not known whether the request may have been
     /// received (and processed) by the remote peer.
+    #[error("Timeout")]
     Timeout,
     /// The connection closed before a response was received.
     ///
     /// It is not known whether the request may have been
     /// received (and processed) by the remote peer.
+    #[error("ConnectionClosed")]
     ConnectionClosed,
     /// The remote supports none of the requested protocols.
+    #[error("UnsupportedProtocols")]
     UnsupportedProtocols,
     /// An IO failure happened on an outbound stream.
+    #[error("{0}")]
     Io(io::Error),
 }
 

--- a/src/message_pool/msg_chain.rs
+++ b/src/message_pool/msg_chain.rs
@@ -566,7 +566,7 @@ where
 }
 
 fn approx_cmp(a: f64, b: f64) -> Ordering {
-    if (a - b).abs() <= (a * std::f64::EPSILON).abs() {
+    if (a - b).abs() <= (a * f64::EPSILON).abs() {
         Ordering::Equal
     } else {
         a.partial_cmp(&b).unwrap()

--- a/src/message_pool/msgpool/msg_pool.rs
+++ b/src/message_pool/msgpool/msg_pool.rs
@@ -30,7 +30,6 @@ use fvm_ipld_encoding::to_vec;
 use itertools::Itertools;
 use lru::LruCache;
 use nonzero_ext::nonzero;
-use num::BigInt;
 use parking_lot::{Mutex, RwLock as SyncRwLock};
 use tokio::{sync::broadcast::error::RecvError, task::JoinSet, time::interval};
 use tracing::warn;
@@ -176,9 +175,6 @@ pub struct MessagePool<T> {
     pub cur_tipset: Arc<Mutex<Arc<Tipset>>>,
     /// The underlying provider
     pub api: Arc<T>,
-    /// The minimum gas price needed for executing the transaction based on
-    /// number of included blocks
-    pub min_gas_price: BigInt,
     pub network_name: String,
     /// Sender half to send messages to other components
     pub network_sender: flume::Sender<NetworkMessage>,
@@ -475,7 +471,6 @@ where
             pending,
             cur_tipset: tipset,
             api: Arc::new(api),
-            min_gas_price: Default::default(),
             network_name,
             bls_sig_cache,
             sig_val_cache,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- upgrade rust toolchain to [1.79.0](https://releases.rs/docs/1.79.0/)
- fix clippy warnings

```
warning: field `0` is never read
  --> src/libp2p/rpc/mod.rs:56:8
   |
56 |     Io(io::Error),
   |     -- ^^^^^^^^^
   |     |
   |     field in this variant
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
56 |     Io(()),
   |        ~~

warning: fields `source` and `request` are never read
  --> src/libp2p/service.rs:94:9
   |
93 |     HelloRequestInbound {
   |     ------------------- fields in this variant
94 |         source: PeerId,
   |         ^^^^^^
95 |         request: HelloRequest,
   |         ^^^^^^^

warning: field `request_id` is never read
   --> src/libp2p/service.rs:102:9
    |
101 |     HelloRequestOutbound {
    |     -------------------- field in this variant
102 |         request_id: request_response::OutboundRequestId,
    |         ^^^^^^^^^^

warning: field `request_id` is never read
   --> src/libp2p/service.rs:105:9
    |
104 |     HelloResponseInbound {
    |     -------------------- field in this variant
105 |         request_id: request_response::OutboundRequestId,
    |         ^^^^^^^^^^

warning: field `request_id` is never read
   --> src/libp2p/service.rs:108:9
    |
107 |     ChainExchangeRequestOutbound {
    |     ---------------------------- field in this variant
108 |         request_id: request_response::OutboundRequestId,
    |         ^^^^^^^^^^

warning: field `request_id` is never read
   --> src/libp2p/service.rs:111:9
    |
110 |     ChainExchangeResponseInbound {
    |     ---------------------------- field in this variant
111 |         request_id: request_response::OutboundRequestId,
    |         ^^^^^^^^^^

warning: field `request_id` is never read
   --> src/libp2p/service.rs:114:9
    |
113 |     ChainExchangeRequestInbound {
    |     --------------------------- field in this variant
114 |         request_id: request_response::InboundRequestId,
    |         ^^^^^^^^^^

warning: field `request_id` is never read
   --> src/libp2p/service.rs:117:9
    |
116 |     ChainExchangeResponseOutbound {
    |     ----------------------------- field in this variant
117 |         request_id: request_response::InboundRequestId,
    |         ^^^^^^^^^^

warning: field `min_gas_price` is never read
   --> src/message_pool/msgpool/msg_pool.rs:181:9
    |
170 | pub struct MessagePool<T> {
    |            ----------- field in this struct
...
181 |     pub min_gas_price: BigInt,
    |         ^^^^^^^^^^^^^

warning: usage of a legacy numeric constant
  --> src/libp2p/discovery.rs:83:32
   |
83 |             target_peer_count: std::u64::MAX,
   |                                ^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
   = note: `#[warn(clippy::legacy_numeric_constants)]` on by default
help: use the associated constant instead
   |
83 |             target_peer_count: u64::MAX,
   |                                ~~~~~~~~

warning: usage of a legacy numeric constant
   --> src/message_pool/msg_chain.rs:569:30
    |
569 |     if (a - b).abs() <= (a * std::f64::EPSILON).abs() {
    |                              ^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
help: use the associated constant instead
    |
569 |     if (a - b).abs() <= (a * f64::EPSILON).abs() {
    |                              ~~~~~~~~~~~~

warning: `forest-filecoin` (lib) generated 11 warnings
warning: `forest-filecoin` (lib test) generated 11 warnings (11 duplicates)
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

https://releases.rs/docs/1.79.0/

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
