### PR TITLE
fix: schema name collisions in VecLotusJson

### DIFF
--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -81,7 +81,7 @@ where
     T: JsonSchema,
 {
     fn schema_name() -> String {
-        std::any::type_name::<T>().to_string()
+        format!("Nullable_Array_of_{}", T::schema_name())
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {


### PR DESCRIPTION
Who the fuck wrote this code?

This fixes, in our openrpc:
- ugly names
- immediate recursion

## Reference issue to close (if applicable)


#4032 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
