### PR TITLE
fix: refactor StateManager::replay to get rid of channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,16 +1822,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -6712,12 +6711,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plotters"

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -116,7 +116,7 @@ impl RpcMethod<2> for StateReplay {
             .state_manager
             .chain_store()
             .load_required_tipset_or_heaviest(&tsk)?;
-        Ok(state_manager.replay(&tipset, message_cid).await?)
+        Ok(state_manager.replay(tipset, message_cid).await?)
     }
 }
 

--- a/src/shim/executor.rs
+++ b/src/shim/executor.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::trace::ExecutionEvent;
-use crate::shim::econ::TokenAmount;
+use crate::shim::{econ::TokenAmount, fvm_shared_latest::error::ExitCode};
 use cid::Cid;
 use fil_actors_shared::fvm_ipld_amt::Amtv0;
 use fvm2::executor::ApplyRet as ApplyRet_v2;
@@ -11,7 +11,6 @@ use fvm4::executor::ApplyRet as ApplyRet_v4;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared2::receipt::Receipt as Receipt_v2;
-use fvm_shared3::error::ExitCode;
 pub use fvm_shared3::receipt::Receipt as Receipt_v3;
 use fvm_shared4::receipt::Receipt as Receipt_v4;
 use serde::Serialize;
@@ -122,16 +121,16 @@ impl Receipt {
     pub fn exit_code(&self) -> ExitCode {
         match self {
             Receipt::V2(v2) => ExitCode::new(v2.exit_code.value()),
-            Receipt::V3(v3) => v3.exit_code,
-            Receipt::V4(v4) => ExitCode::new(v4.exit_code.value()),
+            Receipt::V3(v3) => ExitCode::new(v3.exit_code.value()),
+            Receipt::V4(v4) => v4.exit_code,
         }
     }
 
     pub fn return_data(&self) -> RawBytes {
         match self {
-            Receipt::V2(v2) => RawBytes::from(v2.return_data.to_vec()),
+            Receipt::V2(v2) => v2.return_data.clone(),
             Receipt::V3(v3) => v3.return_data.clone(),
-            Receipt::V4(v4) => RawBytes::from(v4.return_data.to_vec()),
+            Receipt::V4(v4) => v4.return_data.clone(),
         }
     }
 

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -563,51 +563,53 @@ where
     /// indicated message, assuming it was executed in the indicated tipset.
     pub async fn replay(
         self: &Arc<Self>,
-        ts: &Arc<Tipset>,
+        ts: Arc<Tipset>,
         mcid: Cid,
     ) -> Result<ApiInvocResult, Error> {
-        const ERROR_MSG: &str = "replay_halt";
+        let this = Arc::clone(self);
+        tokio::task::spawn_blocking(move || this.replay_blocking(ts, mcid))
+            .await
+            .map_err(|e| Error::Other(format!("{e}")))?
+    }
 
-        // This isn't ideal to have, since the execution is synchronous, but this needs
-        // to be the case because the state transition has to be in blocking
-        // thread to avoid starving executor
-        let (tx, rx) = flume::bounded(1);
-        let callback = move |ctx: &MessageCallbackCtx| {
+    /// Blocking version of `replay`
+    pub fn replay_blocking(
+        self: &Arc<Self>,
+        ts: Arc<Tipset>,
+        mcid: Cid,
+    ) -> Result<ApiInvocResult, Error> {
+        const REPLAY_HALT: &str = "replay_halt";
+
+        let mut api_invoc_result = None;
+        let callback = |ctx: &MessageCallbackCtx| {
             match ctx.at {
-                CalledAt::Applied | CalledAt::Reward => {
-                    if ctx.cid == mcid {
-                        tx.send(ApiInvocResult {
-                            msg_cid: ctx.message.cid()?,
-                            msg: ctx.message.message().clone(),
-                            msg_rct: Some(ctx.apply_ret.msg_receipt()),
-                            error: ctx.apply_ret.failure_info().unwrap_or_default(),
-                            duration: ctx.duration.as_nanos().clamp(0, u64::MAX as u128) as u64,
-                            gas_cost: MessageGasCost::new(ctx.message.message(), ctx.apply_ret)?,
-                            execution_trace: structured::parse_events(ctx.apply_ret.exec_trace())
-                                .unwrap_or_default(),
-                        })?;
-                        anyhow::bail!(ERROR_MSG);
-                    }
-                    Ok(())
+                CalledAt::Applied | CalledAt::Reward
+                    if api_invoc_result.is_none() && ctx.cid == mcid =>
+                {
+                    api_invoc_result = Some(ApiInvocResult {
+                        msg_cid: ctx.message.cid()?,
+                        msg: ctx.message.message().clone(),
+                        msg_rct: Some(ctx.apply_ret.msg_receipt()),
+                        error: ctx.apply_ret.failure_info().unwrap_or_default(),
+                        duration: ctx.duration.as_nanos().clamp(0, u64::MAX as u128) as u64,
+                        gas_cost: MessageGasCost::new(ctx.message.message(), ctx.apply_ret)?,
+                        execution_trace: structured::parse_events(ctx.apply_ret.exec_trace())
+                            .unwrap_or_default(),
+                    });
+                    anyhow::bail!(REPLAY_HALT);
                 }
-                CalledAt::Cron => Ok(()), // ignored
+                _ => Ok(()), // ignored
             }
         };
-        let result = self
-            .compute_tipset_state(Arc::clone(ts), Some(callback), VMTrace::Traced)
-            .await;
-
+        let result = self.compute_tipset_state_blocking(ts, Some(callback), VMTrace::Traced);
         if let Err(error_message) = result {
-            if error_message.to_string() != ERROR_MSG {
+            if error_message.to_string() != REPLAY_HALT {
                 return Err(Error::Other(format!(
                     "unexpected error during execution : {error_message:}"
                 )));
             }
         }
-
-        // Use try_recv here assuming callback execution is synchronous
-        rx.try_recv()
-            .map_err(|err| Error::Other(format!("failed to replay: {err}")))
+        api_invoc_result.ok_or_else(|| Error::Other("failed to replay".into()))
     }
 
     /// Checks the eligibility of the miner. This is used in the validation that
@@ -703,7 +705,7 @@ where
     pub fn compute_tipset_state_blocking(
         &self,
         tipset: Arc<Tipset>,
-        callback: Option<impl FnMut(&MessageCallbackCtx) -> anyhow::Result<()> + Send + 'static>,
+        callback: Option<impl FnMut(&MessageCallbackCtx) -> anyhow::Result<()>>,
         enable_tracing: VMTrace,
     ) -> Result<CidPair, Error> {
         Ok(apply_block_messages(

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -432,15 +432,19 @@ fn print_computed_state(snapshot: PathBuf, epoch: ChainEpoch, json: bool) -> any
         beacon,
         &MultiEngine::default(),
         tipset,
-        Some(|ctx: &MessageCallbackCtx| {
-            message_calls.push((
-                ctx.message.clone(),
-                ctx.apply_ret.clone(),
-                ctx.at,
-                ctx.duration,
-            ));
-            anyhow::Ok(())
-        }),
+        if json {
+            Some(|ctx: &MessageCallbackCtx| {
+                message_calls.push((
+                    ctx.message.clone(),
+                    ctx.apply_ret.clone(),
+                    ctx.at,
+                    ctx.duration,
+                ));
+                Ok(())
+            })
+        } else {
+            None
+        },
         match json {
             true => VMTrace::Traced,
             false => VMTrace::NotTraced,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

To address the original comment
> // This isn't ideal to have, since the execution is synchronous, but this needs
        // to be the case because the state transition has to be in blocking
        // thread to avoid starving executor
        let (tx, rx) = flume::bounded(1);

Changes introduced in this pull request:

- refactor `replay` into `replay_blocking` and `replay` to avoid using channels

```
     Running `target/quick/forest-tool api compare /home/me/fr/snapshots/calibnet/forest_snapshot_calibnet_2024-06-18_height_1711826.forest.car.zst --filter StateReplay`
| RPC Method                | Forest | Lotus |
|---------------------------|--------|-------|
| Filecoin.StateReplay (24) | Valid  | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
