### PR TITLE
fix: change FnMut(&MessageCallbackCtx) to FnMut(MessageCallbackCtx<'_>)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,16 +1822,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -6712,12 +6711,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plotters"

--- a/src/interpreter/vm.rs
+++ b/src/interpreter/vm.rs
@@ -309,7 +309,7 @@ where
     pub fn run_cron(
         &mut self,
         epoch: ChainEpoch,
-        callback: Option<impl FnMut(&MessageCallbackCtx) -> anyhow::Result<()>>,
+        callback: Option<impl FnMut(MessageCallbackCtx<'_>) -> anyhow::Result<()>>,
     ) -> anyhow::Result<()> {
         let cron_msg: Message = Message_v3 {
             from: Address::SYSTEM_ACTOR.into(),
@@ -333,7 +333,7 @@ where
         }
 
         if let Some(mut callback) = callback {
-            callback(&MessageCallbackCtx {
+            callback(MessageCallbackCtx {
                 cid: cron_msg.cid()?,
                 message: &ChainMessage::Unsigned(cron_msg),
                 apply_ret: &ret,
@@ -350,9 +350,7 @@ where
         &mut self,
         messages: &[BlockMessages],
         epoch: ChainEpoch,
-        // note: we take &MessageCallbackCtx rather than MessageCallbackCtx<'_>
-        //       because I'm not smart enough to make the second one work
-        mut callback: Option<impl FnMut(&MessageCallbackCtx) -> anyhow::Result<()>>,
+        mut callback: Option<impl FnMut(MessageCallbackCtx<'_>) -> anyhow::Result<()>>,
     ) -> Result<Vec<Receipt>, anyhow::Error> {
         let mut receipts = Vec::new();
         let mut processed = HashSet::<Cid>::default();
@@ -370,7 +368,7 @@ where
                 let (ret, duration) = self.apply_message(message)?;
 
                 if let Some(cb) = &mut callback {
-                    cb(&MessageCallbackCtx {
+                    cb(MessageCallbackCtx {
                         cid,
                         message,
                         apply_ret: &ret,
@@ -415,7 +413,7 @@ where
                 }
 
                 if let Some(callback) = &mut callback {
-                    callback(&MessageCallbackCtx {
+                    callback(MessageCallbackCtx {
                         cid: rew_msg.cid()?,
                         message: &ChainMessage::Unsigned(rew_msg),
                         apply_ret: &ret,
@@ -548,7 +546,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct MessageCallbackCtx<'a> {
     pub cid: Cid,
     pub message: &'a ChainMessage,

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -221,7 +221,7 @@ pub struct StateManager<DB> {
 }
 
 #[allow(clippy::type_complexity)]
-pub const NO_CALLBACK: Option<fn(&MessageCallbackCtx) -> anyhow::Result<()>> = None;
+pub const NO_CALLBACK: Option<fn(MessageCallbackCtx<'_>) -> anyhow::Result<()>> = None;
 
 impl<DB> StateManager<DB>
 where
@@ -572,7 +572,7 @@ where
         // to be the case because the state transition has to be in blocking
         // thread to avoid starving executor
         let (tx, rx) = flume::bounded(1);
-        let callback = move |ctx: &MessageCallbackCtx| {
+        let callback = move |ctx: MessageCallbackCtx<'_>| {
             match ctx.at {
                 CalledAt::Applied | CalledAt::Reward => {
                     if ctx.cid == mcid {
@@ -688,7 +688,7 @@ where
     pub async fn compute_tipset_state(
         self: &Arc<Self>,
         tipset: Arc<Tipset>,
-        callback: Option<impl FnMut(&MessageCallbackCtx) -> anyhow::Result<()> + Send + 'static>,
+        callback: Option<impl FnMut(MessageCallbackCtx<'_>) -> anyhow::Result<()> + Send + 'static>,
         enable_tracing: VMTrace,
     ) -> Result<CidPair, Error> {
         let this = Arc::clone(self);
@@ -703,7 +703,7 @@ where
     pub fn compute_tipset_state_blocking(
         &self,
         tipset: Arc<Tipset>,
-        callback: Option<impl FnMut(&MessageCallbackCtx) -> anyhow::Result<()> + Send + 'static>,
+        callback: Option<impl FnMut(MessageCallbackCtx<'_>) -> anyhow::Result<()> + Send + 'static>,
         enable_tracing: VMTrace,
     ) -> Result<CidPair, Error> {
         Ok(apply_block_messages(
@@ -1537,7 +1537,7 @@ pub fn apply_block_messages<DB>(
     beacon: Arc<BeaconSchedule>,
     engine: &crate::shim::machine::MultiEngine,
     tipset: Arc<Tipset>,
-    mut callback: Option<impl FnMut(&MessageCallbackCtx) -> anyhow::Result<()>>,
+    mut callback: Option<impl FnMut(MessageCallbackCtx<'_>) -> anyhow::Result<()>>,
     enable_tracing: VMTrace,
 ) -> Result<CidPair, anyhow::Error>
 where

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -432,14 +432,14 @@ fn print_computed_state(snapshot: PathBuf, epoch: ChainEpoch, json: bool) -> any
         beacon,
         &MultiEngine::default(),
         tipset,
-        Some(|ctx: &MessageCallbackCtx| {
+        Some(|ctx: MessageCallbackCtx<'_>| {
             message_calls.push((
                 ctx.message.clone(),
                 ctx.apply_ret.clone(),
                 ctx.at,
                 ctx.duration,
             ));
-            anyhow::Ok(())
+            Ok(())
         }),
         match json {
             true => VMTrace::Traced,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

To address the below comment,  the rust compiler has now become smart enough to compile the desired code with no additional tricks
```
// note: we take &MessageCallbackCtx rather than MessageCallbackCtx<'_>
//       because I'm not smart enough to make the second one work
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
