### PR TITLE
fix: disable NetAgentVersion RPC test

### DIFF
--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -7,3 +7,5 @@
 !Filecoin.StateReplay
 # CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/actions/runs/9593268587/job/26453560366
 !Filecoin.StateCall
+# Rejected("item not found") in Forest: https://github.com/ChainSafe/forest/actions/runs/9581179496/job/26417600610
+!Filecoin.NetAgentVersion


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `Filecoin.NetAgentVersion` fails the RPC test https://github.com/ChainSafe/forest/actions/runs/9581179496/job/26417600610
- the problem is that the node may have disconnected from the peer at hand (here - the last bootstrap node on the list), which in turn clears the entry in the peers collection. Perhaps we could not clear it on disconnects or keep another collection for historical info? @hanabi1224 what do you think? Anyhow, we can address it in a follow-up.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
