### PR TITLE
fix: duplicate schema names

### DIFF
--- a/src/lotus_json/cid.rs
+++ b/src/lotus_json/cid.rs
@@ -5,18 +5,18 @@ use super::*;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(rename = "Cid")]
-pub struct CidLotusJsonGeneric<const S: usize> {
+pub struct CidLotusJson {
     #[schemars(with = "String")]
     #[serde(rename = "/", with = "crate::lotus_json::stringify")]
-    slash: ::cid::CidGeneric<S>,
+    slash: ::cid::Cid,
 }
 
-impl<const S: usize> HasLotusJson for ::cid::CidGeneric<S> {
-    type LotusJson = CidLotusJsonGeneric<S>;
+impl HasLotusJson for ::cid::Cid {
+    type LotusJson = CidLotusJson;
 
     #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
-        unimplemented!("only Cid<64> is tested, below")
+        vec![(json!({"/": "baeaaaaa"}), ::cid::Cid::default())]
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
@@ -26,17 +26,5 @@ impl<const S: usize> HasLotusJson for ::cid::CidGeneric<S> {
     fn from_lotus_json(lotus_json: Self::LotusJson) -> Self {
         let Self::LotusJson { slash } = lotus_json;
         slash
-    }
-}
-
-#[test]
-fn snapshots() {
-    assert_one_snapshot(json!({"/": "baeaaaaa"}), ::cid::Cid::default());
-}
-
-#[cfg(test)]
-quickcheck! {
-    fn quickcheck(val: ::cid::Cid) -> () {
-        assert_unchanged_via_json(val)
     }
 }

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -194,6 +194,7 @@ decl_and_test!(
     beacon_entry for crate::beacon::BeaconEntry,
     big_int for num::BigInt,
     block_header for crate::blocks::CachingBlockHeader,
+    cid for ::cid::Cid,
     election_proof for crate::blocks::ElectionProof,
     gossip_block for crate::blocks::GossipBlock,
     key_info for crate::key_management::KeyInfo,
@@ -219,7 +220,6 @@ decl_and_test!(
 mod allocation;
 mod beneficiary_term; // fil_actor_miner_state::v12::BeneficiaryTerm: !quickcheck::Arbitrary
 mod bit_field; //  fil_actors_shared::fvm_ipld_bitfield::BitField: !quickcheck::Arbitrary
-mod cid; // can't make snapshots of generic type
 mod hash_map;
 mod ipld; // NaN != NaN
 mod miner_info; // fil_actor_miner_state::v12::MinerInfo: !quickcheck::Arbitrary
@@ -446,15 +446,11 @@ where
 }
 
 /// A domain struct that is (de) serialized through its lotus JSON representation.
-#[derive(Debug, Deserialize, From, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[serde(bound = "T: HasLotusJson", transparent)]
+#[derive(
+    Debug, Deserialize, From, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Clone,
+)]
+#[serde(bound = "T: HasLotusJson + Clone", transparent)]
 pub struct LotusJson<T>(#[serde(with = "self")] pub T);
-
-impl<T: Clone> Clone for LotusJson<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
 
 impl<T> JsonSchema for LotusJson<T>
 where
@@ -463,6 +459,10 @@ where
 {
     fn schema_name() -> String {
         T::LotusJson::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        T::LotusJson::schema_id()
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/src/lotus_json/signature_type.rs
+++ b/src/lotus_json/signature_type.rs
@@ -11,16 +11,22 @@ use crate::shim::crypto::SignatureType;
 // and
 // https://github.com/filecoin-project/lotus/blob/7bb1f98ac6f5a6da2cc79afc26d8cd9fe323eb30/chain/types/keystore.go#L47
 
-#[derive(Deserialize, Serialize, JsonSchema)]
+#[derive(Deserialize, Serialize)]
 #[serde(untagged)] // try an int, then a string
-#[schemars(rename = "SignatureType")]
 pub enum SignatureTypeLotusJson {
     Integer(SignatureType),
-    String(
-        #[serde(with = "crate::lotus_json::stringify")]
-        #[schemars(with = "String")]
-        SignatureType,
-    ),
+    String(#[serde(with = "crate::lotus_json::stringify")] SignatureType),
+}
+
+// only advertise the string
+impl JsonSchema for SignatureTypeLotusJson {
+    fn schema_name() -> String {
+        SignatureType::schema_name()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> Schema {
+        SignatureType::json_schema(gen)
+    }
 }
 
 impl HasLotusJson for SignatureType {

--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -3,17 +3,15 @@
 
 use super::*;
 
-pub struct VecLotusJson<T>(Vec<T>); // need a struct to handle the serialization of an empty vec as null
-
 impl<T> HasLotusJson for Vec<T>
 // TODO(aatifsyed): https://github.com/ChainSafe/forest/issues/4032
 //                  This shouldn't recurse - LotusJson<Vec<T>> should only handle
 //                  the OUTER issue of serializing an empty Vec as null, and
 //                  shouldn't be interested in the inner representation.
 where
-    T: HasLotusJson,
+    T: HasLotusJson + Clone,
 {
-    type LotusJson = VecLotusJson<T::LotusJson>;
+    type LotusJson = Option<Vec<T::LotusJson>>;
 
     #[cfg(test)]
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
@@ -21,17 +19,17 @@ where
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        VecLotusJson(self.into_iter().map(T::into_lotus_json).collect())
+        match self.is_empty() {
+            true => None,
+            false => Some(self.into_iter().map(T::into_lotus_json).collect()),
+        }
     }
 
-    fn from_lotus_json(VecLotusJson(vec): Self::LotusJson) -> Self {
-        vec.into_iter().map(T::from_lotus_json).collect()
-    }
-}
-
-impl<T: Clone> Clone for VecLotusJson<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
+    fn from_lotus_json(it: Self::LotusJson) -> Self {
+        match it {
+            Some(it) => it.into_iter().map(T::from_lotus_json).collect(),
+            None => vec![],
+        }
     }
 }
 
@@ -44,47 +42,5 @@ fn snapshots() {
 quickcheck! {
     fn quickcheck(val: Vec<::cid::Cid>) -> () {
         assert_unchanged_via_json(val)
-    }
-}
-
-impl<T> Serialize for VecLotusJson<T>
-where
-    T: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self.0.is_empty() {
-            true => serializer.serialize_none(),
-            false => self.0.serialize(serializer),
-        }
-    }
-}
-
-impl<'de, T> Deserialize<'de> for VecLotusJson<T>
-where
-    T: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Option::<Vec<T>>::deserialize(deserializer)
-            .map(Option::unwrap_or_default)
-            .map(Self)
-    }
-}
-
-impl<T> JsonSchema for VecLotusJson<T>
-where
-    T: JsonSchema,
-{
-    fn schema_name() -> String {
-        format!("Nullable_Array_of_{}", T::schema_name())
-    }
-
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        Option::<Vec<T>>::json_schema(gen)
     }
 }

--- a/src/lotus_json/vec_u8.rs
+++ b/src/lotus_json/vec_u8.rs
@@ -2,20 +2,32 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;
+use schemars::schema::*;
 
 // This code looks odd so we can
 // - use #[serde(with = "...")]
 // - de/ser empty vecs as null
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(rename = "Base64String")]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct VecU8LotusJson(Option<Inner>);
 
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
-struct Inner(
-    #[serde(with = "base64_standard")]
-    #[schemars(with = "String")]
-    Vec<u8>,
-);
+impl JsonSchema for VecU8LotusJson {
+    fn schema_name() -> String {
+        "Base64String".into()
+    }
+
+    fn json_schema(_: &mut schemars::gen::SchemaGenerator) -> Schema {
+        Schema::Object(SchemaObject {
+            instance_type: Some(SingleOrVec::Vec(vec![
+                InstanceType::String,
+                InstanceType::Null,
+            ])),
+            ..Default::default()
+        })
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Inner(#[serde(with = "base64_standard")] Vec<u8>);
 
 impl HasLotusJson for Vec<u8> {
     type LotusJson = VecU8LotusJson;

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -9,7 +9,6 @@ use crate::blocks::{Tipset, TipsetKey};
 use crate::chain::{index::ResolveNullTipset, ChainStore};
 use crate::chain_sync::SyncStage;
 use crate::cid_collections::CidHashSet;
-use crate::lotus_json::LotusJson;
 use crate::lotus_json::{lotus_json_with_self, HasLotusJson};
 use crate::message::{ChainMessage, Message as _, SignedMessage};
 use crate::rpc::error::ServerError;
@@ -92,13 +91,20 @@ enum EVMMethod {
     InvokeContract = 3844450837,
 }
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Default, Clone, JsonSchema)]
-pub struct BigInt(
-    #[schemars(with = "LotusJson<num_bigint::BigInt>")]
-    #[serde(with = "crate::lotus_json::hexify")]
-    pub num_bigint::BigInt,
-);
+// TODO(aatifsyed): just use ethereum_types::H265
+#[derive(PartialEq, Debug, Deserialize, Serialize, Default, Clone)]
+pub struct BigInt(#[serde(with = "crate::lotus_json::hexify")] pub num_bigint::BigInt);
 lotus_json_with_self!(BigInt);
+
+impl JsonSchema for BigInt {
+    fn schema_name() -> String {
+        "BigInt".into()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+}
 
 impl From<TokenAmount> for BigInt {
     fn from(amount: TokenAmount) -> Self {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -465,6 +465,7 @@ where
     module
 }
 
+/// If `include` is not [`None`], only methods that are listed will be returned
 pub fn openrpc(include: Option<&[&str]>) -> openrpc_types::OpenRPC {
     use schemars::gen::{SchemaGenerator, SchemaSettings};
     let mut methods = vec![];

--- a/src/rpc/reflect/mod.rs
+++ b/src/rpc/reflect/mod.rs
@@ -310,7 +310,7 @@ macro_rules! do_impls {
 
         impl<$($arg),*> Params<$arity> for ($($arg,)*)
         where
-            $($arg: HasLotusJson, <$arg as HasLotusJson>::LotusJson: JsonSchema, )*
+            $($arg: HasLotusJson + Clone, <$arg as HasLotusJson>::LotusJson: JsonSchema, )*
         {
             fn parse(
                 raw: Option<RequestParameters>,

--- a/src/tool/subcommands/shed_cmd.rs
+++ b/src/tool/subcommands/shed_cmd.rs
@@ -51,7 +51,7 @@ pub enum ShedCommands {
         output: Option<PathBuf>,
     },
     /// Dump the OpenRPC definition for the node.
-    Openrpc,
+    Openrpc { include: Vec<String> },
 }
 
 impl ShedCommands {
@@ -116,10 +116,15 @@ impl ShedCommands {
                     println!("{}", BASE64_STANDARD.encode(keypair_data));
                 }
             }
-            ShedCommands::Openrpc => {
+            ShedCommands::Openrpc { include } => {
+                let include = include.iter().map(String::as_str).collect::<Vec<_>>();
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&crate::rpc::openrpc()).unwrap()
+                    serde_json::to_string_pretty(&crate::rpc::openrpc(match include.is_empty() {
+                        true => None,
+                        false => Some(&include),
+                    }))
+                    .unwrap()
                 );
             }
         }

--- a/tests/tool_tests.rs
+++ b/tests/tool_tests.rs
@@ -237,3 +237,15 @@ fn keypair_conversion_roundtrip() {
     let keypair_decoded = BASE64_STANDARD.decode(keypair_encoded).unwrap();
     assert_eq!(keypair, keypair_decoded);
 }
+
+#[test]
+fn shed_openrpc_doesnt_crash() {
+    let stdout = tool()
+        .args(["shed", "openrpc"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice::<openrpc_types::OpenRPC>(&stdout).unwrap();
+}


### PR DESCRIPTION
## Summary of changes

Fixes this in our generated OpenRPC
```jsonc
{ "components": { "schemas": { "Cid": ..., "Cid2": ... } } }
```

- add an `include` argument to `forest-tool shed openrpc`
- rename `eth::BigInt` to `eth::EthBigInt`, but see #4436 
- make LotusJson for Vec less special
- make LotusJson for Cid less special
- `<LotusJson as JsonSchema>::schema_id` (this fixes most of the bugs)
- tweak schemas for SignatureType,  Vec<u8>, 

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
