### PR TITLE
fix(rpc): update StateWaitMsg against v1 spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@
 - [#4359](https://github.com/ChainSafe/forest/issues/4359) Add support for the
   `EIP-1898` object scheme.
 
+- [#4444](https://github.com/ChainSafe/forest/issues/4444) Update
+  `Filecoin.StateWaitMsg` RPC method to be API-V1-compatible
+
 ### Changed
 
 ### Removed

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -848,10 +848,12 @@ impl RpcMethod<2> for StateGetReceipt {
 
 /// looks back in the chain for a message. If not found, it blocks until the
 /// message arrives on chain, and gets to the indicated confidence depth.
-pub enum StateWaitMsg {}
+pub enum StateWaitMsgV0 {}
 
-impl RpcMethod<2> for StateWaitMsg {
-    const NAME: &'static str = "Filecoin.StateWaitMsg";
+impl RpcMethod<2> for StateWaitMsgV0 {
+    // TODO(forest): https://github.com/ChainSafe/forest/issues/3960
+    // point v0 implementation back to this one
+    const NAME: &'static str = "Filecoin.StateWaitMsgV0";
     const PARAM_NAMES: [&'static str; 2] = ["message_cid", "confidence"];
     const API_VERSION: ApiVersion = ApiVersion::V0;
     const PERMISSION: Permission = Permission::Read;
@@ -865,7 +867,51 @@ impl RpcMethod<2> for StateWaitMsg {
     ) -> Result<Self::Ok, ServerError> {
         let (tipset, receipt) = ctx
             .state_manager
-            .wait_for_message(message_cid, confidence)
+            .wait_for_message(message_cid, confidence, None, None)
+            .await?;
+        let tipset = tipset.context("wait for msg returned empty tuple")?;
+        let receipt = receipt.context("wait for msg returned empty receipt")?;
+        let ipld = receipt.return_data().deserialize().unwrap_or(Ipld::Null);
+        Ok(MessageLookup {
+            receipt,
+            tipset: tipset.key().clone(),
+            height: tipset.epoch(),
+            message: message_cid,
+            return_dec: ipld,
+        })
+    }
+}
+
+/// looks back in the chain for a message. If not found, it blocks until the
+/// message arrives on chain, and gets to the indicated confidence depth.
+pub enum StateWaitMsg {}
+
+impl RpcMethod<4> for StateWaitMsg {
+    const NAME: &'static str = "Filecoin.StateWaitMsg";
+    const PARAM_NAMES: [&'static str; 4] = [
+        "message_cid",
+        "confidence",
+        "look_back_limit",
+        "allow_replaced",
+    ];
+    const API_VERSION: ApiVersion = ApiVersion::V1;
+    const PERMISSION: Permission = Permission::Read;
+
+    type Params = (Cid, i64, ChainEpoch, bool);
+    type Ok = MessageLookup;
+
+    async fn handle(
+        ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
+        (message_cid, confidence, look_back_limit, allow_replaced): Self::Params,
+    ) -> Result<Self::Ok, ServerError> {
+        let (tipset, receipt) = ctx
+            .state_manager
+            .wait_for_message(
+                message_cid,
+                confidence,
+                Some(look_back_limit),
+                Some(allow_replaced),
+            )
             .await?;
         let tipset = tipset.context("wait for msg returned empty tuple")?;
         let receipt = receipt.context("wait for msg returned empty receipt")?;
@@ -899,7 +945,7 @@ impl RpcMethod<1> for StateSearchMsg {
     ) -> Result<Self::Ok, ServerError> {
         let (tipset, receipt) = ctx
             .state_manager
-            .search_for_message(None, message_cid, None)
+            .search_for_message(None, message_cid, None, None)
             .await?
             .with_context(|| format!("message {message_cid} not found."))?;
         let ipld = receipt.return_data().deserialize().unwrap_or(Ipld::Null);
@@ -932,7 +978,7 @@ impl RpcMethod<2> for StateSearchMsgLimited {
     ) -> Result<Self::Ok, ServerError> {
         let (tipset, receipt) = ctx
             .state_manager
-            .search_for_message(None, message_cid, Some(look_back_limit))
+            .search_for_message(None, message_cid, Some(look_back_limit), None)
             .await?
             .with_context(|| {
                 format!("message {message_cid} not found within the last {look_back_limit} epochs")

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -158,6 +158,7 @@ macro_rules! for_each_method {
         $callback!(crate::rpc::state::StateMarketDeals);
         $callback!(crate::rpc::state::StateDealProviderCollateralBounds);
         $callback!(crate::rpc::state::StateMarketStorageDeal);
+        $callback!(crate::rpc::state::StateWaitMsgV0);
         $callback!(crate::rpc::state::StateWaitMsg);
         $callback!(crate::rpc::state::StateSearchMsg);
         $callback!(crate::rpc::state::StateSearchMsgLimited);

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -980,7 +980,12 @@ fn state_tests_with_tipset<DB: Blockstore>(
             tests.extend([
                 RpcTest::identity(StateReplay::request((tipset.key().into(), msg_cid))?),
                 validate_message_lookup(
-                    StateWaitMsg::request((msg_cid, 0))?.with_timeout(Duration::from_secs(30)),
+                    StateWaitMsg::request((msg_cid, 0, 10101, true))?
+                        .with_timeout(Duration::from_secs(15)),
+                ),
+                validate_message_lookup(
+                    StateWaitMsg::request((msg_cid, 0, 10101, false))?
+                        .with_timeout(Duration::from_secs(15)),
                 ),
                 validate_message_lookup(StateSearchMsg::request((msg_cid,))?),
                 validate_message_lookup(StateSearchMsgLimited::request((msg_cid, 800))?),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

(Part of https://github.com/ChainSafe/forest/issues/4424)
This PR fixes the `StateWaitMsg` RPC method against the [v1 spec](https://github.com/filecoin-project/lotus/blob/master/documentation/en/api-v1-unstable-methods.md#StateWaitMsg) and uses it for both v0 and v1 endpoints until https://github.com/ChainSafe/forest/issues/3960 is resolved. (Keeping the v0 implementation with a different name for now)

Changes introduced in this pull request:

- update `StateWaitMsg` against v1 spec

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
