### PR TITLE
fix: use borrowed impl Blockstore in parameter types when possible

### DIFF
--- a/src/blocks/header.rs
+++ b/src/blocks/header.rs
@@ -271,7 +271,7 @@ impl CachingBlockHeader {
         self.uncached
     }
     /// Returns [`None`] if the blockstore doesn't contain the CID.
-    pub fn load(store: impl Blockstore, cid: Cid) -> anyhow::Result<Option<Self>> {
+    pub fn load(store: &impl Blockstore, cid: Cid) -> anyhow::Result<Option<Self>> {
         if let Some(uncached) = store.get_cbor::<RawBlockHeader>(&cid)? {
             Ok(Some(Self {
                 uncached,

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -208,11 +208,11 @@ impl Tipset {
 
     /// Fetch a tipset from the blockstore. This call fails if the tipset is
     /// present but invalid. If the tipset is missing, None is returned.
-    pub fn load(store: impl Blockstore, tsk: &TipsetKey) -> anyhow::Result<Option<Tipset>> {
+    pub fn load(store: &impl Blockstore, tsk: &TipsetKey) -> anyhow::Result<Option<Tipset>> {
         Ok(tsk
             .to_cids()
             .into_iter()
-            .map(|key| CachingBlockHeader::load(&store, key))
+            .map(|key| CachingBlockHeader::load(store, key))
             .collect::<anyhow::Result<Option<Vec<_>>>>()?
             .map(Tipset::new)
             .transpose()?)
@@ -239,12 +239,12 @@ impl Tipset {
 
     /// Fetch a tipset from the blockstore. This calls fails if the tipset is
     /// missing or invalid.
-    pub fn load_required(store: impl Blockstore, tsk: &TipsetKey) -> anyhow::Result<Tipset> {
+    pub fn load_required(store: &impl Blockstore, tsk: &TipsetKey) -> anyhow::Result<Tipset> {
         Tipset::load(store, tsk)?.context("Required tipset missing from database")
     }
 
     /// Constructs and returns a full tipset if messages from storage exists
-    pub fn fill_from_blockstore(&self, store: impl Blockstore) -> Option<FullTipset> {
+    pub fn fill_from_blockstore(&self, store: &impl Blockstore) -> Option<FullTipset> {
         // Find tipset messages. If any are missing, return `None`.
         let blocks = self
             .block_headers()
@@ -341,8 +341,9 @@ impl Tipset {
         }
         broken
     }
-    /// Returns an iterator of all tipsets
-    pub fn chain(self, store: impl Blockstore) -> impl Iterator<Item = Tipset> {
+
+    /// Returns an iterator of all tipsets, taking an owned [`Blockstore`]
+    pub fn chain_owned(self, store: impl Blockstore) -> impl Iterator<Item = Tipset> {
         let mut tipset = Some(self);
         std::iter::from_fn(move || {
             let child = tipset.take()?;
@@ -352,11 +353,24 @@ impl Tipset {
     }
 
     /// Returns an iterator of all tipsets
-    pub fn chain_arc(self: Arc<Self>, store: impl Blockstore) -> impl Iterator<Item = Arc<Tipset>> {
+    pub fn chain(self, store: &impl Blockstore) -> impl Iterator<Item = Tipset> + '_ {
         let mut tipset = Some(self);
         std::iter::from_fn(move || {
             let child = tipset.take()?;
-            tipset = Tipset::load_required(&store, child.parents())
+            tipset = Tipset::load_required(store, child.parents()).ok();
+            Some(child)
+        })
+    }
+
+    /// Returns an iterator of all tipsets
+    pub fn chain_arc(
+        self: Arc<Self>,
+        store: &impl Blockstore,
+    ) -> impl Iterator<Item = Arc<Tipset>> + '_ {
+        let mut tipset = Some(self);
+        std::iter::from_fn(move || {
+            let child = tipset.take()?;
+            tipset = Tipset::load_required(store, child.parents())
                 .ok()
                 .map(Arc::new);
             Some(child)
@@ -364,7 +378,7 @@ impl Tipset {
     }
 
     /// Fetch the genesis block header for a given tipset.
-    pub fn genesis(&self, store: impl Blockstore) -> anyhow::Result<CachingBlockHeader> {
+    pub fn genesis(&self, store: &impl Blockstore) -> anyhow::Result<CachingBlockHeader> {
         // Scanning through millions of epochs to find the genesis is quite
         // slow. Let's use a list of known blocks to short-circuit the search.
         // The blocks are hash-chained together and known blocks are guaranteed
@@ -380,7 +394,7 @@ impl Tipset {
             serde_yaml::from_str(include_str!("../../build/known_blocks.yaml")).unwrap()
         });
 
-        for tipset in self.clone().chain(&store) {
+        for tipset in self.clone().chain(store) {
             // Search for known calibnet and mainnet blocks
             for (genesis_cid, known_blocks) in [
                 (*calibnet::GENESIS_CID, &headers.calibnet),

--- a/src/interpreter/vm.rs
+++ b/src/interpreter/vm.rs
@@ -90,7 +90,7 @@ pub struct BlockMessages {
 
 impl BlockMessages {
     /// Retrieves block messages to be passed through the VM and removes duplicate messages which appear in multiple blocks.
-    pub fn for_tipset(db: impl Blockstore, ts: &Tipset) -> Result<Vec<BlockMessages>, Error> {
+    pub fn for_tipset(db: &impl Blockstore, ts: &Tipset) -> Result<Vec<BlockMessages>, Error> {
         let mut applied = HashMap::new();
         let mut select_msg = |m: ChainMessage| -> Option<ChainMessage> {
             // The first match for a sender is guaranteed to have correct nonce
@@ -108,7 +108,7 @@ impl BlockMessages {
         ts.block_headers()
             .iter()
             .map(|b| {
-                let (usm, sm) = block_messages(&db, b)?;
+                let (usm, sm) = block_messages(db, b)?;
 
                 let mut messages = Vec::with_capacity(usm.len() + sm.len());
                 messages.extend(

--- a/src/shim/machine/manifest.rs
+++ b/src/shim/machine/manifest.rs
@@ -120,7 +120,7 @@ static_assertions::assert_not_impl_all!(BuiltinActor: std::hash::Hash);
 
 impl BuiltinActorManifest {
     const MANDATORY_BUILTINS: &'static [BuiltinActor] = &[BuiltinActor::Init, BuiltinActor::System];
-    pub fn load_manifest(b: impl Blockstore, manifest_cid: &Cid) -> anyhow::Result<Self> {
+    pub fn load_manifest(b: &impl Blockstore, manifest_cid: &Cid) -> anyhow::Result<Self> {
         let (manifest_version, actor_list_cid) = b.get_cbor_required::<(u32, Cid)>(manifest_cid)?;
         ensure!(
             manifest_version == 1,
@@ -129,7 +129,7 @@ impl BuiltinActorManifest {
         );
         Self::load_v1_actor_list(b, &actor_list_cid)
     }
-    pub fn load_v1_actor_list(b: impl Blockstore, actor_list_cid: &Cid) -> anyhow::Result<Self> {
+    pub fn load_v1_actor_list(b: &impl Blockstore, actor_list_cid: &Cid) -> anyhow::Result<Self> {
         let mut actor_list = b.get_cbor_required::<Vec<(String, Cid)>>(actor_list_cid)?;
         actor_list.sort();
         ensure!(

--- a/src/tool/subcommands/benchmark_cmd.rs
+++ b/src/tool/subcommands/benchmark_cmd.rs
@@ -180,7 +180,7 @@ async fn benchmark_unordered_graph_traversal(input: Vec<PathBuf>) -> anyhow::Res
 
     let mut sink = indicatif_sink("traversed");
 
-    let mut s = unordered_stream_graph(store.clone(), heaviest.chain(store), 0);
+    let mut s = unordered_stream_graph(store.clone(), heaviest.chain_owned(store), 0);
     while let Some(block) = s.try_next().await? {
         sink.write_all(&block.data).await?
     }
@@ -240,7 +240,7 @@ async fn benchmark_exporting(
 
     let blocks = stream_chain(
         Arc::clone(&store),
-        ts.deref().clone().chain(Arc::clone(&store)),
+        ts.deref().clone().chain_owned(Arc::clone(&store)),
         stateroot_lookup_limit,
     );
 

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -301,7 +301,7 @@ where
 // Forest keeps a list of known tipsets for each network. Finding a known tipset
 // short-circuits the search for the genesis block. If no genesis block can be
 // found or if the genesis block is unrecognizable, an error is returned.
-fn query_network(ts: &Tipset, db: impl Blockstore) -> anyhow::Result<NetworkChain> {
+fn query_network(ts: &Tipset, db: &impl Blockstore) -> anyhow::Result<NetworkChain> {
     let pb = validation_spinner("Identifying genesis block:").with_finish(
         indicatif::ProgressFinish::AbandonWithMessage("✅ found!".into()),
     );


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to avoid some `Arc::clone`s and recursive `Arc`s around `Blockstore`

Changes introduced in this pull request:

- use borrowed impl Blockstore in parameter types when possible

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
