### PR TITLE
fix: refactor `sync_headers_in_reverse` to use a standalone function for handling network tipsets

### DIFF
--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -861,7 +861,7 @@ async fn sync_headers_in_reverse<DB: Blockstore + Sync + Send + 'static>(
         // Breaks the loop when `until_epoch` is overreached, which happens
         // when there are null tipsets in the queried range.
         // Note that when the `until_epoch` is null, the outer while condition
-        // is always true, and it relies on the returned boolean flag(until epoch is overreached)
+        // is always true, and it relies on the returned boolean value(until epoch is overreached)
         // to break the loop.
         if for_each_tipset_until_epoch_overreached(network_tipsets, until_epoch, callback)? {
             // Breaks when the `until_epoch` is overreached.

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -822,7 +822,7 @@ async fn sync_headers_in_reverse<DB: Blockstore + Sync + Send + 'static>(
 
     #[allow(deprecated)] // Tracking issue: https://github.com/ChainSafe/forest/issues/3157
     let wp = WithProgressRaw::new("Downloading headers", total_size as u64);
-    'outer: while pending_tipsets.last().epoch() > until_epoch {
+    while pending_tipsets.last().epoch() > until_epoch {
         let oldest_pending_tipset = pending_tipsets.last();
         let work_to_be_done = oldest_pending_tipset.epoch() - until_epoch + 1;
         wp.set((work_to_be_done - total_size).unsigned_abs());
@@ -851,15 +851,20 @@ async fn sync_headers_in_reverse<DB: Blockstore + Sync + Send + 'static>(
             .await
             .map_err(TipsetRangeSyncerError::NetworkTipsetQueryFailed)?;
 
-        for tipset in network_tipsets {
-            // This could happen when the `until_epoch` is a null epoch
-            if tipset.epoch() < until_epoch {
-                break 'outer;
-            }
+        let callback = |tipset: Arc<Tipset>| {
             validate_tipset_against_cache(bad_block_cache, tipset.key(), &accepted_blocks)?;
             accepted_blocks.extend(tipset.cids());
             tracker.write().set_epoch(tipset.epoch());
             pending_tipsets.push(tipset);
+            Ok(())
+        };
+        // Breaks the loop when `until_epoch` is overreached, which happens
+        // when there are null tipsets in the queried range.
+        // Note that when the `until_epoch` is null, the outer while condition
+        // is always true, and it relies on this flag to break the loop
+        if for_each_tipset_until_epoch_overreached(network_tipsets, until_epoch, callback)? {
+            // Breaks when the `until_epoch` is overreached.
+            break;
         }
     }
     drop(wp);
@@ -922,6 +927,22 @@ async fn sync_headers_in_reverse<DB: Blockstore + Sync + Send + 'static>(
     }
 
     Ok(pending_tipsets)
+}
+
+// tipsets is sorted by epoch in descending order
+// returns true when `until_epoch_inclusive` is overreached
+fn for_each_tipset_until_epoch_overreached(
+    tipsets: impl IntoIterator<Item = Arc<Tipset>>,
+    until_epoch_inclusive: ChainEpoch,
+    mut callback: impl FnMut(Arc<Tipset>) -> Result<(), TipsetRangeSyncerError>,
+) -> Result<bool, TipsetRangeSyncerError> {
+    for tipset in tipsets {
+        if tipset.epoch() < until_epoch_inclusive {
+            return Ok(true);
+        }
+        callback(tipset)?;
+    }
+    Ok(false)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -861,7 +861,8 @@ async fn sync_headers_in_reverse<DB: Blockstore + Sync + Send + 'static>(
         // Breaks the loop when `until_epoch` is overreached, which happens
         // when there are null tipsets in the queried range.
         // Note that when the `until_epoch` is null, the outer while condition
-        // is always true, and it relies on this flag to break the loop
+        // is always true, and it relies on the returned boolean flag(until epoch is overreached)
+        // to break the loop.
         if for_each_tipset_until_epoch_overreached(network_tipsets, until_epoch, callback)? {
             // Breaks when the `until_epoch` is overreached.
             break;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

To address

              Could we avoid the inner/outer loop complexity by refactoring this to smaller functions that could potentially be unit tested? At least the block `for tipset in network_tipsets {`

_Originally posted by @LesnyRumcajs in https://github.com/ChainSafe/forest/pull/4459#discussion_r1660713502_
            

Changes introduced in this pull request:

- use a standalone function `for_each_tipset_until_epoch_overreached` for handling network tipsets
- more comments explaining the loop breaking logic

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
