### PR TITLE
fix(rpc): MpoolPending empty result should serialize into `[]` instead of `null`

### DIFF
--- a/src/cli/subcommands/mpool_cmd.rs
+++ b/src/cli/subcommands/mpool_cmd.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr as _;
 
 use crate::blocks::Tipset;
-use crate::lotus_json::HasLotusJson as _;
+use crate::lotus_json::{HasLotusJson as _, NotNullVec};
 use crate::message::SignedMessage;
 use crate::rpc::{self, prelude::*, types::ApiTipsetKey};
 use crate::shim::address::StrictAddress;
@@ -215,7 +215,8 @@ impl MpoolCommands {
                 to,
                 from,
             } => {
-                let messages = MpoolPending::call(&client, (ApiTipsetKey(None),)).await?;
+                let NotNullVec(messages) =
+                    MpoolPending::call(&client, (ApiTipsetKey(None),)).await?;
 
                 let local_addrs = if local {
                     let response = WalletList::call(&client, ()).await?;
@@ -246,7 +247,8 @@ impl MpoolCommands {
                 let atto_str = ChainGetMinBaseFee::call(&client, (basefee_lookback,)).await?;
                 let min_base_fee = TokenAmount::from_atto(atto_str.parse::<BigInt>()?);
 
-                let messages = MpoolPending::call(&client, (ApiTipsetKey(None),)).await?;
+                let NotNullVec(messages) =
+                    MpoolPending::call(&client, (ApiTipsetKey(None),)).await?;
 
                 let local_addrs = if local {
                     let response = WalletList::call(&client, ()).await?;

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -233,6 +233,8 @@ mod receipt; // shim type roundtrip is wrong - see module
 mod vec; // can't make snapshots of generic type
 mod verifreg_claim;
 
+pub use vec::*;
+
 #[cfg(any(test, doc))]
 pub fn assert_all_snapshots<T>()
 where

--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -33,6 +33,33 @@ where
     }
 }
 
+// an empty `Vec<T>` serializes into `null` lotus json by default,
+// while an empty `NotNullVec<T>` serializes into `[]`
+// this is a temporary workaround and will likely be deprecated once
+// other `TODOs` on serde of `Vec<T>` are addressed.
+#[derive(Debug, Clone, PartialEq, JsonSchema)]
+pub struct NotNullVec<T>(pub Vec<T>);
+
+impl<T> HasLotusJson for NotNullVec<T>
+where
+    T: HasLotusJson + Clone,
+{
+    type LotusJson = Vec<T::LotusJson>;
+
+    #[cfg(test)]
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        unimplemented!("only Vec<Cid> is tested, below")
+    }
+
+    fn into_lotus_json(self) -> Self::LotusJson {
+        self.0.into_iter().map(T::into_lotus_json).collect()
+    }
+
+    fn from_lotus_json(it: Self::LotusJson) -> Self {
+        Self(it.into_iter().map(T::from_lotus_json).collect())
+    }
+}
+
 #[test]
 fn snapshots() {
     assert_one_snapshot(json!([{"/": "baeaaaaa"}]), vec![::cid::Cid::default()]);

--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -36,7 +36,7 @@ where
 // an empty `Vec<T>` serializes into `null` lotus json by default,
 // while an empty `NotNullVec<T>` serializes into `[]`
 // this is a temporary workaround and will likely be deprecated once
-// other `TODOs` on serde of `Vec<T>` are addressed.
+// other issues on serde of `Vec<T>` are resolved.
 #[derive(Debug, Clone, PartialEq, JsonSchema)]
 pub struct NotNullVec<T>(pub Vec<T>);
 

--- a/src/rpc/methods/mpool.rs
+++ b/src/rpc/methods/mpool.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::gas::estimate_message_gas;
+use crate::lotus_json::NotNullVec;
 use crate::message::SignedMessage;
 use crate::rpc::error::ServerError;
 use crate::rpc::types::{ApiTipsetKey, MessageSendSpec};
@@ -42,7 +43,7 @@ impl RpcMethod<1> for MpoolPending {
     const PERMISSION: Permission = Permission::Read;
 
     type Params = (ApiTipsetKey,);
-    type Ok = Vec<SignedMessage>;
+    type Ok = NotNullVec<SignedMessage>;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
@@ -61,7 +62,7 @@ impl RpcMethod<1> for MpoolPending {
         }
 
         if mpts.epoch() > ts.epoch() {
-            return Ok(pending.into_iter().collect::<Vec<_>>());
+            return Ok(NotNullVec(pending.into_iter().collect()));
         }
 
         loop {
@@ -105,7 +106,7 @@ impl RpcMethod<1> for MpoolPending {
                 .chain_index
                 .load_required_tipset(ts.parents())?;
         }
-        Ok(pending.into_iter().collect::<Vec<_>>())
+        Ok(NotNullVec(pending.into_iter().collect()))
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to fix the below bug (https://github.com/ChainSafe/forest/issues/4424#issuecomment-2205601945)

> MpoolPending
expected response: empty json array result: [] if no messages found
actual response: result: null

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
