### PR TITLE
fix(rpc): parity tests for StateSectorGetInfo to cover bad address and bad sector cases

### DIFF
--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1804,7 +1804,7 @@ impl RpcMethod<3> for StateSectorGetInfo {
     const PERMISSION: Permission = Permission::Read;
 
     type Params = (Address, u64, ApiTipsetKey);
-    type Ok = SectorOnChainInfo;
+    type Ok = Option<SectorOnChainInfo>;
 
     async fn handle(
         ctx: Ctx<impl Blockstore>,
@@ -1818,8 +1818,7 @@ impl RpcMethod<3> for StateSectorGetInfo {
             .state_manager
             .get_all_sectors(&miner_address, &ts)?
             .into_iter()
-            .find(|info| info.sector_number == sector_number)
-            .context(format!("Info for sector number {sector_number} not found"))?)
+            .find(|info| info.sector_number == sector_number))
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to fix the below bug (https://github.com/ChainSafe/forest/issues/4424#issuecomment-2205601945)

> StateSectorGetInfo
expected response: result: null if sector commit info not found
actual response:
"error": {
"code": -32603,
"message": "Info for sector number 2 not found"
},

Changes introduced in this pull request:

- add parity tests for StateSectorGetInfo to cover bad address and bad sector cases
- fix StateSectorGetInfo implementation

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
