### PR TITLE
fix: install macos sha256sum

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+      - name: Homebrew Utils
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install --verbose coreutils
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         timeout-minutes: 5
@@ -30,9 +34,6 @@ jobs:
           mkdir -p forest-${{ github.ref_name }}
           cp -v target/release/forest target/release/forest-cli target/release/forest-tool forest-${{ github.ref_name }}
           cp -rv CHANGELOG.md LICENSE-APACHE LICENSE-MIT README.md documentation forest-${{ github.ref_name }}
-          # If `sha256sum` is not defined, then we're likely running MacOS. Use an alias.
-          # An alternative is to install `coreutils`.
-          type sha256sum >/dev/null 2>&1 || alias sha256sum='shasum -a 256'
           sha256sum forest-${{ github.ref_name }}/forest > forest-${{ github.ref_name }}/forest.sha256
           sha256sum forest-${{ github.ref_name }}/forest-cli > forest-${{ github.ref_name }}/forest-cli.sha256
           sha256sum forest-${{ github.ref_name }}/forest-tool > forest-${{ github.ref_name }}/forest-tool.sha256

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -1,0 +1,53 @@
+# This workflow is used for emergency artifact releases, e.g., when the release tag can not be created by the linked release workflow.
+name: Release (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            file: forest-${{ github.event.inputs.tag }}-linux-amd64.zip
+          - os: macos-latest
+            file: forest-${{ github.event.inputs.tag }}-macos-amd64.zip
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+      - name: Homebrew Utils
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install --verbose coreutils
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        timeout-minutes: 5
+        continue-on-error: true
+      - name: Cargo Build
+        run: cargo build --release --bin forest --bin forest-cli --bin forest-tool
+      - name: Compress Binary
+        run: |
+          mkdir -p forest-${{ github.event.inputs.tag }}
+          cp -v target/release/forest target/release/forest-cli target/release/forest-tool forest-${{ github.event.inputs.tag }}
+          cp -rv CHANGELOG.md LICENSE-APACHE LICENSE-MIT README.md documentation forest-${{ github.event.inputs.tag }}
+          sha256sum forest-${{ github.event.inputs.tag }}/forest > forest-${{ github.event.inputs.tag }}/forest.sha256
+          sha256sum forest-${{ github.event.inputs.tag }}/forest-cli > forest-${{ github.event.inputs.tag }}/forest-cli.sha256
+          sha256sum forest-${{ github.event.inputs.tag }}/forest-tool > forest-${{ github.event.inputs.tag }}/forest-tool.sha256
+          zip -r ${{ matrix.file }} forest-${{ github.event.inputs.tag }}
+      - name: Upload Binary
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ github.token }}
+          file: ${{ matrix.file }}
+          asset_name: ${{ matrix.file }}
+          tag: ${{ github.event.inputs.tag }}
+          overwrite: true
+          prerelease: true


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- the script works on my MacOS machine on both `fish`, `bash`, `zsh` and `sh`. Likely we could contrive another workaround, but to avoid complexity let's just install `coreutils`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

https://github.com/ChainSafe/forest/actions/runs/9805478327/job/27075215364#step:5:20

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
