### PR TITLE
chore: `Message::cid` is infallible

### DIFF
--- a/src/blocks/tests/serialization_vectors.rs
+++ b/src/blocks/tests/serialization_vectors.rs
@@ -63,13 +63,13 @@ fn signing_test() {
     } in cases
     {
         let priv_key = PrivateKey::from_bytes(&private_key).unwrap();
-        let msg_sign_bz = unsigned.cid().unwrap().to_bytes();
+        let msg_sign_bz = unsigned.cid().to_bytes();
         let bls_sig = priv_key.sign(&msg_sign_bz);
         let sig = Signature::new_bls(bls_sig.as_bytes());
         assert_eq!(sig, signature);
 
         let smsg = SignedMessage::new_from_parts(unsigned, sig).unwrap();
-        let actual_cid = smsg.cid().unwrap();
+        let actual_cid = smsg.cid();
 
         assert_eq!(actual_cid, expected_cid);
     }

--- a/src/chain/store/base_fee.rs
+++ b/src/chain/store/base_fee.rs
@@ -71,14 +71,14 @@ where
     for b in ts.block_headers() {
         let (msg1, msg2) = crate::chain::block_messages(db, b)?;
         for m in msg1 {
-            let m_cid = m.cid()?;
+            let m_cid = m.cid();
             if !seen.contains(&m_cid) {
                 total_limit += m.gas_limit();
                 seen.insert(m_cid);
             }
         }
         for m in msg2 {
-            let m_cid = m.cid()?;
+            let m_cid = m.cid();
             if !seen.contains(&m_cid) {
                 total_limit += m.gas_limit();
                 seen.insert(m_cid);

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -393,7 +393,7 @@ where
                 {
                     if let Ok(hash) = tx.eth_hash() {
                         // newest messages are the ones with lowest index
-                        Some((hash, smsg.cid().unwrap(), *timestamp, i))
+                        Some((hash, smsg.cid(), *timestamp, i))
                     } else {
                         None
                     }

--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1457,15 +1457,7 @@ async fn check_block_messages<DB: Blockstore + Send + Sync + 'static>(
         for m in block.bls_msgs() {
             let pk = StateManager::get_bls_public_key(&db, &m.from, *base_tipset.parent_state())?;
             pub_keys.push(pk);
-            cids.push(
-                m.cid()
-                    .map_err(|e| {
-                        TipsetRangeSyncerError::Validation(format!(
-                            "Failed to get bls message cid: {e}"
-                        ))
-                    })?
-                    .to_bytes(),
-            );
+            cids.push(m.cid().to_bytes());
         }
 
         if !verify_bls_aggregate(
@@ -1573,7 +1565,7 @@ async fn check_block_messages<DB: Blockstore + Send + Sync + 'static>(
             .map_err(|e| TipsetRangeSyncerError::ResolvingAddressFromMessage(e.to_string()))?;
         // SecP256K1 Signature validation
         msg.signature
-            .verify(&msg.message().cid().unwrap().to_bytes(), &key_addr)
+            .verify(&msg.message().cid().to_bytes(), &key_addr)
             .map_err(TipsetRangeSyncerError::MessageSignatureInvalid)?;
     }
 

--- a/src/cli/subcommands/chain_cmd.rs
+++ b/src/cli/subcommands/chain_cmd.rs
@@ -69,7 +69,7 @@ impl ChainCommands {
                 match fvm_ipld_encoding::from_slice::<ChainMessage>(&bytes)? {
                     ChainMessage::Unsigned(m) => print_pretty_lotus_json(m),
                     ChainMessage::Signed(m) => {
-                        let cid = m.cid()?;
+                        let cid = m.cid();
                         println!(
                             "{}",
                             serde_json::to_string_pretty(&m.into_lotus_json().with_cid(cid))?

--- a/src/cli/subcommands/mpool_cmd.rs
+++ b/src/cli/subcommands/mpool_cmd.rs
@@ -229,7 +229,7 @@ impl MpoolCommands {
 
                 for msg in filtered_messages {
                     if cids {
-                        println!("{}", msg.cid().unwrap());
+                        println!("{}", msg.cid());
                     } else {
                         println!("{}", msg.into_lotus_json_string_pretty()?);
                     }

--- a/src/cli/subcommands/send_cmd.rs
+++ b/src/cli/subcommands/send_cmd.rs
@@ -59,7 +59,7 @@ impl SendCommand {
 
         let signed_msg = MpoolPushMessage::call(&client, (message, None)).await?;
 
-        println!("{}", signed_msg.cid().unwrap());
+        println!("{}", signed_msg.cid());
 
         Ok(())
     }

--- a/src/db/ttl/mod.rs
+++ b/src/db/ttl/mod.rs
@@ -127,7 +127,7 @@ mod test {
 
         let timestamp = unix_timestamp.timestamp() as u64;
         blockstore
-            .write_obj(&key0, &(secp0.cid().unwrap(), timestamp))
+            .write_obj(&key0, &(secp0.cid(), timestamp))
             .unwrap();
 
         assert!(blockstore.exists(&key0).unwrap());
@@ -140,7 +140,7 @@ mod test {
             .write_obj(
                 &key1,
                 &(
-                    secp1.cid().unwrap(),
+                    secp1.cid(),
                     unix_timestamp.timestamp() as u64 + 2 * TTL_DURATION.as_secs(),
                 ),
             )

--- a/src/interpreter/vm.rs
+++ b/src/interpreter/vm.rs
@@ -334,7 +334,7 @@ where
 
         if let Some(mut callback) = callback {
             callback(MessageCallbackCtx {
-                cid: cron_msg.cid()?,
+                cid: cron_msg.cid(),
                 message: &ChainMessage::Unsigned(cron_msg),
                 apply_ret: &ret,
                 at: CalledAt::Cron,
@@ -360,7 +360,7 @@ where
             let mut gas_reward = TokenAmount::zero();
 
             let mut process_msg = |message: &ChainMessage| -> Result<(), anyhow::Error> {
-                let cid = message.cid()?;
+                let cid = message.cid();
                 // Ensure no duplicate processing of a message
                 if processed.contains(&cid) {
                     return Ok(());
@@ -414,7 +414,7 @@ where
 
                 if let Some(callback) = &mut callback {
                     callback(MessageCallbackCtx {
-                        cid: rew_msg.cid()?,
+                        cid: rew_msg.cid(),
                         message: &ChainMessage::Unsigned(rew_msg),
                         apply_ret: &ret,
                         at: CalledAt::Reward,

--- a/src/lotus_json/signed_message.rs
+++ b/src/lotus_json/signed_message.rs
@@ -69,7 +69,7 @@ impl HasLotusJson for SignedMessage {
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        let cid = self.cid().ok();
+        let cid = Some(self.cid());
         let Self { message, signature } = self;
         Self::LotusJson {
             message,

--- a/src/message/chain_message.rs
+++ b/src/message/chain_message.rs
@@ -3,7 +3,7 @@
 
 use crate::shim::message::MethodNum;
 use crate::shim::{address::Address, econ::TokenAmount, message::Message};
-use fvm_ipld_encoding::{Error, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use serde::{Deserialize, Serialize};
 
 use super::Message as MessageTrait;
@@ -26,7 +26,7 @@ impl ChainMessage {
         }
     }
 
-    pub fn cid(&self) -> Result<cid::Cid, Error> {
+    pub fn cid(&self) -> cid::Cid {
         match self {
             ChainMessage::Unsigned(msg) => msg.cid(),
             ChainMessage::Signed(msg) => msg.cid(),

--- a/src/message/signed_message.rs
+++ b/src/message/signed_message.rs
@@ -26,7 +26,7 @@ impl SignedMessage {
     /// The signature will be verified.
     pub fn new_from_parts(message: Message, signature: Signature) -> anyhow::Result<SignedMessage> {
         signature
-            .verify(&message.cid()?.to_bytes(), &message.from())
+            .verify(&message.cid().to_bytes(), &message.from())
             .map_err(anyhow::Error::msg)?;
         Ok(SignedMessage { message, signature })
     }
@@ -70,18 +70,18 @@ impl SignedMessage {
     /// Verifies that the from address of the message generated the signature.
     pub fn verify(&self) -> Result<(), String> {
         self.signature
-            .verify(&self.message.cid().unwrap().to_bytes(), &self.from())
+            .verify(&self.message.cid().to_bytes(), &self.from())
     }
 
     // Important note: `msg.cid()` is different from
     // `Cid::from_cbor_blake2b256(msg)`. The behavior comes from Lotus, and
     // Lotus, by, definition, is correct.
-    pub fn cid(&self) -> Result<cid::Cid, fvm_ipld_encoding::Error> {
+    pub fn cid(&self) -> cid::Cid {
         if self.is_bls() {
             self.message.cid()
         } else {
             use crate::utils::cid::CidCborExt;
-            cid::Cid::from_cbor_blake2b256(self)
+            cid::Cid::from_cbor_blake2b256(self).expect("message serialization is infallible")
         }
     }
 }

--- a/src/message_pool/msgpool/mod.rs
+++ b/src/message_pool/msgpool/mod.rs
@@ -100,7 +100,7 @@ where
 
     let mut republished_t = HashSet::new();
     for m in msgs.iter() {
-        republished_t.insert(m.cid()?);
+        republished_t.insert(m.cid());
     }
     *republished.write() = republished_t;
 
@@ -250,13 +250,13 @@ where
                     msg.sequence(),
                     rmsgs.borrow_mut(),
                 )?;
-                if !repub && republished.write().insert(msg.cid()?) {
+                if !repub && republished.write().insert(msg.cid()) {
                     repub = true;
                 }
             }
             for msg in msgs {
                 remove_from_selected_msgs(&msg.from, pending, msg.sequence, rmsgs.borrow_mut())?;
-                if !repub && republished.write().insert(msg.cid()?) {
+                if !repub && republished.write().insert(msg.cid()) {
                     repub = true;
                 }
             }
@@ -394,7 +394,7 @@ pub mod tests {
             ..Message_v3::default()
         }
         .into();
-        let msg_signing_bytes = umsg.cid().unwrap().to_bytes();
+        let msg_signing_bytes = umsg.cid().to_bytes();
         let sig = wallet.sign(from, msg_signing_bytes.as_slice()).unwrap();
         SignedMessage::new_unchecked(umsg, sig)
     }
@@ -422,7 +422,7 @@ pub mod tests {
         .into();
         let sig = Signature::new_secp256k1(vec![]);
         let signed = SignedMessage::new_unchecked(umsg, sig);
-        let cid = signed.cid().unwrap();
+        let cid = signed.cid();
         pool.sig_val_cache.lock().put(cid, ());
         signed
     }

--- a/src/message_pool/msgpool/msg_pool.rs
+++ b/src/message_pool/msgpool/msg_pool.rs
@@ -108,7 +108,7 @@ impl MsgSet {
         }
 
         if let Some(exms) = self.msgs.get(&m.sequence()) {
-            if m.cid()? != exms.cid()? {
+            if m.cid() != exms.cid() {
                 let premium = &exms.message().gas_premium;
                 let min_price = premium.clone()
                     + ((premium * RBF_NUM).div_floor(RBF_DENOM))
@@ -210,7 +210,7 @@ where
     /// checks on the validity of a message.
     pub async fn push(&self, msg: SignedMessage) -> Result<Cid, Error> {
         self.check_message(&msg)?;
-        let cid = msg.cid().map_err(|err| Error::Other(err.to_string()))?;
+        let cid = msg.cid();
         let cur_ts = self.cur_tipset.lock().clone();
         let publish = self.add_tipset(msg.clone(), &cur_ts, true)?;
         let msg_ser = to_vec(&msg)?;
@@ -256,7 +256,7 @@ where
     /// verified and put into cache. If it has not, then manually verify it
     /// then put it into cache for future use.
     fn verify_msg_sig(&self, msg: &SignedMessage) -> Result<(), Error> {
-        let cid = msg.cid()?;
+        let cid = msg.cid();
 
         if let Some(()) = self.sig_val_cache.lock().get(&cid) {
             return Ok(());
@@ -592,9 +592,7 @@ where
     T: Provider,
 {
     if msg.signature().signature_type() == SignatureType::Bls {
-        bls_sig_cache
-            .lock()
-            .put(msg.cid()?, msg.signature().clone());
+        bls_sig_cache.lock().put(msg.cid(), msg.signature().clone());
     }
 
     if msg.message().gas_limit > 100_000_000 {

--- a/src/message_pool/msgpool/utils.rs
+++ b/src/message_pool/msgpool/utils.rs
@@ -50,7 +50,7 @@ pub(in crate::message_pool) fn recover_sig(
     msg: Message,
 ) -> Result<SignedMessage, Error> {
     let val = bls_sig_cache
-        .get(&msg.cid()?)
+        .get(&msg.cid())
         .ok_or_else(|| Error::Other("Could not recover sig".to_owned()))?;
     let smsg = SignedMessage::new_from_parts(msg, val.clone())?;
     Ok(smsg)

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -716,7 +716,7 @@ fn load_api_messages_from_tipset(
     let mut seen = CidHashSet::default();
     for block in blocks {
         for msg in block.bls_msgs() {
-            let cid = msg.cid()?;
+            let cid = msg.cid();
             if seen.insert(cid) {
                 messages.push(ApiMessage {
                     cid,
@@ -726,7 +726,7 @@ fn load_api_messages_from_tipset(
         }
 
         for msg in block.secp_msgs() {
-            let cid = msg.cid()?;
+            let cid = msg.cid();
             if seen.insert(cid) {
                 messages.push(ApiMessage {
                     cid,

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1136,11 +1136,11 @@ pub fn new_eth_tx_from_signed_message<DB: Blockstore>(
     } else if smsg.is_secp256k1() {
         // Secp Filecoin Message
         let tx = eth_tx_from_native_message(smsg.message(), state, chain_id)?;
-        (tx, smsg.cid()?.into())
+        (tx, smsg.cid().into())
     } else {
         // BLS Filecoin message
         let tx = eth_tx_from_native_message(smsg.message(), state, chain_id)?;
-        (tx, smsg.message().cid()?.into())
+        (tx, smsg.message().cid().into())
     };
     Ok(Tx { hash, ..tx })
 }
@@ -1357,10 +1357,10 @@ fn count_messages_in_tipset(store: &impl Blockstore, ts: &Tipset) -> anyhow::Res
     for block in ts.block_headers() {
         let (bls_messages, secp_messages) = crate::chain::store::block_messages(store, block)?;
         for m in bls_messages {
-            message_cids.insert(m.cid()?);
+            message_cids.insert(m.cid());
         }
         for m in secp_messages {
-            message_cids.insert(m.cid()?);
+            message_cids.insert(m.cid());
         }
     }
     Ok(message_cids.len())

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1723,9 +1723,9 @@ impl RpcMethod<1> for EthGetTransactionHashByCid {
                     let chain_id = ctx.state_manager.chain_config().eth_chain_id;
                     eth_tx_from_signed_eth_message(smsg, chain_id)?.eth_hash()?
                 } else if smsg.is_secp256k1() {
-                    smsg.cid()?.into()
+                    smsg.cid().into()
                 } else {
-                    smsg.message().cid()?.into()
+                    smsg.message().cid().into()
                 };
                 return Ok(Some(hash));
             }
@@ -1733,7 +1733,7 @@ impl RpcMethod<1> for EthGetTransactionHashByCid {
 
         let msg_result = crate::chain::get_chain_message(ctx.chain_store.blockstore(), &cid);
         if let Ok(msg) = msg_result {
-            return Ok(Some(msg.cid()?.into()));
+            return Ok(Some(msg.cid().into()));
         }
 
         Ok(None)

--- a/src/rpc/methods/mpool.rs
+++ b/src/rpc/methods/mpool.rs
@@ -58,7 +58,7 @@ impl RpcMethod<1> for MpoolPending {
 
         let mut have_cids = HashSet::new();
         for item in pending.iter() {
-            have_cids.insert(item.cid()?);
+            have_cids.insert(item.cid());
         }
 
         if mpts.epoch() > ts.epoch() {
@@ -78,7 +78,7 @@ impl RpcMethod<1> for MpoolPending {
                     .messages_for_blocks(ts.block_headers().iter())?;
 
                 for sm in have {
-                    have_cids.insert(sm.cid()?);
+                    have_cids.insert(sm.cid());
                 }
             }
 
@@ -88,11 +88,11 @@ impl RpcMethod<1> for MpoolPending {
                 .messages_for_blocks(ts.block_headers().iter())?;
 
             for m in msgs {
-                if have_cids.contains(&m.cid()?) {
+                if have_cids.contains(&m.cid()) {
                     continue;
                 }
 
-                have_cids.insert(m.cid()?);
+                have_cids.insert(m.cid());
                 pending.push(m);
             }
 
@@ -206,7 +206,7 @@ impl RpcMethod<2> for MpoolPushMessage {
         let sig = crate::key_management::sign(
             *key.key_info.key_type(),
             key.key_info.private_key(),
-            umsg.cid().unwrap().to_bytes().as_slice(),
+            umsg.cid().to_bytes().as_slice(),
         )?;
 
         let smsg = SignedMessage::new_from_parts(umsg, sig)?;

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -2062,7 +2062,7 @@ impl RpcMethod<3> for StateListMessages {
 
             for msg in msgs {
                 if from_to.matches(msg.message()) {
-                    out.push(msg.cid()?);
+                    out.push(msg.cid());
                 }
             }
 

--- a/src/rpc/methods/state/types.rs
+++ b/src/rpc/methods/state/types.rs
@@ -84,7 +84,7 @@ lotus_json_with_self!(MessageGasCost);
 impl MessageGasCost {
     pub fn new(message: &Message, apply_ret: &ApplyRet) -> anyhow::Result<Self> {
         Ok(Self {
-            message: Some(message.cid()?),
+            message: Some(message.cid()),
             gas_used: TokenAmount::from_atto(apply_ret.msg_receipt().gas_used()),
             base_fee_burn: apply_ret.base_fee_burn(),
             over_estimation_burn: apply_ret.over_estimation_burn(),

--- a/src/shim/message.rs
+++ b/src/shim/message.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 
 use fvm_ipld_encoding::de::Deserializer;
 use fvm_ipld_encoding::ser::Serializer;
-use fvm_ipld_encoding::{Error as EncError, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared2::message::Message as Message_v2;
 pub use fvm_shared3::message::Message as Message_v3;
 pub use fvm_shared3::METHOD_SEND;
@@ -179,9 +179,9 @@ impl Message {
         }
     }
 
-    pub fn cid(&self) -> Result<cid::Cid, EncError> {
+    pub fn cid(&self) -> cid::Cid {
         use crate::utils::cid::CidCborExt;
-        cid::Cid::from_cbor_blake2b256(self)
+        cid::Cid::from_cbor_blake2b256(self).expect("message serialization is infallible")
     }
 
     /// Tests if a message is equivalent to another replacing message.

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -478,7 +478,7 @@ where
         Ok(ApiInvocResult {
             msg: msg.clone(),
             msg_rct: Some(apply_ret.msg_receipt()),
-            msg_cid: msg.cid().map_err(|err| Error::Other(err.to_string()))?,
+            msg_cid: msg.cid(),
             error: apply_ret.failure_info().unwrap_or_default(),
             duration: duration.as_nanos().clamp(0, u64::MAX as u128) as u64,
             gas_cost: MessageGasCost::default(),
@@ -587,7 +587,7 @@ where
                     if api_invoc_result.is_none() && ctx.cid == mcid =>
                 {
                     api_invoc_result = Some(ApiInvocResult {
-                        msg_cid: ctx.message.cid()?,
+                        msg_cid: ctx.message.cid(),
                         msg: ctx.message.message().clone(),
                         msg_rct: Some(ctx.apply_ret.msg_receipt()),
                         error: ctx.apply_ret.failure_info().unwrap_or_default(),
@@ -760,8 +760,8 @@ where
                 if !allow_replaced && message.cid() != m.cid(){
                     Err(Error::Other(format!(
                         "found message with equal nonce and call params but different CID. wanted {}, found: {}, nonce: {}, from: {}",
-                        message.cid().unwrap_or_default(),
-                        m.cid().unwrap_or_default(),
+                        message.cid(),
+                        m.cid(),
                         message.sequence(),
                         message.from(),
                     )))

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -649,7 +649,7 @@ fn miner_create_block_test(
     let signed_bls_msgs = bls_messages
         .into_iter()
         .map(|message| {
-            let sig = priv_key.sign(message.cid().expect("unexpected").to_bytes());
+            let sig = priv_key.sign(message.cid().to_bytes());
             SignedMessage {
                 message,
                 signature: Signature::new_bls(sig.as_bytes().to_vec()),
@@ -1342,12 +1342,12 @@ fn sample_message_cids<'a>(
     secp_messages: impl Iterator<Item = &'a SignedMessage> + 'a,
 ) -> impl Iterator<Item = Cid> + 'a {
     bls_messages
-        .filter_map(|m| m.cid().ok())
+        .map(|m| m.cid())
         .unique()
         .take(COLLECTION_SAMPLE_SIZE)
         .chain(
             secp_messages
-                .filter_map(|m| m.cid().ok())
+                .map(|m| m.cid())
                 .unique()
                 .take(COLLECTION_SAMPLE_SIZE),
         )

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -494,8 +494,8 @@ mod structured {
     ) -> anyhow::Result<serde_json::Value> {
         let is_explicit = matches!(called_at.apply_kind(), fvm3::executor::ApplyKind::Explicit);
 
-        let chain_message_cid = chain_message.cid()?;
-        let unsigned_message_cid = chain_message.message().cid()?;
+        let chain_message_cid = chain_message.cid();
+        let unsigned_message_cid = chain_message.message().cid();
 
         Ok(json!({
             "MsgCid": chain_message_cid.into_lotus_json(),

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -523,7 +523,7 @@ impl WalletCommands {
                     let sig = crate::key_management::sign(
                         *key.key_info.key_type(),
                         key.key_info.private_key(),
-                        message.cid().unwrap().to_bytes().as_slice(),
+                        message.cid().to_bytes().as_slice(),
                     )?;
 
                     let smsg = SignedMessage::new_from_parts(message, sig)?;
@@ -534,7 +534,7 @@ impl WalletCommands {
                     MpoolPushMessage::call(&backend.remote, (message, None)).await?
                 };
 
-                println!("{}", signed_msg.cid().unwrap());
+                println!("{}", signed_msg.cid());
 
                 Ok(())
             }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- All messages have a CID; message serialization cannot fail.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
