### PR TITLE
chore: use latest Lotus minor in updates

### DIFF
--- a/.github/workflows/lotus-api-bump.yml
+++ b/.github/workflows/lotus-api-bump.yml
@@ -16,8 +16,17 @@ jobs:
         run: |
           NETWORK=calibnet
           TAG=$(curl --silent https://api.github.com/repos/filecoin-project/lotus/releases | jq -r 'first | .tag_name')
-          sed -i "s/\(LOTUS_IMAGE=.*\):.*/\1:$TAG-$NETWORK/" ./scripts/tests/api_compare/.env
-          sed -i "s/\(LOTUS_IMAGE=.*\):.*/\1:$TAG-$NETWORK/" ./scripts/tests/snapshot_parity/.env
+          CURRENT_TAG=$(grep -oP 'LOTUS_IMAGE=.*:\K.*' ./scripts/tests/api_compare/.env)
+          # If the the latest tag reported by the API is greater than the one we are currently using, update it.
+          # This avoids PRs when a new tag is of lower major/minor version than the current one. We still need to follow the
+          # largest version for calibration network compatibility.
+          if [ "$(printf '%s\n' "$TAG" "$CURRENT_TAG" | sort -V | tail -n1)" != "$CURRENT_TAG" ]; then
+            echo "Updating Lotus version to $TAG"
+            sed -i "s/\(LOTUS_IMAGE=.*\):.*/\1:$TAG-$NETWORK/" ./scripts/tests/api_compare/.env
+            sed -i "s/\(LOTUS_IMAGE=.*\):.*/\1:$TAG-$NETWORK/" ./scripts/tests/snapshot_parity/.env
+          else
+            echo "Lotus version is already up to date"
+          fi
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- use latest Lotus major/minor in the updates so that the automated workflow doesn't update `1.28.0` to `1.27.42` if the latter happens to be the latest release.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
