### PR TITLE
fix: reveal the proper logo for the waffle upgrade

### DIFF
--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -109,7 +109,7 @@ where
                 .map(|sr| format!("{}", sr.actors))
                 .unwrap_or_default();
             if new_state != *parent_state {
-                crate::utils::misc::reveal_upgrade_logo(chain_config.network_version(epoch));
+                crate::utils::misc::reveal_upgrade_logo(height.into());
                 tracing::info!("State migration at height {height}(epoch {epoch}) was successful, Previous state: {parent_state}, new state: {new_state}, new state actors: {new_state_actors}. Took: {elapsed}s.");
             } else {
                 anyhow:: bail!("State post migration at height {height} must not match. Previous state: {parent_state}, new state: {new_state}, new state actors: {new_state_actors}. Took {elapsed}s.");


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

There seems to be some off-by-1 error in the current logic that in CI devnet test it reveals the wrong logo on the waffle upgrade, see https://github.com/ChainSafe/forest/actions/runs/9958493368/job/27513328498#step:8:427

After the fix, see https://github.com/ChainSafe/forest/actions/runs/9965722823/job/27536633471?pr=4541#step:8:438

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
