### PR TITLE
fix(rpc): remove duplicate fields from rpc state

### DIFF
--- a/src/chain_sync/tipset_syncer.rs
+++ b/src/chain_sync/tipset_syncer.rs
@@ -1253,7 +1253,7 @@ async fn validate_block<DB: Blockstore + Sync + Send + 'static>(
     state_manager: Arc<StateManager<DB>>,
     block: Arc<Block>,
 ) -> Result<Arc<Block>, (Cid, TipsetRangeSyncerError)> {
-    let consensus = FilecoinConsensus::new(state_manager.beacon_schedule());
+    let consensus = FilecoinConsensus::new(state_manager.beacon_schedule().clone());
     trace!(
         "Validating block: epoch = {}, weight = {}, key = {}",
         block.header().epoch,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -384,15 +384,9 @@ pub(super) async fn start(
     if config.client.enable_rpc {
         let keystore_rpc = Arc::clone(&keystore);
         let rpc_state_manager = Arc::clone(&state_manager);
-        let rpc_chain_store = Arc::clone(&chain_store);
         let rpc_address = config.client.rpc_address;
 
         info!("JSON-RPC endpoint will listen at {rpc_address}");
-        let beacon = Arc::new(
-            rpc_state_manager
-                .chain_config()
-                .get_beacon_schedule(chain_store.genesis_block_header().timestamp),
-        );
 
         services.spawn(async move {
             start_rpc(
@@ -405,8 +399,6 @@ pub(super) async fn start(
                     network_send,
                     network_name,
                     start_time,
-                    beacon,
-                    chain_store: rpc_chain_store,
                     shutdown: shutdown_send,
                     tipset_send: tipset_sender,
                 },

--- a/src/rpc/methods/beacon.rs
+++ b/src/rpc/methods/beacon.rs
@@ -23,8 +23,7 @@ impl RpcMethod<1> for BeaconGetEntry {
         ctx: Ctx<impl Blockstore>,
         (first,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let beacon_schedule = ctx.beacon();
-        let (_, beacon) = beacon_schedule.beacon_for_epoch(first)?;
+        let (_, beacon) = ctx.beacon().beacon_for_epoch(first)?;
         let rr =
             beacon.max_beacon_round_for_epoch(ctx.state_manager.get_network_version(first), first);
         let e = beacon.entry(rr).await?;

--- a/src/rpc/methods/beacon.rs
+++ b/src/rpc/methods/beacon.rs
@@ -23,7 +23,8 @@ impl RpcMethod<1> for BeaconGetEntry {
         ctx: Ctx<impl Blockstore>,
         (first,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let (_, beacon) = ctx.beacon.beacon_for_epoch(first)?;
+        let beacon_schedule = ctx.beacon();
+        let (_, beacon) = beacon_schedule.beacon_for_epoch(first)?;
         let rr =
             beacon.max_beacon_round_for_epoch(ctx.state_manager.get_network_version(first), first);
         let e = beacon.entry(rr).await?;

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -84,7 +84,7 @@ impl RpcMethod<1> for ChainGetParentMessages {
         ctx: Ctx<impl Blockstore>,
         (block_cid,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let store = ctx.state_manager.blockstore();
+        let store = ctx.store();
         let block_header: CachingBlockHeader = store
             .get_cbor(&block_cid)?
             .with_context(|| format!("can't find block header with cid {block_cid}"))?;
@@ -111,7 +111,7 @@ impl RpcMethod<1> for ChainGetParentReceipts {
         ctx: Ctx<impl Blockstore>,
         (block_cid,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let store = ctx.state_manager.blockstore();
+        let store = ctx.store();
         let block_header: CachingBlockHeader = store
             .get_cbor(&block_cid)?
             .with_context(|| format!("can't find block header with cid {block_cid}"))?;
@@ -156,7 +156,7 @@ impl RpcMethod<1> for ChainGetMessagesInTipset {
         ctx: Ctx<impl Blockstore>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let tipset = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let tipset = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         load_api_messages_from_tipset(ctx.store(), &tipset)
     }
 }
@@ -191,7 +191,7 @@ impl RpcMethod<1> for ChainExport {
             return Err(anyhow::anyhow!("Another chain export job is still in progress").into());
         }
 
-        let chain_finality = ctx.state_manager.chain_config().policy.chain_finality;
+        let chain_finality = ctx.chain_config().policy.chain_finality;
         if recent_roots < chain_finality {
             return Err(anyhow::anyhow!(format!(
                 "recent-stateroots must be greater than {chain_finality}"
@@ -199,16 +199,14 @@ impl RpcMethod<1> for ChainExport {
             .into());
         }
 
-        let head = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let start_ts = ctx.chain_store.chain_index.tipset_by_height(
-            epoch,
-            head,
-            ResolveNullTipset::TakeOlder,
-        )?;
+        let head = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let start_ts =
+            ctx.chain_index()
+                .tipset_by_height(epoch, head, ResolveNullTipset::TakeOlder)?;
 
         match if dry_run {
             crate::chain::export::<Sha256>(
-                Arc::clone(&ctx.chain_store.db),
+                ctx.store_owned(),
                 &start_ts,
                 recent_roots,
                 VoidAsyncWriter,
@@ -219,7 +217,7 @@ impl RpcMethod<1> for ChainExport {
         } else {
             let file = tokio::fs::File::create(&output_path).await?;
             crate::chain::export::<Sha256>(
-                Arc::clone(&ctx.chain_store.db),
+                ctx.store_owned(),
                 &start_ts,
                 recent_roots,
                 file,
@@ -271,7 +269,7 @@ impl RpcMethod<1> for ChainHasObj {
         ctx: Ctx<impl Blockstore>,
         (cid,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        Ok(ctx.state_manager.blockstore().get(&cid)?.is_some())
+        Ok(ctx.store().get(&cid)?.is_some())
     }
 }
 
@@ -343,15 +341,11 @@ impl RpcMethod<1> for ChainGetBlockMessages {
         ctx: Ctx<impl Blockstore>,
         (cid,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let blk: CachingBlockHeader = ctx.state_manager.blockstore().get_cbor_required(&cid)?;
+        let blk: CachingBlockHeader = ctx.store().get_cbor_required(&cid)?;
         let blk_msgs = &blk.messages;
-        let (unsigned_cids, signed_cids) =
-            crate::chain::read_msg_cids(ctx.state_manager.blockstore(), blk_msgs)?;
-        let (bls_msg, secp_msg) = crate::chain::block_messages_from_cids(
-            ctx.state_manager.blockstore(),
-            &unsigned_cids,
-            &signed_cids,
-        )?;
+        let (unsigned_cids, signed_cids) = crate::chain::read_msg_cids(ctx.store(), blk_msgs)?;
+        let (bls_msg, secp_msg) =
+            crate::chain::block_messages_from_cids(ctx.store(), &unsigned_cids, &signed_cids)?;
         let cids = unsigned_cids.into_iter().chain(signed_cids).collect();
 
         let ret = BlockMessages {
@@ -377,7 +371,7 @@ impl RpcMethod<2> for ChainGetPath {
         ctx: Ctx<impl Blockstore>,
         (from, to): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        impl_chain_get_path(&ctx.chain_store, &from, &to).map_err(Into::into)
+        impl_chain_get_path(ctx.chain_store(), &from, &to).map_err(Into::into)
     }
 }
 
@@ -505,7 +499,7 @@ impl RpcMethod<0> for ChainGetGenesis {
     type Ok = Option<Tipset>;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
-        let genesis = ctx.state_manager.chain_store().genesis_block_header();
+        let genesis = ctx.chain_store().genesis_block_header();
         Ok(Some(Tipset::from(genesis)))
     }
 }
@@ -521,7 +515,7 @@ impl RpcMethod<0> for ChainHead {
     type Ok = Tipset;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
-        let heaviest = ctx.state_manager.chain_store().heaviest_tipset();
+        let heaviest = ctx.chain_store().heaviest_tipset();
         Ok((*heaviest).clone())
     }
 }
@@ -540,7 +534,7 @@ impl RpcMethod<1> for ChainGetBlock {
         ctx: Ctx<impl Blockstore>,
         (cid,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let blk: CachingBlockHeader = ctx.state_manager.blockstore().get_cbor_required(&cid)?;
+        let blk: CachingBlockHeader = ctx.store().get_cbor_required(&cid)?;
         Ok(blk)
     }
 }
@@ -584,23 +578,14 @@ impl RpcMethod<1> for ChainSetHead {
         // This is basically a port of the reference implementation at
         // https://github.com/filecoin-project/lotus/blob/v1.23.0/node/impl/full/chain.go#L321
 
-        let new_head = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
-        let mut current = ctx.state_manager.chain_store().heaviest_tipset();
+        let new_head = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let mut current = ctx.chain_store().heaviest_tipset();
         while current.epoch() >= new_head.epoch() {
             for cid in current.key().to_cids() {
-                ctx.state_manager
-                    .chain_store()
-                    .unmark_block_as_validated(&cid);
+                ctx.chain_store().unmark_block_as_validated(&cid);
             }
             let parents = &current.block_headers().first().parents;
-            current = ctx
-                .state_manager
-                .chain_store()
-                .chain_index
-                .load_required_tipset(parents)?;
+            current = ctx.chain_index().load_required_tipset(parents)?;
         }
         ctx.state_manager
             .chain_store()
@@ -623,16 +608,12 @@ impl RpcMethod<1> for ChainGetMinBaseFee {
         ctx: Ctx<impl Blockstore>,
         (lookback,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let mut current = ctx.state_manager.chain_store().heaviest_tipset();
+        let mut current = ctx.chain_store().heaviest_tipset();
         let mut min_base_fee = current.block_headers().first().parent_base_fee.clone();
 
         for _ in 0..lookback {
             let parents = &current.block_headers().first().parents;
-            current = ctx
-                .state_manager
-                .chain_store()
-                .chain_index
-                .load_required_tipset(parents)?;
+            current = ctx.chain_index().load_required_tipset(parents)?;
 
             min_base_fee =
                 min_base_fee.min(current.block_headers().first().parent_base_fee.to_owned());
@@ -656,8 +637,8 @@ impl RpcMethod<1> for ChainTipSetWeight {
         ctx: Ctx<impl Blockstore>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let tsk = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let weight = crate::fil_cns::weight(ctx.chain_store.blockstore(), &tsk)?;
+        let tsk = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let weight = crate::fil_cns::weight(ctx.store(), &tsk)?;
         Ok(weight)
     }
 }
@@ -670,7 +651,7 @@ pub(crate) fn chain_notify<DB: Blockstore>(
     let (sender, receiver) = broadcast::channel(100);
 
     // As soon as the channel is created, send the current tipset
-    let current = data.chain_store.heaviest_tipset();
+    let current = data.chain_store().heaviest_tipset();
     let (change, tipset) = ("current".into(), current);
     sender
         .send(vec![ApiHeadChange {
@@ -679,7 +660,7 @@ pub(crate) fn chain_notify<DB: Blockstore>(
         }])
         .expect("receiver is not dropped");
 
-    let mut subscriber = data.chain_store.publisher().subscribe();
+    let mut subscriber = data.chain_store().publisher().subscribe();
 
     tokio::spawn(async move {
         // Skip first message

--- a/src/rpc/methods/common.rs
+++ b/src/rpc/methods/common.rs
@@ -44,7 +44,7 @@ impl RpcMethod<0> for Version {
         Ok(PublicVersion {
             version: crate::utils::version::FOREST_VERSION_STRING.clone(),
             api_version: ShiftingVersion::new(v.major, v.minor, v.patch),
-            block_delay: ctx.state_manager.chain_config().block_delay_secs,
+            block_delay: ctx.chain_config().block_delay_secs,
         })
     }
 }

--- a/src/rpc/methods/gas.rs
+++ b/src/rpc/methods/gas.rs
@@ -43,7 +43,7 @@ fn estimate_fee_cap<DB: Blockstore>(
     max_queue_blks: i64,
     _: ApiTipsetKey,
 ) -> Result<TokenAmount, ServerError> {
-    let ts = data.state_manager.chain_store().heaviest_tipset();
+    let ts = data.chain_store().heaviest_tipset();
 
     let parent_base_fee = &ts.block_headers().first().parent_base_fee;
     let increase_factor =
@@ -94,7 +94,7 @@ pub async fn estimate_gas_premium<DB: Blockstore>(
     let mut prices: Vec<GasMeta> = Vec::new();
     let mut blocks = 0;
 
-    let mut ts = data.state_manager.chain_store().heaviest_tipset();
+    let mut ts = data.chain_store().heaviest_tipset();
 
     for _ in 0..(nblocksincl * 2) {
         if ts.epoch() == 0 {
@@ -106,7 +106,7 @@ pub async fn estimate_gas_premium<DB: Blockstore>(
             .chain_index
             .load_required_tipset(ts.parents())?;
         blocks += pts.block_headers().len();
-        let msgs = crate::chain::messages_for_tipset(data.state_manager.blockstore_owned(), &pts)?;
+        let msgs = crate::chain::messages_for_tipset(data.store_owned(), &pts)?;
 
         prices.append(
             &mut msgs

--- a/src/rpc/methods/gas.rs
+++ b/src/rpc/methods/gas.rs
@@ -100,11 +100,7 @@ pub async fn estimate_gas_premium<DB: Blockstore>(
         if ts.epoch() == 0 {
             break;
         }
-        let pts = data
-            .state_manager
-            .chain_store()
-            .chain_index
-            .load_required_tipset(ts.parents())?;
+        let pts = data.chain_index().load_required_tipset(ts.parents())?;
         blocks += pts.block_headers().len();
         let msgs = crate::chain::messages_for_tipset(data.store_owned(), &pts)?;
 
@@ -210,10 +206,7 @@ where
     msg.set_gas_fee_cap(TokenAmount::from_atto(0));
     msg.set_gas_premium(TokenAmount::from_atto(0));
 
-    let curr_ts = data
-        .state_manager
-        .chain_store()
-        .load_required_tipset_or_heaviest(tsk)?;
+    let curr_ts = data.chain_store().load_required_tipset_or_heaviest(tsk)?;
     let from_a = data
         .state_manager
         .resolve_to_key_addr(&msg.from, &curr_ts)

--- a/src/rpc/methods/miner.rs
+++ b/src/rpc/methods/miner.rs
@@ -132,8 +132,7 @@ impl RpcMethod<1> for MinerCreateBlock {
         let parent_base_fee = compute_base_fee(
             store,
             &parent_tipset,
-            ctx.state_manager
-                .chain_config()
+            ctx.chain_config()
                 .height_infos
                 .get(&Height::Smoke)
                 .context("Missing Smoke height")?
@@ -282,10 +281,7 @@ impl RpcMethod<3> for MinerGetBaseInfo {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, epoch, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
 
         Ok(ctx
             .state_manager

--- a/src/rpc/methods/mpool.rs
+++ b/src/rpc/methods/mpool.rs
@@ -49,10 +49,7 @@ impl RpcMethod<1> for MpoolPending {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let mut ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let mut ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
 
         let (mut pending, mpts) = ctx.mpool.pending()?;
 
@@ -100,11 +97,7 @@ impl RpcMethod<1> for MpoolPending {
                 break;
             }
 
-            ts = ctx
-                .state_manager
-                .chain_store()
-                .chain_index
-                .load_required_tipset(ts.parents())?;
+            ts = ctx.chain_index().load_required_tipset(ts.parents())?;
         }
         Ok(NotNullVec(pending.into_iter().collect()))
     }
@@ -125,10 +118,7 @@ impl RpcMethod<2> for MpoolSelect {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk), ticket_quality): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx.mpool.select_messages(&ts, ticket_quality)?)
     }
 }

--- a/src/rpc/methods/mpool.rs
+++ b/src/rpc/methods/mpool.rs
@@ -174,7 +174,7 @@ impl RpcMethod<2> for MpoolPushMessage {
         let from = umsg.from;
 
         let mut keystore = ctx.keystore.as_ref().write().await;
-        let heaviest_tipset = ctx.state_manager.chain_store().heaviest_tipset();
+        let heaviest_tipset = ctx.chain_store().heaviest_tipset();
         let key_addr = ctx
             .state_manager
             .resolve_to_key_addr(&from, &heaviest_tipset)

--- a/src/rpc/methods/msig.rs
+++ b/src/rpc/methods/msig.rs
@@ -26,7 +26,7 @@ impl RpcMethod<2> for MsigGetAvailableBalance {
         ctx: Ctx<impl Blockstore>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let height = ts.epoch();
         let actor = ctx
             .state_manager
@@ -54,7 +54,7 @@ impl RpcMethod<2> for MsigGetPending {
         ctx: Ctx<impl Blockstore>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -90,9 +90,11 @@ impl RpcMethod<3> for MsigGetVested {
         (addr, ApiTipsetKey(start_tsk), ApiTipsetKey(end_tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let start_ts = ctx
-            .chain_store
+            .chain_store()
             .load_required_tipset_or_heaviest(&start_tsk)?;
-        let end_ts = ctx.chain_store.load_required_tipset_or_heaviest(&end_tsk)?;
+        let end_ts = ctx
+            .chain_store()
+            .load_required_tipset_or_heaviest(&end_tsk)?;
 
         match start_ts.epoch().cmp(&end_ts.epoch()) {
             std::cmp::Ordering::Greater => Err(ServerError::internal_error(
@@ -127,7 +129,7 @@ impl RpcMethod<2> for MsigGetVestingSchedule {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (addr, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
 
         let msig_actor = ctx
             .state_manager

--- a/src/rpc/methods/net.rs
+++ b/src/rpc/methods/net.rs
@@ -232,7 +232,7 @@ impl RpcMethod<0> for NetVersion {
     type Ok = String;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
-        Ok(ctx.state_manager.chain_config().eth_chain_id.to_string())
+        Ok(ctx.chain_config().eth_chain_id.to_string())
     }
 }
 

--- a/src/rpc/methods/node.rs
+++ b/src/rpc/methods/node.rs
@@ -24,7 +24,7 @@ impl RpcMethod<0> for NodeStatus {
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
         let mut node_status = NodeStatusResult::default();
 
-        let head = ctx.state_manager.chain_store().heaviest_tipset();
+        let head = ctx.chain_store().heaviest_tipset();
         let cur_duration: Duration = SystemTime::now().duration_since(UNIX_EPOCH)?;
 
         let ts = head.min_timestamp();
@@ -38,7 +38,7 @@ impl RpcMethod<0> for NodeStatus {
             .into());
         };
 
-        let chain_finality = ctx.state_manager.chain_config().policy.chain_finality;
+        let chain_finality = ctx.chain_config().policy.chain_finality;
 
         node_status.sync_status.epoch = head.epoch() as u64;
         node_status.sync_status.behind = behind;
@@ -50,7 +50,7 @@ impl RpcMethod<0> for NodeStatus {
             for _ in 0..100 {
                 block_count += ts.block_headers().len();
                 let tsk = ts.parents();
-                ts = ctx.chain_store.chain_index.load_required_tipset(tsk)?;
+                ts = ctx.chain_index().load_required_tipset(tsk)?;
             }
 
             node_status.chain_status.blocks_per_tipset_last_100 = block_count as f64 / 100.;
@@ -58,7 +58,7 @@ impl RpcMethod<0> for NodeStatus {
             for _ in 100..chain_finality {
                 block_count += ts.block_headers().len();
                 let tsk = ts.parents();
-                ts = ctx.chain_store.chain_index.load_required_tipset(tsk)?;
+                ts = ctx.chain_index().load_required_tipset(tsk)?;
             }
 
             node_status.chain_status.blocks_per_tipset_last_finality =

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -29,7 +29,6 @@ use crate::shim::{
     address::Address, clock::ChainEpoch, deal::DealID, econ::TokenAmount, executor::Receipt,
     state_tree::ActorState, version::NetworkVersion,
 };
-use crate::state_manager::chain_rand::ChainRand;
 use crate::state_manager::circulating_supply::GenesisInfo;
 use crate::state_manager::MarketBalance;
 use crate::utils::db::{
@@ -86,14 +85,10 @@ impl RpcMethod<2> for StateCall {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (message, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let state_manager = &ctx.state_manager;
-        let tipset = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let tipset = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         // Handle expensive fork error?
         // TODO(elmattic): https://github.com/ChainSafe/forest/issues/3733
-        Ok(state_manager.call(&message, Some(tipset))?)
+        Ok(ctx.state_manager.call(&message, Some(tipset))?)
     }
 }
 
@@ -113,12 +108,8 @@ impl RpcMethod<2> for StateReplay {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk), message_cid): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let state_manager = &ctx.state_manager;
-        let tipset = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
-        Ok(state_manager.replay(tipset, message_cid).await?)
+        let tipset = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        Ok(ctx.state_manager.replay(tipset, message_cid).await?)
     }
 }
 
@@ -133,10 +124,10 @@ impl RpcMethod<0> for StateNetworkName {
     type Ok = String;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
-        let state_manager = &ctx.state_manager;
-        let heaviest_tipset = state_manager.chain_store().heaviest_tipset();
-
-        Ok(state_manager.get_network_name(heaviest_tipset.parent_state())?)
+        let heaviest_tipset = ctx.chain_store().heaviest_tipset();
+        Ok(ctx
+            .state_manager
+            .get_network_name(heaviest_tipset.parent_state())?)
     }
 }
 
@@ -154,7 +145,7 @@ impl RpcMethod<1> for StateNetworkVersion {
         ctx: Ctx<impl Blockstore>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx.state_manager.get_network_version(ts.epoch()))
     }
 }
@@ -176,7 +167,7 @@ impl RpcMethod<2> for StateAccountKey {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx
             .state_manager
             .resolve_to_deterministic_address(address, ts)
@@ -201,7 +192,7 @@ impl RpcMethod<2> for StateLookupID {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx
             .state_manager
             .lookup_required_id(&address, ts.as_ref())?)
@@ -225,7 +216,7 @@ impl RpcMethod<2> for StateVerifierStatus {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let aid = ctx
             .state_manager
             .lookup_required_id(&address, ts.as_ref())?;
@@ -253,7 +244,7 @@ impl RpcMethod<2> for StateGetActor {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let state = ctx.state_manager.get_actor(&address, *ts.parent_state())?;
         Ok(state)
     }
@@ -276,7 +267,7 @@ impl RpcMethod<2> for StateMarketBalance {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         ctx.state_manager
             .market_balance(&address, &ts)
             .map_err(From::from)
@@ -298,7 +289,7 @@ impl RpcMethod<1> for StateMarketDeals {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&Address::MARKET_ACTOR, *ts.parent_state())?;
@@ -345,7 +336,7 @@ impl RpcMethod<2> for StateMinerInfo {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx.state_manager.miner_info(&address, &ts)?)
     }
 }
@@ -365,8 +356,8 @@ impl RpcMethod<2> for StateMinerActiveSectors {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let policy = &ctx.state_manager.chain_config().policy;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let policy = &ctx.chain_config().policy;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -401,7 +392,7 @@ impl RpcMethod<2> for StateMinerAllocated {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -426,8 +417,8 @@ impl RpcMethod<3> for StateMinerPartitions {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, dl_idx, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let policy = &ctx.state_manager.chain_config().policy;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let policy = &ctx.chain_config().policy;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -463,7 +454,7 @@ impl RpcMethod<3> for StateMinerSectors {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, sectors, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -489,8 +480,8 @@ impl RpcMethod<2> for StateMinerSectorCount {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let policy = &ctx.state_manager.chain_config().policy;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let policy = &ctx.chain_config().policy;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -527,7 +518,7 @@ impl RpcMethod<3> for StateMinerSectorAllocated {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (miner_address, sector_number, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&miner_address, *ts.parent_state())?;
@@ -554,7 +545,7 @@ impl RpcMethod<2> for StateMinerPower {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         ctx.state_manager
             .miner_power(&address, &ts)
             .map_err(From::from)
@@ -576,8 +567,8 @@ impl RpcMethod<2> for StateMinerDeadlines {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let policy = &ctx.state_manager.chain_config().policy;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let policy = &ctx.chain_config().policy;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -610,8 +601,8 @@ impl RpcMethod<2> for StateMinerProvingDeadline {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let policy = &ctx.state_manager.chain_config().policy;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let policy = &ctx.chain_config().policy;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -636,7 +627,7 @@ impl RpcMethod<2> for StateMinerFaults {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         ctx.state_manager
             .miner_faults(&address, &ts)
             .map_err(From::from)
@@ -658,7 +649,7 @@ impl RpcMethod<2> for StateMinerRecoveries {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         ctx.state_manager
             .miner_recoveries(&address, &ts)
             .map_err(From::from)
@@ -680,7 +671,7 @@ impl RpcMethod<2> for StateMinerAvailableBalance {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -736,7 +727,7 @@ impl RpcMethod<3> for StateMinerInitialPledgeCollateral {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, pci, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
 
         let state = *ts.parent_state();
 
@@ -770,7 +761,7 @@ impl RpcMethod<3> for StateMinerInitialPledgeCollateral {
             .state_manager
             .get_required_actor(&Address::REWARD_ACTOR, state)?;
         let reward_state = reward::State::load(ctx.store(), actor.code, actor.state)?;
-        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config().clone());
+        let genesis_info = GenesisInfo::from_chain_config(ctx.chain_config().clone());
         let circ_supply = genesis_info.get_vm_circulating_supply_detailed(
             ts.epoch(),
             &Arc::new(ctx.store()),
@@ -805,7 +796,7 @@ impl RpcMethod<3> for StateMinerPreCommitDepositForPower {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, pci, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
 
         let state = *ts.parent_state();
 
@@ -867,10 +858,7 @@ impl RpcMethod<2> for StateGetReceipt {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (cid, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let tipset = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let tipset = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         ctx.state_manager
             .get_receipt(tipset, cid)
             .map_err(From::from)
@@ -1055,7 +1043,7 @@ impl RpcMethod<2> for StateFetchRoot {
         (root_cid, save_to_file): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let network_send = ctx.network_send.clone();
-        let db = ctx.chain_store.db.clone();
+        let db = ctx.store_owned();
 
         let (car_tx, car_handle) = if let Some(save_to_file) = save_to_file {
             let (car_tx, car_rx) = flume::bounded(100);
@@ -1218,9 +1206,9 @@ impl RpcMethod<1> for StateCompute {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (epoch,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let tipset = ctx.chain_store.chain_index.tipset_by_height(
+        let tipset = ctx.chain_index().tipset_by_height(
             epoch,
-            ctx.chain_store.heaviest_tipset(),
+            ctx.chain_store().heaviest_tipset(),
             ResolveNullTipset::TakeOlder,
         )?;
         let (state_root, _) = ctx
@@ -1259,14 +1247,8 @@ impl RpcMethod<4> for StateGetRandomnessFromTickets {
         ctx: Ctx<impl Blockstore>,
         (personalization, rand_epoch, entropy, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let tipset = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
-        let chain_config = ctx.state_manager.chain_config();
-        let chain_index = &ctx.chain_store.chain_index;
-        let beacon = ctx.state_manager.beacon_schedule();
-        let chain_rand = ChainRand::new(chain_config.clone(), tipset, chain_index.clone(), beacon);
+        let tipset = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let chain_rand = ctx.state_manager.chain_rand(tipset);
         let digest = chain_rand.get_chain_randomness(rand_epoch, false)?;
         let value = crate::state_manager::chain_rand::draw_randomness_from_digest(
             &digest,
@@ -1295,14 +1277,8 @@ impl RpcMethod<4> for StateGetRandomnessFromBeacon {
         ctx: Ctx<impl Blockstore>,
         (personalization, rand_epoch, entropy, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let tipset = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
-        let chain_config = ctx.state_manager.chain_config();
-        let chain_index = &ctx.chain_store.chain_index;
-        let beacon = ctx.state_manager.beacon_schedule();
-        let chain_rand = ChainRand::new(chain_config.clone(), tipset, chain_index.clone(), beacon);
+        let tipset = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let chain_rand = ctx.state_manager.chain_rand(tipset);
         let digest = chain_rand.get_beacon_randomness_v3(rand_epoch)?;
         let value = crate::state_manager::chain_rand::draw_randomness_from_digest(
             &digest,
@@ -1330,7 +1306,7 @@ impl RpcMethod<2> for StateReadState {
         ctx: Ctx<impl Blockstore>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&address, *ts.parent_state())?;
@@ -1361,10 +1337,10 @@ impl RpcMethod<1> for StateCirculatingSupply {
         ctx: Ctx<impl Blockstore>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let height = ts.epoch();
         let root = ts.parent_state();
-        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config().clone());
+        let genesis_info = GenesisInfo::from_chain_config(ctx.chain_config().clone());
         let supply = genesis_info.get_state_circulating_supply(height, &ctx.store_owned(), root)?;
         Ok(supply)
     }
@@ -1385,7 +1361,7 @@ impl RpcMethod<2> for StateVerifiedClientStatus {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let status = ctx.state_manager.verified_client_status(&address, &ts)?;
         Ok(status)
     }
@@ -1406,8 +1382,8 @@ impl RpcMethod<1> for StateVMCirculatingSupplyInternal {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
-        let genesis_info = GenesisInfo::from_chain_config(ctx.state_manager.chain_config().clone());
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
+        let genesis_info = GenesisInfo::from_chain_config(ctx.chain_config().clone());
         Ok(genesis_info.get_vm_circulating_supply_detailed(
             ts.epoch(),
             &ctx.store_owned(),
@@ -1431,7 +1407,7 @@ impl RpcMethod<1> for StateListMiners {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&Address::POWER_ACTOR, *ts.parent_state())?;
@@ -1461,7 +1437,7 @@ impl RpcMethod<1> for StateListActors {
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let mut actors = vec![];
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let state_tree = ctx.state_manager.get_state_tree(ts.parent_state())?;
         state_tree.for_each(|addr, _state| {
             actors.push(addr);
@@ -1486,7 +1462,7 @@ impl RpcMethod<2> for StateMarketStorageDeal {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (deal_id, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let store = ctx.store();
         let actor = ctx
             .state_manager
@@ -1517,7 +1493,7 @@ impl RpcMethod<1> for StateMarketParticipants {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let market_state = ctx.state_manager.market_state(&ts)?;
         let escrow_table = market_state.escrow_table(ctx.store())?;
         let locked_table = market_state.locked_table(ctx.store())?;
@@ -1574,17 +1550,17 @@ impl RpcMethod<3> for StateDealProviderCollateralBounds {
         let power_state = power::State::load(store, power_actor.code, power_actor.state)?;
         let reward_state = reward::State::load(store, reward_actor.code, reward_actor.state)?;
 
-        let genesis_info = GenesisInfo::from_chain_config(state_manager.chain_config().clone());
+        let genesis_info = GenesisInfo::from_chain_config(ctx.chain_config().clone());
 
         let supply = genesis_info.get_vm_circulating_supply(
             ts.epoch(),
-            &state_manager.blockstore_owned(),
+            &ctx.store_owned(),
             ts.parent_state(),
         )?;
 
         let power_claim = power_state.total_power();
 
-        let policy = &state_manager.chain_config().policy;
+        let policy = &ctx.chain_config().policy;
 
         let baseline_power = reward_state.this_epoch_baseline_power();
 
@@ -1624,8 +1600,8 @@ impl RpcMethod<1> for StateGetBeaconEntry {
         (epoch,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         {
-            let genesis_timestamp = ctx.chain_store.genesis_block_header().timestamp as i64;
-            let block_delay = ctx.state_manager.chain_config().block_delay_secs as i64;
+            let genesis_timestamp = ctx.chain_store().genesis_block_header().timestamp as i64;
+            let block_delay = ctx.chain_config().block_delay_secs as i64;
             // Give it a 1s clock drift buffer
             let epoch_timestamp = genesis_timestamp + block_delay * epoch + 1;
             let now_timestamp = chrono::Utc::now().timestamp();
@@ -1637,7 +1613,8 @@ impl RpcMethod<1> for StateGetBeaconEntry {
             };
         }
 
-        let (_, beacon) = ctx.beacon.beacon_for_epoch(epoch)?;
+        let beacon_schedule = ctx.beacon();
+        let (_, beacon) = beacon_schedule.beacon_for_epoch(epoch)?;
         let network_version = ctx.state_manager.get_network_version(epoch);
         let round = beacon.max_beacon_round_for_epoch(network_version, epoch);
         let entry = beacon.entry(round).await?;
@@ -1967,7 +1944,7 @@ impl RpcMethod<3> for StateSectorExpiration {
         (miner_address, sector_number, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let store = ctx.store();
-        let policy = &ctx.state_manager.chain_config().policy;
+        let policy = &ctx.chain_config().policy;
         let ts = ctx
             .state_manager
             .chain_store()
@@ -2092,7 +2069,7 @@ impl RpcMethod<3> for StateListMessages {
         let mut cur_ts = ts.clone();
 
         while cur_ts.epoch() >= max_height {
-            let msgs = ctx.chain_store.messages_for_tipset(&cur_ts)?;
+            let msgs = ctx.chain_store().messages_for_tipset(&cur_ts)?;
 
             for msg in msgs {
                 if from_to.matches(msg.message()) {
@@ -2104,10 +2081,7 @@ impl RpcMethod<3> for StateListMessages {
                 break;
             }
 
-            let next = ctx
-                .chain_store
-                .chain_index
-                .load_required_tipset(cur_ts.parents())?;
+            let next = ctx.chain_index().load_required_tipset(cur_ts.parents())?;
             cur_ts = next;
         }
 
@@ -2130,7 +2104,7 @@ impl RpcMethod<3> for StateGetClaim {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, claim_id, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx.state_manager.get_claim(&address, &ts, claim_id)?)
     }
 }
@@ -2150,7 +2124,7 @@ impl RpcMethod<2> for StateGetClaims {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(Self::get_claims(&ctx.store_owned(), &address, &ts)?)
     }
 }
@@ -2185,7 +2159,7 @@ impl RpcMethod<3> for StateGetAllocation {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, allocation_id, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx
             .state_manager
             .get_allocation(&address, &ts, allocation_id)?)
@@ -2207,7 +2181,7 @@ impl RpcMethod<2> for StateGetAllocations {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (address, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(Self::get_allocations(&ctx.store_owned(), &address, &ts)?)
     }
 }
@@ -2355,7 +2329,7 @@ impl RpcMethod<2> for StateGetAllocationIdForPendingDeal {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (deal_id, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let state_tree = StateTree::new_from_root(ctx.store_owned(), ts.parent_state())?;
         let market_actor = state_tree.get_required_actor(&Address::MARKET_ACTOR)?;
         let market_state = market::State::load(ctx.store(), market_actor.code, market_actor.state)?;
@@ -2415,7 +2389,7 @@ impl RpcMethod<0> for StateGetNetworkParams {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let config = ctx.state_manager.chain_config().as_ref();
+        let config = ctx.chain_config().as_ref();
         let policy = &config.policy;
 
         // This is the correct implementation, but for conformance with Lotus,

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1535,9 +1535,7 @@ impl RpcMethod<3> for StateDealProviderCollateralBounds {
         let _: bool = verified;
 
         let state_manager = &ctx.state_manager;
-        let ts = state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
 
         let power_actor =
             state_manager.get_required_actor(&Address::POWER_ACTOR, *ts.parent_state())?;
@@ -1639,10 +1637,7 @@ impl RpcMethod<3> for StateSectorPreCommitInfoV0 {
         ctx: Ctx<impl Blockstore>,
         (miner_address, sector_number, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&miner_address, *ts.parent_state())?;
@@ -1668,10 +1663,7 @@ impl RpcMethod<3> for StateSectorPreCommitInfo {
         ctx: Ctx<impl Blockstore>,
         (miner_address, sector_number, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&miner_address, *ts.parent_state())?;
@@ -1899,10 +1891,7 @@ impl RpcMethod<3> for StateSectorGetInfo {
         ctx: Ctx<impl Blockstore>,
         (miner_address, sector_number, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx
             .state_manager
             .get_all_sectors(&miner_address, &ts)?
@@ -1945,10 +1934,7 @@ impl RpcMethod<3> for StateSectorExpiration {
     ) -> Result<Self::Ok, ServerError> {
         let store = ctx.store();
         let policy = &ctx.chain_config().policy;
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&miner_address, *ts.parent_state())?;
@@ -2006,19 +1992,13 @@ impl RpcMethod<3> for StateSectorPartition {
         (miner_address, sector_number, ApiTipsetKey(tsk)): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let store = ctx.store();
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let actor = ctx
             .state_manager
             .get_required_actor(&miner_address, *ts.parent_state())?;
         let state = miner::State::load(store, actor.code, actor.state)?;
-        let (deadline, partition) = state.find_sector(
-            store,
-            sector_number,
-            &ctx.state_manager.chain_config().policy,
-        )?;
+        let (deadline, partition) =
+            state.find_sector(store, sector_number, &ctx.chain_config().policy)?;
         Ok(SectorLocation {
             deadline,
             partition,
@@ -2042,10 +2022,7 @@ impl RpcMethod<3> for StateListMessages {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (from_to, ApiTipsetKey(tsk), max_height): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx
-            .state_manager
-            .chain_store()
-            .load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         if from_to.is_empty() {
             return Err(ErrorObject::owned(
                 1,

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1611,8 +1611,7 @@ impl RpcMethod<1> for StateGetBeaconEntry {
             };
         }
 
-        let beacon_schedule = ctx.beacon();
-        let (_, beacon) = beacon_schedule.beacon_for_epoch(epoch)?;
+        let (_, beacon) = ctx.beacon().beacon_for_epoch(epoch)?;
         let network_version = ctx.state_manager.get_network_version(epoch);
         let round = beacon.max_beacon_round_for_epoch(network_version, epoch);
         let entry = beacon.entry(round).await?;

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -2135,7 +2135,7 @@ impl RpcMethod<1> for StateGetAllClaims {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx.state_manager.get_all_claims(&ts)?)
     }
 }
@@ -2325,7 +2325,7 @@ impl RpcMethod<1> for crate::rpc::prelude::StateGetAllAllocations {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        let ts = ctx.chain_store.load_required_tipset_or_heaviest(&tsk)?;
+        let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         Ok(ctx.state_manager.get_all_allocations(&ts)?)
     }
 }

--- a/src/rpc/methods/sync.rs
+++ b/src/rpc/methods/sync.rs
@@ -93,21 +93,21 @@ impl RpcMethod<1> for SyncSubmitBlock {
         let encoded_message = to_vec(&block_msg)?;
         let pubsub_block_str = format!("{}/{}", PUBSUB_BLOCK_STR, ctx.network_name);
         let (bls_messages, secp_messages) =
-            chain::store::block_messages(&ctx.chain_store.db, &block_msg.header)?;
+            chain::store::block_messages(&ctx.chain_store().db, &block_msg.header)?;
         let block = Block {
             header: block_msg.header.clone(),
             bls_messages,
             secp_messages,
         };
         let ts = FullTipset::from(block);
-        let genesis_ts = Arc::new(Tipset::from(ctx.chain_store.genesis_block_header()));
+        let genesis_ts = Arc::new(Tipset::from(ctx.chain_store().genesis_block_header()));
 
         TipsetValidator(&ts)
             .validate(
-                ctx.chain_store.clone(),
+                ctx.chain_store().clone(),
                 ctx.bad_blocks.clone(),
                 genesis_ts,
-                ctx.state_manager.chain_config().block_delay_secs,
+                ctx.chain_config().block_delay_secs,
             )
             .context("failed to validate the tipset")?;
 
@@ -136,7 +136,7 @@ lotus_json_with_self!(RPCSyncState);
 mod tests {
     use std::sync::Arc;
 
-    use crate::beacon::{mock_beacon::MockBeacon, BeaconPoint, BeaconSchedule};
+    use super::*;
     use crate::blocks::RawBlockHeader;
     use crate::blocks::{CachingBlockHeader, Tipset};
     use crate::chain::ChainStore;
@@ -153,16 +153,9 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::{sync::RwLock, task::JoinSet};
 
-    use super::*;
-
     const TEST_NET_NAME: &str = "test";
 
     fn ctx() -> (Arc<RPCState<MemoryDB>>, flume::Receiver<NetworkMessage>) {
-        let beacon = Arc::new(BeaconSchedule(vec![BeaconPoint {
-            height: 0,
-            beacon: Box::<MockBeacon>::default(),
-        }]));
-
         let (network_send, network_rx) = flume::bounded(5);
         let (tipset_send, _) = flume::bounded(5);
         let mut services = JoinSet::new();
@@ -191,7 +184,6 @@ mod tests {
             Arc::new(StateManager::new(cs_arc.clone(), chain_config, sync_config).unwrap());
         let state_manager_for_thread = state_manager.clone();
         let cs_for_test = &cs_arc;
-        let cs_for_chain = &cs_arc;
         let mpool_network_send = network_send.clone();
         let pool = {
             let bz = hex::decode("904300e80781586082cb7477a801f55c1f2ea5e5d1167661feea60a39f697e1099af132682b81cc5047beacf5b6e80d5f52b9fd90323fb8510a5396416dd076c13c85619e176558582744053a3faef6764829aa02132a1571a76aabdc498a638ea0054d3bb57f41d82015860812d2396cc4592cdf7f829374b01ffd03c5469a4b0a9acc5ccc642797aa0a5498b97b28d90820fedc6f79ff0a6005f5c15dbaca3b8a45720af7ed53000555667207a0ccb50073cd24510995abd4c4e45c1e9e114905018b2da9454190499941e818201582012dd0a6a7d0e222a97926da03adb5a7768d31cc7c5c2bd6828e14a7d25fa3a608182004b76616c69642070726f6f6681d82a5827000171a0e4022030f89a8b0373ad69079dbcbc5addfe9b34dce932189786e50d3eb432ede3ba9c43000f0001d82a5827000171a0e4022052238c7d15c100c1b9ebf849541810c9e3c2d86e826512c6c416d2318fcd496dd82a5827000171a0e40220e5658b3d18cd06e1db9015b4b0ec55c123a24d5be1ea24d83938c5b8397b4f2fd82a5827000171a0e4022018d351341c302a21786b585708c9873565a0d07c42521d4aaf52da3ff6f2e461586102c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001a5f2c5439586102b5cd48724dce0fec8799d77fd6c5113276e7f470c8391faa0b5a6033a3eaf357d635705c36abe10309d73592727289680515afd9d424793ba4796b052682d21b03c5c8a37d94827fecc59cdc5750e198fdf20dee012f4d627c6665132298ab95004500053724e0").unwrap();
@@ -231,8 +223,6 @@ mod tests {
             network_send,
             network_name: TEST_NET_NAME.to_owned(),
             start_time,
-            chain_store: cs_for_chain.clone(),
-            beacon,
             shutdown: mpsc::channel(1).0, // dummy for tests
             tipset_send,
         });

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -335,7 +335,7 @@ pub struct RPCState<DB> {
 }
 
 impl<DB: Blockstore> RPCState<DB> {
-    pub fn beacon(&self) -> Arc<crate::beacon::BeaconSchedule> {
+    pub fn beacon(&self) -> &Arc<crate::beacon::BeaconSchedule> {
         self.state_manager.beacon_schedule()
     }
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -323,7 +323,6 @@ const MAX_RESPONSE_BODY_SIZE: u32 = MAX_REQUEST_BODY_SIZE;
 /// data.
 pub struct RPCState<DB> {
     pub keystore: Arc<RwLock<KeyStore>>,
-    pub chain_store: Arc<crate::chain::ChainStore<DB>>,
     pub state_manager: Arc<crate::state_manager::StateManager<DB>>,
     pub mpool: Arc<crate::message_pool::MessagePool<crate::message_pool::MpoolRpcProvider<DB>>>,
     pub bad_blocks: Arc<crate::chain_sync::BadBlockCache>,
@@ -332,13 +331,28 @@ pub struct RPCState<DB> {
     pub network_name: String,
     pub tipset_send: flume::Sender<Arc<Tipset>>,
     pub start_time: chrono::DateTime<chrono::Utc>,
-    pub beacon: Arc<crate::beacon::BeaconSchedule>,
     pub shutdown: mpsc::Sender<()>,
 }
 
 impl<DB: Blockstore> RPCState<DB> {
+    pub fn beacon(&self) -> Arc<crate::beacon::BeaconSchedule> {
+        self.state_manager.beacon_schedule()
+    }
+
+    pub fn chain_store(&self) -> &Arc<crate::chain::ChainStore<DB>> {
+        self.state_manager.chain_store()
+    }
+
+    pub fn chain_index(&self) -> &Arc<crate::chain::index::ChainIndex<Arc<DB>>> {
+        &self.chain_store().chain_index
+    }
+
+    pub fn chain_config(&self) -> &Arc<crate::networks::ChainConfig> {
+        self.state_manager.chain_config()
+    }
+
     pub fn store(&self) -> &DB {
-        self.chain_store.blockstore()
+        self.chain_store().blockstore()
     }
 
     pub fn store_owned(&self) -> Arc<DB> {

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -295,6 +295,15 @@ where
         &self.cs
     }
 
+    pub fn chain_rand(&self, tipset: Arc<Tipset>) -> ChainRand<DB> {
+        ChainRand::new(
+            self.chain_config.clone(),
+            tipset,
+            self.cs.chain_index.clone(),
+            self.beacon.clone(),
+        )
+    }
+
     /// Returns the internal, protocol-level network name.
     pub fn get_network_name(&self, st: &Cid) -> Result<String, Error> {
         let init_act = self
@@ -1406,15 +1415,6 @@ where
                 state.resolve_to_deterministic_addr(self.chain_store().blockstore(), address)
             }
         }
-    }
-
-    fn chain_rand(&self, tipset: Arc<Tipset>) -> ChainRand<DB> {
-        ChainRand::new(
-            self.chain_config.clone(),
-            tipset,
-            self.cs.chain_index.clone(),
-            self.beacon.clone(),
-        )
     }
 }
 

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -245,8 +245,8 @@ where
         })
     }
 
-    pub fn beacon_schedule(&self) -> Arc<BeaconSchedule> {
-        Arc::clone(&self.beacon)
+    pub fn beacon_schedule(&self) -> &Arc<BeaconSchedule> {
+        &self.beacon
     }
 
     /// Returns network version for the given epoch.
@@ -721,7 +721,7 @@ where
             self.chain_store().genesis_block_header().timestamp,
             Arc::clone(&self.chain_store().chain_index),
             Arc::clone(&self.chain_config),
-            self.beacon_schedule(),
+            self.beacon_schedule().clone(),
             &self.engine,
             tipset,
             callback,
@@ -1176,7 +1176,7 @@ where
 
     pub async fn miner_get_base_info(
         self: &Arc<Self>,
-        beacon_schedule: Arc<BeaconSchedule>,
+        beacon_schedule: &Arc<BeaconSchedule>,
         tipset: Arc<Tipset>,
         addr: Address,
         epoch: ChainEpoch,
@@ -1324,7 +1324,7 @@ where
             genesis_timestamp,
             self.chain_store().chain_index.clone(),
             self.chain_config().clone(),
-            self.beacon_schedule(),
+            self.beacon_schedule().clone(),
             &self.engine,
             tipsets,
         )

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -1176,7 +1176,7 @@ where
 
     pub async fn miner_get_base_info(
         self: &Arc<Self>,
-        beacon_schedule: &Arc<BeaconSchedule>,
+        beacon_schedule: &BeaconSchedule,
         tipset: Arc<Tipset>,
         addr: Address,
         epoch: ChainEpoch,

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -1526,11 +1526,6 @@ async fn start_offline_server(
 
     populate_eth_mappings(&state_manager, &head_ts)?;
 
-    let beacon = Arc::new(
-        state_manager
-            .chain_config()
-            .get_beacon_schedule(chain_store.genesis_block_header().timestamp),
-    );
     let (network_send, _) = flume::bounded(5);
     let (tipset_send, _) = flume::bounded(5);
     let network_name = get_network_name_from_genesis(&genesis_header, &state_manager)?;
@@ -1565,8 +1560,6 @@ async fn start_offline_server(
         network_send,
         network_name,
         start_time: chrono::Utc::now(),
-        chain_store,
-        beacon,
         shutdown,
         tipset_send,
     };


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR removes `chain_store` and `beacon` fields from `RPCState` that are accessible from `state_manager`.

Changes introduced in this pull request:

- removes `chain_store` and `beacon` fields from `RPCState`
- add methods to `RPCState` for accessing `beacon`, `chain_store`, `chain_config` and `chain_index`
- publicly expose `StateManager::chain_rand` to avoid manually call `ChainRand::new` in RPC implementations
- cleanup and simplify RPC implementations code

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
