### PR TITLE
feat(rpc): Add MpoolPushUntrusted as an alias of MpoolPush

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -100,6 +100,7 @@ macro_rules! for_each_method {
         $callback!(crate::rpc::mpool::MpoolPending);
         $callback!(crate::rpc::mpool::MpoolSelect);
         $callback!(crate::rpc::mpool::MpoolPush);
+        $callback!(crate::rpc::mpool::MpoolPushUntrusted);
         $callback!(crate::rpc::mpool::MpoolPushMessage);
 
         // msig vertical


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `MpoolPushUntrusted` is an alias of `MpoolPush`. We omit some sanity checks here as they only offer an illusion of safety.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #4546

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
