### PR TITLE
chore(rpc): new state manager api to simplify actor state loading logic

### DIFF
--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -217,10 +217,7 @@ impl RpcMethod<1> for StateVerifiedRegistryRootKey {
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
-        let actor = ctx
-            .state_manager
-            .get_required_actor(&Address::VERIFIED_REGISTRY_ACTOR, *ts.parent_state())?;
-        let state = verifreg::State::load(ctx.store(), actor.code, actor.state)?;
+        let state: verifreg::State = ctx.state_manager.get_actor_state(&ts)?;
         Ok(state.root_key())
     }
 }
@@ -421,10 +418,7 @@ impl RpcMethod<1> for StateMarketDeals {
         (ApiTipsetKey(tsk),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
         let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
-        let actor = ctx
-            .state_manager
-            .get_required_actor(&Address::MARKET_ACTOR, *ts.parent_state())?;
-        let market_state = market::State::load(ctx.store(), actor.code, actor.state)?;
+        let market_state: market::State = ctx.state_manager.get_actor_state(&ts)?;
 
         let da = market_state.proposals(ctx.store())?;
         let sa = market_state.states(ctx.store())?;
@@ -489,10 +483,9 @@ impl RpcMethod<2> for StateMinerActiveSectors {
     ) -> Result<Self::Ok, ServerError> {
         let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let policy = &ctx.chain_config().policy;
-        let actor = ctx
+        let miner_state: miner::State = ctx
             .state_manager
-            .get_required_actor(&address, *ts.parent_state())?;
-        let miner_state = miner::State::load(ctx.store(), actor.code, actor.state)?;
+            .get_actor_state_from_address(&ts, &address)?;
         // Collect active sectors from each partition in each deadline.
         let mut active_sectors = vec![];
         miner_state.for_each_deadline(policy, ctx.store(), |_dlidx, deadline| {

--- a/src/shim/actors/common.rs
+++ b/src/shim/actors/common.rs
@@ -1,0 +1,39 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::shim::{address::Address, state_tree::ActorState};
+use fvm_ipld_blockstore::Blockstore;
+
+pub trait LoadActorStateFromBlockstore: Sized {
+    const ACTOR: Option<Address> = None;
+
+    fn load(store: &impl Blockstore, actor: &ActorState) -> anyhow::Result<Self>;
+}
+
+mod load_actor_state_trait_impl {
+    use super::*;
+
+    macro_rules! impl_for {
+        ($actor:ident $(, $addr:expr)?) => {
+            impl LoadActorStateFromBlockstore for fil_actor_interface::$actor::State {
+                $(const ACTOR: Option<Address> = Some($addr);)?
+                fn load(store: &impl Blockstore, actor: &ActorState) -> anyhow::Result<Self> {
+                    Self::load(store, actor.code, actor.state)
+                }
+            }
+        };
+    }
+
+    impl_for!(account);
+    impl_for!(cron, Address::CRON_ACTOR);
+    impl_for!(datacap, Address::DATACAP_TOKEN_ACTOR);
+    impl_for!(evm);
+    impl_for!(init, Address::INIT_ACTOR);
+    impl_for!(market, Address::MARKET_ACTOR);
+    impl_for!(miner);
+    impl_for!(multisig);
+    impl_for!(power, Address::POWER_ACTOR);
+    impl_for!(reward, Address::REWARD_ACTOR);
+    impl_for!(system, Address::SYSTEM_ACTOR);
+    impl_for!(verifreg, Address::VERIFIED_REGISTRY_ACTOR);
+}

--- a/src/shim/actors/mod.rs
+++ b/src/shim/actors/mod.rs
@@ -1,7 +1,10 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+pub mod common;
 pub mod market;
 pub mod miner;
 pub mod multisig;
 pub mod verifreg;
+
+pub use common::*;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

There is a lot of repetitive code to load actor states in the RPC code. This PR introduces a new StateManager API to simplify that.

```rust
// before
let actor = ctx
    .state_manager
    .get_required_actor(&Address::VERIFIED_REGISTRY_ACTOR, *ts.parent_state())?;
let state = verifreg::State::load(ctx.store(), actor.code, actor.state)?;

// after 
let state: verifreg::State = ctx.state_manager.get_actor_state(&ts)?;
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
