### PR TITLE
chore: use actor cids from the manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,9 +2620,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fil_actor_account_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d32c2b5601caa2dd2bea95530d0fe2aabbfaf95ab9162e230f4bddd6f14b8fb"
+checksum = "8db33234fd100f531a9e0caee6b06587df4435a30d6756423bafd83052ed2048"
 dependencies = [
  "frc42_macros",
  "fvm_ipld_encoding",
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2152e9454180195d8df5588205790969e7997ef69a1b627e45fd1990e4d24c"
+checksum = "ebe5bc24103967ce158afcf3dd07fb293ecb8f2b6fa808c3f714e48b05a603e9"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.7.0",
@@ -2651,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd3f41b8b5275cb71404fdf76b82b4e768d37ce3b2c5b58d39b435835956a02"
+checksum = "c6e7cb5d6bec1b43387880b42cc776a63fb8e888fd64b96ae5b7425d64f409bf"
 dependencies = [
  "fil_actors_shared",
  "frc42_macros",
@@ -2671,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9d7b4c977cc43ff471984039ac30f04fa9a13008c5b0eaea9cd6d26a2e7a0c"
+checksum = "627158dda5621fd72a1e0a5a2bf706da114310aca3536780bf1198290f52d1e9"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -2691,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fdb8be617a9b6d0be9ba6c314cc12011fe2055cb041145acced3133be6b0aa"
+checksum = "77d0ee352c07963a96d956a57c0347182183279ff1a7cd5eaa4b0969a24c135e"
 dependencies = [
  "anyhow",
  "cid",
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_interface"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2a4007127d0bcd8d2067ff03fbd01b84f6b99bf93538cfc16d0871460bfe80"
+checksum = "45cf2cc8e5bd571156212d4498080353aba3df0cde4f2b99908e0250676deb95"
 dependencies = [
  "anyhow",
  "cid",
@@ -2745,14 +2745,13 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yaml",
 ]
 
 [[package]]
 name = "fil_actor_market_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819569b9cb1ab8f297579aa56a4de0c19630122e38e07df9629df71e98aeea47"
+checksum = "f8ac688c876a4d9c39ec137cd8fc2a86b2ee6052dddf9ceffb6d77208871e571"
 dependencies = [
  "anyhow",
  "cid",
@@ -2777,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ea731d8bbba13f385260e7c6a5477290b599797f43d6954c3289d2f76502ac"
+checksum = "d8fa4da68d948bdb7ca25177e73f896cf5911ec568af1533442abe8ce478acbc"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -2808,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2049c06ad6c90d76756099a637924fd01ae22bb499f7ec4e7617bc4171b10c3d"
+checksum = "f320b047c0257eaba488d46627f0e7aaebb3be4b5768af7590d422e1d08b8cc8"
 dependencies = [
  "anyhow",
  "cid",
@@ -2832,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66118ca91e91e121806d45a455a9f2e1724c97e6376f3d56d7e434e189d2484f"
+checksum = "4be8c4d5848278eb1f484a0a3511db57acc436f0a74d20d81e4c45fed49878f1"
 dependencies = [
  "anyhow",
  "cid",
@@ -2856,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d3fb0770f0e4b58d74cbd178eda246cacb80fe6850ae557f562adaa54974e"
+checksum = "615aeb19bf76b9ae00e1ef5d02db7c5d86833952d7e7dc2ced0cbce228a8c4a3"
 dependencies = [
  "fil_actor_miner_state",
  "fil_actors_shared",
@@ -2874,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe011c4f18245af9d3caacfbcdc6717884457bf26caf583e4d5086f3ab2aa22"
+checksum = "f7b5db9c2a39f4d081e17d8ce8ecece90ef557566728e9be34e0402d030b5831"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -2891,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg_state"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ed5cf4b39aff5957554f58dd5f3fb5878e0f14a14b2b35617c74e16fd95376"
+checksum = "b8cd10c31abee3a1ade8208fd4087cfbac98579699f048bf07278535f7c374b4"
 dependencies = [
  "anyhow",
  "cid",
@@ -2913,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_shared"
-version = "15.2.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a3107d59d8488603ad2ee25a0d1eb112ed94e9339ed2bf6f76190dbf1682fb"
+checksum = "f02a5f08fb86041e0bb12f6fe16cbf5730b36bf2c215a1ca6a6a3f75724683f1"
 dependencies = [
  "anyhow",
  "cid",
@@ -3208,6 +3207,7 @@ dependencies = [
  "openrpc-types",
  "parity-db",
  "parking_lot",
+ "paste",
  "pathfinding",
  "petgraph",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,18 +47,18 @@ digest = "0.10"
 directories = "5"
 displaydoc = "0.2"
 ethereum-types = "0.14"
-fil_actor_account_state = { version = "15.2" }
-fil_actor_cron_state = { version = "15.2" }
-fil_actor_datacap_state = { version = "15.2" }
-fil_actor_init_state = { version = "15.2" }
-fil_actor_interface = { version = "15.2" }
-fil_actor_market_state = { version = "15.2" }
-fil_actor_miner_state = { version = "15.2" }
-fil_actor_power_state = { version = "15.2" }
-fil_actor_reward_state = { version = "15.2" }
-fil_actor_system_state = { version = "15.2" }
-fil_actor_verifreg_state = { version = "15.2" }
-fil_actors_shared = { version = "15.2", features = ["json"] }
+fil_actor_account_state = { version = "16.0.0" }
+fil_actor_cron_state = { version = "16.0.0" }
+fil_actor_datacap_state = { version = "16.0.0" }
+fil_actor_init_state = { version = "16.0.0" }
+fil_actor_interface = { version = "16.0.0" }
+fil_actor_market_state = { version = "16.0.0" }
+fil_actor_miner_state = { version = "16.0.0" }
+fil_actor_power_state = { version = "16.0.0" }
+fil_actor_reward_state = { version = "16.0.0" }
+fil_actor_system_state = { version = "16.0.0" }
+fil_actor_verifreg_state = { version = "16.0.0" }
+fil_actors_shared = { version = "16.0.0", features = ["json"] }
 flume = "0.11"
 fs_extra = "1"
 futures = "0.3"
@@ -196,6 +196,7 @@ zstd = "0.13"
 # optional dependencies
 console-subscriber = { version = "0.3", features = ["parking_lot"], optional = true }
 mimalloc = { version = "0.1", optional = true, default-features = false }
+paste = "1.0.15"
 tikv-jemallocator = { version = "0.5", optional = true }
 tracing-chrome = { version = "0.7", optional = true }
 tracing-loki = { version = "0.2", default-features = false, features = ["compat-0-2-1", "rustls"], optional = true }

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -3,6 +3,73 @@
     "network": {
       "type": "calibnet"
     },
+    "version": "8.0.0-rc.1",
+    "bundle_cid": "bafy2bzacedrdn6z3z7xz7lx4wll3tlgktirhllzqxb766dxpaqp3ukxsjfsba",
+    "manifest": {
+      "actors": [
+        [
+          "system",
+          1,
+          "bafk2bzaceaqrkllksxv2jsfgjvmuewx5vbzrammw5mdscod6gkdr3ijih2q64"
+        ],
+        [
+          "init",
+          2,
+          "bafk2bzaceadyfilb22bcvzvnpzbg2lyg6npmperyq6es2brvzjdh5rmywc4ry"
+        ],
+        [
+          "cron",
+          3,
+          "bafk2bzaceaxlezmclw5ugldhhtfgvn7yztux45scqik3ez4yhwiqhg5ssib44"
+        ],
+        [
+          "account",
+          4,
+          "bafk2bzacecruossn66xqbeutqx5r4k2kjzgd43frmwd4qkw6haez44ubvvpxo"
+        ],
+        [
+          "storagepower",
+          5,
+          "bafk2bzacecpwr4mynn55bg5hrlns3osvg7sty3rca6zlai3vl52vbbjk7ulfa"
+        ],
+        [
+          "storageminer",
+          6,
+          "bafk2bzacea6rabflc7kpwr6y4lzcqsnuahr4zblyq3rhzrrsfceeiw2lufrb4"
+        ],
+        [
+          "storagemarket",
+          7,
+          "bafk2bzacebotg5coqnglzsdrqxtkqk2eq4krxt6zvds3i3vb2yejgxhexl2n6"
+        ],
+        [
+          "paymentchannel",
+          8,
+          "bafk2bzaceblot4pemhfgwb3lceellwrpgxaqkpselzbpqu32maffpopdunlha"
+        ],
+        [
+          "multisig",
+          9,
+          "bafk2bzacec66wmb4kohuzvuxsulhcgiwju7sqkldwfpmmgw7dbbwgm5l2574q"
+        ],
+        [
+          "reward",
+          10,
+          "bafk2bzaceayah37uvj7brl5no4gmvmqbmtndh5raywuts7h6tqbgbq2ge7dhu"
+        ],
+        [
+          "verifiedregistry",
+          11,
+          "bafk2bzaceaihibfu625lbtzdp3tcftscshrmbgghgrc7kzqhxn4455pycpdkm"
+        ]
+      ],
+      "actor_list_cid": "bafy2bzacec7ewi4djlixcaqzaqpivf3pdzgdhlh5bvbj2qvgdpuuih22tt3aq"
+    }
+  },
+  {
+    "network": {
+      "type": "calibnet"
+    },
     "version": "v9.0.3",
     "bundle_cid": "bafy2bzacedbedgynklc4dgpyxippkxmba2mgtw7ecntoneclsvvl4klqwuyyy",
     "manifest": {

--- a/src/fil_cns/validation.rs
+++ b/src/fil_cns/validation.rs
@@ -9,6 +9,7 @@ use crate::chain::ChainStore;
 use crate::chain_sync::collect_errs;
 use crate::metrics::HistogramTimerExt;
 use crate::networks::{ChainConfig, Height};
+use crate::shim::actors::PowerActorStateLoad as _;
 use crate::shim::crypto::{
     cid_to_replica_commitment_v1, verify_bls_sig, TICKET_RANDOMNESS_LOOKBACK,
 };

--- a/src/fil_cns/weight.rs
+++ b/src/fil_cns/weight.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::blocks::Tipset;
+use crate::shim::actors::PowerActorStateLoad as _;
 use crate::shim::{address::Address, state_tree::StateTree};
 use fil_actor_interface::power;
 use fvm_ipld_blockstore::Blockstore;

--- a/src/interpreter/fvm2.rs
+++ b/src/interpreter/fvm2.rs
@@ -9,6 +9,7 @@ use crate::blocks::Tipset;
 use crate::chain::{index::ChainIndex, store::ChainStore};
 use crate::interpreter::errors::Error;
 use crate::networks::ChainConfig;
+use crate::shim::actors::MinerActorStateLoad as _;
 use crate::shim::{
     gas::{price_list_by_network_version, Gas, GasTracker},
     state_tree::StateTree,

--- a/src/interpreter/fvm3.rs
+++ b/src/interpreter/fvm3.rs
@@ -11,6 +11,7 @@ use crate::chain::{
 };
 use crate::interpreter::errors::Error;
 use crate::networks::ChainConfig;
+use crate::shim::actors::MinerActorStateLoad as _;
 use crate::shim::{
     address::Address, gas::price_list_by_network_version, state_tree::StateTree,
     version::NetworkVersion,

--- a/src/interpreter/fvm4.rs
+++ b/src/interpreter/fvm4.rs
@@ -11,6 +11,7 @@ use crate::chain::{
 };
 use crate::interpreter::errors::Error;
 use crate::networks::{ChainConfig, Height, NetworkChain};
+use crate::shim::actors::MinerActorStateLoad as _;
 use crate::shim::{
     address::Address, gas::price_list_by_network_version, state_tree::StateTree,
     version::NetworkVersion,

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -7,6 +7,7 @@ pub mod fvm3;
 mod fvm4;
 mod vm;
 
+use crate::shim::actors::AccountActorStateLoad as _;
 use crate::shim::{
     address::{Address, Protocol},
     state_tree::StateTree,

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -61,7 +61,7 @@ pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
         make_height!(Hyperdrive, 420),
         make_height!(Chocolate, 450),
         make_height!(OhSnap, 480),
-        make_height!(Skyr, 510),
+        make_height!(Skyr, 510, get_bundle_cid("8.0.0-rc.1")),
         make_height!(Shark, 16_800, get_bundle_cid("v9.0.3")),
         make_height!(Hygge, 322_354, get_bundle_cid("v10.0.0-rc.1")),
         make_height!(Lightning, LIGHTNING_EPOCH, get_bundle_cid("v11.0.0-rc2")),

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -24,6 +24,7 @@ use crate::{make_butterfly_policy, make_calibnet_policy, make_devnet_policy, mak
 mod actors_bundle;
 pub use actors_bundle::{
     generate_actor_bundle, get_actor_bundles_metadata, ActorBundleInfo, ACTOR_BUNDLES,
+    ACTOR_BUNDLES_METADATA,
 };
 
 mod drand;

--- a/src/rpc/methods/msig.rs
+++ b/src/rpc/methods/msig.rs
@@ -6,6 +6,7 @@ use crate::rpc::types::ApiTipsetKey;
 use crate::rpc::types::*;
 use crate::rpc::{ApiPaths, Ctx, Permission, RpcMethod};
 use crate::shim::actors::multisig::MultisigExt;
+use crate::shim::actors::MultisigActorStateLoad as _;
 use crate::shim::{address::Address, econ::TokenAmount};
 use fil_actor_interface::multisig;
 use fvm_ipld_blockstore::Blockstore;

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -16,9 +16,11 @@ use crate::eth::EthChainId;
 use crate::libp2p::NetworkMessage;
 use crate::lotus_json::lotus_json_with_self;
 use crate::networks::{ChainConfig, NetworkChain};
+use crate::shim::actors::market::MarketStateExt as _;
+use crate::shim::actors::state_load::*;
 use crate::shim::actors::verifreg::VerifiedRegistryStateExt as _;
 use crate::shim::actors::{
-    market::{BalanceTableExt as _, MarketStateExt as _},
+    market::BalanceTableExt as _,
     miner::{MinerStateExt as _, PartitionExt as _},
 };
 use crate::shim::address::Payload;

--- a/src/shim/actors/common.rs
+++ b/src/shim/actors/common.rs
@@ -7,17 +7,18 @@ use fvm_ipld_blockstore::Blockstore;
 pub trait LoadActorStateFromBlockstore: Sized {
     const ACTOR: Option<Address> = None;
 
-    fn load(store: &impl Blockstore, actor: &ActorState) -> anyhow::Result<Self>;
+    fn load_from_blockstore(store: &impl Blockstore, actor: &ActorState) -> anyhow::Result<Self>;
 }
 
 mod load_actor_state_trait_impl {
     use super::*;
+    use crate::shim::actors::state_load::*;
 
     macro_rules! impl_for {
         ($actor:ident $(, $addr:expr)?) => {
             impl LoadActorStateFromBlockstore for fil_actor_interface::$actor::State {
                 $(const ACTOR: Option<Address> = Some($addr);)?
-                fn load(store: &impl Blockstore, actor: &ActorState) -> anyhow::Result<Self> {
+                fn load_from_blockstore(store: &impl Blockstore, actor: &ActorState) -> anyhow::Result<Self> {
                     Self::load(store, actor.code, actor.state)
                 }
             }

--- a/src/shim/actors/mod.rs
+++ b/src/shim/actors/mod.rs
@@ -8,3 +8,8 @@ pub mod multisig;
 pub mod verifreg;
 
 pub use common::*;
+
+pub mod state_load;
+pub use state_load::*;
+mod version;
+pub use version::*;

--- a/src/shim/actors/state_load.rs
+++ b/src/shim/actors/state_load.rs
@@ -1,0 +1,69 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+use cid::Cid;
+use paste::paste;
+
+use super::version::*;
+use fvm_ipld_blockstore::Blockstore;
+use serde::de::DeserializeOwned;
+
+fn get_obj<T>(store: &impl Blockstore, cid: &Cid) -> anyhow::Result<Option<T>>
+where
+    T: DeserializeOwned,
+{
+    match store.get(cid)? {
+        Some(bz) => Ok(Some(fvm_ipld_encoding::from_slice(&bz)?)),
+        None => Ok(None),
+    }
+}
+
+macro_rules! actor_state_load_trait {
+    ($($actor:ident),*) => {
+        $(
+paste! {
+    pub trait [< $actor ActorStateLoad >] {
+        fn load<BS: fvm_ipld_blockstore::Blockstore>(store: &BS, code: Cid, state: Cid) -> anyhow::Result<fil_actor_interface::[< $actor:lower >]::State>;
+    }
+}
+        )*
+        }
+}
+
+actor_state_load_trait!(
+    System, Init, Cron, Account, Power, Miner, Market, Multisig, Reward, Verifreg, DataCap, EVM
+);
+
+// We need to provide both the version and the version identifier to the macro; it is a limitation
+// of the `paste` crate.
+macro_rules! actor_state_load_impl {
+    ($actor:ident, $($version:literal, $version_ident:ident),*) => {
+        paste! {
+        impl [< $actor ActorStateLoad >] for fil_actor_interface::[< $actor:lower >]::State {
+            fn load<BS: fvm_ipld_blockstore::Blockstore>(store: &BS, code: Cid, state: Cid) -> anyhow::Result<fil_actor_interface::[< $actor:lower >]::State> {
+                use anyhow::Context as _;
+                $(
+                    if [< is_ $actor:lower _cid_version >](&code, $version) {
+                        return get_obj(store, &state)?
+                            .map(fil_actor_interface::[< $actor:lower >]::State::[< $version_ident >])
+                            .context("Actor state doesn't exist in store");
+                    }
+                )*
+                anyhow::bail!("Unknown actor code {}", code)
+            }
+        }
+                }
+    };
+}
+
+actor_state_load_impl!(Account, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(Cron, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(DataCap, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(EVM, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(Init, 0, V0, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(Market, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(Miner, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(Multisig, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(Power, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(System, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(Verifreg, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);
+actor_state_load_impl!(Reward, 8, V8, 9, V9, 10, V10, 11, V11, 12, V12, 13, V13, 14, V14);

--- a/src/shim/actors/version.rs
+++ b/src/shim/actors/version.rs
@@ -1,0 +1,81 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+use cid::multihash::{Code, MultihashDigest as _};
+use cid::Cid;
+use fil_actors_shared::v11::runtime::builtins::Type;
+use once_cell::sync::Lazy;
+use paste::paste;
+
+macro_rules! impl_actor_cids_type_actor {
+    ($($actor_type:ident, $actor:ident),*) => {
+        $(
+paste! {
+static [<$actor:upper _ACTOR_CIDS>]: Lazy<Vec<(u64, Cid)>> = Lazy::new(|| {
+    let mut actors: Vec<_> = crate::networks::ACTOR_BUNDLES_METADATA
+        .values()
+        .filter_map(|bundle| {
+            if let Ok(cid) = bundle.manifest.get(Type::$actor_type) {
+                Some((bundle.actor_major_version().ok()?, cid))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // we need to add manually init actors for V0.
+    if Type::$actor_type == Type::Init {
+        let init = Cid::new_v1(fvm_ipld_encoding::IPLD_RAW, Code::Identity.digest(b"fil/1/init"));
+        actors.push((0, init));
+    }
+    actors
+
+});
+
+#[allow(unused)]
+/// Checks if the provided actor code CID is valid for the given actor (any version).
+pub fn [<is_ $actor:lower _actor>](actor_code_cid: &Cid) -> bool {
+    [<$actor:upper _ACTOR_CIDS>]
+        .iter()
+        .any(|(_, cid)| cid == actor_code_cid)
+}
+
+#[allow(unused)]
+/// Checks if the provided actor code CID and version are valid for the given actor.
+pub fn [<is_ $actor:lower _cid_version>](actor_code_cid: &Cid, version: u64) -> bool {
+    [<$actor:upper _ACTOR_CIDS>]
+        .iter()
+        .any(|(v, cid)| *v == version && cid == actor_code_cid)
+}
+}
+        )*
+    };
+}
+
+macro_rules! impl_actor_cids {
+    ($($actor:ident),*) => {
+        $(
+            impl_actor_cids_type_actor!($actor, $actor);
+        )*
+    };
+}
+
+impl_actor_cids!(
+    System,
+    Init,
+    Cron,
+    Account,
+    Power,
+    Miner,
+    Market,
+    PaymentChannel,
+    Multisig,
+    Reward,
+    DataCap,
+    Placeholder,
+    EVM,
+    EAM,
+    EthAccount
+);
+
+// A special snowflake which has a slightly different type and and package name.
+impl_actor_cids_type_actor!(VerifiedRegistry, Verifreg);

--- a/src/shim/machine/manifest.rs
+++ b/src/shim/machine/manifest.rs
@@ -20,7 +20,7 @@ pub use fil_actors_shared::v11::runtime::builtins::Type as BuiltinActor;
 // Theoretically, this struct could just have fields for all the actors,
 // acting as a kind of perfect hash map, but performance will be fine as-is
 // #[derive(Serialize, Deserialize, Debug)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct BuiltinActorManifest {
     builtin2cid: BTreeMap<BuiltinActor, Cid>,
     /// The CID that this manifest was built from

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -25,7 +25,7 @@ use num_derive::FromPrimitive;
 use serde::{Deserialize, Serialize};
 
 pub use super::fvm_shared_latest::{state::StateRoot, ActorID};
-use crate::shim::{address::Address, econ::TokenAmount};
+use crate::shim::{actors::AccountActorStateLoad as _, address::Address, econ::TokenAmount};
 
 #[derive(
     Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Serialize_repr, Deserialize_repr, FromPrimitive,
@@ -510,6 +510,7 @@ mod tests {
     use crate::blocks::CachingBlockHeader;
     use crate::db::car::AnyCar;
     use crate::networks::{calibnet, mainnet};
+    use crate::shim::actors::InitActorStateLoad as _;
     use cid::Cid;
     use fil_actor_interface::init::{self, State};
     use std::sync::Arc;

--- a/src/state_manager/circulating_supply.rs
+++ b/src/state_manager/circulating_supply.rs
@@ -6,6 +6,12 @@ use std::sync::Arc;
 use crate::chain::*;
 use crate::networks::{ChainConfig, Height};
 use crate::rpc::types::CirculatingSupply;
+use crate::shim::actors::{
+    is_account_actor, is_ethaccount_actor, is_evm_actor, is_miner_actor, is_multisig_actor,
+    is_paymentchannel_actor, is_placeholder_actor, MarketActorStateLoad as _,
+    MinerActorStateLoad as _, MultisigActorStateLoad as _, PowerActorStateLoad as _,
+    RewardActorStateLoad as _,
+};
 use crate::shim::version::NetworkVersion;
 use crate::shim::{
     address::Address,
@@ -15,10 +21,6 @@ use crate::shim::{
 };
 use anyhow::{bail, Context as _};
 use cid::Cid;
-use fil_actor_interface::{
-    is_account_actor, is_eth_account_actor, is_evm_actor, is_miner_actor, is_multisig_actor,
-    is_paych_actor, is_placeholder_actor,
-};
 use fil_actor_interface::{market, miner, multisig, power, reward};
 use fvm_ipld_blockstore::Blockstore;
 use num_traits::Zero;
@@ -158,8 +160,8 @@ impl GenesisInfo {
                         }
                     }
                     _ if is_account_actor(&actor.code)
-                    || is_paych_actor(&actor.code)
-                    || is_eth_account_actor(&actor.code)
+                    || is_paymentchannel_actor(&actor.code)
+                    || is_ethaccount_actor(&actor.code)
                     || is_evm_actor(&actor.code)
                     || is_placeholder_actor(&actor.code) => {
                         circ += actor_balance;

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -28,6 +28,7 @@ use crate::networks::ChainConfig;
 use crate::rpc::state::{ApiInvocResult, InvocResult, MessageGasCost};
 use crate::rpc::types::{MiningBaseInfo, SectorOnChainInfo};
 use crate::shim::actors::miner::MinerStateExt as _;
+use crate::shim::actors::state_load::*;
 use crate::shim::actors::verifreg::VerifiedRegistryStateExt;
 use crate::shim::actors::LoadActorStateFromBlockstore;
 use crate::shim::{
@@ -287,7 +288,7 @@ where
             )
         })?;
         let actor = self.get_required_actor(&address, *ts.parent_state())?;
-        S::load(self.blockstore(), &actor)
+        S::load_from_blockstore(self.blockstore(), &actor)
     }
 
     /// Gets actor state from explicit actor address
@@ -297,7 +298,7 @@ where
         actor_address: &Address,
     ) -> anyhow::Result<S> {
         let actor = self.get_required_actor(actor_address, *ts.parent_state())?;
-        S::load(self.blockstore(), &actor)
+        S::load_from_blockstore(self.blockstore(), &actor)
     }
 
     /// Gets required actor from given [`Cid`].

--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::shim::{
+    actors::{is_account_actor, is_ethaccount_actor, is_placeholder_actor},
     address::{Address, Payload},
     randomness::Randomness,
     sector::{RegisteredPoStProof, RegisteredSealProof, SectorInfo},
@@ -10,13 +11,15 @@ use crate::shim::{
 };
 use crate::utils::encoding::prover_id_from_u64;
 use cid::Cid;
-use fil_actor_interface::{is_account_actor, is_eth_account_actor, is_placeholder_actor, miner};
+use fil_actor_interface::miner;
 use fil_actors_shared::filecoin_proofs_api::post;
 use fil_actors_shared::fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::bytes_32;
 
 use crate::state_manager::{errors::*, StateManager};
+
+use super::MinerActorStateLoad as _;
 
 impl<DB> StateManager<DB>
 where
@@ -125,7 +128,7 @@ pub fn is_valid_for_sending(network_version: NetworkVersion, actor: &ActorState)
     }
 
     // After nv18, we also support other kinds of senders.
-    if is_account_actor(&actor.code) || is_eth_account_actor(&actor.code) {
+    if is_account_actor(&actor.code) || is_ethaccount_actor(&actor.code) {
         return true;
     }
 

--- a/src/statediff/mod.rs
+++ b/src/statediff/mod.rs
@@ -12,6 +12,7 @@ use std::{
 use crate::{
     lotus_json::HasLotusJson as _,
     shim::{
+        actors::state_load::*,
         address::Address,
         state_tree::{ActorState, StateTree},
     },

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -22,6 +22,7 @@ use crate::rpc::state::StateGetAllClaims;
 use crate::rpc::types::{ApiTipsetKey, MessageFilter, MessageLookup};
 use crate::rpc::{self, eth::*};
 use crate::rpc::{prelude::*, start_rpc, RPCState};
+use crate::shim::actors::MarketActorStateLoad as _;
 use crate::shim::address::{CurrentNetwork, Network};
 use crate::shim::{
     address::{Address, Protocol},


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- use CIDs from our self-generated manifest and not from Go-parsed code.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4347

## Other information and links

~~Can be reviewed now, but blocked on https://github.com/ChainSafe/fil-actor-states/pull/320 to adjust the `fil-actor-states` version.~~

~~Also, tests blocked by https://github.com/ChainSafe/forest-iac/pull/460~~

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
