### PR TITLE
fix(p2p): make kademlia in forest work for lotus

### DIFF
--- a/src/libp2p/discovery.rs
+++ b/src/libp2p/discovery.rs
@@ -139,7 +139,7 @@ impl<'a> DiscoveryConfig<'a> {
             // `go-libp2p-kad-dht` sends the remote peer id as query key during bootstrap,
             // however, `rust-libp2p` returns empty peer list when the key it receives
             // matches the local one. It's fine to use a random peer id as a workaround
-            // since Kadmelia is not used as value providers in filecoin p2p network.
+            // since Kademlia not used as value providers in filecoin p2p network.
             let kad_random_peer_id = PeerId::random();
             let store = MemoryStore::new(kad_random_peer_id);
             let kad_config = {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Part of #4576

`go-libp2p-kad-dht` sends the remote peer id as query key during bootstrap, however, `rust-libp2p` returns empty peer list when the key it receives matches the local one. This PR configures Kademlia with a random peer ID as a workaround

Changes introduced in this pull request:

- 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
