### PR TITLE
fix: align root JWT token expiration behavior with Lotus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 
 ### Changed
 
+- [#4583](https://github.com/ChainSafe/forest/pull/4583) Removed the expiration
+  date for the master token. The new behavior aligns with Lotus.
+
 ### Removed
 
 ### Fixed

--- a/src/cli_shared/cli/client.rs
+++ b/src/cli_shared/cli/client.rs
@@ -7,10 +7,9 @@ use std::{
     str::FromStr,
 };
 
-use chrono::Duration;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DurationSeconds};
+use serde_with::serde_as;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
@@ -65,14 +64,6 @@ pub struct Client {
     /// RPC bind, e.g. 127.0.0.1:1234
     pub rpc_address: SocketAddr,
     pub healthcheck_address: SocketAddr,
-    /// Period of validity for JWT in seconds. Defaults to 60 days.
-    #[serde_as(as = "DurationSeconds<i64>")]
-    #[cfg_attr(test, arbitrary(gen(
-        // Note: this a workaround for `chrono` not supporting `i64::MIN` as a valid duration.
-        // [[https://github.com/chronotope/chrono/blob/dc196062650c05528cbe259e340210f0340a05d1/src/time_delta.rs#L223-L232]]
-        |g| Duration::try_milliseconds(i64::arbitrary(g).max(-i64::MAX)).expect("Infallible")
-    )))]
-    pub token_exp: Duration,
     /// Load actors from the bundle file (possibly generating it if it doesn't exist)
     pub load_actors: bool,
     /// `TTL` to set for Ethereum `Hash` to `Cid` entries or `None` to never reclaim them.
@@ -103,7 +94,6 @@ impl Default for Client {
                 IpAddr::V4(Ipv4Addr::LOCALHOST),
                 crate::health::DEFAULT_HEALTHCHECK_PORT,
             ),
-            token_exp: Duration::try_seconds(5184000).expect("Infallible"), // 60 Days = 5184000 Seconds
             load_actors: true,
             eth_mapping_ttl: None,
         }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The root token in Lotus does not expire. We _require_ expiration dates, though. This PR sets the expiration date of the root token to 100 years in the future. This aligns our behavior with that of Lotus.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #4582

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
