### PR TITLE
workaround: filter out flaky Eth methods

### DIFF
--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -9,3 +9,7 @@
 !Filecoin.StateCall
 # CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4446
 !Filecoin.StateCirculatingSupply
+# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4584
+Filecoin.EthGetBlockByHash
+# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4585
+Filecoin.EthGetBlockByNumber

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -19,3 +19,7 @@
 !Filecoin.StateCirculatingSupply
 # The estimation is inaccurate only for offline RPC server, to be investigated: https://github.com/ChainSafe/forest/issues/4555
 !Filecoin.EthEstimateGas
+# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4584
+Filecoin.EthGetBlockByHash
+# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4585
+Filecoin.EthGetBlockByNumber


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The methods turned out to be flaky, see the linked issues https://github.com/ChainSafe/forest/issues/4584 and https://github.com/ChainSafe/forest/issues/4585

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
