### PR TITLE
Revert "feat(metric): add forest version to prometheus (#4535)"

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -53,9 +53,7 @@ where
         warn!("Failed to register process metrics: {err}");
     }
 
-    DEFAULT_REGISTRY.write().register_collector(Box::new(
-        crate::utils::version::ForestVersionCollector::new(),
-    ));
+    // Add the DBCollector to the registry
     DEFAULT_REGISTRY
         .write()
         .register_collector(Box::new(crate::metrics::db::DBCollector::new(db_directory)));

--- a/src/utils/version/mod.rs
+++ b/src/utils/version/mod.rs
@@ -3,11 +3,6 @@
 
 use git_version::git_version;
 use once_cell::sync::Lazy;
-use prometheus_client::{
-    collector::Collector,
-    encoding::{DescriptorEncoder, EncodeMetric},
-    metrics::info::Info,
-};
 
 /// Current git commit hash of the Forest repository.
 pub const GIT_HASH: &str =
@@ -20,28 +15,3 @@ pub static FOREST_VERSION_STRING: Lazy<String> =
 
 pub static FOREST_VERSION: Lazy<semver::Version> =
     Lazy::new(|| semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Invalid version"));
-
-#[derive(Debug)]
-pub struct ForestVersionCollector {
-    version: Info<Vec<(&'static str, &'static str)>>,
-}
-
-impl ForestVersionCollector {
-    pub fn new() -> Self {
-        let version = Info::new(vec![("version", FOREST_VERSION_STRING.as_str())]);
-        Self { version }
-    }
-}
-
-impl Collector for ForestVersionCollector {
-    fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
-        let metric_encoder = encoder.encode_descriptor(
-            "forest_version",
-            "semantic version of the forest binary",
-            None,
-            self.version.metric_type(),
-        )?;
-        self.version.encode(metric_encoder)?;
-        Ok(())
-    }
-}


### PR DESCRIPTION
This reverts commit 1103ac70fa749ec304751fa9a9be403bb1153a1b.

## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- the `Info` metric is not compliant with the default Prometheus/Grafana stack and so we should not use it (unless proven it works fine). See https://github.com/ChainSafe/forest/issues/4533#issuecomment-2250242854

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
