### PR TITLE
fix: fix invalid deserialization in `EthGetBlock`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
 
 ### Fixed
 
+- [#4603](https://github.com/ChainSafe/forest/pull/4603) Fixed incorrect
+  deserialisation in `Filecoin.EthGetBlockByNumber` and
+  `Filecoin.EthGetBlockByHash` RPC methods.
+
 ## Forest 0.19.2 "Eagle"
 
 Non-mandatory release that includes a fix for the Prometheus-incompatible

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -9,7 +9,3 @@
 !Filecoin.StateCall
 # CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4446
 !Filecoin.StateCirculatingSupply
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4584
-!Filecoin.EthGetBlockByHash
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4585
-!Filecoin.EthGetBlockByNumber

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -19,7 +19,3 @@
 !Filecoin.StateCirculatingSupply
 # The estimation is inaccurate only for offline RPC server, to be investigated: https://github.com/ChainSafe/forest/issues/4555
 !Filecoin.EthEstimateGas
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4584
-!Filecoin.EthGetBlockByHash
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4585
-!Filecoin.EthGetBlockByNumber

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -35,7 +35,8 @@ use crate::shim::trace::{CallReturn, ExecutionEvent};
 use crate::shim::{clock::ChainEpoch, state_tree::StateTree};
 use crate::utils::db::BlockstoreExt as _;
 use anyhow::{bail, Result};
-use bytes::Buf;
+use cbor4ii::core::dec::Decode as _;
+use cbor4ii::core::Value;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{RawBytes, CBOR, DAG_CBOR, IPLD_RAW};
@@ -806,10 +807,10 @@ fn encode_as_abi_helper(param1: u64, param2: u64, data: &[u8]) -> Vec<u8> {
 fn decode_payload(payload: &fvm_ipld_encoding::RawBytes, codec: u64) -> Result<EthBytes> {
     match codec {
         DAG_CBOR | CBOR => {
-            let result: Result<Vec<u8>, _> = serde_ipld_dagcbor::de::from_reader(payload.reader());
-            match result {
-                Ok(buffer) => Ok(EthBytes(buffer)),
-                Err(err) => bail!("decode_payload: failed to decode cbor payload: {err}"),
+            let mut reader = cbor4ii::core::utils::SliceReader::new(payload.bytes());
+            match Value::decode(&mut reader) {
+                Ok(Value::Bytes(bytes)) => Ok(EthBytes(bytes)),
+                _ => bail!("failed to read params byte array"),
             }
         }
         IPLD_RAW => Ok(EthBytes(payload.to_vec())),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Ran the fixed methods with the offending snapshot, now it works fine:
```
❯ forest-tool api compare --filter-file scripts/tests/api_compare/filter-list ~/prj/snapshots/forest_snapshot_calibnet_2024-07-24_height_1816297.forest.car.zst -n 10
| RPC Method                        | Forest | Lotus |
|-----------------------------------|--------|-------|
| Filecoin.EthGetBlockByHash (20)   | Valid  | Valid |
| Filecoin.EthGetBlockByNumber (20) | Valid  | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4584
Closes https://github.com/ChainSafe/forest/issues/4585

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
