### PR TITLE
fix: dockerfile FromAs casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN --mount=type=cache,sharing=private,target=/root/.cargo/registry \
 # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#cached-docker-images
 ##
 # A slim image contains only forest binaries
-FROM ubuntu:22.04 as slim-image
+FROM ubuntu:22.04 AS slim-image
 
 ARG SERVICE_USER=forest
 ARG SERVICE_GROUP=forest
@@ -93,7 +93,7 @@ RUN forest -V && forest-cli -V && forest-tool -V
 ENTRYPOINT ["forest"]
 
 # A fat image contains forest binaries and fil proof parameter files under $FIL_PROOFS_PARAMETER_CACHE
-FROM slim-image as fat-image
+FROM slim-image AS fat-image
 
 # Move FIL_PROOFS_PARAMETER_CACHE out of forest data dir since users always need to mount the data dir
 ENV FIL_PROOFS_PARAMETER_CACHE="/var/tmp/filecoin-proof-parameters"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes `docker build` warning:

```
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 63)                                                                                                           0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 96)                                                                                                           0.0s
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
