### PR TITLE
fix(ci): remove unnecessary software in RPC build to reduce disk usage

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -402,17 +402,22 @@ jobs:
       # We use a custom Dockerfile for CI to speed up the build process.
       FOREST_DOCKERFILE_OVERRIDE: scripts/devnet/forest_ci.dockerfile
     steps:
-      # Remove some unnecessary software to free up space.
+      # Remove some unnecessary software to free up space. This should free up around 15-20 GB.
       # This is required because of the limited space on the runner,
       # and disk space-hungry snapshots used in the setup.
+      # This is taken from:
+      # https://github.com/easimon/maximize-build-space/blob/fc881a613ad2a34aca9c9624518214ebc21dfc0c/action.yml#L121-L136
+      # Using the action directly is not feasible as it does some more modifications that break the setup in our case.
       -   name: Remove unnecessary software
-          shell: bash
           run: |
+              echo "Disk space before cleanup"
               df -h
               sudo rm -rf /usr/share/dotnet
               sudo rm -rf /usr/local/lib/android
               sudo rm -rf /opt/ghc
               sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+              echo "Disk space after cleanup"
               df -h
 
       - uses: actions/checkout@v4

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -402,15 +402,19 @@ jobs:
       # We use a custom Dockerfile for CI to speed up the build process.
       FOREST_DOCKERFILE_OVERRIDE: scripts/devnet/forest_ci.dockerfile
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 25600
-          swap-size-mb: 4096
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
+      # Remove some unnecessary software to free up space.
+      # This is required because of the limited space on the runner,
+      # and disk space-hungry snapshots used in the setup.
+      -   name: Remove unnecessary software
+          shell: bash
+          run: |
+              df -h
+              sudo rm -rf /usr/share/dotnet
+              sudo rm -rf /usr/local/lib/android
+              sudo rm -rf /opt/ghc
+              sudo rm -rf /opt/hostedtoolcache/CodeQL
+              df -h
+
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -402,6 +402,15 @@ jobs:
       # We use a custom Dockerfile for CI to speed up the build process.
       FOREST_DOCKERFILE_OVERRIDE: scripts/devnet/forest_ci.dockerfile
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 25600
+          swap-size-mb: 4096
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -412,6 +412,12 @@ jobs:
       - name: Dump docker logs
         if: always()
         uses: jwalton/gh-docker-logs@v2
+      - name: Dump Docker usage
+        if: always()
+        run: |
+          docker system df
+          docker system df --verbose
+          df -h
   bootstrap-checks-forest:
     needs:
       - build-ubuntu


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- this reduces the disk space usage in the RPC test job that is failing due to heavy disk usage (GH workers out of the box guarantee only ~14-16 GB).
- added some visibility to disk space usage to facilitate future investigations.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
