### PR TITLE
fix: fix winning proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@
   deserialisation in `Filecoin.EthGetBlockByNumber` and
   `Filecoin.EthGetBlockByHash` RPC methods.
 
+- [#4610](https://github.com/ChainSafe/forest/issues/4610) Fixed incorrect
+  structure in the `Filecoin.MinerGetBaseInfo` RPC method.
+
 ## Forest 0.19.2 "Eagle"
 
 Non-mandatory release that includes a fix for the Prometheus-incompatible

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -1,6 +1,5 @@
 # This list contains potentially broken methods (or tests) that are ignored.
 # They should be considered bugged, and not used until the root cause is resolved.
-!Filecoin.MinerGetBaseInfo
 # Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619017774/job/23623141130?pr=4170
 !Filecoin.MpoolGetNonce
 # CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/actions/runs/9593268587/job/26453560366

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -1,6 +1,5 @@
 # This list contains potentially broken methods (or tests) that are ignored.
 # They should be considered bugged, and not used until the root cause is resolved.
-!Filecoin.MinerGetBaseInfo
 # Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619314467/job/23624081698
 !Filecoin.MpoolGetNonce
 !Filecoin.EthSyncing

--- a/src/fil_cns/validation.rs
+++ b/src/fil_cns/validation.rs
@@ -13,6 +13,7 @@ use crate::shim::actors::PowerActorStateLoad as _;
 use crate::shim::crypto::{
     cid_to_replica_commitment_v1, verify_bls_sig, TICKET_RANDOMNESS_LOOKBACK,
 };
+use crate::shim::sector::RegisteredSealProof;
 use crate::shim::{
     address::Address,
     randomness::Randomness,
@@ -411,7 +412,9 @@ fn to_fil_public_replica_infos(
         .map::<Result<(SectorId, PublicReplicaInfo), String>, _>(|sector_info: &SectorInfo| {
             let commr = cid_to_replica_commitment_v1(&sector_info.sealed_cid)?;
             let proof = match typ {
-                ProofType::Winning => sector_info.proof.registered_winning_post_proof()?,
+                ProofType::Winning => RegisteredSealProof::from(sector_info.proof)
+                    .registered_winning_post_proof()
+                    .map_err(|e| e.to_string())?,
                 // ProofType::Window => sector_info.proof.registered_window_post_proof()?,
             };
             let replica = PublicReplicaInfo::new(proof.try_into()?, commr);

--- a/src/fil_cns/validation.rs
+++ b/src/fil_cns/validation.rs
@@ -29,6 +29,7 @@ use fil_actors_shared::v10::runtime::DomainSeparationTag;
 use futures::stream::FuturesUnordered;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{bytes_32, to_vec};
+use itertools::Itertools;
 use nunny::Vec as NonEmpty;
 
 use crate::fil_cns::{metrics, FilecoinConsensusError};
@@ -392,6 +393,7 @@ fn verify_winning_post_proof<DB: Blockstore>(
             &header.miner_address,
             Randomness::new(rand.to_vec()),
         )
+        .map(|sectors| sectors.iter().map(Into::into).collect_vec())
         .map_err(|e| FilecoinConsensusError::WinningPoStValidation(e.to_string()))?;
 
     verify_winning_post(

--- a/src/lotus_json/extended_sector_info.rs
+++ b/src/lotus_json/extended_sector_info.rs
@@ -1,0 +1,70 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+use crate::shim::sector::{ExtendedSectorInfo, RegisteredSealProof};
+use ::cid::Cid;
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "PascalCase")]
+#[schemars(rename = "ExtendedSectorInfo")]
+pub struct ExtendedSectorInfoLotusJson {
+    #[schemars(with = "LotusJson<RegisteredSealProof>")]
+    #[serde(with = "crate::lotus_json")]
+    seal_proof: RegisteredSealProof,
+    sector_number: u64,
+    #[schemars(with = "LotusJson<Option<Cid>>")]
+    #[serde(with = "crate::lotus_json")]
+    sector_key: Option<Cid>,
+    #[schemars(with = "LotusJson<Cid>")]
+    #[serde(with = "crate::lotus_json")]
+    sealed_c_i_d: Cid,
+}
+
+impl HasLotusJson for ExtendedSectorInfo {
+    type LotusJson = ExtendedSectorInfoLotusJson;
+
+    #[cfg(test)]
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        vec![(
+            json!({
+                "SealProof": 0,
+                "SectorNumber": 0,
+                "SectorKey": null,
+                "SealedCID": {
+                    "/": "baeaaaaa"
+                }
+            }),
+            Self {
+                proof: fvm_shared3::sector::RegisteredSealProof::StackedDRG2KiBV1.into(),
+                sector_number: 0,
+                sector_key: None,
+                sealed_cid: ::cid::Cid::default(),
+            },
+        )]
+    }
+
+    fn into_lotus_json(self) -> Self::LotusJson {
+        Self::LotusJson {
+            seal_proof: self.proof,
+            sector_number: self.sector_number,
+            sector_key: self.sector_key,
+            sealed_c_i_d: self.sealed_cid,
+        }
+    }
+
+    fn from_lotus_json(lotus_json: Self::LotusJson) -> Self {
+        let Self::LotusJson {
+            seal_proof,
+            sector_number,
+            sector_key,
+            sealed_c_i_d,
+        } = lotus_json;
+        Self {
+            proof: seal_proof,
+            sector_number,
+            sector_key,
+            sealed_cid: sealed_c_i_d,
+        }
+    }
+}

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -196,6 +196,7 @@ decl_and_test!(
     block_header for crate::blocks::CachingBlockHeader,
     cid for ::cid::Cid,
     election_proof for crate::blocks::ElectionProof,
+    extended_sector_info for crate::shim::sector::ExtendedSectorInfo,
     gossip_block for crate::blocks::GossipBlock,
     key_info for crate::key_management::KeyInfo,
     message for crate::shim::message::Message,

--- a/src/lotus_json/po_st_proof.rs
+++ b/src/lotus_json/po_st_proof.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::shim::sector::{PoStProof, RegisteredPoStProof};
-use fvm_shared3::sector::PoStProof as PoStProofV3;
+use fvm_shared4::sector::PoStProof as PoStProofV4;
 
 use super::*;
 
@@ -30,7 +30,7 @@ impl HasLotusJson for PoStProof {
             }),
             PoStProof::new(
                 crate::shim::sector::RegisteredPoStProof::from(
-                    crate::shim::sector::RegisteredPoStProofV3::StackedDRGWinning2KiBV1,
+                    crate::shim::sector::RegisteredPoStProofV4::StackedDRGWinning2KiBV1,
                 ),
                 Vec::from_iter(*b"hello world!"),
             ),
@@ -38,7 +38,7 @@ impl HasLotusJson for PoStProof {
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        let PoStProofV3 {
+        let PoStProofV4 {
             post_proof,
             proof_bytes,
         } = self.into();
@@ -53,7 +53,7 @@ impl HasLotusJson for PoStProof {
             po_st_proof,
             proof_bytes,
         } = lotus_json;
-        Self::from(PoStProofV3 {
+        Self::from(PoStProofV4 {
             post_proof: po_st_proof.into(),
             proof_bytes,
         })

--- a/src/lotus_json/registered_po_st_proof.rs
+++ b/src/lotus_json/registered_po_st_proof.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::shim::sector::RegisteredPoStProof;
-use fvm_shared3::sector::RegisteredPoStProof as RegisteredPoStProofV3;
+use fvm_shared4::sector::RegisteredPoStProof as RegisteredPoStProofV4;
 
 use super::*;
 
@@ -13,15 +13,15 @@ impl HasLotusJson for RegisteredPoStProof {
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!(0),
-            RegisteredPoStProof::from(RegisteredPoStProofV3::StackedDRGWinning2KiBV1),
+            RegisteredPoStProof::from(RegisteredPoStProofV4::StackedDRGWinning2KiBV1),
         )]
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        i64::from(RegisteredPoStProofV3::from(self))
+        i64::from(RegisteredPoStProofV4::from(self))
     }
 
     fn from_lotus_json(i: Self::LotusJson) -> Self {
-        Self::from(RegisteredPoStProofV3::from(i))
+        Self::from(RegisteredPoStProofV4::from(i))
     }
 }

--- a/src/lotus_json/registered_seal_proof.rs
+++ b/src/lotus_json/registered_seal_proof.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::shim::sector::RegisteredSealProof;
-use fvm_shared3::sector::RegisteredSealProof as RegisteredSealProofV3;
+use fvm_shared4::sector::RegisteredSealProof as RegisteredSealProofV4;
 
 impl HasLotusJson for RegisteredSealProof {
     type LotusJson = i64;
@@ -12,15 +12,15 @@ impl HasLotusJson for RegisteredSealProof {
     fn snapshots() -> Vec<(serde_json::Value, Self)> {
         vec![(
             json!(0),
-            Self::from(RegisteredSealProofV3::StackedDRG2KiBV1),
+            Self::from(RegisteredSealProofV4::StackedDRG2KiBV1),
         )]
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        i64::from(RegisteredSealProofV3::from(self))
+        i64::from(RegisteredSealProofV4::from(self))
     }
 
     fn from_lotus_json(i: Self::LotusJson) -> Self {
-        Self::from(RegisteredSealProofV3::from(i))
+        Self::from(RegisteredSealProofV4::from(i))
     }
 }

--- a/src/lotus_json/sector_info.rs
+++ b/src/lotus_json/sector_info.rs
@@ -32,7 +32,7 @@ impl HasLotusJson for SectorInfo {
                 }
             }),
             Self::new(
-                fvm_shared3::sector::RegisteredSealProof::StackedDRG2KiBV1,
+                fvm_shared4::sector::RegisteredSealProof::StackedDRG2KiBV1,
                 0,
                 ::cid::Cid::default(),
             ),
@@ -40,7 +40,7 @@ impl HasLotusJson for SectorInfo {
     }
 
     fn into_lotus_json(self) -> Self::LotusJson {
-        let fvm_shared3::sector::SectorInfo {
+        let fvm_shared4::sector::SectorInfo {
             proof,
             sector_number,
             sealed_cid,

--- a/src/rpc/types/mod.rs
+++ b/src/rpc/types/mod.rs
@@ -25,7 +25,7 @@ use crate::shim::{
     executor::Receipt,
     fvm_shared_latest::MethodNum,
     message::Message,
-    sector::{RegisteredSealProof, SectorInfo, SectorNumber, StoragePower},
+    sector::{ExtendedSectorInfo, RegisteredSealProof, SectorNumber, StoragePower},
 };
 use cid::Cid;
 use fil_actor_interface::market::AllocationID;
@@ -503,8 +503,8 @@ pub struct MiningBaseInfo {
     #[schemars(with = "LotusJson<StoragePower>")]
     pub network_power: StoragePower,
     #[serde(with = "crate::lotus_json")]
-    #[schemars(with = "LotusJson<Vec<SectorInfo>>")]
-    pub sectors: Vec<SectorInfo>,
+    #[schemars(with = "LotusJson<Vec<ExtendedSectorInfo>>")]
+    pub sectors: Vec<ExtendedSectorInfo>,
     #[serde(with = "crate::lotus_json")]
     #[schemars(with = "LotusJson<Address>")]
     pub worker_key: Address,

--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -77,9 +77,7 @@ where
         let info = mas.info(store)?;
         let spt = RegisteredSealProof::from_sector_size(info.sector_size().into(), nv);
 
-        let wpt = spt
-            .registered_winning_post_proof()
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        let wpt = spt.registered_winning_post_proof()?;
 
         let m_id = miner_address.id()?;
 

--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -5,7 +5,7 @@ use crate::shim::{
     actors::{is_account_actor, is_ethaccount_actor, is_placeholder_actor},
     address::{Address, Payload},
     randomness::Randomness,
-    sector::{RegisteredPoStProof, RegisteredSealProof, SectorInfo},
+    sector::{ExtendedSectorInfo, RegisteredPoStProof, RegisteredSealProof},
     state_tree::ActorState,
     version::NetworkVersion,
 };
@@ -33,7 +33,7 @@ where
         nv: NetworkVersion,
         miner_address: &Address,
         rand: Randomness,
-    ) -> Result<Vec<SectorInfo>, anyhow::Error> {
+    ) -> Result<Vec<ExtendedSectorInfo>, anyhow::Error> {
         let store = self.blockstore();
 
         let actor = self
@@ -100,7 +100,12 @@ where
 
         let out = sectors
             .into_iter()
-            .map(|s_info| SectorInfo::new(*spt, s_info.sector_number, s_info.sealed_cid))
+            .map(|s_info| ExtendedSectorInfo {
+                proof: s_info.seal_proof.into(),
+                sector_number: s_info.sector_number,
+                sector_key: s_info.sector_key_cid,
+                sealed_cid: s_info.sealed_cid,
+            })
             .collect();
 
         Ok(out)


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixed consensus issues caused by using obsolete proof enums,
- I had to revive a function deleted in https://github.com/filecoin-project/ref-fvm/pull/1903 with some modifications `registered_winning_post_proof`
- re-applied the fix for `MinerGetBaseInfo` where the issue surfaced. 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4626
Closes https://github.com/ChainSafe/forest/issues/4610

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
