### PR TITLE
feat: use millis in RPC metrics

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -54,8 +54,8 @@ pub static RPC_METHOD_FAILURE: Lazy<Family<RpcMethodLabel, Counter>> = Lazy::new
 
 pub static RPC_METHOD_TIME: Lazy<Family<RpcMethodLabel, Histogram>> = Lazy::new(|| {
     let metric = Family::<RpcMethodLabel, Histogram>::new_with_constructor(|| {
-        // Histogram with 10 buckets starting from 0.1ms going to 26.21s, each bucket four times as big as the last.
-        Histogram::new(exponential_buckets(0.1, 4., 10))
+        // Histogram with 5 buckets starting from 0.1ms going to 1s, each bucket 10 times as big as the last.
+        Histogram::new(exponential_buckets(0.1, 10., 5))
     });
     crate::metrics::default_registry().register(
         "rpc_processing_time",

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -54,12 +54,12 @@ pub static RPC_METHOD_FAILURE: Lazy<Family<RpcMethodLabel, Counter>> = Lazy::new
 
 pub static RPC_METHOD_TIME: Lazy<Family<RpcMethodLabel, Histogram>> = Lazy::new(|| {
     let metric = Family::<RpcMethodLabel, Histogram>::new_with_constructor(|| {
-        // Histogram with 10 buckets starting from 0.01s going to 5.12s, each bucket twice as big as the last.
-        Histogram::new(exponential_buckets(0.01, 2.0, 10))
+        // Histogram with 10 buckets starting from 0.1ms going to 26.21s, each bucket four times as big as the last.
+        Histogram::new(exponential_buckets(0.1, 4., 10))
     });
     crate::metrics::default_registry().register(
         "rpc_processing_time",
-        "Duration of RPC method call",
+        "Duration of RPC method call in milliseconds",
         metric.clone(),
     );
     metric

--- a/src/rpc/metrics_layer.rs
+++ b/src/rpc/metrics_layer.rs
@@ -44,7 +44,8 @@ where
 
             metrics::RPC_METHOD_TIME
                 .get_or_create(&method)
-                .observe(start_time.elapsed().as_secs_f64());
+                // Observe the elapsed time in milliseconds
+                .observe(start_time.elapsed().as_secs_f64() * 1000.0);
 
             if req.is_error() {
                 metrics::RPC_METHOD_FAILURE.get_or_create(&method).inc();


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

Based on the feedback from Glif:
- changed the unit of RPC metrics to milliseconds, same as is reported in Lotus. This will facilitate cross-implementation performance testing,
- added unit of measure to the metric description.

Based on my subjective opinion (and so I'm open to reverting that):
- changed the histogram characteristics a bit, otherwise the majority of the methods would fall into all buckets. Should we change the bucket count to 5 and increase the factor to 10 @lemmih ?

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

```
# HELP rpc_processing_time Duration of RPC method call in milliseconds.
# TYPE rpc_processing_time histogram
rpc_processing_time_sum{method="Filecoin.ChainGetTipSetByHeight"} 0.039538
rpc_processing_time_count{method="Filecoin.ChainGetTipSetByHeight"} 1
rpc_processing_time_bucket{le="0.1",method="Filecoin.ChainGetTipSetByHeight"} 1
rpc_processing_time_bucket{le="1.0",method="Filecoin.ChainGetTipSetByHeight"} 1
rpc_processing_time_bucket{le="10.0",method="Filecoin.ChainGetTipSetByHeight"} 1
rpc_processing_time_bucket{le="100.0",method="Filecoin.ChainGetTipSetByHeight"} 1
rpc_processing_time_bucket{le="1000.0",method="Filecoin.ChainGetTipSetByHeight"} 1
rpc_processing_time_bucket{le="+Inf",method="Filecoin.ChainGetTipSetByHeight"} 1
rpc_processing_time_sum{method="Filecoin.ChainExport"} 35033.210394999995
rpc_processing_time_count{method="Filecoin.ChainExport"} 1
rpc_processing_time_bucket{le="0.1",method="Filecoin.ChainExport"} 0
rpc_processing_time_bucket{le="1.0",method="Filecoin.ChainExport"} 0
rpc_processing_time_bucket{le="10.0",method="Filecoin.ChainExport"} 0
rpc_processing_time_bucket{le="100.0",method="Filecoin.ChainExport"} 0
rpc_processing_time_bucket{le="1000.0",method="Filecoin.ChainExport"} 0
rpc_processing_time_bucket{le="+Inf",method="Filecoin.ChainExport"} 1
rpc_processing_time_sum{method="Filecoin.StateNetworkName"} 0.43903800000000006
rpc_processing_time_count{method="Filecoin.StateNetworkName"} 5
rpc_processing_time_bucket{le="0.1",method="Filecoin.StateNetworkName"} 3
rpc_processing_time_bucket{le="1.0",method="Filecoin.StateNetworkName"} 5
rpc_processing_time_bucket{le="10.0",method="Filecoin.StateNetworkName"} 5
rpc_processing_time_bucket{le="100.0",method="Filecoin.StateNetworkName"} 5
rpc_processing_time_bucket{le="1000.0",method="Filecoin.StateNetworkName"} 5
rpc_processing_time_bucket{le="+Inf",method="Filecoin.StateNetworkName"} 5
rpc_processing_time_sum{method="Filecoin.ChainHead"} 0.058253
rpc_processing_time_count{method="Filecoin.ChainHead"} 1
rpc_processing_time_bucket{le="0.1",method="Filecoin.ChainHead"} 1
rpc_processing_time_bucket{le="1.0",method="Filecoin.ChainHead"} 1
rpc_processing_time_bucket{le="10.0",method="Filecoin.ChainHead"} 1
rpc_processing_time_bucket{le="100.0",method="Filecoin.ChainHead"} 1
rpc_processing_time_bucket{le="1000.0",method="Filecoin.ChainHead"} 1
rpc_processing_time_bucket{le="+Inf",method="Filecoin.ChainHead"} 1

```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
