### PR TITLE
fix: align `StateMinerProvingDeadline` with Lotus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@
 - [#4610](https://github.com/ChainSafe/forest/issues/4610) Fixed incorrect
   structure in the `Filecoin.MinerGetBaseInfo` RPC method.
 
+- [#4635](https://github.com/ChainSafe/forest/pull/4635) Fixed bug in
+  `StateMinerProvingDeadline`.
+
 ## Forest 0.19.2 "Eagle"
 
 Non-mandatory release that includes a fix for the Prometheus-incompatible

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -8,5 +8,3 @@
 !Filecoin.StateCall
 # CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4446
 !Filecoin.StateCirculatingSupply
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4630
-!Filecoin.StateMinerProvingDeadline

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -23,5 +23,3 @@
 # Offline server won't provide correct results for finality-related methods
 !Filecoin.EthGetBlockByNumber
 !eth_getBlockByNumber
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/4630
-!Filecoin.StateMinerProvingDeadline

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -719,7 +719,11 @@ impl RpcMethod<2> for StateMinerProvingDeadline {
         let state: miner::State = ctx
             .state_manager
             .get_actor_state_from_address(&ts, &address)?;
-        Ok(ApiDeadlineInfo(state.deadline_info(policy, ts.epoch())))
+        Ok(ApiDeadlineInfo(
+            state
+                .recorded_deadline_info(policy, ts.epoch())
+                .next_not_elapsed(),
+        ))
     }
 }
 

--- a/src/shim/actors/miner.rs
+++ b/src/shim/actors/miner.rs
@@ -5,11 +5,15 @@ mod partition;
 mod state;
 
 use cid::Cid;
-use fil_actor_interface::miner::State;
+use fil_actor_interface::{
+    miner::{DeadlineInfo, State},
+    Policy,
+};
 use fil_actors_shared::fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
 
 use crate::rpc::types::{SectorOnChainInfo, SectorPreCommitOnChainInfo};
+use crate::shim::clock::ChainEpoch;
 use crate::utils::db::CborStoreExt as _;
 
 pub trait MinerStateExt {
@@ -31,6 +35,8 @@ pub trait MinerStateExt {
         store: &BS,
         sector_number: u64,
     ) -> anyhow::Result<Option<SectorPreCommitOnChainInfo>>;
+
+    fn recorded_deadline_info(&self, policy: &Policy, current_epoch: ChainEpoch) -> DeadlineInfo;
 }
 
 pub trait PartitionExt {

--- a/src/shim/actors/miner/state.rs
+++ b/src/shim/actors/miner/state.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use anyhow::Context as _;
+use fil_actor_interface::{convert::*, Policy};
+
+use crate::shim::clock::ChainEpoch;
 
 use super::*;
 
@@ -179,5 +182,31 @@ impl MinerStateExt for State {
                 .context("precommit info does not exist")?
                 .map(SectorPreCommitOnChainInfo::from),
         })
+    }
+
+    /// Returns deadline calculations for the state recorded proving period and deadline.
+    /// This is out of date if the a miner does not have an active miner cron
+    fn recorded_deadline_info(&self, policy: &Policy, current_epoch: ChainEpoch) -> DeadlineInfo {
+        match self {
+            State::V8(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v9(policy), current_epoch)
+                .into(),
+            State::V9(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v9(policy), current_epoch)
+                .into(),
+            State::V10(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v10(policy), current_epoch)
+                .into(),
+            State::V11(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v11(policy), current_epoch)
+                .into(),
+            State::V12(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v12(policy), current_epoch)
+                .into(),
+            State::V13(st) => st.recorded_deadline_info(policy, current_epoch).into(),
+            State::V14(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v14(policy), current_epoch)
+                .into(),
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- In Lotus, calling `DeadlineInfo` redirects to `RecordedDeadlineInfo`. For reasons I don't understand, there exists `deadline_info()` and `recorded_deadline_info()`. There may be more places where we call the wrong function.
- This PR only fixes `StateMinerProvingDeadline`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #4630

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
