### PR TITLE
[automated] Update Lotus version in API tests

### DIFF
--- a/scripts/tests/api_compare/.env
+++ b/scripts/tests/api_compare/.env
@@ -1,6 +1,6 @@
 # Note: this should be a `fat` image so that it contains the pre-downloaded filecoin proof parameters
 FOREST_IMAGE=ghcr.io/chainsafe/forest:edge-fat
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.29.0-rc1-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.29.0-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/scripts/tests/api_compare/.env
+++ b/scripts/tests/api_compare/.env
@@ -1,6 +1,6 @@
 # Note: this should be a `fat` image so that it contains the pre-downloaded filecoin proof parameters
 FOREST_IMAGE=ghcr.io/chainsafe/forest:edge-fat
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.28.2-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.29.0-rc1-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/scripts/tests/snapshot_parity/.env
+++ b/scripts/tests/snapshot_parity/.env
@@ -1,4 +1,4 @@
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.28.2-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.29.0-rc1-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/scripts/tests/snapshot_parity/.env
+++ b/scripts/tests/snapshot_parity/.env
@@ -1,4 +1,4 @@
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.29.0-rc1-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.29.0-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -567,9 +567,12 @@ fn common_tests() -> Vec<RpcTest> {
 }
 
 fn beacon_tests() -> Vec<RpcTest> {
-    vec![RpcTest::identity(
-        BeaconGetEntry::request((10101,)).unwrap(),
-    )]
+    // TODO(forest): https://github.com/ChainSafe/forest/issues/4718
+    // Blocked by Lotus.
+    //vec![RpcTest::identity(
+    //    BeaconGetEntry::request((10101,)).unwrap(),
+    //)]
+    vec![]
 }
 
 fn chain_tests() -> Vec<RpcTest> {
@@ -683,10 +686,13 @@ fn node_tests() -> Vec<RpcTest> {
 }
 
 fn state_tests() -> Vec<RpcTest> {
-    vec![
-        RpcTest::identity(StateGetBeaconEntry::request((0.into(),)).unwrap()),
-        RpcTest::identity(StateGetBeaconEntry::request((1.into(),)).unwrap()),
-    ]
+    // TODO(forest): https://github.com/ChainSafe/forest/issues/4718
+    // Blocked by Lotus.
+    //vec![
+    //    RpcTest::identity(StateGetBeaconEntry::request((0.into(),)).unwrap()),
+    //    RpcTest::identity(StateGetBeaconEntry::request((1.into(),)).unwrap()),
+    //]
+    vec![]
 }
 
 fn miner_tests_with_tipset<DB: Blockstore>(
@@ -832,6 +838,7 @@ fn state_tests_with_tipset<DB: Blockstore>(
             Address::new_id(18101), // msig address id
             tipset.key().into(),
         ))?),
+        RpcTest::identity(BeaconGetEntry::request((tipset.epoch(),))?),
         RpcTest::identity(StateGetBeaconEntry::request((tipset.epoch(),))?),
         // Not easily verifiable by using addresses extracted from blocks as most of those yield `null`
         // for both Lotus and Forest. Therefore the actor addresses are hardcoded to values that allow


### PR DESCRIPTION
### Changes
- Updates Lotus version in the JSON-RPC API tests to the latest release.
- Ignore tests requesting old beacons, see https://github.com/ChainSafe/forest/issues/4718