### PR TITLE
fix: `APIVersion` in `Filecoin.Version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@
 - [#4656](https://github.com/ChainSafe/forest/pull/4656) Fixed bug in
   `StateCall`.
 
+- [#4498](https://github.com/ChainSafe/forest/issues/4498) Fixed incorrect
+  `Filecoin.Version`s `APIVersion` field value.
+
 ## Forest 0.19.2 "Eagle"
 
 Non-mandatory release that includes a fix for the Prometheus-incompatible

--- a/src/rpc/methods/common.rs
+++ b/src/rpc/methods/common.rs
@@ -33,17 +33,18 @@ pub enum Version {}
 impl RpcMethod<0> for Version {
     const NAME: &'static str = "Filecoin.Version";
     const PARAM_NAMES: [&'static str; 0] = [];
-    const API_PATHS: ApiPaths = ApiPaths::V0;
+    const API_PATHS: ApiPaths = ApiPaths::V1;
     const PERMISSION: Permission = Permission::Read;
 
     type Params = ();
     type Ok = PublicVersion;
 
     async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
-        let v = &*crate::utils::version::FOREST_VERSION;
         Ok(PublicVersion {
             version: crate::utils::version::FOREST_VERSION_STRING.clone(),
-            api_version: ShiftingVersion::new(v.major, v.minor, v.patch),
+            // This matches Lotus's versioning for the API v1.
+            // For the API v0, we don't support it but it should be `1.5.0`.
+            api_version: ShiftingVersion::new(2, 3, 0),
             block_delay: ctx.chain_config().block_delay_secs,
         })
     }
@@ -81,7 +82,7 @@ impl RpcMethod<0> for StartTime {
 }
 
 /// Represents the current version of the API.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "PascalCase")]
 pub struct PublicVersion {
     pub version: String,
@@ -93,7 +94,7 @@ lotus_json_with_self!(PublicVersion);
 
 /// Integer based value on version information. Highest order bits for Major,
 /// Mid order for Minor and lowest for Patch.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ShiftingVersion(u32);
 
 impl ShiftingVersion {

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -557,7 +557,10 @@ impl RpcTest {
 
 fn common_tests() -> Vec<RpcTest> {
     vec![
-        RpcTest::basic(Version::request(()).unwrap()),
+        // We don't check the `version` field as it differs between Lotus and Forest.
+        RpcTest::validate(Version::request(()).unwrap(), |forest, lotus| {
+            forest.api_version == lotus.api_version && forest.block_delay == lotus.block_delay
+        }),
         RpcTest::basic(StartTime::request(()).unwrap()),
         RpcTest::basic(Session::request(()).unwrap()),
     ]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes the `APIVersion` returned by Forest. We only do it for `V1`, as `V0` is not going to be supported https://github.com/ChainSafe/forest/issues/3960#issuecomment-2276286349

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4498

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
