### PR TITLE
fix: sort and fill methods

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -39,74 +39,77 @@ macro_rules! for_each_method {
         $callback!(crate::rpc::beacon::BeaconGetEntry);
 
         // chain vertical
+        $callback!(crate::rpc::chain::ChainExport);
+        $callback!(crate::rpc::chain::ChainGetBlock);
+        $callback!(crate::rpc::chain::ChainGetBlockMessages);
+        $callback!(crate::rpc::chain::ChainGetEvents);
+        $callback!(crate::rpc::chain::ChainGetGenesis);
         $callback!(crate::rpc::chain::ChainGetMessage);
+        $callback!(crate::rpc::chain::ChainGetMessagesInTipset);
+        $callback!(crate::rpc::chain::ChainGetMinBaseFee);
         $callback!(crate::rpc::chain::ChainGetParentMessages);
         $callback!(crate::rpc::chain::ChainGetParentReceipts);
-        $callback!(crate::rpc::chain::ChainGetMessagesInTipset);
-        $callback!(crate::rpc::chain::ChainExport);
-        $callback!(crate::rpc::chain::ChainReadObj);
-        $callback!(crate::rpc::chain::ChainHasObj);
-        $callback!(crate::rpc::chain::ChainStatObj);
-        $callback!(crate::rpc::chain::ChainGetBlockMessages);
         $callback!(crate::rpc::chain::ChainGetPath);
-        $callback!(crate::rpc::chain::ChainGetTipSetByHeight);
-        $callback!(crate::rpc::chain::ChainGetTipSetAfterHeight);
-        $callback!(crate::rpc::chain::ChainGetGenesis);
-        $callback!(crate::rpc::chain::ChainHead);
-        $callback!(crate::rpc::chain::ChainGetBlock);
         $callback!(crate::rpc::chain::ChainGetTipSet);
+        $callback!(crate::rpc::chain::ChainGetTipSetAfterHeight);
+        $callback!(crate::rpc::chain::ChainGetTipSetByHeight);
+        $callback!(crate::rpc::chain::ChainHasObj);
+        $callback!(crate::rpc::chain::ChainHead);
+        $callback!(crate::rpc::chain::ChainReadObj);
         $callback!(crate::rpc::chain::ChainSetHead);
-        $callback!(crate::rpc::chain::ChainGetMinBaseFee);
+        $callback!(crate::rpc::chain::ChainStatObj);
         $callback!(crate::rpc::chain::ChainTipSetWeight);
 
         // common vertical
         $callback!(crate::rpc::common::Session);
-        $callback!(crate::rpc::common::Version);
         $callback!(crate::rpc::common::Shutdown);
         $callback!(crate::rpc::common::StartTime);
+        $callback!(crate::rpc::common::Version);
 
         // eth vertical
-        $callback!(crate::rpc::eth::Web3ClientVersion);
-        $callback!(crate::rpc::eth::EthSyncing);
         $callback!(crate::rpc::eth::EthAccounts);
+        $callback!(crate::rpc::eth::EthAddressToFilecoinAddress);
         $callback!(crate::rpc::eth::EthBlockNumber);
+        $callback!(crate::rpc::eth::EthCall);
         $callback!(crate::rpc::eth::EthChainId);
         $callback!(crate::rpc::eth::EthEstimateGas);
         $callback!(crate::rpc::eth::EthFeeHistory);
-        $callback!(crate::rpc::eth::EthGetCode);
-        $callback!(crate::rpc::eth::EthGetStorageAt);
         $callback!(crate::rpc::eth::EthGasPrice);
         $callback!(crate::rpc::eth::EthGetBalance);
         $callback!(crate::rpc::eth::EthGetBlockByHash);
         $callback!(crate::rpc::eth::EthGetBlockByNumber);
         $callback!(crate::rpc::eth::EthGetBlockTransactionCountByHash);
         $callback!(crate::rpc::eth::EthGetBlockTransactionCountByNumber);
+        $callback!(crate::rpc::eth::EthGetCode);
         $callback!(crate::rpc::eth::EthGetMessageCidByTransactionHash);
+        $callback!(crate::rpc::eth::EthGetStorageAt);
+        $callback!(crate::rpc::eth::EthGetTransactionByHash);
         $callback!(crate::rpc::eth::EthGetTransactionCount);
+        $callback!(crate::rpc::eth::EthGetTransactionHashByCid);
         $callback!(crate::rpc::eth::EthMaxPriorityFeePerGas);
         $callback!(crate::rpc::eth::EthProtocolVersion);
-        $callback!(crate::rpc::eth::EthGetTransactionByHash);
-        $callback!(crate::rpc::eth::EthGetTransactionHashByCid);
-        $callback!(crate::rpc::eth::EthCall);
-        $callback!(crate::rpc::eth::EthAddressToFilecoinAddress);
+        $callback!(crate::rpc::eth::EthSyncing);
+        $callback!(crate::rpc::eth::Web3ClientVersion);
 
         // gas vertical
-        $callback!(crate::rpc::gas::GasEstimateGasLimit);
-        $callback!(crate::rpc::gas::GasEstimateMessageGas);
         $callback!(crate::rpc::gas::GasEstimateFeeCap);
+        $callback!(crate::rpc::gas::GasEstimateGasLimit);
         $callback!(crate::rpc::gas::GasEstimateGasPremium);
+        $callback!(crate::rpc::gas::GasEstimateMessageGas);
 
         // miner vertical
         $callback!(crate::rpc::miner::MinerCreateBlock);
         $callback!(crate::rpc::miner::MinerGetBaseInfo);
 
         // mpool vertical
+        $callback!(crate::rpc::mpool::MpoolBatchPush);
+        $callback!(crate::rpc::mpool::MpoolBatchPushUntrusted);
         $callback!(crate::rpc::mpool::MpoolGetNonce);
         $callback!(crate::rpc::mpool::MpoolPending);
-        $callback!(crate::rpc::mpool::MpoolSelect);
         $callback!(crate::rpc::mpool::MpoolPush);
-        $callback!(crate::rpc::mpool::MpoolPushUntrusted);
         $callback!(crate::rpc::mpool::MpoolPushMessage);
+        $callback!(crate::rpc::mpool::MpoolPushUntrusted);
+        $callback!(crate::rpc::mpool::MpoolSelect);
 
         // msig vertical
         $callback!(crate::rpc::msig::MsigGetAvailableBalance);
@@ -116,84 +119,86 @@ macro_rules! for_each_method {
 
         // net vertical
         $callback!(crate::rpc::net::NetAddrsListen);
-        $callback!(crate::rpc::net::NetPeers);
-        $callback!(crate::rpc::net::NetListening);
-        $callback!(crate::rpc::net::NetInfo);
-        $callback!(crate::rpc::net::NetConnect);
-        $callback!(crate::rpc::net::NetDisconnect);
         $callback!(crate::rpc::net::NetAgentVersion);
         $callback!(crate::rpc::net::NetAutoNatStatus);
-        $callback!(crate::rpc::net::NetVersion);
-        $callback!(crate::rpc::net::NetProtectAdd);
+        $callback!(crate::rpc::net::NetConnect);
+        $callback!(crate::rpc::net::NetDisconnect);
         $callback!(crate::rpc::net::NetFindPeer);
+        $callback!(crate::rpc::net::NetInfo);
+        $callback!(crate::rpc::net::NetListening);
+        $callback!(crate::rpc::net::NetPeers);
+        $callback!(crate::rpc::net::NetProtectAdd);
+        $callback!(crate::rpc::net::NetProtectList);
+        $callback!(crate::rpc::net::NetProtectRemove);
+        $callback!(crate::rpc::net::NetVersion);
 
         // node vertical
         $callback!(crate::rpc::node::NodeStatus);
 
         // state vertical
-        $callback!(crate::rpc::state::StateCall);
-        $callback!(crate::rpc::state::StateGetBeaconEntry);
-        $callback!(crate::rpc::state::StateListMessages);
-        $callback!(crate::rpc::state::StateGetNetworkParams);
-        $callback!(crate::rpc::state::StateNetworkName);
-        $callback!(crate::rpc::state::StateReplay);
-        $callback!(crate::rpc::state::StateSectorGetInfo);
-        $callback!(crate::rpc::state::StateSectorPreCommitInfoV0);
-        $callback!(crate::rpc::state::StateSectorPreCommitInfo);
         $callback!(crate::rpc::state::StateAccountKey);
-        $callback!(crate::rpc::state::StateLookupID);
-        $callback!(crate::rpc::state::StateGetActor);
-        $callback!(crate::rpc::state::StateMinerInfo);
-        $callback!(crate::rpc::state::StateMinerActiveSectors);
-        $callback!(crate::rpc::state::StateMinerAllocated);
-        $callback!(crate::rpc::state::StateMinerPartitions);
-        $callback!(crate::rpc::state::StateMinerSectors);
-        $callback!(crate::rpc::state::StateMinerSectorCount);
-        $callback!(crate::rpc::state::StateMinerSectorAllocated);
-        $callback!(crate::rpc::state::StateMinerPower);
-        $callback!(crate::rpc::state::StateMinerDeadlines);
-        $callback!(crate::rpc::state::StateMinerProvingDeadline);
-        $callback!(crate::rpc::state::StateMinerFaults);
-        $callback!(crate::rpc::state::StateMinerRecoveries);
-        $callback!(crate::rpc::state::StateMinerAvailableBalance);
-        $callback!(crate::rpc::state::StateMinerInitialPledgeCollateral);
-        $callback!(crate::rpc::state::StateGetReceipt);
-        $callback!(crate::rpc::state::StateGetRandomnessFromTickets);
-        $callback!(crate::rpc::state::StateGetRandomnessDigestFromTickets);
-        $callback!(crate::rpc::state::StateGetRandomnessFromBeacon);
-        $callback!(crate::rpc::state::StateGetRandomnessDigestFromBeacon);
-        $callback!(crate::rpc::state::StateReadState);
+        $callback!(crate::rpc::state::StateCall);
         $callback!(crate::rpc::state::StateCirculatingSupply);
-        $callback!(crate::rpc::state::StateVerifiedClientStatus);
-        $callback!(crate::rpc::state::StateVMCirculatingSupplyInternal);
-        $callback!(crate::rpc::state::StateListMiners);
-        $callback!(crate::rpc::state::StateListActors);
-        $callback!(crate::rpc::state::StateNetworkVersion);
-        $callback!(crate::rpc::state::StateMarketBalance);
-        $callback!(crate::rpc::state::StateMarketParticipants);
-        $callback!(crate::rpc::state::StateMarketDeals);
-        $callback!(crate::rpc::state::StateDealProviderCollateralBounds);
-        $callback!(crate::rpc::state::StateMarketStorageDeal);
-        $callback!(crate::rpc::state::StateWaitMsgV0);
-        $callback!(crate::rpc::state::StateWaitMsg);
-        $callback!(crate::rpc::state::StateSearchMsg);
-        $callback!(crate::rpc::state::StateSearchMsgLimited);
-        $callback!(crate::rpc::state::StateFetchRoot);
         $callback!(crate::rpc::state::StateCompute);
-        $callback!(crate::rpc::state::StateMinerPreCommitDepositForPower);
-        $callback!(crate::rpc::state::StateVerifiedRegistryRootKey);
-        $callback!(crate::rpc::state::StateVerifierStatus);
-        $callback!(crate::rpc::state::StateGetClaim);
-        $callback!(crate::rpc::state::StateGetClaims);
+        $callback!(crate::rpc::state::StateDealProviderCollateralBounds);
+        $callback!(crate::rpc::state::StateFetchRoot);
+        $callback!(crate::rpc::state::StateGetActor);
+        $callback!(crate::rpc::state::StateGetAllAllocations);
         $callback!(crate::rpc::state::StateGetAllClaims);
         $callback!(crate::rpc::state::StateGetAllocation);
-        $callback!(crate::rpc::state::StateGetAllocations);
-        $callback!(crate::rpc::state::StateGetAllAllocations);
-        $callback!(crate::rpc::state::StateGetAllocationIdForPendingDeal);
         $callback!(crate::rpc::state::StateGetAllocationForPendingDeal);
-        $callback!(crate::rpc::state::StateSectorExpiration);
-        $callback!(crate::rpc::state::StateSectorPartition);
+        $callback!(crate::rpc::state::StateGetAllocationIdForPendingDeal);
+        $callback!(crate::rpc::state::StateGetAllocations);
+        $callback!(crate::rpc::state::StateGetBeaconEntry);
+        $callback!(crate::rpc::state::StateGetClaim);
+        $callback!(crate::rpc::state::StateGetClaims);
+        $callback!(crate::rpc::state::StateGetNetworkParams);
+        $callback!(crate::rpc::state::StateGetRandomnessDigestFromBeacon);
+        $callback!(crate::rpc::state::StateGetRandomnessDigestFromTickets);
+        $callback!(crate::rpc::state::StateGetRandomnessFromBeacon);
+        $callback!(crate::rpc::state::StateGetRandomnessFromTickets);
+        $callback!(crate::rpc::state::StateGetReceipt);
+        $callback!(crate::rpc::state::StateListActors);
+        $callback!(crate::rpc::state::StateListMessages);
+        $callback!(crate::rpc::state::StateListMiners);
+        $callback!(crate::rpc::state::StateLookupID);
         $callback!(crate::rpc::state::StateLookupRobustAddress);
+        $callback!(crate::rpc::state::StateMarketBalance);
+        $callback!(crate::rpc::state::StateMarketDeals);
+        $callback!(crate::rpc::state::StateMarketParticipants);
+        $callback!(crate::rpc::state::StateMarketStorageDeal);
+        $callback!(crate::rpc::state::StateMinerActiveSectors);
+        $callback!(crate::rpc::state::StateMinerAllocated);
+        $callback!(crate::rpc::state::StateMinerAvailableBalance);
+        $callback!(crate::rpc::state::StateMinerDeadlines);
+        $callback!(crate::rpc::state::StateMinerFaults);
+        $callback!(crate::rpc::state::StateMinerInfo);
+        $callback!(crate::rpc::state::StateMinerInitialPledgeCollateral);
+        $callback!(crate::rpc::state::StateMinerPartitions);
+        $callback!(crate::rpc::state::StateMinerPower);
+        $callback!(crate::rpc::state::StateMinerPreCommitDepositForPower);
+        $callback!(crate::rpc::state::StateMinerProvingDeadline);
+        $callback!(crate::rpc::state::StateMinerRecoveries);
+        $callback!(crate::rpc::state::StateMinerSectorAllocated);
+        $callback!(crate::rpc::state::StateMinerSectorCount);
+        $callback!(crate::rpc::state::StateMinerSectors);
+        $callback!(crate::rpc::state::StateNetworkName);
+        $callback!(crate::rpc::state::StateNetworkVersion);
+        $callback!(crate::rpc::state::StateReadState);
+        $callback!(crate::rpc::state::StateReplay);
+        $callback!(crate::rpc::state::StateSearchMsg);
+        $callback!(crate::rpc::state::StateSearchMsgLimited);
+        $callback!(crate::rpc::state::StateSectorExpiration);
+        $callback!(crate::rpc::state::StateSectorGetInfo);
+        $callback!(crate::rpc::state::StateSectorPartition);
+        $callback!(crate::rpc::state::StateSectorPreCommitInfo);
+        $callback!(crate::rpc::state::StateSectorPreCommitInfoV0);
+        $callback!(crate::rpc::state::StateVerifiedClientStatus);
+        $callback!(crate::rpc::state::StateVerifiedRegistryRootKey);
+        $callback!(crate::rpc::state::StateVerifierStatus);
+        $callback!(crate::rpc::state::StateVMCirculatingSupplyInternal);
+        $callback!(crate::rpc::state::StateWaitMsg);
+        $callback!(crate::rpc::state::StateWaitMsgV0);
 
         // sync vertical
         $callback!(crate::rpc::sync::SyncCheckBad);
@@ -204,6 +209,7 @@ macro_rules! for_each_method {
         // wallet vertical
         $callback!(crate::rpc::wallet::WalletBalance);
         $callback!(crate::rpc::wallet::WalletDefaultAddress);
+        $callback!(crate::rpc::wallet::WalletDelete);
         $callback!(crate::rpc::wallet::WalletExport);
         $callback!(crate::rpc::wallet::WalletHas);
         $callback!(crate::rpc::wallet::WalletImport);
@@ -214,21 +220,20 @@ macro_rules! for_each_method {
         $callback!(crate::rpc::wallet::WalletSignMessage);
         $callback!(crate::rpc::wallet::WalletValidateAddress);
         $callback!(crate::rpc::wallet::WalletVerify);
-        $callback!(crate::rpc::wallet::WalletDelete);
 
         // f3
-        $callback!(crate::rpc::f3::GetTipsetByEpoch);
-        $callback!(crate::rpc::f3::GetTipset);
-        $callback!(crate::rpc::f3::GetHead);
-        $callback!(crate::rpc::f3::GetParent);
-        $callback!(crate::rpc::f3::GetPowerTable);
-        $callback!(crate::rpc::f3::ProtectPeer);
-        $callback!(crate::rpc::f3::GetParticipatingMinerIDs);
-        $callback!(crate::rpc::f3::SignMessage);
         $callback!(crate::rpc::f3::F3GetCertificate);
-        $callback!(crate::rpc::f3::F3GetLatestCertificate);
         $callback!(crate::rpc::f3::F3GetECPowerTable);
         $callback!(crate::rpc::f3::F3GetF3PowerTable);
+        $callback!(crate::rpc::f3::F3GetLatestCertificate);
+        $callback!(crate::rpc::f3::GetHead);
+        $callback!(crate::rpc::f3::GetParent);
+        $callback!(crate::rpc::f3::GetParticipatingMinerIDs);
+        $callback!(crate::rpc::f3::GetPowerTable);
+        $callback!(crate::rpc::f3::GetTipset);
+        $callback!(crate::rpc::f3::GetTipsetByEpoch);
+        $callback!(crate::rpc::f3::ProtectPeer);
+        $callback!(crate::rpc::f3::SignMessage);
 
         // misc
         $callback!(crate::rpc::misc::GetActorEventsRaw);


### PR DESCRIPTION
We've added some methods that we neglect to actually emit the OpenRPC spec for.

I've added that, and sorted the lists of methods for good measure