### PR TITLE
feat: log RPC calls

### DIFF
--- a/.config/forest.dic
+++ b/.config/forest.dic
@@ -70,6 +70,7 @@ MDNS
 mempool
 Merkle
 MiB
+middleware
 milliGas
 multiaddr/SM
 multihash

--- a/src/cli_shared/logger/mod.rs
+++ b/src/cli_shared/logger/mod.rs
@@ -147,7 +147,6 @@ fn default_env_filter() -> EnvFilter {
         "libp2p_bitswap=off",
         "libp2p_gossipsub=error",
         "libp2p_kad=error",
-        "rpc=error",
         "storage_proofs_core=warn",
         "tracing_loki=off",
         "quinn_udp=error",

--- a/src/rpc/log_layer.rs
+++ b/src/rpc/log_layer.rs
@@ -59,11 +59,10 @@ where
 
             let resp = service.call(req).await;
             let elapsed = start_time.elapsed();
-            let result = if let Some(code) = resp.as_error_code() {
-                Cow::Owned(format!("ERR({code})"))
-            } else {
-                "OK".into()
-            };
+            let result = resp.as_error_code().map_or(
+                Cow::Borrowed("OK"),
+                |code| Cow::Owned(format!("ERR({code})"))
+            );
             tracing::info!("RPC#{id} {result}: {method_name}. Took {elapsed:?}");
             tracing::debug!(
                 "RPC#{id}: {method_name}. Params: {params}",

--- a/src/rpc/log_layer.rs
+++ b/src/rpc/log_layer.rs
@@ -1,0 +1,124 @@
+// Copyright 2019-2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Middleware layer for logging RPC calls.
+
+use std::{
+    borrow::Cow,
+    hash::{DefaultHasher, Hash as _, Hasher},
+};
+
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use jsonrpsee::MethodResponse;
+use jsonrpsee::{server::middleware::rpc::RpcServiceT, types::Id};
+use tower::Layer;
+
+// State-less jsonrpcsee layer for logging information about RPC calls
+#[derive(Clone, Default)]
+pub(super) struct LogLayer {}
+
+impl<S> Layer<S> for LogLayer {
+    type Service = Logging<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        Logging { service }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Logging<S> {
+    service: S,
+}
+
+impl<'a, S> RpcServiceT<'a> for Logging<S>
+where
+    S: RpcServiceT<'a> + Send + Sync + Clone + 'static,
+{
+    type Future = BoxFuture<'a, MethodResponse>;
+
+    fn call(&self, req: jsonrpsee::types::Request<'a>) -> Self::Future {
+        let service = self.service.clone();
+
+        async move {
+            // Avoid performance overhead if INFO level is not enabled.
+            if !tracing::enabled!(tracing::Level::INFO) {
+                return service.call(req).await;
+            }
+
+            let start_time = std::time::Instant::now();
+            let method_name = req.method_name().to_owned();
+            let id = req.id();
+            let id = create_unique_id(id, start_time);
+
+            let params = if tracing::enabled!(tracing::Level::DEBUG) {
+                req.params().as_str().map(ToOwned::to_owned)
+            } else {
+                None
+            };
+
+            let resp = service.call(req).await;
+            let elapsed = start_time.elapsed();
+            let result = if let Some(code) = resp.as_error_code() {
+                Cow::Owned(format!("ERR({code})"))
+            } else {
+                "OK".into()
+            };
+            tracing::info!("RPC#{id} {result}: {method_name}. Took {elapsed:?}");
+            tracing::debug!(
+                "RPC#{id}: {method_name}. Params: {params}",
+                params = params.unwrap_or_else(|| "[]".to_owned())
+            );
+
+            resp
+        }
+        .boxed()
+    }
+}
+
+/// Creates a unique ID for the RPC call, so it can be easily tracked in logs.
+fn create_unique_id(id: Id, start_time: std::time::Instant) -> String {
+    const ID_LEN: usize = 6;
+    let mut hasher = DefaultHasher::new();
+    id.hash(&mut hasher);
+    start_time.hash(&mut hasher);
+    let mut id = format!("{:x}", hasher.finish());
+    id.truncate(ID_LEN);
+    id
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn test_create_unique_id_same() {
+        let id = Id::Number(1);
+        let start_time = std::time::Instant::now();
+        let id1 = create_unique_id(id.clone(), start_time);
+        let id2 = create_unique_id(id, start_time);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_create_unique_id_different_ids() {
+        let id1 = Id::Number(1);
+        let id2 = Id::Number(2);
+        let start_time = std::time::Instant::now();
+        let id1 = create_unique_id(id1, start_time);
+        let id2 = create_unique_id(id2, start_time);
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_create_unique_id_different_times() {
+        let id = Id::Number(1);
+        let start_time1 = std::time::Instant::now();
+        let start_time2 = std::time::Instant::now() + Duration::from_nanos(1);
+        let id1 = create_unique_id(id.clone(), start_time1);
+        let id2 = create_unique_id(id, start_time2);
+        assert_ne!(id1, id2);
+    }
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -4,6 +4,7 @@
 mod auth_layer;
 mod channel;
 mod client;
+mod log_layer;
 mod metrics_layer;
 mod request;
 
@@ -11,6 +12,7 @@ pub use client::Client;
 pub use error::ServerError;
 use eth::filter::EthEventHandler;
 use futures::FutureExt as _;
+use log_layer::LogLayer;
 use reflect::Ctx;
 pub use reflect::{ApiPath, ApiPaths, RpcMethod, RpcMethodExt};
 pub use request::Request;
@@ -481,7 +483,8 @@ where
                         headers,
                         keystore: keystore.clone(),
                     })
-                    .layer(MetricsLayer {});
+                    .layer(LogLayer::default())
+                    .layer(MetricsLayer::default());
                 let mut jsonrpsee_svc = svc_builder
                     .set_rpc_middleware(rpc_middleware)
                     .build(methods, stop_handle);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- added server-side logs for RPC calls.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

Default:
```
2024-09-06T11:29:27.964357Z  INFO forest_filecoin::chain_sync::chain_muxer: Bootstrap successfully completed, now evaluating the network head to ensure the node is in sync
2024-09-06T11:29:27.964369Z  INFO forest_filecoin::chain_sync::chain_muxer: Evaluating network head...
2024-09-06T11:29:27.964380Z  INFO forest_filecoin::chain_sync::chain_muxer: Local node is in sync with the network
2024-09-06T11:29:28.209002Z  INFO forest_filecoin::rpc::log_layer: RPC#7e600a OK: Filecoin.StateNetworkName. Took 92.986µs
2024-09-06T11:29:28.209320Z  INFO forest_filecoin::rpc::log_layer: RPC#d6ce46 OK: Filecoin.NetPeers. Took 107.429µs
2024-09-06T11:29:28.209522Z  INFO forest_filecoin::rpc::log_layer: RPC#c4f0e0 OK: Filecoin.NetAgentVersion. Took 34.714µs
2024-09-06T11:29:28.209858Z  INFO forest_filecoin::rpc::log_layer: RPC#e72ce7 OK: Filecoin.NetAgentVersion. Took 27.736µs
2024-09-06T11:29:28.209924Z  INFO forest_filecoin::rpc::log_layer: RPC#79fcc7 OK: Filecoin.NetAgentVersion. Took 23.947µs
2024-09-06T11:29:28.209930Z  INFO forest_filecoin::rpc::log_layer: RPC#d9246e OK: Filecoin.NetAgentVersion. Took 18.93µs
2024-09-06T11:29:28.209936Z  INFO forest_filecoin::rpc::log_layer: RPC#4404c5 OK: Filecoin.NetAgentVersion. Took 10.07µs
2024-09-06T11:29:28.209959Z  INFO forest_filecoin::rpc::log_layer: RPC#209663 ERR(-32603): Filecoin.NetAgentVersion. Took 46.694µs
2024-09-06T11:29:28.209991Z  INFO forest_filecoin::rpc::log_layer: RPC#e28eda OK: Filecoin.NetAgentVersion. Took 21.681µs
2024-09-06T11:29:28.210002Z  INFO forest_filecoin::rpc::log_layer: RPC#ca151e ERR(-32603): Filecoin.NetAgentVersion. Took 36.594µs
2024-09-06T11:29:28.210015Z  INFO forest_filecoin::rpc::log_layer: RPC#557350 OK: Filecoin.NetAgentVersion. Took 34.621µs
2024-09-06T11:29:28.210021Z  INFO forest_filecoin::rpc::log_layer: RPC#23b6e5 OK: Filecoin.NetAgentVersion. Took 6.995µs
2024-09-06T11:29:28.210025Z  INFO forest_filecoin::rpc::log_layer: RPC#6bb328 OK: Filecoin.NetAgentVersion. Took 17.989µs
2024-09-06T11:29:28.210035Z  INFO forest_filecoin::rpc::log_layer: RPC#1feb8d OK: Filecoin.NetAgentVersion. Took 37.023µs
2024-09-06T11:29:28.210048Z  INFO forest_filecoin::rpc::log_layer: RPC#7a0476 OK: Filecoin.NetAgentVersion. Took 37.227µs
```

Debug:
```
❯ RUST_LOG=warning,forest_filecoin::rpc=debug forest --chain calibnet --encrypt-keystore=false
2024-09-06T11:33:34.545142Z  INFO forest_filecoin::rpc: Ready for RPC connections
2024-09-06T11:33:36.668335Z DEBUG forest_filecoin::rpc::auth_layer: Decoded JWT Claims: read
2024-09-06T11:33:36.668442Z  INFO forest_filecoin::rpc::log_layer: RPC#38f1eb OK: Filecoin.StateNetworkName. Took 87.752µs
2024-09-06T11:33:36.668445Z DEBUG forest_filecoin::rpc::log_layer: RPC#38f1eb: Filecoin.StateNetworkName. Params: []
2024-09-06T11:33:36.668579Z DEBUG forest_filecoin::rpc::auth_layer: Decoded JWT Claims: read
2024-09-06T11:33:36.668648Z  INFO forest_filecoin::rpc::log_layer: RPC#79faae OK: Filecoin.NetPeers. Took 66.356µs
2024-09-06T11:33:36.668655Z DEBUG forest_filecoin::rpc::log_layer: RPC#79faae: Filecoin.NetPeers. Params: []
2024-09-06T11:33:36.668795Z DEBUG forest_filecoin::rpc::auth_layer: Decoded JWT Claims: read
2024-09-06T11:33:36.668812Z  INFO forest_filecoin::rpc::log_layer: RPC#371a0e OK: Filecoin.NetAgentVersion. Took 14.665µs
2024-09-06T11:33:36.668814Z DEBUG forest_filecoin::rpc::log_layer: RPC#371a0e: Filecoin.NetAgentVersion. Params: ["12D3KooWEiBN8jBX8EBoM3M47pVRLRWV812gDRUJhMxgyVkUoR48"]
2024-09-06T11:33:36.669013Z DEBUG forest_filecoin::rpc::auth_layer: Decoded JWT Claims: read
2024-09-06T11:33:36.669024Z  INFO forest_filecoin::rpc::log_layer: RPC#ea0dab OK: Filecoin.NetAgentVersion. Took 9.864µs
2024-09-06T11:33:36.669026Z DEBUG forest_filecoin::rpc::log_layer: RPC#ea0dab: Filecoin.NetAgentVersion. Params: ["12D3KooWGcsALYimqXxTVLERGnLGBBHdAFdpNkyyrbK39QC2pV6r"]
2024-09-06T11:33:36.669049Z DEBUG forest_filecoin::rpc::auth_layer: Decoded JWT Claims: read
2024-09-06T11:33:36.669065Z DEBUG forest_filecoin::rpc::auth_layer: Decoded JWT Claims: read
2024-09-06T11:33:36.669063Z  INFO forest_filecoin::rpc::log_layer: RPC#f4aa60 OK: Filecoin.NetAgentVersion. Took 11.867µs
2024-09-06T11:33:36.669070Z DEBUG forest_filecoin::rpc::log_layer: RPC#f4aa60: Filecoin.NetAgentVersion. Params: ["12D3KooWQMhAtqMaGRygXeH7jXgVwEKwF1WZNb9XS7TktzU4mnoJ"]
2024-09-06T11:33:36.669074Z  INFO forest_filecoin::rpc::log_layer: RPC#18b136 OK: Filecoin.NetAgentVersion. Took 7.181µs
2024-09-06T11:33:36.669076Z DEBUG forest_filecoin::rpc::log_layer: RPC#18b136: Filecoin.NetAgentVersion. Params: ["12D3KooWNmDqNR8V1qDPwQJANDmdepzQ4uQuMfxEm4wLgDj43eWC"]
```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
