### PR TITLE
chore: upgrade rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]

--- a/src/key_management/keystore.rs
+++ b/src/key_management/keystore.rs
@@ -129,12 +129,8 @@ impl KeyStore {
                         // Existing cleartext JSON keystore
                         let persisted_key_info: HashMap<String, PersistentKeyInfo> =
                             serde_json::from_reader(reader)
-                                .map_err(|e| {
-                                    error!(
-                                "failed to deserialize keyfile, initializing new keystore at: {:?}",
-                                file_path
-                            );
-                                    e
+                                .inspect_err(|error| {
+                                    error!(%error, "failed to deserialize keyfile, initializing new keystore at: {}.", file_path.display());
                                 })
                                 .unwrap_or_default();
 
@@ -160,8 +156,8 @@ impl KeyStore {
                     Err(e) => {
                         if e.kind() == ErrorKind::NotFound {
                             warn!(
-                                "Keystore does not exist, initializing new keystore at: {:?}",
-                                file_path
+                                "Keystore does not exist, initializing new keystore at: {}",
+                                file_path.display()
                             );
                             Ok(Self {
                                 key_info: HashMap::new(),
@@ -230,9 +226,8 @@ impl KeyStore {
                                 .map_err(|error| Error::Other(error.to_string()))?;
 
                             let key_info = from_slice_with_fallback(&decrypted_data)
-                                .map_err(|e| {
-                                    error!("Failed to deserialize keyfile, initializing new");
-                                    e
+                                .inspect_err(|error| {
+                                    error!(%error, "Failed to deserialize keyfile, initializing new");
                                 })
                                 .unwrap_or_default();
 

--- a/src/libp2p/peer_manager.rs
+++ b/src/libp2p/peer_manager.rs
@@ -349,6 +349,7 @@ impl PeerManager {
         self.protected_peers.write().insert(peer_id);
     }
 
+    #[allow(dead_code)]
     pub fn unprotect_peer(&self, peer_id: &PeerId) {
         self.protected_peers.write().remove(peer_id);
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- upgrade rust toolchain to 1.81.0
- fix clippy warnings

```
warning: method `unprotect_peer` is never used
   --> src/libp2p/peer_manager.rs:352:12
    |
107 | impl PeerManager {
    | ---------------- method in this implementation
...
352 |     pub fn unprotect_peer(&self, peer_id: &PeerId) {
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: using `map_err` over `inspect_err`
   --> src/key_management/keystore.rs:132:34
    |
132 | ...                   .map_err(|e| {
    |                        ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
    = note: `#[warn(clippy::manual_inspect)]` on by default
help: try
    |
132 ~                                 .inspect_err(|e| {
133 |                                     error!(
134 |                                 "failed to deserialize keyfile, initializing new keystore at: {:?}",
135 |                                 file_path
136 ~                             );
    |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

https://releases.rs/docs/1.81.0/

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
