### PR TITLE
feat: support hardlink in --import-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,14 @@
   `Filecoin.EthGetTransactionByBlockNumberAndIndex` to existing methods (though
   without support, which matches the current Lotus's behavior).
 
+- [#4757](https://github.com/ChainSafe/forest/pull/4757) Added an option to
+  hardlink snapshots instead of moving or copying them. This can be invoked with
+  `--import-snapshot <path> --import-mode=hardlink`.
+
+- [#4757](https://github.com/ChainSafe/forest/pull/4757) Added an option to
+  hardlink snapshots and fallback to copying them if not applicable. This can be
+  invoked with `--import-snapshot <path> --import-mode=auto`.
+
 ### Changed
 
 - [#4583](https://github.com/ChainSafe/forest/pull/4583) Removed the expiration

--- a/documentation/src/configuration.md
+++ b/documentation/src/configuration.md
@@ -21,7 +21,7 @@ use of the following flags:
 | --kademlia           | Boolean      | Determines whether Kademilia is allowed                                                             |
 | --mdns               | Boolean      | Determines whether MDNS is allowed                                                                  |
 | --import-snapshot    | OS File Path | Path to snapshot CAR file                                                                           |
-| --import-mode        | String       | Snapshot import mode: Copy, Move, Symlink                                                           |
+| --import-mode        | String       | Snapshot import mode: auto, copy, move, symlink, hardlink                                           |
 | --skip-load          | Boolean      | Skips loading CAR File and uses header to index chain                                               |
 | --req-window         | Integer      | Sets the number of tipsets requested over chain exchange                                            |
 | --tipset-sample-size | Integer      | Number of tipsets to include in the sample which determines the network head during synchronization |

--- a/scripts/tests/bootstrapper/docker-compose-forest.yml
+++ b/scripts/tests/bootstrapper/docker-compose-forest.yml
@@ -76,6 +76,8 @@ services:
 
         # Make sure to use the Forest bootstrapper as the only bootstrap peer
         cat > config.toml <<EOF
+        [client]
+        data_dir = "/data/forest"
         [network]
         bootstrap_peers = ["/dns/forest-bootstrapper/tcp/$FOREST_P2P_PORT/p2p/$${PEER_ID}"]
         EOF
@@ -83,8 +85,7 @@ services:
         forest --chain ${CHAIN} --encrypt-keystore false --no-gc \
           --config config.toml \
           --rpc-address 0.0.0.0:${FOREST_RPC_PORT} \
-          --import-snapshot $(ls /data/*.car.zst | tail -n 1) \
-          --import-mode=move
+          --import-snapshot $(ls /data/*.car.zst | tail -n 1)
     healthcheck:
       test: [ "CMD", "forest-cli", "sync", "wait" ]
       interval: 15s

--- a/src/cli_shared/cli/mod.rs
+++ b/src/cli_shared/cli/mod.rs
@@ -84,8 +84,8 @@ pub struct CliOpts {
     /// Import a snapshot from a local CAR file or URL
     #[arg(long)]
     pub import_snapshot: Option<String>,
-    /// Snapshot import mode. Available modes are `copy`, `move` and `symlink`.
-    #[arg(long, default_value = "copy")]
+    /// Snapshot import mode. Available modes are `auto`, `copy`, `move`, `symlink` and `hardlink`.
+    #[arg(long, default_value = "auto")]
     pub import_mode: ImportMode,
     /// Halt with exit code 0 after successfully importing a snapshot
     #[arg(long)]

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -303,36 +303,46 @@ mod test {
 
     #[tokio::test]
     async fn import_snapshot_from_file_valid() {
-        for import_mode in &[ImportMode::Copy, ImportMode::Move] {
-            import_snapshot_from_file("test-snapshots/chain4.car", *import_mode)
+        for import_mode in [ImportMode::Auto, ImportMode::Copy, ImportMode::Move] {
+            import_snapshot_from_file("test-snapshots/chain4.car", import_mode)
                 .await
                 .unwrap();
         }
 
         // Linking is not supported for raw CAR files.
-        import_snapshot_from_file("test-snapshots/chain4.car", ImportMode::Symlink)
-            .await
-            .unwrap_err();
+        for import_mode in [ImportMode::Symlink, ImportMode::Hardlink] {
+            import_snapshot_from_file("test-snapshots/chain4.car", import_mode)
+                .await
+                .unwrap_err();
+        }
     }
 
     #[tokio::test]
     async fn import_snapshot_from_compressed_file_valid() {
-        for import_mode in &[ImportMode::Copy, ImportMode::Move] {
-            import_snapshot_from_file("test-snapshots/chain4.car.zst", *import_mode)
+        for import_mode in [ImportMode::Auto, ImportMode::Copy, ImportMode::Move] {
+            import_snapshot_from_file("test-snapshots/chain4.car.zst", import_mode)
                 .await
                 .unwrap();
         }
 
-        // Linking is supported only for `forest.car.zst` files.
-        import_snapshot_from_file("test-snapshots/chain4.car.zst", ImportMode::Symlink)
-            .await
-            .unwrap_err();
+        // Linking is not supported for raw CAR files.
+        for import_mode in [ImportMode::Symlink, ImportMode::Hardlink] {
+            import_snapshot_from_file("test-snapshots/chain4.car", import_mode)
+                .await
+                .unwrap_err();
+        }
     }
 
     #[tokio::test]
     async fn import_snapshot_from_forest_car_valid() {
-        for import_mode in &[ImportMode::Copy, ImportMode::Move, ImportMode::Symlink] {
-            import_snapshot_from_file("test-snapshots/chain4.forest.car.zst", *import_mode)
+        for import_mode in [
+            ImportMode::Auto,
+            ImportMode::Copy,
+            ImportMode::Move,
+            ImportMode::Symlink,
+            ImportMode::Hardlink,
+        ] {
+            import_snapshot_from_file("test-snapshots/chain4.forest.car.zst", import_mode)
                 .await
                 .unwrap();
         }
@@ -340,7 +350,13 @@ mod test {
 
     #[tokio::test]
     async fn import_snapshot_from_file_invalid() {
-        for import_mode in &[ImportMode::Copy, ImportMode::Move, ImportMode::Symlink] {
+        for import_mode in &[
+            ImportMode::Auto,
+            ImportMode::Copy,
+            ImportMode::Move,
+            ImportMode::Symlink,
+            ImportMode::Hardlink,
+        ] {
             import_snapshot_from_file("Cargo.toml", *import_mode)
                 .await
                 .unwrap_err();
@@ -349,7 +365,13 @@ mod test {
 
     #[tokio::test]
     async fn import_snapshot_from_file_not_found() {
-        for import_mode in &[ImportMode::Copy, ImportMode::Move, ImportMode::Symlink] {
+        for import_mode in &[
+            ImportMode::Auto,
+            ImportMode::Copy,
+            ImportMode::Move,
+            ImportMode::Symlink,
+            ImportMode::Hardlink,
+        ] {
             import_snapshot_from_file("dummy.car", *import_mode)
                 .await
                 .unwrap_err();
@@ -358,7 +380,13 @@ mod test {
 
     #[tokio::test]
     async fn import_snapshot_from_url_not_found() {
-        for import_mode in &[ImportMode::Copy, ImportMode::Move, ImportMode::Symlink] {
+        for import_mode in &[
+            ImportMode::Auto,
+            ImportMode::Copy,
+            ImportMode::Move,
+            ImportMode::Symlink,
+            ImportMode::Hardlink,
+        ] {
             import_snapshot_from_file("https://forest.chainsafe.io/dummy.car", *import_mode)
                 .await
                 .unwrap_err();
@@ -384,7 +412,12 @@ mod test {
                     std::path::absolute(file_path)?
                 );
             }
+            ImportMode::Move => {
+                assert!(!file_path.exists());
+                assert!(path.is_file());
+            }
             _ => {
+                assert!(file_path.is_file());
                 assert!(path.is_file());
             }
         }

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -75,12 +75,16 @@ pub fn load_all_forest_cars<T>(store: &ManyCar<T>, forest_car_db_dir: &Path) -> 
 #[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
 pub enum ImportMode {
     #[default]
+    /// Hard link the snapshot and fallback to `Copy` if not applicable
+    Auto,
     /// Copies the snapshot to the database directory.
     Copy,
     /// Moves the snapshot to the database directory (or copies and deletes the original).
     Move,
     /// Creates a symbolic link to the snapshot in the database directory.
     Symlink,
+    /// Creates a symbolic link to the snapshot in the database directory.
+    Hardlink,
 }
 
 /// This function validates and stores the CAR binary from `from_path`(either local path or URL) into the `{DB_ROOT}/car_db/`
@@ -99,14 +103,15 @@ pub async fn import_chain_as_forest_car(
         chrono::Utc::now().timestamp_millis()
     ));
 
-    match import_mode {
-        ImportMode::Copy | ImportMode::Move => {
+    let move_or_copy = |mode: ImportMode| {
+        let forest_car_db_path = forest_car_db_path.clone();
+        async move {
             let downloaded_car_temp_path =
                 tempfile::NamedTempFile::new_in(forest_car_db_dir)?.into_temp_path();
             if let Ok(url) = Url::parse(&from_path.display().to_string()) {
                 download_to(&url, &downloaded_car_temp_path).await?;
             } else {
-                move_or_copy_file(from_path, &downloaded_car_temp_path, import_mode)?;
+                move_or_copy_file(from_path, &downloaded_car_temp_path, mode)?;
             }
 
             if ForestCar::is_valid(&EitherMmapOrRandomAccessFile::open(
@@ -121,12 +126,58 @@ pub async fn import_chain_as_forest_car(
                     .await?;
                 forest_car_db_temp_path.persist(&forest_car_db_path)?;
             }
+            anyhow::Ok(())
+        }
+    };
+
+    match import_mode {
+        ImportMode::Auto => {
+            if Url::parse(&from_path.display().to_string()).is_ok() {
+                // Fallback to move if from_path is url
+                move_or_copy(ImportMode::Move).await?;
+            } else if ForestCar::is_valid(&EitherMmapOrRandomAccessFile::open(from_path)?) {
+                tracing::info!(
+                    "Hardlinking {} to {}",
+                    from_path.display(),
+                    forest_car_db_path.display()
+                );
+                if std::fs::hard_link(from_path, &forest_car_db_path).is_err() {
+                    tracing::warn!("Error creating hardlink, fallback to copy");
+                    move_or_copy(ImportMode::Copy).await?;
+                }
+            } else {
+                tracing::warn!(
+                    "Snapshot file is not a valid forest.car.zst file, fallback to copy"
+                );
+                move_or_copy(ImportMode::Copy).await?;
+            }
+        }
+        ImportMode::Copy | ImportMode::Move => {
+            move_or_copy(import_mode).await?;
         }
         ImportMode::Symlink => {
             let from_path = std::path::absolute(from_path)?;
             if ForestCar::is_valid(&EitherMmapOrRandomAccessFile::open(&from_path)?) {
+                tracing::info!(
+                    "Symlinking {} to {}",
+                    from_path.display(),
+                    forest_car_db_path.display()
+                );
                 std::os::unix::fs::symlink(from_path, &forest_car_db_path)
                     .context("Error creating symlink")?;
+            } else {
+                bail!("Snapshot file must be a valid forest.car.zst file");
+            }
+        }
+        ImportMode::Hardlink => {
+            if ForestCar::is_valid(&EitherMmapOrRandomAccessFile::open(from_path)?) {
+                tracing::info!(
+                    "Hardlinking {} to {}",
+                    from_path.display(),
+                    forest_car_db_path.display()
+                );
+                std::fs::hard_link(from_path, &forest_car_db_path)
+                    .context("Error creating hardlink")?;
             } else {
                 bail!("Snapshot file must be a valid forest.car.zst file");
             }
@@ -165,6 +216,7 @@ pub async fn download_to(url: &Url, destination: &Path) -> anyhow::Result<()> {
 fn move_or_copy_file(from: &Path, to: &Path, import_mode: ImportMode) -> anyhow::Result<()> {
     match import_mode {
         ImportMode::Move => {
+            tracing::info!("Moving {} to {}", from.display(), to.display());
             if fs::rename(from, to).is_ok() {
                 Ok(())
             } else {
@@ -173,9 +225,12 @@ fn move_or_copy_file(from: &Path, to: &Path, import_mode: ImportMode) -> anyhow:
                 Ok(())
             }
         }
-        ImportMode::Copy => fs::copy(from, to).map(|_| ()).context("Error copying file"),
-        ImportMode::Symlink => {
-            bail!("Symlinking must be handled elsewhere");
+        ImportMode::Copy => {
+            tracing::info!("Copying {} to {}", from.display(), to.display());
+            fs::copy(from, to).map(|_| ()).context("Error copying file")
+        }
+        m => {
+            bail!("{m} must be handled elsewhere");
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

As follow up of #4620

Changes introduced in this pull request:

- add `--import-mode=hardlink` to hard link snapshots instead of copying them to save time and disk space
- add `--import-mode=auto` as default to hard link snapshots and fallback to copying them.
- add some info logs that print modes during snapshot import

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
