### PR TITLE
fix: disable F3 FFI build on non x86_64 archs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,9 +28,15 @@ fn is_docs_rs() -> bool {
 }
 
 fn is_sidecar_ffi_enabled() -> bool {
-    // Opt-out building the F3 sidecar staticlib
-    match std::env::var("FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT") {
-        Ok(value) => !matches!(value.to_lowercase().as_str(), "1" | "true"),
-        _ => true,
+    // Note: arm64 is disabled for now as cross-compilation is not yet supported in rust2go
+    // and it's reported rust2go build does not work on arm64 MacOS
+    if cfg!(target_arch = "x86_64") {
+        // Opt-out building the F3 sidecar staticlib
+        match std::env::var("FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT") {
+            Ok(value) => !matches!(value.to_lowercase().as_str(), "1" | "true"),
+            _ => true,
+        }
+    } else {
+        false
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
