### PR TITLE
fix: demote `safe` eth methods to basic tests

### DIFF
--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -4,8 +4,5 @@
 !Filecoin.MpoolGetNonce
 # CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/actions/runs/9593268587/job/26453560366
 !Filecoin.StateReplay
-# https://github.com/ChainSafe/forest/issues/4661
-!Filecoin.EthGetBlockByNumber
-!eth_getBlockByNumber
 # TODO(elmattic): https://github.com/ChainSafe/forest/issues/4759
 !Filecoin.EthGetTransactionReceipt

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -1412,14 +1412,14 @@ fn eth_tests_with_tipset<DB: Blockstore>(store: &Arc<DB>, shared_tipset: &Tipset
             ))
             .unwrap(),
         ),
-        RpcTest::identity(
+        RpcTest::basic(
             EthGetBlockByNumber::request((
                 BlockNumberOrHash::from_predefined(Predefined::Safe),
                 true,
             ))
             .unwrap(),
         ),
-        RpcTest::identity(
+        RpcTest::basic(
             EthGetBlockByNumber::request((
                 BlockNumberOrHash::from_predefined(Predefined::Finalized),
                 true,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- we have no means of ensuring two nodes are completely in sync with regards to the chain head. As such, we can't, with the current setup, check for parity of methods relying on that.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4661

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
