### PR TITLE
fix: expand environment variables available for curio script

### DIFF
--- a/scripts/devnet-curio/docker-compose.yml
+++ b/scripts/devnet-curio/docker-compose.yml
@@ -275,6 +275,7 @@ services:
       - ./run_curio.sh:/run_curio.sh
     env_file:
       - curio.env
+      - .env
     networks:
       - devnet
     entrypoint: [ "/bin/bash", "/run_curio.sh" ]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The variables from `.env` are required but were lost in the script refactoring. This PR makes them available to the curio script.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://www.notion.so/chainsafe/Documentation-practices-1a7ec5e5486b4a56b26d9df6b1677a63),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
