### PR TITLE
chore: remove doc workflows and targets

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Closes
 <!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->
 
 - [ ] I have performed a self-review of my own code,
-- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://www.notion.so/chainsafe/Documentation-practices-1a7ec5e5486b4a56b26d9df6b1677a63),
+- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
 - [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
 - [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Link Checker (Repo Readme)
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: './**/*.md'
+          args: '.**/*.md'
           # Fail action on broken links
           fail: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,14 +9,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**.md'
   merge_group:
   pull_request:
     branches:
       - main
+    paths:
+      - '**.md'
 
 jobs:
   check-docs:
-    name: Check Markdown Links
+    name: Markdown Lint
     runs-on: ubuntu-24.04
     steps:
       - name: Link Checker (Repo Readme)
@@ -25,3 +29,6 @@ jobs:
           args: '*.md'
           # Fail action on broken links
           fail: true
+      - name: Lint Markdown
+        uses: actions/checkout@v4
+      - run: make md-check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,12 +23,12 @@ jobs:
     name: Markdown Lint
     runs-on: ubuntu-24.04
     steps:
+      - name: Lint Markdown
+        uses: actions/checkout@v4
+        run: make md-check
       - name: Link Checker (Repo Readme)
         uses: lycheeverse/lychee-action@v1.10.0
         with:
           args: '*.md'
           # Fail action on broken links
           fail: true
-      - name: Lint Markdown
-        uses: actions/checkout@v4
-      - run: make md-check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Link Checker (Repo Readme)
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: '*.md'
+          args: './**/*.md'
           # Fail action on broken links
           fail: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,70 +14,14 @@ on:
     branches:
       - main
 
-env:
-  CACHE_TIMEOUT_MINUTES: 5
-  AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
-  AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
-  RUSTC_WRAPPER: "sccache"
-
 jobs:
-  check-publish-docs:
+  check-docs:
     name: Publish
     runs-on: ubuntu-24.04
     steps:
-      - name: Configure SCCache variables
-        run: |
-          # External PRs do not have access to 'vars' or 'secrets'.
-          if [[ "$AWS_ACCESS_KEY_ID" != "" ]]; then
-            echo "SCCACHE_ENDPOINT=${{ vars.SCCACHE_ENDPOINT}}" >> $GITHUB_ENV
-            echo "SCCACHE_BUCKET=${{ vars.SCCACHE_BUCKET}}" >> $GITHUB_ENV
-            echo "SCCACHE_REGION=${{ vars.SCCACHE_REGION}}" >> $GITHUB_ENV
-          fi
-      - name: Checkout Sources
-        uses: actions/checkout@v4
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
-        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
-        continue-on-error: true
       - name: Link Checker (Repo Readme)
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: 'README.md'
+          args: '*.md'
           # Fail action on broken links
           fail: true
-      - uses: hanabi1224/cache-cargo-bin-action@v1.0.0
-      - name: Install MDBook
-        run: make install-doc-tools
-        env:
-          RUSTFLAGS: "-Cstrip=symbols"
-      - name: Execute MDBook
-        run: make mdbook-build
-      - name: Build vendored docs
-        run: make vendored-docs
-        env:
-          CC: "sccache clang"
-          CXX: "sccache clang++"
-      - name: Link Checker (Library Documentation)
-        uses: lycheeverse/lychee-action@v1.10.0
-        with:
-          args: './target/doc/forest_filecoin/**/index.html'
-          # Fail action on broken links
-          fail: true
-      - name: Prepare rustdoc for publishing
-        run: mv ./target/doc ./documentation/book/html/rustdoc
-      # The deploy steps are identical expect for name and 'dry-run' attribute.
-      # Ideally this would be refactored.
-      - name: Deploy GH Pages (dry-run)
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          branch: gh-pages
-          folder: ./documentation/book/html/
-          dry-run: true
-      - name: Deploy GH Pages
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
-        if: ${{ github.event_name == 'push' }}
-        with:
-          branch: gh-pages
-          folder: ./documentation/book/html/
-          dry-run: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-docs:
-    name: Publish
+    name: Check Markdown Links
     runs-on: ubuntu-24.04
     steps:
       - name: Link Checker (Repo Readme)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Link Checker (Repo Readme)
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: '.**/*.md'
+          args: '*.md .github/*.md .github/**/*.md .config/*.md'
           # Fail action on broken links
           fail: true

--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -18,11 +18,11 @@ jobs:
   shellcheck:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
-    - name: Run shellcheck
-      uses: ludeeus/action-shellcheck@2.0.0
-      env:
-        SHELLCHECK_OPTS: --external-sources --source-path=SCRIPTDIR
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        env:
+          SHELLCHECK_OPTS: --external-sources --source-path=SCRIPTDIR
   rubocop:
     runs-on: ubuntu-24.04
     steps:
@@ -38,19 +38,13 @@ jobs:
   docker-lint:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
-    - name: validate compose file
-      run: docker compose -f monitoring/docker-compose.yml config
-    - uses: hadolint/hadolint-action@v3.1.0
-      with:
-        dockerfile: "Dockerfile*"
-        recursive: true
-        # https://github.com/hadolint/hadolint/wiki/DL3008
-        # https://github.com/hadolint/hadolint/wiki/DL3018
-        ignore: DL3008,DL3018
-  markdown-lint:
-    runs-on: ubuntu-24.04
-    steps:
       - uses: actions/checkout@v4
-      - run: |
-          make md-check
+      - name: validate compose file
+        run: docker compose -f monitoring/docker-compose.yml config
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: "Dockerfile*"
+          recursive: true
+          # https://github.com/hadolint/hadolint/wiki/DL3008
+          # https://github.com/hadolint/hadolint/wiki/DL3018
+          ignore: DL3008,DL3018

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,3 @@
 http://open-rpc.org/
+https://github.com/
+https:://www.notion.so/chainsafe/Documentation-practices-1a7ec5e5486b4a56b26d9df6b1677a63

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,2 @@
 http://open-rpc.org/
 https://github.com/
-https:://www.notion.so/chainsafe/Documentation-practices-1a7ec5e5486b4a56b26d9df6b1677a63

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1706,8 +1706,8 @@ All initial change sets:
 - `ccf1ac11` Return Ok when validating drand beacon entries similar to how Lotus
   does as per the audit recommendation.
   ([#1206](https://github.com/ChainSafe/forest/pull/1206)) (Hunter Trujillo)
-- `f5fe14d2` [Audit fixes] FOR-03 - Inconsistent Deserialization of Randomness ([#1205](https://github.com/ChainSafe/forest/pull/1205))
-  (Hunter Trujillo)
+- `f5fe14d2` [Audit fixes] FOR-03 - Inconsistent Deserialization of Randomness
+  ([#1205](https://github.com/ChainSafe/forest/pull/1205)) (Hunter Trujillo)
 - `32a9ae5f` Rest of V5 Updates
   ([#1217](https://github.com/ChainSafe/forest/pull/1217)) (Eric Tu)
 - `e6e1c8ad` API_IMPLEMENTATION.md build script formatting improvements
@@ -1762,10 +1762,11 @@ All initial change sets:
   ([#1160](https://github.com/ChainSafe/forest/pull/1160)) (creativcoder)
 - `34799734` Wallet CLI Implementation
   ([#1128](https://github.com/ChainSafe/forest/pull/1128)) (Connor Mullett)
-- `f698ba88` [Audit fixes] FOR-02: Inconsistent Deserialization of Address ID ([#1149](https://github.com/ChainSafe/forest/pull/1149))
-  (Hunter Trujillo)
+- `f698ba88` [Audit fixes] FOR-02: Inconsistent Deserialization of Address ID
+  ([#1149](https://github.com/ChainSafe/forest/pull/1149)) (Hunter Trujillo)
 - `e50d2ae8` [Audit fixes] FOR-16: Unnecessary Extensive Permissions for Private
-  Keys ([#1151](https://github.com/ChainSafe/forest/pull/1151)) (Hunter Trujillo)
+  Keys ([#1151](https://github.com/ChainSafe/forest/pull/1151)) (Hunter
+  Trujillo)
 - `665ca476` Subtract 1 ([#1152](https://github.com/ChainSafe/forest/pull/1152))
   (Eric Tu)
 - `4047ff5e` 3 -> 4 ([#1153](https://github.com/ChainSafe/forest/pull/1153))

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,6 @@ install-lint-tools-ci:
 
 	cargo binstall --no-confirm taplo-cli cargo-spellcheck cargo-audit
 
-install-doc-tools:
-	cargo install --locked mdbook
-	cargo install --locked mdbook-linkcheck
-
 clean-all:
 	cargo clean
 
@@ -120,17 +116,5 @@ license:
 
 docs:
 	cargo doc --no-deps
-
-mdbook:
-	mdbook serve documentation
-
-mdbook-build:
-	mdbook build ./documentation
-
-# These are the docs that are hosted at https://chainsafe.github.io/forest/rustdoc/.
-# The root index.html simply redirects to the main `forest-filecoin` library documentation.
-vendored-docs:
-	cargo doc --document-private-items
-	cp ./build/vendored-docs-redirect.index.html target/doc/index.html
 
 .PHONY: $(MAKECMDGOALS)

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ docker exec -it forest /bin/bash
 ```
 
 For more in-depth usage and sample use cases, please refer to the Forest Docker
-documentation in the [Forest Book]. Keep in mind that the `latest` tag is the latest
-stable release. If you want to use the current development build, use the `edge`
-tag.
+documentation in the [Forest Book]. Keep in mind that the `latest` tag is the
+latest stable release. If you want to use the current development build, use the
+`edge` tag.
 
 ## Dependencies
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -30,7 +30,7 @@ predefined dashboards. Use the default Grafana credentials: `admin`/`admin`.
 To receive telemetries via `Loki`, run `forest-daemon` with `--loki`, then go to
 `Configuration/Data Sources` on `grafana` webapp, select `Loki`, click on
 `Explore`, and then you can run queries with `LogQL`. For details of `LogQL`
-refer to its [documentation](https://grafana.com/docs/loki/latest/logql/).
+refer to its [documentation](https://grafana.com/docs/loki/latest/logql /).
 
 ## Reload Dashboards
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Removed documentation workflow
- Removed make the now-obsolete documentation make targets

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links
Follow-up: https://github.com/ChainSafe/forest/issues/4793

Do we still need `make docs`?
We also copy `documentation` folder as part of `release` and `release-dispatch` workflows, but that can be removed as part of `documentation` folder cleanup later on.

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://www.notion.so/chainsafe/Documentation-practices-1a7ec5e5486b4a56b26d9df6b1677a63),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
