### PR TITLE
feat(f3): add initial power table support to F3 sidecar

### DIFF
--- a/f3-sidecar/ffi_gen.go
+++ b/f3-sidecar/ffi_gen.go
@@ -33,12 +33,12 @@ import (
 var GoF3NodeImpl GoF3Node
 
 type GoF3Node interface {
-	run(rpc_endpoint string, f3_rpc_endpoint string, finality int64, db string, manifest_server string) bool
+	run(rpc_endpoint string, f3_rpc_endpoint string, initial_power_table string, finality int64, db string, manifest_server string) bool
 }
 
 //export CGoF3Node_run
-func CGoF3Node_run(rpc_endpoint C.StringRef, f3_rpc_endpoint C.StringRef, finality C.int64_t, db C.StringRef, manifest_server C.StringRef, slot *C.void, cb *C.void) {
-	resp := GoF3NodeImpl.run(newString(rpc_endpoint), newString(f3_rpc_endpoint), newC_int64_t(finality), newString(db), newString(manifest_server))
+func CGoF3Node_run(rpc_endpoint C.StringRef, f3_rpc_endpoint C.StringRef, initial_power_table C.StringRef, finality C.int64_t, db C.StringRef, manifest_server C.StringRef, slot *C.void, cb *C.void) {
+	resp := GoF3NodeImpl.run(newString(rpc_endpoint), newString(f3_rpc_endpoint), newString(initial_power_table), newC_int64_t(finality), newString(db), newString(manifest_server))
 	resp_ref, buffer := cvt_ref(cntC_bool, refC_bool)(&resp)
 	C.GoF3Node_run_cb(unsafe.Pointer(cb), resp_ref, unsafe.Pointer(slot))
 	runtime.KeepAlive(resp)

--- a/f3-sidecar/ffi_impl.go
+++ b/f3-sidecar/ffi_impl.go
@@ -21,8 +21,8 @@ type f3Impl struct {
 	ctx context.Context
 }
 
-func (f3 *f3Impl) run(rpc_endpoint string, f3_rpc_endpoint string, finality int64, db string, manifest_server string) bool {
-	err := run(f3.ctx, rpc_endpoint, f3_rpc_endpoint, finality, db, manifest_server)
+func (f3 *f3Impl) run(rpc_endpoint string, f3_rpc_endpoint string, initial_power_table string, finality int64, db string, manifest_server string) bool {
+	err := run(f3.ctx, rpc_endpoint, f3_rpc_endpoint, initial_power_table, finality, db, manifest_server)
 	return err == nil
 }
 

--- a/f3-sidecar/go.mod
+++ b/f3-sidecar/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/filecoin-project/go-f3 v0.3.0
 	github.com/filecoin-project/go-jsonrpc v0.6.0
 	github.com/filecoin-project/go-state-types v0.14.0
+	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-log/v2 v2.5.1
@@ -49,7 +50,6 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/boxo v0.21.0 // indirect
-	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipld/go-ipld-prime v0.21.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect

--- a/f3-sidecar/main.go
+++ b/f3-sidecar/main.go
@@ -22,6 +22,8 @@ func main() {
 	flag.StringVar(&rpcEndpoint, "rpc", "http://127.0.0.1:2345/rpc/v1", "forest RPC endpoint")
 	var f3RpcEndpoint string
 	flag.StringVar(&f3RpcEndpoint, "f3-rpc", "127.0.0.1:23456", "The RPC endpoint F3 sidecar listens on")
+	var initialPowerTable string
+	flag.StringVar(&initialPowerTable, "initial-power-table", "", "The CID of the initial power table")
 	var finality int64
 	flag.Int64Var(&finality, "finality", 900, "chain finality epochs")
 	var db string
@@ -32,7 +34,7 @@ func main() {
 
 	ctx := context.Background()
 
-	err := run(ctx, rpcEndpoint, f3RpcEndpoint, finality, db, manifestServer)
+	err := run(ctx, rpcEndpoint, f3RpcEndpoint, initialPowerTable, finality, db, manifestServer)
 	if err != nil {
 		panic(err)
 	}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -434,9 +434,14 @@ pub(super) async fn start(
                 .data_dir
                 .join(format!("f3-db/{}", config.chain));
             move || {
+                // This will be used post-bootstrap to hard-code the initial F3's initial power table CID.
+                // Read from an environment variable for now before the hard-coded value is determined.
+                let initial_power_table =
+                    std::env::var("FOREST_F3_INITIAL_POWER_TABLE").unwrap_or_default();
                 crate::f3::run_f3_sidecar_if_enabled(
                     format!("http://{rpc_address}/rpc/v1"),
                     crate::rpc::f3::get_f3_rpc_endpoint().to_string(),
+                    initial_power_table,
                     finality,
                     std::env::var("FOREST_F3_DB_PATH")
                         .unwrap_or(default_f3_db_path.display().to_string()),

--- a/src/f3/go_ffi.rs
+++ b/src/f3/go_ffi.rs
@@ -12,6 +12,7 @@ pub trait GoF3Node {
     fn run(
         rpc_endpoint: String,
         f3_rpc_endpoint: String,
+        initial_power_table: String,
         finality: i64,
         db: String,
         manifest_server: String,

--- a/src/f3/mod.rs
+++ b/src/f3/mod.rs
@@ -11,6 +11,7 @@ use crate::utils::misc::env::is_env_truthy;
 pub fn run_f3_sidecar_if_enabled(
     _rpc_endpoint: String,
     _f3_rpc_endpoint: String,
+    _initial_power_table: String,
     _finality: i64,
     _db: String,
     _manifest_server: String,
@@ -21,6 +22,7 @@ pub fn run_f3_sidecar_if_enabled(
             GoF3NodeImpl::run(
                 _rpc_endpoint,
                 _f3_rpc_endpoint,
+                _initial_power_table,
                 _finality,
                 _db,
                 _manifest_server,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR ports https://github.com/filecoin-project/lotus/pull/12502 to Forest F3 sidecar integration

Changes introduced in this pull request:

-

CI log: https://github.com/ChainSafe/forest/actions/runs/11029965114/job/30633871974?pr=4795#step:8:265
```
  2024-09-25T09:22:14.821Z	INFO	f3	go-f3@v0.3.0/host.go:662	reached a decision	{"instance": 14, "ecHeadEpoch": 19}
  2024-09-25T09:22:14.832Z	INFO	f3	go-f3@v0.3.0/host.go:284	backing off for: 1m10s
  2024-09-25T09:22:20.867Z	INFO	f3	go-f3@v0.3.0/host.go:662	reached a decision	{"instance": 15, "ecHeadEpoch": 19}
  2024-09-25T09:22:20.875Z	INFO	f3	go-f3@v0.3.0/host.go:284	backing off for: 1m39.68s
  2024-09-25T09:22:20.912Z	INFO	f3	go-f3@v0.3.0/host.go:662	reached a decision	{"instance": 16, "ecHeadEpoch": 22}
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://www.notion.so/chainsafe/Documentation-practices-1a7ec5e5486b4a56b26d9df6b1677a63),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
