### PR TITLE
fix: align f3 configuration with the regular devnet

### DIFF
--- a/scripts/devnet-curio/docker-compose.yml
+++ b/scripts/devnet-curio/docker-compose.yml
@@ -177,8 +177,10 @@ services:
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
       - RUST_LOG=info,forest_filecoin::blocks::header=trace
+      - FOREST_F3_SIDECAR_FFI_ENABLED=1
+      - FOREST_F3_FINALITY=${F3_FINALITY}
       - FOREST_F3_PERMANENT_PARTICIPATING_MINER_ADDRESSES=${MINER_ACTOR_ADDRESS}
-      - FOREST_F3_SIDECAR_RPC_ENDPOINT=f3:${F3_RPC_PORT}
+      - FOREST_F3_SIDECAR_RPC_ENDPOINT=127.0.0.1:${F3_RPC_PORT}
       - FOREST_GENESIS_NETWORK_VERSION=${GENESIS_NETWORK_VERSION}
       - FOREST_SHARK_HEIGHT=${SHARK_HEIGHT}
       - FOREST_HYGGE_HEIGHT=${HYGGE_HEIGHT}
@@ -224,27 +226,6 @@ services:
         export FULLNODE_API_INFO=$$TOKEN:/dns/forest/tcp/${FOREST_RPC_PORT}/http
         forest-wallet --remote-wallet import ${LOTUS_DATA_DIR}/genesis-sectors/pre-seal-${MINER_ACTOR_ADDRESS}.key || true
         forest-cli net connect /dns/lotus/tcp/${LOTUS_P2P_PORT}/p2p/$$(cat ${LOTUS_DATA_DIR}/PEER_ID)
-  f3:
-    user: root
-    depends_on:
-      forest_connecter:
-        condition: service_completed_successfully
-    build:
-      context: ../../f3-sidecar
-      dockerfile: Dockerfile
-    container_name: f3
-    volumes:
-      - ./data/lotus:${LOTUS_DATA_DIR}
-      - ./data/forest:${FOREST_DATA_DIR}
-    ports:
-      - ${F3_RPC_PORT}:${F3_RPC_PORT}
-    networks:
-      - devnet
-    entrypoint: [ "/bin/bash", "-c" ]
-    command:
-      - |
-        set -euxo pipefail
-        f3-sidecar -finality ${F3_FINALITY} -rpc http://forest:${FOREST_RPC_PORT}/rpc/v1 -f3-rpc 0.0.0.0:${F3_RPC_PORT}
 
   curio:
     depends_on:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- f3 is no longer a separate container.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://www.notion.so/chainsafe/Documentation-practices-1a7ec5e5486b4a56b26d9df6b1677a63),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
