### PR TITLE
fix(ci): add s3 key prefix for macos and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Configure SCCache variables
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: |
           # External PRs do not have access to 'vars' or 'secrets'.
           if [[ "${{secrets.AWS_ACCESS_KEY_ID}}" != "" ]]; then
@@ -84,27 +84,28 @@ jobs:
             echo "SCCACHE_BUCKET=${{ vars.SCCACHE_BUCKET}}" >> $GITHUB_ENV
             echo "SCCACHE_REGION=${{ vars.SCCACHE_REGION}}" >> $GITHUB_ENV
           fi
+          echo "SCCACHE_S3_KEY_PREFIX=aarch64" >> $GITHUB_ENV
       - run: lscpu
       - name: Show IP
         run: curl ifconfig.me
         continue-on-error: true
       - name: Checkout Sources
         uses: actions/checkout@v4
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.5
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         timeout-minutes: '${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}'
         continue-on-error: true
       - uses: actions/setup-go@v5
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           go-version-file: "go.work"
       - name: Cargo Install
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: make install
       - uses: actions/upload-artifact@v4
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: 'forest-linux-arm64'
           path: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Configure SCCache variables
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: |
           # External PRs do not have access to 'vars' or 'secrets'.
           if [[ "${{secrets.AWS_ACCESS_KEY_ID}}" != "" ]]; then
@@ -92,21 +92,21 @@ jobs:
         continue-on-error: true
       - name: Checkout Sources
         uses: actions/checkout@v4
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.5
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         timeout-minutes: '${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}'
         continue-on-error: true
       - uses: actions/setup-go@v5
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           go-version-file: "go.work"
       - name: Cargo Install
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: make install
       - uses: actions/upload-artifact@v4
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: 'forest-linux-arm64'
           path: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,13 +70,13 @@ jobs:
   
   build-ubuntu-2204-arm64:
     name: Build forest binaries on Ubuntu-22.04-arm64
-    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    runs-on: buildjet-8vcpu-ubuntu-2204-arm
     # Run the job only if the PR is not a draft.
     # This is done to limit the runner cost.
     if: github.event.pull_request.draft == false
     steps:
       - name: Configure SCCache variables
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: |
           # External PRs do not have access to 'vars' or 'secrets'.
           if [[ "${{secrets.AWS_ACCESS_KEY_ID}}" != "" ]]; then
@@ -86,26 +86,27 @@ jobs:
           fi
           echo "SCCACHE_S3_KEY_PREFIX=aarch64" >> $GITHUB_ENV
       - run: lscpu
+      - run: vmstat -s
       - name: Show IP
         run: curl ifconfig.me
         continue-on-error: true
       - name: Checkout Sources
         uses: actions/checkout@v4
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.5
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         timeout-minutes: '${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}'
         continue-on-error: true
       - uses: actions/setup-go@v5
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           go-version-file: "go.work"
       - name: Cargo Install
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: make install
       - uses: actions/upload-artifact@v4
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: 'forest-linux-arm64'
           path: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Configure SCCache variables
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: |
           # External PRs do not have access to 'vars' or 'secrets'.
           if [[ "${{secrets.AWS_ACCESS_KEY_ID}}" != "" ]]; then
@@ -91,21 +91,21 @@ jobs:
         continue-on-error: true
       - name: Checkout Sources
         uses: actions/checkout@v4
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.5
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         timeout-minutes: '${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}'
         continue-on-error: true
       - uses: actions/setup-go@v5
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           go-version-file: "go.work"
       - name: Cargo Install
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: make install
       - uses: actions/upload-artifact@v4
-        # if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           name: 'forest-linux-arm64'
           path: |

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -38,6 +38,7 @@ jobs:
             echo "SCCACHE_BUCKET=${{ vars.SCCACHE_BUCKET}}" >> $GITHUB_ENV
             echo "SCCACHE_REGION=${{ vars.SCCACHE_REGION}}" >> $GITHUB_ENV
           fi
+          echo "SCCACHE_S3_KEY_PREFIX=macos" >> $GITHUB_ENV
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup sccache


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR separates sccache directory of macos/amd64 and linux/amd64 by setting `SCCACHE_S3_KEY_PREFIX=[maxos|aarch64]`, and increase RAM on the runner to address build failures in https://github.com/ChainSafe/forest/actions/runs/11034989905/job/30675114594

Note: https://github.com/ChainSafe/forest/actions/runs/11034989905/job/30675114594 passed after retry so the root cause should be OOM.  upgrading buildjet runner model should be the actual fix

Changes introduced in this pull request:

- set SCCACHE_S3_KEY_PREFIX for macos and arm64 build to avoid potential hash confilicts(in file names)
- upgrade `buildjet-4vcpu-ubuntu-2204-arm` to `buildjet-8vcpu-ubuntu-2204-arm` to get rid of OOM

CI log with the change: https://github.com/ChainSafe/forest/actions/runs/11046284131/job/30685340347?pr=4807

https://github.com/ChainSafe/forest/actions/runs/11043424676/job/30677680727?pr=4807#step:11:72
```
Cache location                  s3, name: forest-sccache-us-west, prefix: /macos/
```

https://github.com/ChainSafe/forest/actions/runs/11046284131/job/30685340347?pr=4807#step:19:76
```
Cache location                  s3, name: forest-sccache-us-west, prefix: /aarch64/
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
