### PR TITLE
fix: mac os x aarch64 sidecar compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 ### Fixed
 
 - [#4809](https://github.com/ChainSafe/forest/issues/4777) the Mac OS X build on
-  Apple silicons is now working again.
+  Apple silicons works
 
 ## Forest 0.20.0 "Brexit"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 
 ### Fixed
 
+- [#4809](https://github.com/ChainSafe/forest/issues/4777) the Mac OS X build on
+  Apple silicons is now working again.
+
 ## Forest 0.20.0 "Brexit"
 
 Non-mandatory release including a number of new RPC methods, fixes, and other

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,8 @@ fn main() {
     if !is_docs_rs() && is_sidecar_ffi_enabled() {
         println!("cargo:rustc-cfg=f3sidecar");
         std::env::set_var("GOWORK", "off");
+        // See <https://github.com/golang/go/issues/58159>
+        std::env::set_var("GOFLAGS", "-tags=netgo -lresolv");
         rust2go::Builder::default()
             .with_go_src("./f3-sidecar")
             // the generated Go file has been commited to the git repository,
@@ -30,14 +32,9 @@ fn is_docs_rs() -> bool {
 }
 
 fn is_sidecar_ffi_enabled() -> bool {
-    // Note: arm64 is disabled on MacOS for now as it's reported rust2go build does not work there
-    if cfg!(all(target_arch = "aarch64", target_os = "macos")) {
-        false
-    } else {
-        // Opt-out building the F3 sidecar staticlib
-        match std::env::var("FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT") {
-            Ok(value) => !matches!(value.to_lowercase().as_str(), "1" | "true"),
-            _ => true,
-        }
+    // Opt-out building the F3 sidecar staticlib
+    match std::env::var("FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT") {
+        Ok(value) => !matches!(value.to_lowercase().as_str(), "1" | "true"),
+        _ => true,
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
         // `Netgo` is enabled for all the platforms to be consistent across different builds. It
         // is using pure Go implementation for functionality like name resolution. In the case of
         // sidecar it does not make much difference, but it does fix the Apple silicons builds.
-        // See <https://github.com/golang/go/issues/58159>
+        // See <https://github.com/status-im/status-mobile/issues/20135#issuecomment-2137400475>
         std::env::set_var("GOFLAGS", "-tags=netgo");
         rust2go::Builder::default()
             .with_go_src("./f3-sidecar")

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,9 @@ fn main() {
     if !is_docs_rs() && is_sidecar_ffi_enabled() {
         println!("cargo:rustc-cfg=f3sidecar");
         std::env::set_var("GOWORK", "off");
+        // `Netgo` is enabled for all the platforms to be consistent across different builds. It
+        // is using pure Go implementation for functionality like name resolution. In the case of
+        // sidecar it does not make much difference, but it does fix the Apple silicons builds.
         // See <https://github.com/golang/go/issues/58159>
         std::env::set_var("GOFLAGS", "-tags=netgo");
         rust2go::Builder::default()

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() {
         println!("cargo:rustc-cfg=f3sidecar");
         std::env::set_var("GOWORK", "off");
         // See <https://github.com/golang/go/issues/58159>
-        std::env::set_var("GOFLAGS", "-tags=netgo -lresolv");
+        std::env::set_var("GOFLAGS", "-tags=netgo");
         rust2go::Builder::default()
             .with_go_src("./f3-sidecar")
             // the generated Go file has been commited to the git repository,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fixes the Go compilation on a mac for aarch64 target.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4777

## Other information and links

Has been tested running on calibnet. Works.

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
