### PR TITLE
Documentation change

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,12 @@ forest --config /path/to/your_config.toml
 Example of config options available:
 
 ```toml
+[client]
 data_dir = "<directory for all chain and networking data>"
 genesis_file = "<relative file path of genesis car file>"
 
 [network]
-listening_multiaddr = "<multiaddress>"
+listening_multiaddrs = ["<multiaddress>"]
 bootstrap_peers = ["<multiaddress>"]
 ```
 
@@ -327,5 +328,3 @@ Forest is dual licensed under [MIT] + [Apache 2.0].
 [security at chainsafe dot io]: mailto:security@chainsafe.io
 [MIT]: https://github.com/ChainSafe/forest/blob/main/LICENSE-MIT
 [Apache 2.0]: https://github.com/ChainSafe/forest/blob/main/LICENSE-APACHE
-
-I was here

--- a/README.md
+++ b/README.md
@@ -327,3 +327,5 @@ Forest is dual licensed under [MIT] + [Apache 2.0].
 [security at chainsafe dot io]: mailto:security@chainsafe.io
 [MIT]: https://github.com/ChainSafe/forest/blob/main/LICENSE-MIT
 [Apache 2.0]: https://github.com/ChainSafe/forest/blob/main/LICENSE-APACHE
+
+I was here

--- a/documentation/src/configuration.md
+++ b/documentation/src/configuration.md
@@ -37,18 +37,19 @@ and provide it to the process with the `--config` flag or through the
 The following is an sample configuration file:
 
 ```toml
-genesis = "/path/to/genesis/file"
-rpc = true
-port = 1234
-token = "0394j3094jg0394jg34g"
-metrics-port = 2345
-kademlia = true
-mdns = true
-import-snapshot = /path/to/snapshot/file
-import-chain = /path/to/chain/file
-skip-load = false
-req-window = 100
-tipset-sample-size = 10
-target-peer-count = 100
-encrypt-keystore = false
+[client]
+encrypt_keystore = false
+genesis_file = "/path/to/genesis/file"
+
+[chain]
+name = "<NetworkName taken from localnet.json>"
+type = "devnet"
+
+[sync]
+recent_state_roots = 1
+request_window = 100
+tipset_sample_size = 10
+
+[network]
+bootstrap_peers = ["<multiaddress>"]
 ```


### PR DESCRIPTION
I was trying to setup Forest on a Devnet and noticed that some of the docs are out of date
This PR has corrected a spelling error on the `README` and updated the `configuration.md` file to represent a working configuration
