### PR TITLE
chore: demote RPC logs by one level

### DIFF
--- a/src/rpc/log_layer.rs
+++ b/src/rpc/log_layer.rs
@@ -41,8 +41,8 @@ where
         let service = self.service.clone();
 
         async move {
-            // Avoid performance overhead if INFO level is not enabled.
-            if !tracing::enabled!(tracing::Level::INFO) {
+            // Avoid performance overhead if DEBUG level is not enabled.
+            if !tracing::enabled!(tracing::Level::DEBUG) {
                 return service.call(req).await;
             }
 
@@ -51,7 +51,7 @@ where
             let id = req.id();
             let id = create_unique_id(id, start_time);
 
-            tracing::debug!(
+            tracing::trace!(
                 "RPC#{id}: {method_name}. Params: {params}",
                 params = req.params().as_str().unwrap_or("[]")
             );
@@ -62,7 +62,7 @@ where
             let result = resp.as_error_code().map_or(Cow::Borrowed("OK"), |code| {
                 Cow::Owned(format!("ERR({code})"))
             });
-            tracing::info!("RPC#{id} {result}: {method_name}. Took {elapsed:?}");
+            tracing::debug!("RPC#{id} {result}: {method_name}. Took {elapsed:?}");
 
             resp
         }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- demoted `info` to `debug` and `debug` to `trace` in the log layer of RPC. This avoids spamming logs when the RPC endpoint is repeatedly called, e.g., by F3. See https://github.com/ChainSafe/forest/issues/4790

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
