### PR TITLE
fix: return null in `MinerGetBaseInfo` if miner hasn't been around for 900 epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 - [#4809](https://github.com/ChainSafe/forest/issues/4777) the Mac OS X build on
   Apple silicons works
+- [#4820](https://github.com/ChainSafe/forest/pull/4820) Fix edge-case in
+  `Filecoin.MinerGetBaseInfo` RPC method.
 
 ## Forest 0.20.0 "Brexit"
 

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -1214,7 +1214,14 @@ where
             epoch,
         )?;
 
+        // If the miner actor doesn't exist in the current tipset, it is a
+        // user-error and we must return an error message. If the miner exists
+        // in the current tipset but not in the lookback tipset, we may not
+        // error and should instead return None.
         let actor = self.get_required_actor(&addr, *tipset.parent_state())?;
+        if self.get_actor(&addr, lb_state_root)?.is_none() {
+            return Ok(None);
+        }
 
         let miner_state = miner::State::load(self.blockstore(), actor.code, actor.state)?;
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- If a miner isn't found in the look-back state, we must return `null` to match Lotus' behavior.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
