### PR TITLE
curio devnet: move miner wallet to forest

### DIFF
--- a/scripts/devnet-curio/run_curio.sh
+++ b/scripts/devnet-curio/run_curio.sh
@@ -26,6 +26,7 @@ if [ ! -f "$CURIO_REPO_PATH"/.init.curio ]; then
     echo Create a new miner actor ...
     lotus-shed miner create "$DEFAULT_WALLET" "$DEFAULT_WALLET" "$DEFAULT_WALLET" 8MiB
     touch "$CURIO_REPO_PATH"/.init.setup
+    lotus wallet export "$DEFAULT_WALLET" >"$CURIO_REPO_PATH"/default.key
   fi
 
   if [ ! -f "$CURIO_REPO_PATH"/.init.config ]; then
@@ -54,5 +55,6 @@ fi
 TOKEN=$(cat "$FOREST_DATA_DIR"/token.jwt)
 FULLNODE_API_INFO=$TOKEN:/dns/forest/tcp/${FOREST_RPC_PORT}/http
 export FULLNODE_API_INFO
+lotus wallet import "$CURIO_REPO_PATH"/default.key || true
 echo Starting curio node ...
 exec curio run --nosync --name devnet --layers seal,post,gui


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Forest requires access to the miner key pair. This is solved by exporting the wallet from Lotus and importing it into Forest.
- Errors are ignored since this code is run multiple times and has to be idempotent. I'll fix it soon. Later. Eventually. I promise.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
