### PR TITLE
fix(ci): explicitly specify clang version(14)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,8 @@ env:
   AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
   AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
   RUSTC_WRAPPER: sccache
-  CC: sccache clang
-  CXX: sccache clang++
+  CC: sccache clang-14
+  CXX: sccache clang++-14
 
 jobs:
   build-ubuntu-2204-amd64:

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -21,8 +21,8 @@ env:
   AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
   AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
   RUSTC_WRAPPER: sccache
-  CC: sccache clang
-  CXX: sccache clang++
+  CC: sccache clang-14
+  CXX: sccache clang++-14
   FIL_PROOFS_PARAMETER_CACHE: /var/tmp/filecoin-proof-parameters
   SHELL_IMAGE: busybox
 jobs:
@@ -150,9 +150,6 @@ jobs:
       - name: Other commands check
         run: ./scripts/tests/calibnet_other_check.sh
         timeout-minutes: '${{ fromJSON(env.SCRIPT_TIMEOUT_MINUTES) }}'
-        env:
-          CC: clang
-          CXX: clang++
   calibnet-stateless-mode-check:
     needs:
       - build-ubuntu

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -23,9 +23,9 @@ env:
   CACHE_TIMEOUT_MINUTES: 5
   AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
   AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
-  RUSTC_WRAPPER: "sccache"
-  CC: "sccache clang"
-  CXX: "sccache clang++"
+  RUSTC_WRAPPER: sccache
+  CC: sccache clang-14
+  CXX: sccache clang++-14
 
 jobs:
   lint-all:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,8 +25,8 @@ env:
   CARGO_INCREMENTAL: 0
   CACHE_TIMEOUT_MINUTES: 5
   RUSTC_WRAPPER: "sccache"
-  CC: "sccache clang"
-  CXX: "sccache clang++"
+  CC: sccache clang-14
+  CXX: sccache clang++-14
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -65,30 +65,30 @@ Install [rustup](https://rustup.rs/)
 Install [Go](https://go.dev/doc/install)
 
 - OS Base-Devel/Build-Essential
-- Clang compiler
+- Clang-14 compiler
 
-### Ubuntu (20.04)
+### Ubuntu (22.04)
 
 ```
-sudo apt install build-essential clang
+sudo apt install build-essential clang-14
 ```
 
 ### Archlinux
 
 ```
-sudo pacman -S base-devel clang
+sudo pacman -S base-devel clang-14
 ```
 
 ### Fedora (36)
 
 ```
-sudo dnf install -y clang-devel
+sudo dnf install -y clang-14-devel
 ```
 
 ### Alpine
 
 ```
-apk add git curl make gcc clang clang-dev musl-dev
+apk add git curl make gcc clang-14 clang-14-dev musl-dev
 ```
 
 ## Installation


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

The new Go FFI module of F3 requires clang-14 to build. This PR updates CI manifests and `readme.md` accordingly to specify the working clang version.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
