### PR TITLE
test(rpc): pairty test for Filecoin.F3GetECPowerTable

### DIFF
--- a/src/rpc/methods/f3.rs
+++ b/src/rpc/methods/f3.rs
@@ -16,7 +16,7 @@ use crate::{
     chain::index::ResolveNullTipset,
     libp2p::{NetRPCMethods, NetworkMessage},
     lotus_json::HasLotusJson as _,
-    rpc::{ApiPaths, Ctx, Permission, RpcMethod, ServerError},
+    rpc::{types::ApiTipsetKey, ApiPaths, Ctx, Permission, RpcMethod, ServerError},
     shim::{
         address::{Address, Protocol},
         clock::ChainEpoch,
@@ -539,14 +539,15 @@ impl RpcMethod<1> for F3GetECPowerTable {
     const API_PATHS: ApiPaths = ApiPaths::V1;
     const PERMISSION: Permission = Permission::Read;
 
-    type Params = (F3TipSetKey,);
+    type Params = (ApiTipsetKey,);
     type Ok = Vec<F3PowerEntry>;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
-        params: Self::Params,
+        (ApiTipsetKey(tsk_opt),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        GetPowerTable::handle(ctx, params).await
+        let tsk = tsk_opt.unwrap_or_else(|| ctx.chain_store().heaviest_tipset().key().clone());
+        GetPowerTable::handle(ctx, (tsk.into(),)).await
     }
 }
 
@@ -557,13 +558,16 @@ impl RpcMethod<1> for F3GetF3PowerTable {
     const API_PATHS: ApiPaths = ApiPaths::V1;
     const PERMISSION: Permission = Permission::Read;
 
-    type Params = (F3TipSetKey,);
+    type Params = (ApiTipsetKey,);
     type Ok = serde_json::Value;
 
     async fn handle(
-        _: Ctx<impl Blockstore>,
-        (tsk,): Self::Params,
+        ctx: Ctx<impl Blockstore>,
+        (ApiTipsetKey(tsk_opt),): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
+        let tsk: F3TipSetKey = tsk_opt
+            .unwrap_or_else(|| ctx.chain_store().heaviest_tipset().key().clone())
+            .into();
         let client = get_rpc_http_client()?;
         let mut params = ArrayParams::new();
         params.insert(tsk.into_lotus_json())?;

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -1614,6 +1614,14 @@ fn gas_tests_with_tipset(shared_tipset: &Tipset) -> Vec<RpcTest> {
     )]
 }
 
+fn f3_tests_with_tipset(tipset: &Tipset) -> anyhow::Result<Vec<RpcTest>> {
+    Ok(vec![
+        // using basic because 2 nodes are not garanteed to be at the same head
+        RpcTest::basic(F3GetECPowerTable::request((None.into(),))?),
+        RpcTest::identity(F3GetECPowerTable::request((tipset.key().into(),))?),
+    ])
+}
+
 // Extract tests that use chain-specific data such as block CIDs or message
 // CIDs. Right now, only the last `n_tipsets` tipsets are used.
 fn snapshot_tests(
@@ -1640,6 +1648,7 @@ fn snapshot_tests(
         tests.extend(gas_tests_with_tipset(&tipset));
         tests.extend(mpool_tests_with_tipset(&tipset));
         tests.extend(eth_state_tests_with_tipset(&store, &tipset, eth_chain_id)?);
+        tests.extend(f3_tests_with_tipset(&tipset)?);
     }
 
     Ok(tests)


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- API compare tests for `Filecoin.F3GetECPowerTable`(which does not require F3 to be running)
- (Parity tests for other F3 methods will come later when F3 is enabled by default)

```
| RPC Method                      | Forest | Lotus |
|---------------------------------|--------|-------|
| Filecoin.F3GetECPowerTable (11) | Valid  | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
