### PR TITLE
fix: add the limit check when identify protocol received

### DIFF
--- a/src/libp2p/discovery.rs
+++ b/src/libp2p/discovery.rs
@@ -429,6 +429,10 @@ impl NetworkBehaviour for DiscoveryBehaviour {
                                     Some(info.clone());
                                 if let Some(kademlia) = self.discovery.kademlia.as_mut() {
                                     for address in &info.listen_addrs {
+                                        if self.n_node_connected >= self.target_peer_count {
+                                            // Already over discovery max, don't add new peers.
+                                            continue;
+                                        }
                                         kademlia.add_address(peer_id, address.clone());
                                     }
                                 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Identify discovery protocol that will break up the limitations of the target_peer_count.
- So I add the limit checking at that point.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
