### PR TITLE
fix: failing macos build, wrong arch, missing wallet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           - os: ubuntu-24.04
             file: forest-${{ github.ref_name }}-linux-amd64.zip
           - os: macos-latest
-            file: forest-${{ github.ref_name }}-macos-amd64.zip
+            file: forest-${{ github.ref_name }}-macos-arm64.zip
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -27,8 +27,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         timeout-minutes: 5
         continue-on-error: true
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.work"
       - name: Cargo Build
-        run: cargo build --release --bin forest --bin forest-cli --bin forest-tool
+        run: cargo build --release --bin forest --bin forest-cli --bin forest-tool --bin forest-wallet
       - name: Compress Binary
         run: |
           mkdir -p forest-${{ github.ref_name }}
@@ -37,6 +40,7 @@ jobs:
           sha256sum forest-${{ github.ref_name }}/forest > forest-${{ github.ref_name }}/forest.sha256
           sha256sum forest-${{ github.ref_name }}/forest-cli > forest-${{ github.ref_name }}/forest-cli.sha256
           sha256sum forest-${{ github.ref_name }}/forest-tool > forest-${{ github.ref_name }}/forest-tool.sha256
+          sha256sum forest-${{ github.ref_name }}/forest-wallet > forest-${{ github.ref_name }}/forest-wallet.sha256
           zip -r ${{ matrix.file }} forest-${{ github.ref_name }}
       - name: Upload Binary
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,16 @@ jobs:
         with:
           go-version-file: "go.work"
       - name: Cargo Build
-        run: cargo build --release --bin forest --bin forest-cli --bin forest-tool --bin forest-wallet
-      - name: Compress Binary
         run: |
-          mkdir -p forest-${{ github.ref_name }}
-          cp -v target/release/forest target/release/forest-cli target/release/forest-tool forest-${{ github.ref_name }}
-          cp -rv CHANGELOG.md LICENSE-APACHE LICENSE-MIT README.md documentation forest-${{ github.ref_name }}
-          sha256sum forest-${{ github.ref_name }}/forest > forest-${{ github.ref_name }}/forest.sha256
-          sha256sum forest-${{ github.ref_name }}/forest-cli > forest-${{ github.ref_name }}/forest-cli.sha256
-          sha256sum forest-${{ github.ref_name }}/forest-tool > forest-${{ github.ref_name }}/forest-tool.sha256
-          sha256sum forest-${{ github.ref_name }}/forest-wallet > forest-${{ github.ref_name }}/forest-wallet.sha256
+          mkdir -p release-binaries forest-${{ github.ref_name }}
+          cargo install --locked --path . --force --root release-binaries
+          mv -v release-binaries/bin/* forest-${{ github.ref_name }}
+      - name: Pack artifacts
+        run: |
+          for bin in forest-${{ github.ref_name }}/*; do
+            sha256sum $bin > $bin.sha256
+          done
+          cp -rv CHANGELOG.md LICENSE-APACHE LICENSE-MIT README.md forest-${{ github.ref_name }}
           zip -r ${{ matrix.file }} forest-${{ github.ref_name }}
       - name: Upload Binary
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -35,16 +35,16 @@ jobs:
         with:
           go-version-file: "go.work"
       - name: Cargo Build
-        run: cargo build --release --bin forest --bin forest-cli --bin forest-tool --bin forest-wallet
-      - name: Compress Binary
         run: |
-          mkdir -p forest-${{ github.event.inputs.tag }}
-          cp -v target/release/forest target/release/forest-cli target/release/forest-tool forest-${{ github.event.inputs.tag }}
-          cp -rv CHANGELOG.md LICENSE-APACHE LICENSE-MIT README.md documentation forest-${{ github.event.inputs.tag }}
-          sha256sum forest-${{ github.event.inputs.tag }}/forest > forest-${{ github.event.inputs.tag }}/forest.sha256
-          sha256sum forest-${{ github.event.inputs.tag }}/forest-cli > forest-${{ github.event.inputs.tag }}/forest-cli.sha256
-          sha256sum forest-${{ github.event.inputs.tag }}/forest-tool > forest-${{ github.event.inputs.tag }}/forest-tool.sha256
-          sha256sum forest-${{ github.event.inputs.tag }}/forest-wallet > forest-${{ github.event.inputs.tag }}/forest-wallet.sha256
+          mkdir -p release-binaries forest-${{ github.event.inputs.tag }}
+          cargo install --locked --path . --force --root release-binaries
+          mv -v release-binaries/bin/* forest-${{ github.event.inputs.tag }}
+      - name: Pack artifacts
+        run: |
+          for bin in forest-${{ github.event.inputs.tag }}/*; do
+            sha256sum $bin > $bin.sha256
+          done
+          cp -rv CHANGELOG.md LICENSE-APACHE LICENSE-MIT README.md forest-${{ github.event.inputs.tag }}
           zip -r ${{ matrix.file }} forest-${{ github.event.inputs.tag }}
       - name: Upload Binary
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -19,7 +19,7 @@ jobs:
           - os: ubuntu-24.04
             file: forest-${{ github.event.inputs.tag }}-linux-amd64.zip
           - os: macos-latest
-            file: forest-${{ github.event.inputs.tag }}-macos-amd64.zip
+            file: forest-${{ github.event.inputs.tag }}-macos-arm64.zip
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -31,8 +31,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         timeout-minutes: 5
         continue-on-error: true
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.work"
       - name: Cargo Build
-        run: cargo build --release --bin forest --bin forest-cli --bin forest-tool
+        run: cargo build --release --bin forest --bin forest-cli --bin forest-tool --bin forest-wallet
       - name: Compress Binary
         run: |
           mkdir -p forest-${{ github.event.inputs.tag }}
@@ -41,6 +44,7 @@ jobs:
           sha256sum forest-${{ github.event.inputs.tag }}/forest > forest-${{ github.event.inputs.tag }}/forest.sha256
           sha256sum forest-${{ github.event.inputs.tag }}/forest-cli > forest-${{ github.event.inputs.tag }}/forest-cli.sha256
           sha256sum forest-${{ github.event.inputs.tag }}/forest-tool > forest-${{ github.event.inputs.tag }}/forest-tool.sha256
+          sha256sum forest-${{ github.event.inputs.tag }}/forest-wallet > forest-${{ github.event.inputs.tag }}/forest-wallet.sha256
           zip -r ${{ matrix.file }} forest-${{ github.event.inputs.tag }}
       - name: Upload Binary
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes failing build for MacOS (missing Go setup),
- fixes wrong architecture for the build (`macos-latest` moved to arm-based workers)
- fixes missing wallet binary.
- removes legacy `documentation`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
