### PR TITLE
fix(f3): port CertificateExchange.*PollInterval config from lotus

### DIFF
--- a/f3-sidecar/run.go
+++ b/f3-sidecar/run.go
@@ -77,6 +77,8 @@ func run(ctx context.Context, rpcEndpoint string, jwt string, f3RpcEndpoint stri
 	blockDelay := time.Duration(versionInfo.BlockDelay) * time.Second
 	m.EC.Period = blockDelay
 	m.CatchUpAlignment = blockDelay / 2
+	m.CertificateExchange.MinimumPollInterval = blockDelay
+	m.CertificateExchange.MaximumPollInterval = 4 * blockDelay
 
 	head, err := ec.GetHead(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR ports the cert exchange poll interval settings from https://github.com/filecoin-project/lotus/pull/12552/files#diff-7c1c1d6fc05d13d1b9fdb96e27a9dfb356073fb6afb16d2654392d9dee4070d5R66

It makes no difference for chains whose epoch delay is 30s, but should reduce poll interval on devnet.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
