### PR TITLE
fix: curio docker build/publish

### DIFF
--- a/.github/workflows/curio-devnet-publish.yml
+++ b/.github/workflows/curio-devnet-publish.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v6
         with:
+          build-args: |
+            LOTUS_IMAGE=ghcr.io/chainsafe/lotus-devnet:2024-10-10-600728e
+            GOFLAGS="-tags=debug"
           file: ./scripts/devnet-curio/curio.dockerfile
           context: ./scripts/devnet-curio
           tags: ${{ steps.meta.outputs.tags }}

--- a/scripts/devnet-curio/.env
+++ b/scripts/devnet-curio/.env
@@ -1,4 +1,5 @@
 LOTUS_IMAGE=ghcr.io/chainsafe/lotus-devnet:2024-10-10-600728e
+CURIO_IMAGE=ghcr.io/chainsafe/curio-devnet:2024-10-22-d0b5671
 FOREST_DATA_DIR=/forest_data
 LOTUS_DATA_DIR=/lotus_data
 CURIO_REPO_PATH=/var/lib/curio

--- a/scripts/devnet-curio/docker-compose.yml
+++ b/scripts/devnet-curio/docker-compose.yml
@@ -238,12 +238,7 @@ services:
       lotus_node:
         condition: service_healthy
     container_name: curio
-    build:
-      context: .
-      dockerfile: curio.dockerfile
-      args:
-        GOFLAGS: "-tags=debug"
-        LOTUS_IMAGE: ${LOTUS_IMAGE}
+    image: ${CURIO_IMAGE}
     init: true
     ports:
       - "12300:12300" # API


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes the curio devnet build/publish workflow,
- uses the cached image in the CI so that Curio is not rebuilt on every commit in a PR

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
