### PR TITLE
chore: use v1.30.0 stable Lotus in CI tests

### DIFF
--- a/scripts/tests/api_compare/.env
+++ b/scripts/tests/api_compare/.env
@@ -1,6 +1,6 @@
 # Note: this should be a `fat` image so that it contains the pre-downloaded filecoin proof parameters
 FOREST_IMAGE=ghcr.io/chainsafe/forest:edge-fat
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.30.0-rc3-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.30.0-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/scripts/tests/bootstrapper/.env
+++ b/scripts/tests/bootstrapper/.env
@@ -1,5 +1,5 @@
 # Note: this should be a `fat` image so that it contains the pre-downloaded filecoin proof parameters
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.30.0-rc3-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.30.0-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/scripts/tests/snapshot_parity/.env
+++ b/scripts/tests/snapshot_parity/.env
@@ -1,4 +1,4 @@
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.30.0-rc3-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.30.0-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- use v1.30.0 stable Lotus in CI tests, @LeshyBot can't deal with this at its current capacities.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
