### PR TITLE
chore: remove libipld usage from bitswap module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,10 +3299,10 @@ name = "forest-interop-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cid",
  "flume 0.11.1",
  "forest-filecoin",
  "futures",
- "libipld",
  "libp2p",
  "libp2p-swarm-test",
  "rust2go",
@@ -8003,9 +8003,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,20 @@ license = "MIT OR Apache-2.0"
 description = "Rust Filecoin implementation."
 exclude = [".config", ".github", ".maintain", "documentation", "scripts", "interop-tests", "go.work*"]
 
+[workspace.dependencies]
+anyhow = "1"
+cid = { version = "0.10", default-features = false, features = ["std"] }
+flume = "0.11"
+futures = "0.3"
+libp2p = { version = "0.54", default-features = false }
+libp2p-swarm-test = "0.4"
+rust2go = "0.3"
+tokio = "1"
+
 [dependencies]
 ahash = "0.8"
 anes = "0.2"
-anyhow = "1.0"
+anyhow = { workspace = true }
 argon2 = "0.5"
 async-compression = { version = "0.4", features = ["tokio", "zstd"] }
 async-fs = "2"
@@ -33,7 +43,7 @@ cbor4ii = { version = "0.2", default-features = false, features = ["use_alloc", 
 cfg-if = "1"
 cfg-vis = "0.3"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-cid = { version = "0.10", default-features = false, features = ["std"] }
+cid = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 colored = "2.0"
 crypto_secretbox = "0.1"
@@ -60,9 +70,9 @@ fil_actor_reward_state = { version = "17.0.3" }
 fil_actor_system_state = { version = "17.0.3" }
 fil_actor_verifreg_state = { version = "17.0.3" }
 fil_actors_shared = { version = "17.0.3", features = ["json"] }
-flume = "0.11"
+flume = { workspace = true }
 fs_extra = "1"
-futures = "0.3"
+futures = { workspace = true }
 fvm2 = { package = "fvm", version = "~2.9", default-features = false }
 fvm3 = { package = "fvm", default-features = false, version = "~3.11", features = ["arb"] }
 fvm4 = { package = "fvm", default-features = false, version = "~4.3.3", features = ["arb", "verify-signature"] }
@@ -93,7 +103,7 @@ lazy-regex = "3"
 libipld = { version = "0.16", default-features = false, features = ["dag-cbor", "dag-json", "derive", "serde-codec"] }
 libipld-core = { version = "0.16", features = ['arb', 'serde-codec'] }
 libipld-macro = "0.16"
-libp2p = { version = "0.54", default-features = false, features = [
+libp2p = { workspace = true, features = [
   'autonat',
   'gossipsub',
   'kad',
@@ -155,7 +165,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 rlimit = "0.10"
 rlp = "0.6"
 rs-car-ipfs = "0.3"
-rust2go = { version = "0.3" }
+rust2go = { workspace = true }
 sailfish = "0.9"
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
 scopeguard = "1"
@@ -222,7 +232,7 @@ fvm_shared4 = { package = "fvm_shared", version = "~4.3.3", features = ["arb", "
 glob = "0.3"
 http-range-header = "0.4"
 insta = { version = "1", features = ["yaml"] }
-libp2p-swarm-test = "0.4"
+libp2p-swarm-test = { workspace = true }
 num-bigint = { version = "0.4", features = ['quickcheck'] }
 petgraph = "0.6"
 predicates = "3"
@@ -236,7 +246,7 @@ syn = { version = "2", default-features = false, features = ["full", "parsing", 
 tokio-test = "0.4"
 
 [build-dependencies]
-rust2go = { version = "0.3", features = ["build"] }
+rust2go = { workspace = true, features = ["build"] }
 
 # This needs to be set as default. Otherwise, a regular build or test will produce
 # gargantuan artifacts (around 70G for all tests). For a debugging session, you can

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -11,12 +11,12 @@ publish = false
 [dependencies]
 
 [dev-dependencies]
-anyhow = "1"
-flume = "0.11"
+anyhow = { workspace = true }
+cid = { workspace = true }
+flume = { workspace = true }
 forest-filecoin = { path = "../", default-features = false, features = ["interop-tests-private", "no-f3-sidecar"] }
-futures = "0.3"
-libipld = { version = "0.16", default-features = false }
-libp2p = { version = "0.54", default-features = false, features = [
+futures = { workspace = true }
+libp2p = { workspace = true, features = [
   'kad',
   'identify',
   'noise',
@@ -30,9 +30,9 @@ libp2p = { version = "0.54", default-features = false, features = [
   'ed25519',
   'secp256k1',
 ] }
-libp2p-swarm-test = "0.4"
-rust2go = { version = "0.3" }
-tokio = { version = "1", features = ['full'] }
+libp2p-swarm-test = { workspace = true }
+rust2go = { workspace = true }
+tokio = { workspace = true, features = ['full'] }
 
 [build-dependencies]
-rust2go = { version = "0.3", features = ["build"] }
+rust2go = { workspace = true, features = ["build"] }

--- a/interop-tests/src/tests/bitswap_go_compat.rs
+++ b/interop-tests/src/tests/bitswap_go_compat.rs
@@ -2,20 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::go_ffi::*;
-
-use std::time::Duration;
-
-use forest_filecoin::interop_tests_private::libp2p_bitswap::{
-    BitswapBehaviour, BitswapBehaviourEvent, BitswapMessage, BitswapRequest, BitswapResponse,
-};
-use libipld::{
+use cid::{
     multihash::{self, MultihashDigest as _},
     Cid,
+};
+use forest_filecoin::interop_tests_private::libp2p_bitswap::{
+    BitswapBehaviour, BitswapBehaviourEvent, BitswapMessage, BitswapRequest, BitswapResponse,
 };
 use libp2p::{
     futures::StreamExt as _, noise, request_response, swarm::SwarmEvent, tcp, yamux, Multiaddr,
     Swarm, SwarmBuilder,
 };
+use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 const LISTEN_ADDR: &str = "/ip4/127.0.0.1/tcp/0";

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -100,9 +100,9 @@ impl<DB> BitswapStoreReadWrite for ChainStore<DB>
 where
     DB: BitswapStoreReadWrite,
 {
-    type Params = <DB as BitswapStoreReadWrite>::Params;
+    type Hashes = <DB as BitswapStoreReadWrite>::Hashes;
 
-    fn insert(&self, block: &libipld::Block<Self::Params>) -> anyhow::Result<()> {
+    fn insert(&self, block: &crate::libp2p_bitswap::Block64<Self::Hashes>) -> anyhow::Result<()> {
         self.db.insert(block)
     }
 }

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -186,10 +186,10 @@ impl<WriterT: BitswapStoreRead + Blockstore> BitswapStoreRead for ManyCar<Writer
 }
 
 impl<WriterT: BitswapStoreReadWrite + Blockstore> BitswapStoreReadWrite for ManyCar<WriterT> {
-    type Params = libipld::DefaultParams;
+    type Hashes = cid::multihash::Code;
 
-    fn insert(&self, block: &libipld::Block<Self::Params>) -> anyhow::Result<()> {
-        Blockstore::put_keyed(self, block.cid(), block.data())
+    fn insert(&self, block: &crate::libp2p_bitswap::Block64<Self::Hashes>) -> anyhow::Result<()> {
+        self.put_keyed(block.cid(), block.data())
     }
 }
 

--- a/src/db/memory.rs
+++ b/src/db/memory.rs
@@ -150,9 +150,9 @@ impl BitswapStoreRead for MemoryDB {
 }
 
 impl BitswapStoreReadWrite for MemoryDB {
-    type Params = libipld::DefaultParams;
+    type Hashes = cid::multihash::Code;
 
-    fn insert(&self, block: &libipld::Block<Self::Params>) -> anyhow::Result<()> {
+    fn insert(&self, block: &crate::libp2p_bitswap::Block64<Self::Hashes>) -> anyhow::Result<()> {
         self.put_keyed(block.cid(), block.data())
     }
 }

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -291,11 +291,9 @@ impl BitswapStoreRead for ParityDb {
 }
 
 impl BitswapStoreReadWrite for ParityDb {
-    /// `fvm_ipld_encoding::DAG_CBOR(0x71)` is covered by
-    /// [`libipld::DefaultParams`] under feature `dag-cbor`
-    type Params = libipld::DefaultParams;
+    type Hashes = cid::multihash::Code;
 
-    fn insert(&self, block: &libipld::Block<Self::Params>) -> anyhow::Result<()> {
+    fn insert(&self, block: &crate::libp2p_bitswap::Block64<Self::Hashes>) -> anyhow::Result<()> {
         self.put_keyed(block.cid(), block.data())
     }
 }

--- a/src/libp2p_bitswap/internals/prefix.rs
+++ b/src/libp2p_bitswap/internals/prefix.rs
@@ -1,15 +1,13 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::convert::TryFrom;
-
-use libipld::cid::{
+use crate::libp2p_bitswap::*;
+use cid::{
     multihash::{Code, MultihashDigest},
     Version,
 };
+use std::convert::TryFrom;
 use unsigned_varint::{decode as varint_decode, encode as varint_encode};
-
-use crate::libp2p_bitswap::*;
 
 /// Prefix represents all metadata of a CID, without the actual content.
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/libp2p_bitswap/mod.rs
+++ b/src/libp2p_bitswap/mod.rs
@@ -23,7 +23,7 @@
 
 use std::io::Result as IOResult;
 
-use libipld::{cid::Cid, prelude::*};
+use cid::Cid;
 use tracing::*;
 
 mod bitswap_pb;

--- a/src/libp2p_bitswap/request_manager.rs
+++ b/src/libp2p_bitswap/request_manager.rs
@@ -11,9 +11,9 @@ use std::{
 
 use crate::cid_collections::CidHashMap;
 use ahash::{HashSet, HashSetExt};
+use cid::Cid;
 use flume::TryRecvError;
 use futures::StreamExt;
-use libipld::{Block, Cid};
 use libp2p::PeerId;
 use parking_lot::RwLock;
 

--- a/src/libp2p_bitswap/store.rs
+++ b/src/libp2p_bitswap/store.rs
@@ -1,11 +1,10 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::sync::Arc;
-
-use libipld::Block;
-
-use crate::libp2p_bitswap::*;
+use super::*;
+use cid::multihash::MultihashDigest;
+use std::ops::Deref;
+use std::{marker::PhantomData, sync::Arc};
 
 /// Trait implemented by a block store for reading.
 pub trait BitswapStoreRead {
@@ -18,11 +17,11 @@ pub trait BitswapStoreRead {
 
 /// Trait implemented by a block store for reading and writing.
 pub trait BitswapStoreReadWrite: BitswapStoreRead + Send + Sync + 'static {
-    /// The store parameters.
-    type Params: StoreParams;
+    /// The hashes parameters.
+    type Hashes: cid::multihash::MultihashDigest<64>;
 
     /// A block response needs to insert the block into the store.
-    fn insert(&self, block: &Block<Self::Params>) -> anyhow::Result<()>;
+    fn insert(&self, block: &Block64<Self::Hashes>) -> anyhow::Result<()>;
 }
 
 impl<T: BitswapStoreRead> BitswapStoreRead for Arc<T> {
@@ -36,11 +35,71 @@ impl<T: BitswapStoreRead> BitswapStoreRead for Arc<T> {
 }
 
 impl<T: BitswapStoreReadWrite> BitswapStoreReadWrite for Arc<T> {
-    /// `fvm_ipld_encoding::DAG_CBOR(0x71)` is covered by
-    /// [`libipld::DefaultParams`] under feature `dag-cbor`
-    type Params = <T as BitswapStoreReadWrite>::Params;
+    type Hashes = <T as BitswapStoreReadWrite>::Hashes;
 
-    fn insert(&self, block: &libipld::Block<Self::Params>) -> anyhow::Result<()> {
+    fn insert(&self, block: &Block64<Self::Hashes>) -> anyhow::Result<()> {
         BitswapStoreReadWrite::insert(self.as_ref(), block)
+    }
+}
+
+pub type Block64<H> = Block<H, 64>;
+
+/// Block
+#[derive(Clone, Debug)]
+pub struct Block<H, const S: usize> {
+    /// Content identifier.
+    cid: Cid,
+    /// Binary data.
+    data: Vec<u8>,
+    _pd: PhantomData<H>,
+}
+
+impl<H, const S: usize> Deref for Block<H, S> {
+    type Target = Cid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cid
+    }
+}
+
+impl<H, const S: usize> PartialEq for Block<H, S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cid == other.cid
+    }
+}
+
+impl<H, const S: usize> Eq for Block<H, S> {}
+
+impl<H: MultihashDigest<S>, const S: usize> Block<H, S> {
+    /// Creates a new block. Returns an error if the hash doesn't match
+    /// the data.
+    pub fn new(cid: Cid, data: Vec<u8>) -> anyhow::Result<Self> {
+        Self::verify_cid(&cid, &data)?;
+        Ok(Self {
+            cid,
+            data,
+            _pd: Default::default(),
+        })
+    }
+
+    /// Returns the [`Cid`].
+    pub fn cid(&self) -> &Cid {
+        &self.cid
+    }
+
+    /// Returns the payload.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn verify_cid(cid: &Cid, payload: &[u8]) -> anyhow::Result<()> {
+        let code = cid.hash().code();
+        let mh = H::try_from(code)
+            .map_err(|_| anyhow::anyhow!("unsupported multihash code {code}"))?
+            .digest(payload);
+        if mh.digest() != cid.hash().digest() {
+            anyhow::bail!("invalid multihash digest");
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

`libipld` crate has been superseded by `ipld-core`. Also, to upgrade `fvm`to latest, we have to deprecate `libipld` in which `cid` will no longer be upgraded. This PR removes `libipld` usage from `bitswap` module in preparation for `fvm`(and `cid`) upgrade.

Changes introduced in this pull request:

- remove `libipld` usage from `bitswap` module

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
