### PR TITLE
fix: include TukTuk in the network params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
 - [#4988](https://github.com/ChainSafe/forest/pull/4988) Fix the `logs` member
   in `EthTxReceipt` that was initialized with a default value.
 
+- [#5043](https://github.com/ChainSafe/forest/pull/5043) Added missing entry for
+  `TukTuk` upgrade in the `Filecoin.StateGetNetworkParams` RPC method.
+
 ## Forest 0.22.0 "Pad Thai"
 
 Mandatory release for mainnet node operators. It sets the upgrade epoch for the

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -2686,6 +2686,7 @@ pub struct ForkUpgradeParams {
     upgrade_dragon_height: ChainEpoch,
     upgrade_phoenix_height: ChainEpoch,
     upgrade_waffle_height: ChainEpoch,
+    upgrade_tuktuk_height: ChainEpoch,
 }
 
 impl TryFrom<&ChainConfig> for ForkUpgradeParams {
@@ -2730,8 +2731,7 @@ impl TryFrom<&ChainConfig> for ForkUpgradeParams {
             upgrade_dragon_height: get_height(Dragon)?,
             upgrade_phoenix_height: get_height(Phoenix)?,
             upgrade_waffle_height: get_height(Waffle)?,
-            // TODO(forest): https://github.com/ChainSafe/forest/issues/4800
-            // upgrade_tuktuk_height: get_height(TukTuk)?,
+            upgrade_tuktuk_height: get_height(TukTuk)?,
         })
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- added missing TukTuk entry in the network params info

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
