### PR TITLE
fix(p2p): log user agent on banning a peer

### DIFF
--- a/src/chain_sync/network_context.rs
+++ b/src/chain_sync/network_context.rs
@@ -451,10 +451,12 @@ where
                 // Internal libp2p error, score failure for peer and potentially disconnect
                 match e {
                     RequestResponseError::UnsupportedProtocols => {
+                        // refactor this into Networkevent if user agent logging is critical here
                         peer_manager
                             .ban_peer_with_default_duration(
                                 peer_id,
                                 "ChainExchange protocol unsupported",
+                                |_| None,
                             )
                             .await;
                     }

--- a/src/libp2p/discovery.rs
+++ b/src/libp2p/discovery.rs
@@ -226,7 +226,7 @@ pub struct DiscoveryBehaviour {
     /// Keeps hash set of peers connected.
     peers: HashSet<PeerId>,
     /// Keeps hash map of peers and their information.
-    peer_info: HashMap<PeerId, PeerInfo>,
+    pub(crate) peer_info: HashMap<PeerId, PeerInfo>,
     /// Number of connected peers to pause discovery on.
     target_peer_count: u64,
     /// Seed peers


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

We occasionally see a lot of expected `banning peer PEER for REASON` logs, it'd help troubleshooting the issue to add user agent to the log

Changes introduced in this pull request:

-

Sample logs:
```
2024-12-10T00:41:20.357572Z  DEBUG forest_filecoin::libp2p::service: Banning peer peer=12D3KooWJe3QWBUFPa7DBaYLq1BXWcK2LVM39VBawuVz3ePHT45K user_agent= reason=Hello protocol unsupported
2024-12-10T00:41:20.357801Z  DEBUG forest_filecoin::libp2p::service: Banning peer peer=12D3KooWJe3QWBUFPa7DBaYLq1BXWcK2LVM39VBawuVz3ePHT45K user_agent=sophon-messager reason=hello protocol unsupported
2024-12-10T00:41:20.435089Z  DEBUG forest_filecoin::libp2p::service: Banning peer peer=12D3KooWQtcfpAhnu89D3YkyA1ZVXmDBmCLwA62LEfHinfLcHzoL user_agent= reason=Hello protocol unsupported
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
