### PR TITLE
chore: do not keep track of which tipsets peers have seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
 
 ### Removed
 
+- [#5077](https://github.com/ChainSafe/forest/pull/5077) Remove
+  `peer_tipset_epoch` from the metrics.
+
 ### Fixed
 
 ## Forest v0.23.1 "Lappe"

--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -295,7 +295,7 @@ where
         }
     }
 
-    async fn handle_peer_disconnected_event(network: SyncNetworkContext<DB>, peer_id: PeerId) {
+    fn handle_peer_disconnected_event(network: SyncNetworkContext<DB>, peer_id: PeerId) {
         network.peer_manager().remove_peer(&peer_id);
         network.peer_manager().unmark_peer_bad(&peer_id);
     }
@@ -378,11 +378,7 @@ where
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::PEER_DISCONNECTED)
                     .inc();
-                // Spawn and immediately move on to the next event
-                tokio::task::spawn(Self::handle_peer_disconnected_event(
-                    network.clone(),
-                    peer_id,
-                ));
+                Self::handle_peer_disconnected_event(network.clone(), peer_id);
                 return Ok(None);
             }
             NetworkEvent::PubsubMessage { message } => match message {

--- a/src/chain_sync/chain_muxer.rs
+++ b/src/chain_sync/chain_muxer.rs
@@ -321,7 +321,7 @@ where
         block_delay: u32,
         stateless_mode: bool,
     ) -> Result<Option<FullTipset>, ChainMuxerError> {
-        let (tipset, source) = match event {
+        let tipset = match event {
             NetworkEvent::HelloRequestInbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
                     .get_or_create(&metrics::values::HELLO_REQUEST_INBOUND)
@@ -347,7 +347,7 @@ where
                         return Err(why);
                     }
                 };
-                (tipset, source)
+                tipset
             }
             NetworkEvent::HelloRequestOutbound => {
                 metrics::LIBP2P_MESSAGE_TOTAL
@@ -385,7 +385,7 @@ where
                 ));
                 return Ok(None);
             }
-            NetworkEvent::PubsubMessage { source, message } => match message {
+            NetworkEvent::PubsubMessage { message } => match message {
                 PubsubMessage::Block(b) => {
                     metrics::LIBP2P_MESSAGE_TOTAL
                         .get_or_create(&metrics::values::PUBSUB_BLOCK)
@@ -401,7 +401,7 @@ where
                         TipsetKey::from(nunny::vec![*b.header.cid()]),
                     )
                     .await?;
-                    (tipset, source)
+                    tipset
                 }
                 PubsubMessage::Message(m) => {
                     metrics::LIBP2P_MESSAGE_TOTAL
@@ -443,7 +443,7 @@ where
             < chain_store.heaviest_tipset().epoch()
         {
             debug!(
-                "Skip processing tipset at epoch {} from {source} that is too old",
+                "Skip processing tipset at epoch {} that is too old",
                 tipset.epoch()
             );
             return Ok(None);

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -196,6 +196,7 @@ mod test {
         // instrument the state so that the live requirements are met
         sync_state.write().set_stage(SyncStage::Headers);
         let peer = libp2p::PeerId::random();
+        peer_manager.touch_peer(&peer);
 
         assert_eq!(
             call_healthcheck(false).await.unwrap().status(),
@@ -272,6 +273,7 @@ mod test {
         sync_state.write().set_epoch(i64::MAX);
         sync_state.write().set_stage(SyncStage::Headers);
         let peer = libp2p::PeerId::random();
+        peer_manager.touch_peer(&peer);
 
         assert_eq!(
             call_healthcheck(false).await.unwrap().status(),

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -63,13 +63,8 @@ mod test {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     use crate::db::SettingsExt;
-    use crate::{
-        blocks::{CachingBlockHeader, Tipset},
-        chain_sync::SyncStage,
-        Client,
-    };
+    use crate::{chain_sync::SyncStage, Client};
 
-    use itertools::Either;
     use reqwest::StatusCode;
 
     use super::*;
@@ -201,12 +196,6 @@ mod test {
         // instrument the state so that the live requirements are met
         sync_state.write().set_stage(SyncStage::Headers);
         let peer = libp2p::PeerId::random();
-        peer_manager.update_peer_head(
-            peer,
-            Either::Right(Arc::new(
-                Tipset::new(vec![CachingBlockHeader::default()]).unwrap(),
-            )),
-        );
 
         assert_eq!(
             call_healthcheck(false).await.unwrap().status(),
@@ -283,12 +272,6 @@ mod test {
         sync_state.write().set_epoch(i64::MAX);
         sync_state.write().set_stage(SyncStage::Headers);
         let peer = libp2p::PeerId::random();
-        peer_manager.update_peer_head(
-            peer,
-            Either::Right(Arc::new(
-                Tipset::new(vec![CachingBlockHeader::default()]).unwrap(),
-            )),
-        );
 
         assert_eq!(
             call_healthcheck(false).await.unwrap().status(),

--- a/src/libp2p/metrics.rs
+++ b/src/libp2p/metrics.rs
@@ -5,7 +5,7 @@ use libp2p::PeerId;
 use once_cell::sync::Lazy;
 use prometheus_client::{
     encoding::{EncodeLabelKey, EncodeLabelSet, EncodeLabelValue, LabelSetEncoder},
-    metrics::{counter::Counter, family::Family, gauge::Gauge},
+    metrics::{counter::Counter, gauge::Gauge},
 };
 
 pub static PEER_FAILURE_TOTAL: Lazy<Counter> = Lazy::new(|| {

--- a/src/libp2p/metrics.rs
+++ b/src/libp2p/metrics.rs
@@ -1,12 +1,8 @@
 // Copyright 2019-2024 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use libp2p::PeerId;
 use once_cell::sync::Lazy;
-use prometheus_client::{
-    encoding::{EncodeLabelKey, EncodeLabelSet, EncodeLabelValue, LabelSetEncoder},
-    metrics::{counter::Counter, gauge::Gauge},
-};
+use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 
 pub static PEER_FAILURE_TOTAL: Lazy<Counter> = Lazy::new(|| {
     let metric = Counter::default();
@@ -37,23 +33,3 @@ pub static BAD_PEERS: Lazy<Gauge> = Lazy::new(|| {
     );
     metric
 });
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct PeerLabel(PeerId);
-
-impl PeerLabel {
-    pub const fn new(peer: PeerId) -> Self {
-        Self(peer)
-    }
-}
-
-impl EncodeLabelSet for PeerLabel {
-    fn encode(&self, mut encoder: LabelSetEncoder) -> Result<(), std::fmt::Error> {
-        let mut label_encoder = encoder.encode_label();
-        let mut label_key_encoder = label_encoder.encode_label_key()?;
-        EncodeLabelKey::encode(&"PEER", &mut label_key_encoder)?;
-        let mut label_value_encoder = label_key_encoder.encode_label_value()?;
-        EncodeLabelValue::encode(&self.0.to_string(), &mut label_value_encoder)?;
-        label_value_encoder.finish()
-    }
-}

--- a/src/libp2p/metrics.rs
+++ b/src/libp2p/metrics.rs
@@ -38,16 +38,6 @@ pub static BAD_PEERS: Lazy<Gauge> = Lazy::new(|| {
     metric
 });
 
-pub static PEER_TIPSET_EPOCH: Lazy<Family<PeerLabel, Gauge>> = Lazy::new(|| {
-    let metric = Family::default();
-    crate::metrics::default_registry().register(
-        "peer_tipset_epoch",
-        "peer tipset epoch",
-        metric.clone(),
-    );
-    metric
-});
-
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct PeerLabel(PeerId);
 

--- a/src/libp2p/peer_manager.rs
+++ b/src/libp2p/peer_manager.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::{
-    cmp::Ordering,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -109,7 +108,7 @@ impl PeerManager {
             .collect();
 
         // Unstable sort because hashmap iter order doesn't need to be preserved.
-        peers.sort_unstable_by(|(_, v1), (_, v2)| v1.partial_cmp(v2).unwrap_or(Ordering::Equal));
+        peers.sort_unstable_by(|(_, v1), (_, v2)| v1.total_cmp(v2));
 
         peers.into_iter().map(|(peer, _)| peer).collect()
     }

--- a/src/libp2p/peer_manager.rs
+++ b/src/libp2p/peer_manager.rs
@@ -85,6 +85,8 @@ impl PeerManager {
         !peers.bad_peers.contains(peer_id) && !peers.full_peers.contains_key(peer_id)
     }
 
+    /// Mark peer as active even if we haven't communicated with it yet.
+    #[cfg(test)]
     pub fn touch_peer(&self, peer_id: &PeerId) {
         let mut peers = self.peers.write();
         peers.full_peers.entry(*peer_id).or_default();

--- a/src/libp2p/peer_manager.rs
+++ b/src/libp2p/peer_manager.rs
@@ -7,13 +7,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
-    blocks::{Tipset, TipsetKey},
-    shim::clock::ChainEpoch,
-};
 use ahash::{HashMap, HashSet};
 use flume::{Receiver, Sender};
-use itertools::Either;
 use parking_lot::RwLock;
 use rand::seq::SliceRandom;
 use tracing::{debug, trace, warn};
@@ -31,35 +26,15 @@ const LOCAL_INV_ALPHA: u32 = 5;
 /// Global duration multiplier, affects duration delta change.
 const GLOBAL_INV_ALPHA: u32 = 20;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 /// Contains info about the peer's head [Tipset], as well as the request stats.
 struct PeerInfo {
-    /// Head tipset key received from hello message or gossip sub message.
-    head: Either<TipsetKey, Arc<Tipset>>,
     /// Number of successful requests.
     successes: u32,
     /// Number of failed requests.
     failures: u32,
     /// Average response time for the peer.
     average_time: Duration,
-}
-
-impl PeerInfo {
-    fn new(head: Either<TipsetKey, Arc<Tipset>>) -> Self {
-        Self {
-            head,
-            successes: 0,
-            failures: 0,
-            average_time: Default::default(),
-        }
-    }
-
-    fn head_epoch(&self) -> Option<ChainEpoch> {
-        match &self.head {
-            Either::Left(_) => None,
-            Either::Right(ts) => Some(ts.epoch()),
-        }
-    }
 }
 
 /// Peer tracking sets, these are handled together to avoid race conditions or
@@ -105,32 +80,6 @@ impl Default for PeerManager {
 }
 
 impl PeerManager {
-    /// Updates peer's heaviest tipset. If the peer does not exist in the set, a
-    /// new `PeerInfo` will be generated.
-    pub fn update_peer_head(&self, peer_id: PeerId, head: Either<TipsetKey, Arc<Tipset>>) {
-        let mut peers = self.peers.write();
-        trace!("Updating head for PeerId {}", &peer_id);
-        let head_epoch = if let Some(pi) = peers.full_peers.get_mut(&peer_id) {
-            pi.head = head;
-            pi.head_epoch()
-        } else {
-            let pi = PeerInfo::new(head);
-            let head_epoch = pi.head_epoch();
-            peers.full_peers.insert(peer_id, pi);
-            metrics::FULL_PEERS.set(peers.full_peers.len() as _);
-            head_epoch
-        };
-        metrics::PEER_TIPSET_EPOCH
-            .get_or_create(&metrics::PeerLabel::new(peer_id))
-            .set(head_epoch.unwrap_or(-1));
-    }
-
-    /// Gets the head epoch of a peer
-    pub fn get_peer_head_epoch(&self, peer_id: &PeerId) -> Option<i64> {
-        let peers = self.peers.read();
-        peers.full_peers.get(peer_id).and_then(|pi| pi.head_epoch())
-    }
-
     /// Returns true if peer is not marked as bad or not already in set.
     pub fn is_peer_new(&self, peer_id: &PeerId) -> bool {
         let peers = self.peers.read();
@@ -142,16 +91,10 @@ impl PeerManager {
     pub(in crate::libp2p) fn sorted_peers(&self) -> Vec<PeerId> {
         let peer_lk = self.peers.read();
         let average_time = self.avg_global_time.read();
-        let mut n_stateful = 0;
         let mut peers: Vec<_> = peer_lk
             .full_peers
             .iter()
             .map(|(&p, info)| {
-                let is_stateful = info.head_epoch() != Some(0);
-                if is_stateful {
-                    n_stateful += 1;
-                }
-
                 let cost = if info.successes + info.failures > 0 {
                     // Calculate cost based on fail rate and latency
                     // Note that when `success` is zero, the result is `inf`
@@ -161,32 +104,14 @@ impl PeerManager {
                     // There have been no failures or successes
                     average_time.as_secs_f64() * NEW_PEER_MUL
                 };
-                (p, is_stateful, cost)
+                (p, cost)
             })
             .collect();
 
         // Unstable sort because hashmap iter order doesn't need to be preserved.
-        peers.sort_unstable_by(|(_, _, v1), (_, _, v2)| {
-            v1.partial_cmp(v2).unwrap_or(Ordering::Equal)
-        });
+        peers.sort_unstable_by(|(_, v1), (_, v2)| v1.partial_cmp(v2).unwrap_or(Ordering::Equal));
 
-        // Filter out nodes that are stateless when `n_stateful > 0`
-        if n_stateful > 0 {
-            peers
-                .into_iter()
-                .filter_map(
-                    |(peer, is_stateful, _)| {
-                        if is_stateful {
-                            Some(peer)
-                        } else {
-                            None
-                        }
-                    },
-                )
-                .collect()
-        } else {
-            peers.into_iter().map(|(peer, _, _)| peer).collect()
-        }
+        peers.into_iter().map(|(peer, _)| peer).collect()
     }
 
     /// Return shuffled slice of ordered peers from the peer manager. Ordering
@@ -228,10 +153,9 @@ impl PeerManager {
         if peers.bad_peers.remove(peer) {
             metrics::BAD_PEERS.set(peers.bad_peers.len() as _);
         };
-        if let Some(peer_stats) = peers.full_peers.get_mut(peer) {
-            peer_stats.successes += 1;
-            log_time(peer_stats, dur);
-        }
+        let peer_stats = peers.full_peers.entry(*peer).or_default();
+        peer_stats.successes += 1;
+        log_time(peer_stats, dur);
     }
 
     /// Logs a failure for the given peer, and updates the average request
@@ -241,10 +165,9 @@ impl PeerManager {
         let mut peers = self.peers.write();
         if !peers.bad_peers.contains(peer) {
             metrics::PEER_FAILURE_TOTAL.inc();
-            if let Some(peer_stats) = peers.full_peers.get_mut(peer) {
-                peer_stats.failures += 1;
-                log_time(peer_stats, dur);
-            }
+            let peer_stats = peers.full_peers.entry(*peer).or_default();
+            peer_stats.failures += 1;
+            log_time(peer_stats, dur);
         }
     }
 

--- a/src/libp2p/peer_manager.rs
+++ b/src/libp2p/peer_manager.rs
@@ -85,6 +85,11 @@ impl PeerManager {
         !peers.bad_peers.contains(peer_id) && !peers.full_peers.contains_key(peer_id)
     }
 
+    pub fn touch_peer(&self, peer_id: &PeerId) {
+        let mut peers = self.peers.write();
+        peers.full_peers.entry(*peer_id).or_default();
+    }
+
     /// Sort peers based on a score function with the success rate and latency
     /// of requests.
     pub(in crate::libp2p) fn sorted_peers(&self) -> Vec<PeerId> {

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -90,7 +90,6 @@ pub const BITSWAP_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Debug)]
 pub enum NetworkEvent {
     PubsubMessage {
-        source: PeerId,
         message: PubsubMessage,
     },
     HelloRequestInbound,
@@ -628,7 +627,6 @@ async fn handle_gossip_event(
                     emit_event(
                         network_sender_out,
                         NetworkEvent::PubsubMessage {
-                            source,
                             message: PubsubMessage::Block(b),
                         },
                     )
@@ -644,7 +642,6 @@ async fn handle_gossip_event(
                     emit_event(
                         network_sender_out,
                         NetworkEvent::PubsubMessage {
-                            source,
                             message: PubsubMessage::Message(m),
                         },
                     )

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -574,8 +574,6 @@ async fn handle_discovery_event(
         }
         DiscoveryEvent::PeerDisconnected(peer_id) => {
             trace!("Peer disconnected, {peer_id}");
-            // Remove peer id labels for disconnected peers
-            super::metrics::PEER_TIPSET_EPOCH.remove(&super::metrics::PeerLabel::new(peer_id));
             emit_event(network_sender_out, NetworkEvent::PeerDisconnected(peer_id)).await;
         }
         DiscoveryEvent::Discovery(discovery_event) => match &*discovery_event {

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1302,7 +1302,6 @@ impl RpcMethod<2> for StateFetchRoot {
                             network_send.send(NetworkMessage::BitswapRequest {
                                 cid,
                                 response_channel: tx,
-                                epoch: None,
                             })?;
                             // Bitswap requests do not fail. They are just ignored if no-one has
                             // the requested data. Here we arbitrary decide to only wait for


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Do not keep track of which epoch peers are at. There are no good ways of doing it and we don't need it.
- Remove dead code.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
