### PR TITLE
fix(f3): F3 sidecar should work with Kademlia disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ### Fixed
 
+- [#5111](https://github.com/ChainSafe/forest/issues/5111) Make F3 work when the node Kademlia is disabled.
+
 ## Forest v.0.23.3 "Plumber"
 
 Mandatory release for calibnet node operators. It fixes a sync error at epoch 2281645.

--- a/scripts/tests/calibnet_no_discovery_check.sh
+++ b/scripts/tests/calibnet_no_discovery_check.sh
@@ -5,7 +5,8 @@ set -euxo pipefail
 
 source "$(dirname "$0")/harness.sh"
 
-$FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --log-dir "$LOG_DIRECTORY" --detach --save-token ./admin_token
+$FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --log-dir "$LOG_DIRECTORY" --save-token ./admin_token &
+FOREST_NODE_PID=$!
 FULLNODE_API_INFO="$(cat admin_token):/ip4/127.0.0.1/tcp/2345/http"
 export FULLNODE_API_INFO
 
@@ -18,3 +19,4 @@ done
 until [[ $($FOREST_CLI_PATH f3 certs get --output json | jq '.GPBFTInstance') -gt 100 ]]; do
     sleep 1s;
 done
+kill -KILL $FOREST_NODE_PID

--- a/scripts/tests/calibnet_no_discovery_check.sh
+++ b/scripts/tests/calibnet_no_discovery_check.sh
@@ -5,9 +5,10 @@ set -euxo pipefail
 
 source "$(dirname "$0")/harness.sh"
 
-$FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --log-dir "$LOG_DIRECTORY" --save-token ./admin_token &
+$FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --save-token ./admin_token --exit-after-init
+$FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --log-dir "$LOG_DIRECTORY" &
 FOREST_NODE_PID=$!
-sleep 10s # to allow admin_token being saved
+
 FULLNODE_API_INFO="$(cat admin_token):/ip4/127.0.0.1/tcp/2345/http"
 export FULLNODE_API_INFO
 
@@ -21,4 +22,4 @@ until [[ $($FOREST_CLI_PATH f3 certs get --output json | jq '.GPBFTInstance') -g
     sleep 1s;
 done
 kill -KILL $FOREST_NODE_PID
-sleep 5s
+wait $FOREST_NODE_PID || true

--- a/scripts/tests/calibnet_no_discovery_check.sh
+++ b/scripts/tests/calibnet_no_discovery_check.sh
@@ -13,3 +13,8 @@ export FULLNODE_API_INFO
 until $FOREST_CLI_PATH net peers | grep "calib"; do
     sleep 1s;
 done
+
+# Verify F3 is getting certificates from the network
+until [[ $($FOREST_CLI_PATH f3 certs get --output json | jq '.GPBFTInstance') -gt 100 ]]; do
+    sleep 1s;
+done

--- a/scripts/tests/calibnet_other_check.sh
+++ b/scripts/tests/calibnet_other_check.sh
@@ -40,8 +40,3 @@ echo "Test subcommand: net info"
 $FOREST_CLI_PATH net info
 
 $FOREST_CLI_PATH sync wait # allow the node to re-sync
-
-# Verify F3 is getting certificates from the network
-until [[ $($FOREST_CLI_PATH f3 certs get --output json | jq '.GPBFTInstance') -gt 100 ]]; do
-    sleep 1s;
-done

--- a/scripts/tests/calibnet_other_check.sh
+++ b/scripts/tests/calibnet_other_check.sh
@@ -40,3 +40,8 @@ echo "Test subcommand: net info"
 $FOREST_CLI_PATH net info
 
 $FOREST_CLI_PATH sync wait # allow the node to re-sync
+
+# Verify F3 is getting certificates from the network
+until [[ $($FOREST_CLI_PATH f3 certs get --output json | jq '.GPBFTInstance') -gt 100 ]]; do
+    sleep 1s;
+done

--- a/src/f3/mod.rs
+++ b/src/f3/mod.rs
@@ -100,6 +100,7 @@ pub fn run_f3_sidecar_if_enabled(
     if is_sidecar_ffi_enabled(chain_config) {
         #[cfg(all(f3sidecar, not(feature = "no-f3-sidecar")))]
         {
+            tracing::info!("Starting F3 sidecar service ...");
             GoF3NodeImpl::run(
                 _rpc_endpoint,
                 _jwt,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR introduces a second internal Kademlia for bootstrapping F3 when the node Kademlia is disabled.

Changes introduced in this pull request:

- add a second internal Kademlia
- update test scripts accordingly

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #5065

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
