### PR TITLE
fix: docs paths in workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,14 +11,14 @@ on:
     tags:
       - "*"
     paths-ignore:
-      - 'docs/'
+      - 'docs/**'
   merge_group:
   pull_request:
     # This needs to be declared explicitly so that the job is actually
     # run when moved out of draft.
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
-      - 'docs/'
+      - 'docs/**'
 
 env:
   CI: 1

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -11,7 +11,7 @@ on:
       - main
     paths:
       - '**.md'
-      - '/docs'
+      - 'docs/**'
       - '.github/workflows/docs-check.yml'
   merge_group:
   pull_request:
@@ -19,7 +19,7 @@ on:
       - main
     paths:
       - '**.md'
-      - '/docs'
+      - 'docs/**'
       - '.github/workflows/docs-check.yml'
 
 jobs:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
     paths:
-      - '/docs'
+      - 'docs/**'
       - '.github/workflows/docs-deploy.yml'
   merge_group:
   pull_request:
     branches:
       - main
     paths:
-      - '/docs'
+      - 'docs/**'
       - '.github/workflows/docs-deploy.yml'
 
 permissions:

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -9,12 +9,12 @@ concurrency:
     branches:
       - main
     paths-ignore:
-      - 'docs/'
+      - 'docs/**'
   push:
     branches:
       - main
     paths-ignore:
-      - 'docs/'
+      - 'docs/**'
   schedule:
     - cron: 0 0 * * *
 env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,12 +15,12 @@ on:
     # run when moved out of draft.
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
-      - 'docs/'
+      - 'docs/**'
   push:
     branches:
       - main
     paths-ignore:
-      - 'docs/'
+      - 'docs/**'
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `.gitignore` styles rules used didn't trigger workflows in https://github.com/ChainSafe/forest/pull/5104, wildcard ones, as outlined in the [GH documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#example-excluding-paths), should work.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
