### PR TITLE
fix: docs don't trigger required checks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ on:
       - "*"
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs-*.yml'
   merge_group:
   pull_request:
     # This needs to be declared explicitly so that the job is actually
@@ -19,6 +20,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs-*.yml'
 
 env:
   CI: 1

--- a/.github/workflows/docs-required-override.yml
+++ b/.github/workflows/docs-required-override.yml
@@ -15,16 +15,14 @@ on:
     paths:
       - '**.md'
       - 'docs/**'
-      - '.github/workflows/docs-check.yml'
-      - '.github/workflows/docs-required-override.yml'
+      - '.github/workflows/docs-*.yml'
   push:
     branches:
       - main
     paths:
       - '**.md'
       - 'docs/**'
-      - '.github/workflows/docs-check.yml'
-      - '.github/workflows/docs-required-override.yml'
+      - '.github/workflows/docs-*.yml'
 
 jobs:
   # We need this because merge groups dont support path filters
@@ -42,8 +40,7 @@ jobs:
             changesFound:
                     - 'docs/**'
                     - '**.md'
-                    - '.github/workflows/docs-check.yml'
-                    - '.github/workflows/docs-required-override.yml'
+                    - '.github/workflows/docs-*.yml'
   changes-not-docs:
     runs-on: ubuntu-latest
     outputs:
@@ -59,8 +56,7 @@ jobs:
                     - '**'
                     - '!docs/**'
                     - '!**.md'
-                    - '!.github/workflows/docs-check.yml'
-                    - '!.github/workflows/docs-required-override.yml'
+                    - '!.github/workflows/docs-*.yml'
 
   override_integration_tests:
     name: Integration tests status

--- a/.github/workflows/docs-required-override.yml
+++ b/.github/workflows/docs-required-override.yml
@@ -1,0 +1,103 @@
+# This workflow is triggered by changes on the documentation. Normally, if only documentation is modified, the required Forest checks are not triggered which makes it impossible to merge the PR. See <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks>. The workaround is to provide no-op jobs that are triggered by the same events as the docs-check job. This way, the "required checks" are passing and the PR can be merged.
+# We check that changes affect only the documentation and that no other changes are present. If this is the case, we trigger the no-op jobs.
+
+name: Docs Required Override
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: '${{ github.ref != ''refs/heads/main'' }}'
+
+on:
+  workflow_dispatch:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/docs-check.yml'
+      - '.github/workflows/docs-required-override.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/docs-check.yml'
+      - '.github/workflows/docs-required-override.yml'
+
+jobs:
+  # We need this because merge groups dont support path filters
+  # https://github.com/community/community/discussions/45899
+  changes-docs:
+    runs-on: ubuntu-latest
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            changesFound:
+                    - 'docs/**'
+                    - '**.md'
+                    - '.github/workflows/docs-check.yml'
+                    - '.github/workflows/docs-required-override.yml'
+  changes-not-docs:
+    runs-on: ubuntu-latest
+    outputs:
+      otherChangesFound: ${{ steps.filter.outputs.otherChangesFound }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            otherChangesFound:
+                    - '**'
+                    - '!docs/**'
+                    - '!**.md'
+                    - '!.github/workflows/docs-check.yml'
+                    - '!.github/workflows/docs-required-override.yml'
+
+  override_integration_tests:
+    name: Integration tests status
+    runs-on: ubuntu-latest
+    needs:
+      - changes-docs
+      - changes-not-docs
+    if: ${{ (needs.changes-docs.outputs.changesFound == 'true') && (needs.changes-not-docs.outputs.otherChangesFound == 'false') }}
+    steps:
+      - run: echo "No-op job to trigger the required checks."
+
+  override_unit_tests:
+    name: tests
+    runs-on: ubuntu-latest
+    needs:
+      - changes-docs
+      - changes-not-docs
+    if: ${{ (needs.changes-docs.outputs.changesFound == 'true') && (needs.changes-not-docs.outputs.otherChangesFound == 'false') }}
+    steps:
+      - run: echo "No-op job to trigger the required checks."
+
+  override_unit_tests_release:
+    name: tests-release
+    runs-on: ubuntu-latest
+    needs:
+      - changes-docs
+      - changes-not-docs
+    if: ${{ (needs.changes-docs.outputs.changesFound == 'true') && (needs.changes-not-docs.outputs.otherChangesFound == 'false') }}
+    steps:
+      - run: echo "No-op job to trigger the required checks."
+
+  override_docker_build:
+    name: Build images and push to GHCR
+    runs-on: ubuntu-latest
+    needs:
+      - changes-docs
+      - changes-not-docs
+    if: ${{ (needs.changes-docs.outputs.changesFound == 'true') && (needs.changes-not-docs.outputs.otherChangesFound == 'false') }}
+    steps:
+      - run: echo "No-op job to trigger the required checks."

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -10,11 +10,13 @@ concurrency:
       - main
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs-*.yml'
   push:
     branches:
       - main
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs-*.yml'
   schedule:
     - cron: 0 0 * * *
 env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,11 +16,13 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs-*.yml'
   push:
     branches:
       - main
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs-*.yml'
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- workaround for required checks for docs as documented in the workflow file,
- don't trigger expensive jobs on doc workflow changes

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
