### PR TITLE
fix(tracing): rename lib name from forest_filecoin to forest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT OR Apache-2.0"
 description = "Rust Filecoin implementation."
 exclude = [".config", ".github", ".maintain", "documentation", "scripts", "interop-tests", "go.work*"]
 
+[lib]
+name = "forest"
+
 [workspace.dependencies]
 anyhow = "1"
 cid = { version = "0.11", default-features = false, features = ["std"] }

--- a/benches/car-index.rs
+++ b/benches/car-index.rs
@@ -3,7 +3,7 @@
 
 use cid::Cid;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use forest_filecoin::benchmark_private::{
+use forest::benchmark_private::{
     cid::CidCborExt as _,
     forest::index::{self, hash, NonMaximalU64},
 };

--- a/docs/docs/users/guides/monitoring/logs.md
+++ b/docs/docs/users/guides/monitoring/logs.md
@@ -7,10 +7,10 @@ Logs are written to standard output by default. They can be written to rolling l
 ```console
 ❯ RUST_LOG=info,forest_filecoin=debug forest --chain calibnet
 
-2024-08-28T12:49:59.830012Z  INFO forest_filecoin::daemon::main: Using default calibnet config
-2024-08-28T12:49:59.834109Z  INFO forest_filecoin::daemon: Starting Forest daemon, version 0.19.2+git.74fd562acce
-2024-08-28T12:49:59.834123Z DEBUG forest_filecoin::daemon: Increased file descriptor limit from 1024 to 8192
-2024-08-28T12:49:59.834164Z DEBUG forest_filecoin::libp2p::keypair: Recovered libp2p keypair from /home/rumcajs/.local/share/forest/libp2p/keypair
+2024-08-28T12:49:59.830012Z  INFO forest::daemon::main: Using default calibnet config
+2024-08-28T12:49:59.834109Z  INFO forest::daemon: Starting Forest daemon, version 0.19.2+git.74fd562acce
+2024-08-28T12:49:59.834123Z DEBUG forest::daemon: Increased file descriptor limit from 1024 to 8192
+2024-08-28T12:49:59.834164Z DEBUG forest::libp2p::keypair: Recovered libp2p keypair from /home/rumcajs/.local/share/forest/libp2p/keypair
 ```
 
 :::tip

--- a/docs/docs/users/knowledge_base/jwt_handling.md
+++ b/docs/docs/users/knowledge_base/jwt_handling.md
@@ -30,12 +30,12 @@ Technically, tokens have an expiration date, the default is 100 years, so there'
 
 ```bash
 ❯ forest --chain calibnet --encrypt-keystore=false
-2024-08-21T11:26:37.608429Z  INFO forest_filecoin::daemon::main: Using default calibnet config
-2024-08-21T11:26:37.611063Z  INFO forest_filecoin::daemon: Starting Forest daemon, version 0.19.2+git.76266421b1e
-2024-08-21T11:26:37.611140Z  WARN forest_filecoin::daemon: Forest has encryption disabled
+2024-08-21T11:26:37.608429Z  INFO forest::daemon::main: Using default calibnet config
+2024-08-21T11:26:37.611063Z  INFO forest::daemon: Starting Forest daemon, version 0.19.2+git.76266421b1e
+2024-08-21T11:26:37.611140Z  WARN forest::daemon: Forest has encryption disabled
 ### Admin token is printed here
-2024-08-21T11:26:37.611185Z  INFO forest_filecoin::daemon: Admin token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXSwiZXhwIjo0ODc3ODM5NTk3fQ.lnlboKjZhidbH177hWAD8m61MGwCu6w9AYCWaUZoepM
-2024-08-21T11:26:37.611211Z  INFO forest_filecoin::db::migration::db_migration: No database migration required
+2024-08-21T11:26:37.611185Z  INFO forest::daemon: Admin token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXSwiZXhwIjo0ODc3ODM5NTk3fQ.lnlboKjZhidbH177hWAD8m61MGwCu6w9AYCWaUZoepM
+2024-08-21T11:26:37.611211Z  INFO forest::db::migration::db_migration: No database migration required
 ```
 
 Alternative, with `--save-token <PATH>`:

--- a/documentation/src/developer_documentation/state_migration_guide.md
+++ b/documentation/src/developer_documentation/state_migration_guide.md
@@ -289,8 +289,8 @@ While the migration itself should succeed, there will be a state mismatch
 afterwards. This is not an issue.
 
 ```
-2023-12-05T15:46:37.988136Z  INFO forest_filecoin::state_migration: State migration at height Watermelon(epoch 3411547) was successful, Previous state: bafy2bzacedqswtcnhub5ea6upcjp4s7ghba5lgxri7ckezgsdxbkgnh6oyz3w, new state: bafy2bzacecxvz7jl3pt3ki4cirp4arfbmdxxcdb2ni4mzhkbbxqaug5z747gu, new state actors: bafy2bzaceb53kdtubm74czvthzah5inpejrrw7tdueajuhp3n7pbirzjwpqok. Took: 349.9679s.
-2023-12-05T15:46:42.438174Z ERROR forest_filecoin::state_manager: state mismatch height=3411549 expected_state=Cid(bafy2bzacecr6ll3w6kb5cyvcsl2e5z6wqrbhaxntzaabkbqikmhuj5a7ukbxk) expected_receipt=Cid(bafy2bzacebhp2zlhpabxgquiht7cu5rqug5sxtxyfadkiijdpaxmcrhdyfs3s) actual_state=Cid(bafy2bzacecjb4tc4hub2yytxdsr7kpozdabufgsvdixqkkllg3yqv7zxujs2g) actual_receipt=Cid(bafy2bzaceaqdlwllmddokd5izwvf7isqlzglueqcw62ttyn5j3nx2hzk4ecwg)
+2023-12-05T15:46:37.988136Z  INFO forest::state_migration: State migration at height Watermelon(epoch 3411547) was successful, Previous state: bafy2bzacedqswtcnhub5ea6upcjp4s7ghba5lgxri7ckezgsdxbkgnh6oyz3w, new state: bafy2bzacecxvz7jl3pt3ki4cirp4arfbmdxxcdb2ni4mzhkbbxqaug5z747gu, new state actors: bafy2bzaceb53kdtubm74czvthzah5inpejrrw7tdueajuhp3n7pbirzjwpqok. Took: 349.9679s.
+2023-12-05T15:46:42.438174Z ERROR forest::state_manager: state mismatch height=3411549 expected_state=Cid(bafy2bzacecr6ll3w6kb5cyvcsl2e5z6wqrbhaxntzaabkbqikmhuj5a7ukbxk) expected_receipt=Cid(bafy2bzacebhp2zlhpabxgquiht7cu5rqug5sxtxyfadkiijdpaxmcrhdyfs3s) actual_state=Cid(bafy2bzacecjb4tc4hub2yytxdsr7kpozdabufgsvdixqkkllg3yqv7zxujs2g) actual_receipt=Cid(bafy2bzaceaqdlwllmddokd5izwvf7isqlzglueqcw62ttyn5j3nx2hzk4ecwg)
 ```
 
 While the resulting state might be incorrect (not matching what Lotus

--- a/documentation/src/offline-forest.md
+++ b/documentation/src/offline-forest.md
@@ -41,13 +41,13 @@ height: 1859736.
 
 ```bash
 ❯ forest-tool api serve --chain calibnet ~/Downloads/forest_snapshot_calibnet_2024-08-08_height_1859736.forest.car.zst
-2024-08-12T12:29:16.624698Z  INFO forest_filecoin::tool::offline_server::server: Configuring Offline RPC Server
-2024-08-12T12:29:16.640402Z  INFO forest_filecoin::tool::offline_server::server: Using chain config for calibnet
-2024-08-12T12:29:16.641654Z  INFO forest_filecoin::genesis: Initialized genesis: bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4
-2024-08-12T12:29:16.643263Z  INFO forest_filecoin::daemon::db_util: Populating column EthMappings from range: [322354, 1859736]
+2024-08-12T12:29:16.624698Z  INFO forest::tool::offline_server::server: Configuring Offline RPC Server
+2024-08-12T12:29:16.640402Z  INFO forest::tool::offline_server::server: Using chain config for calibnet
+2024-08-12T12:29:16.641654Z  INFO forest::genesis: Initialized genesis: bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4
+2024-08-12T12:29:16.643263Z  INFO forest::daemon::db_util: Populating column EthMappings from range: [322354, 1859736]
 ...
-2024-08-12T12:29:44.218675Z  INFO forest_filecoin::tool::offline_server::server: Starting offline RPC Server
-2024-08-12T12:29:44.218804Z  INFO forest_filecoin::rpc: Ready for RPC connections
+2024-08-12T12:29:44.218675Z  INFO forest::tool::offline_server::server: Starting offline RPC Server
+2024-08-12T12:29:44.218804Z  INFO forest::rpc: Ready for RPC connections
 ```
 
 The server can then be queried using `forest-cli` or raw requests.

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -14,7 +14,10 @@ publish = false
 anyhow = { workspace = true }
 cid = { workspace = true }
 flume = { workspace = true }
-forest-filecoin = { path = "../", default-features = false, features = ["interop-tests-private", "no-f3-sidecar"] }
+forest = { package = "forest-filecoin", path = "../", default-features = false, features = [
+  "interop-tests-private",
+  "no-f3-sidecar",
+] }
 futures = { workspace = true }
 libp2p = { workspace = true, features = [
   'kad',

--- a/interop-tests/src/tests/bitswap_go_compat.rs
+++ b/interop-tests/src/tests/bitswap_go_compat.rs
@@ -3,7 +3,7 @@
 
 use super::go_ffi::*;
 use cid::Cid;
-use forest_filecoin::interop_tests_private::libp2p_bitswap::{
+use forest::interop_tests_private::libp2p_bitswap::{
     BitswapBehaviour, BitswapBehaviourEvent, BitswapMessage, BitswapRequest, BitswapResponse,
 };
 use libp2p::{

--- a/interop-tests/src/tests/kad_go_compat.rs
+++ b/interop-tests/src/tests/kad_go_compat.rs
@@ -3,7 +3,7 @@
 
 use super::go_ffi::*;
 
-use forest_filecoin::interop_tests_private::libp2p::discovery::new_kademlia;
+use forest::interop_tests_private::libp2p::discovery::new_kademlia;
 use futures::StreamExt as _;
 use libp2p::{
     identify, identity, kad, noise, swarm::SwarmEvent, tcp, yamux, Multiaddr, StreamProtocol,

--- a/scripts/devnet-curio/docker-compose.yml
+++ b/scripts/devnet-curio/docker-compose.yml
@@ -184,7 +184,7 @@ services:
       - ./forest_config.toml.tpl:/forest/forest_config.toml.tpl
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
-      - RUST_LOG=info,forest_filecoin::blocks::header=trace
+      - RUST_LOG=info,forest::blocks::header=trace
       - FOREST_F3_SIDECAR_FFI_ENABLED=1
       - FOREST_F3_FINALITY=${F3_FINALITY}
       - FOREST_F3_PERMANENT_PARTICIPATING_MINER_ADDRESSES=${MINER_ACTOR_ADDRESS}

--- a/scripts/devnet/docker-compose.yml
+++ b/scripts/devnet/docker-compose.yml
@@ -184,7 +184,7 @@ services:
       - ./forest_config.toml.tpl:/forest/forest_config.toml.tpl
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
-      - RUST_LOG=info,forest_filecoin::blocks::header=trace
+      - RUST_LOG=info,forest::blocks::header=trace
       - FOREST_F3_SIDECAR_FFI_ENABLED=1
       - FOREST_F3_FINALITY=${F3_FINALITY}
       - FOREST_F3_PERMANENT_PARTICIPATING_MINER_ADDRESSES=${MINER_ACTOR_ADDRESS}
@@ -236,7 +236,7 @@ services:
       - forest-data:${FOREST_DATA_DIR}
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
-      - RUST_LOG=info,forest_filecoin::blocks::header=trace
+      - RUST_LOG=info,forest::blocks::header=trace
       - FOREST_GENESIS_NETWORK_VERSION=${GENESIS_NETWORK_VERSION}
       - FOREST_SHARK_HEIGHT=${SHARK_HEIGHT}
       - FOREST_HYGGE_HEIGHT=${HYGGE_HEIGHT}

--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     networks:
       - api-tests
     environment:
-      - RUST_LOG=info,forest_filecoin::tool::subcommands=debug
+      - RUST_LOG=info,forest::tool::subcommands=debug
       - FOREST_RPC_DEFAULT_TIMEOUT=120
     entrypoint: [ "/bin/bash", "-c" ]
     user: 0:0
@@ -229,7 +229,7 @@ services:
     networks:
       - api-tests
     environment:
-      - RUST_LOG=info,forest_filecoin::tool::subcommands=debug
+      - RUST_LOG=info,forest::tool::subcommands=debug
       - FOREST_RPC_DEFAULT_TIMEOUT=120
     entrypoint: [ "/bin/bash", "-c" ]
     user: 0:0

--- a/src/bin/forest-cli.rs
+++ b/src/bin/forest-cli.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 fn main() -> anyhow::Result<()> {
-    forest_filecoin::forest_main(std::env::args_os())
+    forest::forest_main(std::env::args_os())
 }

--- a/src/bin/forest-tool.rs
+++ b/src/bin/forest-tool.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 fn main() -> anyhow::Result<()> {
-    forest_filecoin::forest_tool_main(std::env::args_os())
+    forest::forest_tool_main(std::env::args_os())
 }

--- a/src/bin/forest-wallet.rs
+++ b/src/bin/forest-wallet.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 fn main() -> anyhow::Result<()> {
-    forest_filecoin::forest_wallet_main(std::env::args_os())
+    forest::forest_wallet_main(std::env::args_os())
 }

--- a/src/bin/forest.rs
+++ b/src/bin/forest.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 fn main() -> anyhow::Result<()> {
-    forest_filecoin::forestd_main(std::env::args_os())
+    forest::forestd_main(std::env::args_os())
 }

--- a/src/cli/humantoken.rs
+++ b/src/cli/humantoken.rs
@@ -121,7 +121,7 @@ mod parse {
 
     /// Parse token amounts as floats with SI prefixed-units.
     /// ```
-    /// # use forest_filecoin::doctest_private::{TokenAmount, parse};
+    /// # use forest::doctest_private::{TokenAmount, parse};
     /// fn assert_attos(input: &str, attos: u64) {
     ///     let expected = TokenAmount::from_atto(attos);
     ///     let actual = parse(input).unwrap();
@@ -408,7 +408,7 @@ mod print {
         /// - `{:.#4}`: both
         ///
         /// ```
-        /// # use forest_filecoin::doctest_private::{TokenAmountPretty as _, TokenAmount};
+        /// # use forest::doctest_private::{TokenAmountPretty as _, TokenAmount};
         ///
         /// let amount = TokenAmount::from_nano(1500);
         ///

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1264,7 +1264,7 @@ impl RpcMethod<2> for StateFetchRoot {
                     for new_cid in ipld.iter().filter_map(&mut get_ipld_link) {
                         counter += 1;
                         if counter % 1_000 == 0 {
-                            // set RUST_LOG=forest_filecoin::rpc::state_api=debug to enable these printouts.
+                            // set RUST_LOG=forest::rpc::state_api=debug to enable these printouts.
                             tracing::debug!(
                                 "Graph walk: CIDs: {counter}, Fetched: {fetched}, Failures: {failures}, dfs: {}, Concurrent: {}",
                                 dfs_guard.len(), task_set.len()

--- a/src/shim/error.rs
+++ b/src/shim/error.rs
@@ -13,7 +13,7 @@ use std::fmt;
 ///
 /// # Examples
 /// ```
-/// # use forest_filecoin::doctest_private::ExitCode;
+/// # use forest::doctest_private::ExitCode;
 /// let fvm2_success = fvm_shared2::error::ExitCode::new(0);
 /// let fvm3_success = fvm_shared3::error::ExitCode::new(0);
 ///

--- a/src/shim/randomness.rs
+++ b/src/shim/randomness.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Examples
 /// ```
-/// # use forest_filecoin::doctest_private::Randomness;
+/// # use forest::doctest_private::Randomness;
 ///
 /// // Create FVM2 Randomness normally
 /// let fvm2_rand = fvm_shared2::randomness::Randomness(vec![]);

--- a/src/shim/sector.rs
+++ b/src/shim/sector.rs
@@ -31,7 +31,7 @@ pub type SectorNumber = fvm_shared4::sector::SectorNumber;
 ///
 /// # Examples
 /// ```
-/// # use forest_filecoin::doctest_private::RegisteredSealProof;
+/// # use forest::doctest_private::RegisteredSealProof;
 /// // Create FVM2 RegisteredSealProof normally
 /// let fvm2_proof = fvm_shared2::sector::RegisteredSealProof::StackedDRG2KiBV1;
 ///

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -376,7 +376,7 @@ where
 ///
 /// # Examples
 /// ```
-/// # use forest_filecoin::doctest_private::ActorState;
+/// # use forest::doctest_private::ActorState;
 /// use cid::Cid;
 ///
 /// // Create FVM2 ActorState normally

--- a/src/shim/version.rs
+++ b/src/shim/version.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Examples
 /// ```
-/// # use forest_filecoin::doctest_private::NetworkVersion;
+/// # use forest::doctest_private::NetworkVersion;
 /// let v0 = NetworkVersion::V0;
 ///
 /// // dereference to convert to FVM4

--- a/src/state_migration/tests/mod.rs
+++ b/src/state_migration/tests/mod.rs
@@ -21,7 +21,7 @@ use std::{str::FromStr, sync::Arc};
 #[ignore = "flaky"]
 #[tokio::test]
 async fn test_nv17_state_migration_calibnet() {
-    // forest_filecoin::state_migration: State migration at height Shark(epoch 16800) was successful,
+    // forest::state_migration: State migration at height Shark(epoch 16800) was successful,
     // Previous state: bafy2bzacedxtdhqjsrw2twioyaeomdk4z7umhgfv36vzrrotjb4woutphqgyg,
     // new state: bafy2bzacecrejypa2rqdh3geg2u3qdqdrejrfqvh2ykqcrnyhleehpiynh4k4.
     //

--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -78,7 +78,7 @@ pub mod serde_byte_array {
 ///
 /// # Example
 /// ```
-/// # use forest_filecoin::doctest_private::blake2b_256;
+/// # use forest::doctest_private::blake2b_256;
 ///
 /// let ingest: Vec<u8> = vec![];
 /// let hash = blake2b_256(&ingest);

--- a/src/utils/io/mod.rs
+++ b/src/utils/io/mod.rs
@@ -49,7 +49,7 @@ pub fn create_new_sensitive_file(path: &Path) -> Result<File> {
 /// # Example
 /// ```
 /// use serde::Deserialize;
-/// use forest_filecoin::doctest_private::read_toml;
+/// use forest::doctest_private::read_toml;
 ///
 /// #[derive(Deserialize)]
 /// struct Config {

--- a/src/utils/io/progress_log.rs
+++ b/src/utils/io/progress_log.rs
@@ -19,7 +19,7 @@
 //! ```
 //! use tokio_test::block_on;
 //! use tokio::io::AsyncBufReadExt;
-//! use forest_filecoin::doctest_private::WithProgress;
+//! use forest::doctest_private::WithProgress;
 //! block_on(async {
 //!     let data: String = "some very big string".into();
 //!     let mut reader = tokio::io::BufReader::new(data.as_bytes());

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use std::io::Write;
 
-use forest_filecoin::{Client, Config};
+use forest::{Client, Config};
 use tempfile::TempDir;
 
 pub mod common;

--- a/tests/keystore_tests.rs
+++ b/tests/keystore_tests.rs
@@ -3,8 +3,8 @@
 
 pub mod common;
 
-use forest_filecoin::{verify_token, JWT_IDENTIFIER};
-use forest_filecoin::{
+use forest::{verify_token, JWT_IDENTIFIER};
+use forest::{
     KeyStore, KeyStoreConfig, ENCRYPTED_KEYSTORE_NAME, FOREST_KEYSTORE_PHRASE_ENV, KEYSTORE_NAME,
 };
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- shorten `forest_filecoin` to `forest` in log

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #4649

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
