### PR TITLE
fix: increase RPC request timeout in API compare tests

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -199,7 +199,7 @@ services:
       - api-tests
     environment:
       - RUST_LOG=info,forest::tool::subcommands=debug
-      - FOREST_RPC_DEFAULT_TIMEOUT=120
+      - FOREST_RPC_DEFAULT_TIMEOUT=300
     entrypoint: [ "/bin/bash", "-c" ]
     user: 0:0
     command:
@@ -230,7 +230,7 @@ services:
       - api-tests
     environment:
       - RUST_LOG=info,forest::tool::subcommands=debug
-      - FOREST_RPC_DEFAULT_TIMEOUT=120
+      - FOREST_RPC_DEFAULT_TIMEOUT=300
     entrypoint: [ "/bin/bash", "-c" ]
     user: 0:0
     command:

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -11,5 +11,3 @@
 !Filecoin.EthGetTransactionReceiptLimited
 # TODO: https://github.com/ChainSafe/forest/issues/5006
 !Filecoin.EthGetBlockReceipts
-# TODO: https://github.com/ChainSafe/forest/issues/5100
-!Filecoin.StateMinerSectors

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -41,5 +41,3 @@
 !Filecoin.EthGetTransactionReceiptLimited
 # TODO: https://github.com/ChainSafe/forest/issues/5006
 !Filecoin.EthGetBlockReceipts
-# TODO: https://github.com/ChainSafe/forest/issues/5100
-!Filecoin.StateMinerSectors


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Forest is returning some results, and Lotus is timing out. We can either accept such an outcome as okay-ish or increase the timeout. Let's try to do the latter, otherwise, we'll be missing the output comparison.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5100

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
