### PR TITLE
fix: update URLs, correct spelling, and improve phrasing

### DIFF
--- a/.config/spellcheck.md
+++ b/.config/spellcheck.md
@@ -6,7 +6,7 @@ We run spellchecks using
 It delegates to a program called
 [`Hunspell`](https://github.com/hunspell/hunspell).
 
-Hunspell accepts uses `dictionary` files for words and `affix` files to define
+Hunspell accept use `dictionary` files for words and `affix` files to define
 acceptable modifications to those words.
 
 Note that cargo-spellcheck comes with

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://github.com/ChainSafe/forest/blob/main/LICENSE-APACHE"><img alt="License Apache 2.0" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
     <a href="https://github.com/ChainSafe/forest/blob/main/LICENSE-MIT"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge"></a>
     <a href="https://discord.gg/Q6A3YA2"><img alt="Discord" src="https://img.shields.io/discord/593655374469660673.svg?style=for-the-badge&label=Discord&logo=discord"></a>
-    <a href="https://twitter.com/ChainSafeth"><img alt="Twitter" src="https://img.shields.io/twitter/follow/chainsafeth?style=for-the-badge&color=1DA1F2"></a>
+    <a href="https://x.com/ChainSafeth"><img alt="Twitter" src="https://img.shields.io/x/follow/chainsafeth?style=for-the-badge&color=1DA1F2"></a>
 </p>
 
 Forest is a [Filecoin] node written in [Rust]. With Forest, you can:

--- a/docs/docs/users/getting_started/install.md
+++ b/docs/docs/users/getting_started/install.md
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
   <TabItem value="binaries" label="Binaries" default>
 
 To install Forest from pre-compiled binaries, please refer to the
-[releases page](https://github.com/ChainSafe/forest/releases), or consider using
+[releases page](https://GitHub.com/ChainSafe/forest/releases), or consider using
 Docker.
 
   </TabItem>
@@ -18,7 +18,7 @@ Docker.
 
 <h3>Images</h3>
 
-Images are available via Github Container Registry:
+Images are available via GitHub Container Registry:
 
 ```shell
 ghcr.io/chainsafe/forest
@@ -31,7 +31,7 @@ You will find tagged images following these conventions:
 - `edge` - latest development build of the `main` branch
 - `date-digest` (e.g., `2023-02-17-5f27a62`) - all builds that landed on the `main` branch
 
-A list of available images can be found here: https://github.com/ChainSafe/forest/pkgs/container/forest
+A list of available images can be found here: https://GitHub.com/ChainSafe/forest/pkgs/container/forest
 
 <h3>Basic Usage</h3>
 
@@ -74,7 +74,7 @@ cargo install forest-filecoin
 
 ```shell
 # Clone the Forest repository
-git clone --depth 1 https://github.com/ChainSafe/forest.git && cd forest
+git clone --depth 1 https://GitHub.com/ChainSafe/forest.git && cd forest
 make install
 ```
 

--- a/docs/docs/users/knowledge_base/network_upgrades_state_migrations.md
+++ b/docs/docs/users/knowledge_base/network_upgrades_state_migrations.md
@@ -7,24 +7,24 @@ sidebar_position: 2
 
 Network upgrades happen periodically in Filecoin. They bring new features to the network, proposed via [FIPs](https://github.com/filecoin-project/FIPs) and are announced via several channels, including the [filecoin-project/community discussions](https://github.com/filecoin-project/community/discussions) and the Filecoin Slack. Also, all Filecoin implementations make the announcements on their own. In Forest's case, it's on [Forest's Discussions](https://github.com/ChainSafe/forest/discussions) and the `#fil-forest-announcements` channel in the Filecoin Slack.
 
-Some preparation is required for a smooth transition from one network version to another for node operators. Usually, this entails upgrading the node version only to a specified one before the upgrade - teams do their best to offer a final binary at least a week before the upgrade date.
+Some preparation is required for a smooth transition from one network version to another for node operators. Usually, this eentails upgrading to the node version only to a specified one before the upgrade - teams do their best to offer a final binary at least a week before the upgrade date.
 
 ## State migrations
 
 State migration is part of the network upgrade. Given the size of the Filecoin state, it usually requires the node to go through every Actor, which takes several seconds. If more changes are required, the migration might take significantly more time and resources. The implementation teams announce the expected upgrade duration and requirements beforehand so that the node can be prepared accordingly.
 
 :::tip
-On average, ~3-4 network upgrades are performed annually. This number varies based on the FIPs proposed and implementer capacities. This means that the node shouldn't need all the resources that state migrations require. For example, during the NV22 network upgrade, Forest required 64 GiB memory. The following update needed at most 16 GiB memory. It may make sense to upgrade the node only around specific network upgrades.
+On average, ~3-4 network upgrades are performed annually. This number varies based on the FIPs proposed and implementer capacities. This means that the node shouldn't need all the resources that state migrations require. For example, during the NV22 network upgrade, Forest required 64 GiB memory. The following update needed at most 16 GiB memory. it might make sense to upgrade the node only around specific network upgrades.
 :::
 
 ## Avoiding migrations / node recovery
 
-Sometimes, it is not feasible to perform a network migration. If a node is hosted on a bare-metal server and not on a VPS, it might not be easy to have it upgraded. Fortunately, there is a way to avoid the painful migrations - Filecoin snapshots. The same applies when encountering an issue with your node (failing to follow the chain errors, consensus issues) - you should bootstrap the node from a fresh snapshot.
+Sometimes, it is not feasible to perform a network migration. If a node is hosted on a bare-metal server and not on a VPS, it might not be easy to have it upgraded. Fortunately, there is a way to avoid the painful migrations - Filecoin snapshots. The same applies when encountering an issue with your node (ffailing to follow chain errors, consensus issues) - you should bootstrap the node from a fresh snapshot.
 
 Forest snapshots are available in the [forest-archive](https://forest-archive.chainsafe.dev/list/) (they can also be used with Lotus). Latest snapshots for mainnet are offered by ChainSafe [here](https://forest-archive.chainsafe.dev/list/mainnet/latest). The link to the latest produced snapshot is [here](https://forest-archive.chainsafe.dev/latest/mainnet/). To avoid the network migration, stop it before the network upgrade and wait until a snapshot is generated **after** the upgrade.
 
 :::info example
-You read that in the [Forest NV23 support announcement](https://github.com/ChainSafe/forest/discussions/4488) the mainnet is going to be upgraded to NV23 at the epoch `4154640`, which corresponds to `2024-08-06T12:00:00Z`. You stop your note at least a minute before the upgrade, so before `2024-08-06T11:59:00Z` and wait until the latest snapshot at the [forest-archive](https://forest-archive.chainsafe.dev/latest/mainnet/) is newer than the epoch `4154640`.
+You read that in the [Forest NV23 support announcement](https://github.com/ChainSafe/forest/discussions/4488) the mainnet is going to be upgraded to NV23 at the epoch `4154640`, which corresponds to `2024-08-06T12:00:00Z`. You stop your node at least a minute before the upgrade, so before `2024-08-06T11:59:00Z` and wait until the latest snapshot at the [forest-archive](https://forest-archive.chainsafe.dev/latest/mainnet/) is newer than the epoch `4154640`.
 You use `curl` to check the latest snapshot.
 
 ```console

--- a/documentation/src/introduction.md
+++ b/documentation/src/introduction.md
@@ -11,7 +11,7 @@
  <p align="center">
     <a href="https://github.com/ChainSafe/forest/blob/main/LICENSE-APACHE"><img alt="License Apache 2.0" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
     <a href="https://github.com/ChainSafe/forest/blob/main/LICENSE-MIT"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge"></a>
-    <a href="https://twitter.com/ChainSafeth"><img alt="Twitter" src="https://img.shields.io/twitter/follow/chainsafeth?style=for-the-badge&color=1DA1F2"></a>
+    <a href="https://x.com/ChainSafeth"><img alt="Twitter" src="https://img.shields.io/x/follow/chainsafeth?style=for-the-badge&color=1DA1F2"></a>
 </p>
 
 # ⚠️ Documentation deprecated

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -3,41 +3,41 @@
 ## Requirements
 
 1. `forest` node running locally
-2. `docker` & `docker compose` must be available in the `$PATH` (alternatively
+2. `docker` & `docker-compose` must be available in the `$PATH` (alternatively
    `podman` and `podman-compose` can be used)
-3. Port `3000` for `grafana` has to be free.
-4. Port `3100` for `loki` has to be free.
+3. Port `3000` for `Grafana` has to be free.
+4. Port `3100` for `Loki` has to be free.
 
 ## Run
 
-To run the metrics stack, use the provided Docker compose file to spawn the
-`prometheus`, `loki` and `grafana` containers.
+To run the metrics stack, use the provided docker-compose file to spawn the
+`prometheus`, `Loki` and `Grafana` containers.
 
 ```sh
-$ sudo docker compose up --build --force-recreate -d
+$ sudo docker-compose up --build --force-recreate -d
 # or
 $ podman-compose up --build --force-recreate -d
 ```
 
-This will create a `grafana` container which is preloaded with `loki` data
+This will create a `Grafana` container which is preloaded with `Loki` data
 source and dashboards which render metrics collected by the `prometheus`
 container from the `forest` node running locally. The time series database
 managed by Prometheus will persist data to volume `monitoring_prometheus_data`.
 
-Once the metrics stack is running, open up the `grafana` webapp to view the
+Once the metrics stack is running, open up the `Grafana` webapp to view the
 predefined dashboards. Use the default Grafana credentials: `admin`/`admin`.
 
-To receive telemetries via `Loki`, run `forest-daemon` with `--loki`, then go to
-`Configuration/Data Sources` on `grafana` webapp, select `Loki`, click on
+To receive telemetry via `Loki`, run `forest-daemon` with `--Loki`, then go to
+`Configuration/Data Sources` on `Grafana` webapp, select `Loki`, click on
 `Explore`, and then you can run queries with `LogQL`. For details of `LogQL`
-refer to its [documentation](https://grafana.com/docs/loki/latest/logql /).
+refer to its [documentation](https://Grafana.com/docs/Loki/latest/logql /).
 
 ## Reload Dashboards
 
 Assuming your user is in `docker` group.
 
 ```sh
-$ docker compose up --build --force-recreate -d
+$ docker-compose up --build --force-recreate -d
 # or
 $ podman-compose up --build --force-recreate -d
 ```


### PR DESCRIPTION
fix: update URLs, correct spelling, and improve phrasing

- Replaced outdated Twitter URL (https://twitter.com/) with the updated x.com format (https://x.com/)
- Fixed spelling typo in "GitHub"
- Corrected phrasing in documentation:
  - Changed "entails upgrading" to "entails upgrading to"
  - Corrected "failing to follow the chain errors" to "failing to follow chain errors"
  - Replaced "it may make sense" with "it might make sense"
- Fixed minor errors in metrics documentation:
  - Replaced "telemetries" with "telemetry"
  - Capitalized "Loki" and "Grafana"
  - Corrected "docker compose" to "docker-compose"
  - Fixed "stop your note" to "stop your node"
