### PR TITLE
fix: check f3 running status on healthz and readyz endpoints

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -147,6 +147,11 @@ pub(super) async fn start(
     config: Config,
     shutdown_send: mpsc::Sender<()>,
 ) -> anyhow::Result<()> {
+    if opts.detach {
+        tracing::warn!("F3 sidecar is disabled in detach mode");
+        std::env::set_var("FOREST_F3_SIDECAR_FFI_ENABLED", "0");
+    }
+
     let chain_config = Arc::new(ChainConfig::from_chain(config.chain()));
     if chain_config.is_testnet() {
         CurrentNetwork::set_global(Network::Testnet);

--- a/src/f3/mod.rs
+++ b/src/f3/mod.rs
@@ -116,7 +116,7 @@ pub fn run_f3_sidecar_if_enabled(
 }
 
 /// Whether F3 sidecar via FFI is enabled.
-fn is_sidecar_ffi_enabled(chain_config: &ChainConfig) -> bool {
+pub fn is_sidecar_ffi_enabled(chain_config: &ChainConfig) -> bool {
     // Respect the environment variable when set, and fallback to chain config when not set.
     let enabled =
         is_env_set_and_truthy("FOREST_F3_SIDECAR_FFI_ENABLED").unwrap_or(chain_config.f3_enabled);

--- a/src/health/endpoints.rs
+++ b/src/health/endpoints.rs
@@ -177,7 +177,7 @@ async fn check_f3_running(state: &ForestState, acc: &mut MessageAccumulator) -> 
     if !crate::f3::is_sidecar_ffi_enabled(&state.chain_config) {
         acc.push_ok("f3 disabled");
         true
-    } else if let Ok(true) = F3IsRunning::is_f3_running().await {
+    } else if F3IsRunning::is_f3_running().await.unwrap_or_default() {
         acc.push_ok("f3 running");
         true
     } else {

--- a/src/rpc/methods/f3.rs
+++ b/src/rpc/methods/f3.rs
@@ -653,6 +653,15 @@ impl RpcMethod<1> for F3GetF3PowerTable {
 }
 
 pub enum F3IsRunning {}
+
+impl F3IsRunning {
+    pub async fn is_f3_running() -> anyhow::Result<bool> {
+        let client = get_rpc_http_client()?;
+        let response = client.request(Self::NAME, ArrayParams::new()).await?;
+        Ok(response)
+    }
+}
+
 impl RpcMethod<0> for F3IsRunning {
     const NAME: &'static str = "Filecoin.F3IsRunning";
     const PARAM_NAMES: [&'static str; 0] = [];
@@ -663,9 +672,7 @@ impl RpcMethod<0> for F3IsRunning {
     type Ok = bool;
 
     async fn handle(_: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
-        let client = get_rpc_http_client()?;
-        let response = client.request(Self::NAME, ArrayParams::new()).await?;
-        Ok(response)
+        Ok(Self::is_f3_running().await?)
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- check f3 running status on healthz and readyz endpoints

```
➜  forest git:(hm/f3-health-check) forest-cli healthcheck ready
[+] sync complete
[+] epoch up to date
[+] rpc server running
[+] eth mapping up to date
[+] f3 running
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #4955

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
