### PR TITLE
Fix incorrect Tipset passed to `new_eth_tx_receipt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@
 
 - [#5006](https://github.com/ChainSafe/forest/issues/5006) Fix incorrect logs, logs bloom and event index for the `Filecoin.EthGetBlockReceipts` RPC method.
 
+- [#4996](https://github.com/ChainSafe/forest/issues/4996) Fix incorrect logs and logs bloom for the `Filecoin.EthGetTransactionReceipt` and
+  `Filecoin.EthGetTransactionReceiptLimited` RPC methods on some blocks.
+
 ## Forest v.0.23.3 "Plumber"
 
 Mandatory release for calibnet node operators. It fixes a sync error at epoch 2281645.

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -4,6 +4,3 @@
 !Filecoin.MpoolGetNonce
 # CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/actions/runs/9593268587/job/26453560366
 !Filecoin.StateReplay
-# TODO: https://github.com/ChainSafe/forest/issues/4996
-!Filecoin.EthGetTransactionReceipt
-!Filecoin.EthGetTransactionReceiptLimited

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -34,6 +34,3 @@
 !Filecoin.EthGetBlockByNumber
 !eth_getBlockByNumber
 !Filecoin.ChainSetHead
-# TODO: https://github.com/ChainSafe/forest/issues/4996
-!Filecoin.EthGetTransactionReceipt
-!Filecoin.EthGetTransactionReceiptLimited

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -2360,7 +2360,23 @@ async fn get_eth_transaction_receipt(
     let tx = new_eth_tx_from_message_lookup(&ctx, &message_lookup, None)
         .with_context(|| format!("failed to convert {} into an Eth Tx", tx_hash))?;
 
-    let tx_receipt = new_eth_tx_receipt(&ctx, &tipset, &tx, &message_lookup.receipt).await?;
+    let ts = ctx
+        .chain_index()
+        .load_required_tipset(&message_lookup.tipset)?;
+
+    // The tx is located in the parent tipset
+    let parent_ts = ctx
+        .chain_index()
+        .load_required_tipset(ts.parents())
+        .map_err(|e| {
+            format!(
+                "failed to lookup tipset {} when constructing the eth txn receipt: {}",
+                ts.parents(),
+                e
+            )
+        })?;
+
+    let tx_receipt = new_eth_tx_receipt(&ctx, &parent_ts, &tx, &message_lookup.receipt).await?;
 
     Ok(tx_receipt)
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fix flakyness in `Filecoin.EthGetTransactionReceipt` and `Filecoin.EthGetTransactionReceiptLimited` methods, because wrong tipset was sometimes passed to `new_eth_tx_receipt`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #4996

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
