### PR TITLE
feat: add format flag in chain head command

### DIFF
--- a/src/cli/subcommands/chain_cmd.rs
+++ b/src/cli/subcommands/chain_cmd.rs
@@ -12,6 +12,12 @@ use nunny::Vec as NonEmpty;
 
 use super::{print_pretty_lotus_json, print_rpc_res_cids};
 
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum Format {
+    Json,
+    Text,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum ChainCommands {
     /// Retrieves and prints out the block specified by the given CID
@@ -29,6 +35,8 @@ pub enum ChainCommands {
         /// Tipsets are categorized by epoch in descending order.
         #[arg(short = 'n', long, default_value = "1")]
         tipsets: u64,
+        #[arg(short, long, default_value = "text")]
+        format: Format,
     },
 
     /// Reads and prints out a message referenced by the specified CID from the
@@ -68,7 +76,7 @@ impl ChainCommands {
                 print_pretty_lotus_json(ChainGetBlock::call(&client, (cid,)).await?)
             }
             Self::Genesis => print_pretty_lotus_json(ChainGetGenesis::call(&client, ()).await?),
-            Self::Head { tipsets } => print_chain_head(&client, tipsets).await,
+            Self::Head { tipsets, format } => print_chain_head(&client, tipsets, format).await,
             Self::Message { cid } => {
                 let bytes = ChainReadObj::call(&client, (cid,)).await?;
                 match fvm_ipld_encoding::from_slice::<ChainMessage>(&bytes)? {
@@ -151,15 +159,41 @@ fn maybe_confirm(no_confirm: bool, prompt: impl Into<String>) -> anyhow::Result<
     }
 }
 
-/// Print the first `n` tipsets from the head (inclusive).
-async fn print_chain_head(client: &rpc::Client, n: u64) -> anyhow::Result<()> {
+#[derive(Debug, serde::Serialize)]
+struct TipsetInfo {
+    epoch: u64,
+    cids: Vec<String>,
+}
+
+async fn collect_tipsets(client: &rpc::Client, n: u64) -> anyhow::Result<Vec<TipsetInfo>> {
     ensure!(n > 0, "number of tipsets must be positive");
     let current_epoch = ChainHead::call(client, ()).await?.epoch() as u64;
-
+    let mut result = Vec::with_capacity(n as usize);
     for epoch in (current_epoch.saturating_sub(n - 1)..=current_epoch).rev() {
         let tipset = tipset_by_epoch_or_offset(client, epoch.try_into()?).await?;
-        println!("[{}]", epoch);
-        print_rpc_res_cids(tipset)?;
+        result.push(TipsetInfo {
+            epoch,
+            cids: tipset.cids().iter().map(|cid| cid.to_string()).collect(),
+        });
+    }
+    Ok(result)
+}
+
+/// Print the first `n` tipsets from the head (inclusive).
+async fn print_chain_head(client: &rpc::Client, n: u64, format: Format) -> anyhow::Result<()> {
+    let result = collect_tipsets(client, n).await?;
+    match format {
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        Format::Text => {
+            result.iter().for_each(|epoch_info| {
+                println!("[{}]", epoch_info.epoch);
+                epoch_info.cids.iter().for_each(|cid| {
+                    println!("{}", cid);
+                });
+            });
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Adds `--format` or `-f` flag to the `forest-cli chain head` command
- `--format` flag accepts `json` or `text` value, by default `text`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
