### PR TITLE
Fix loading tipsets past the range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
 - [#4996](https://github.com/ChainSafe/forest/issues/4996) Fix incorrect logs and logs bloom for the `Filecoin.EthGetTransactionReceipt` and
   `Filecoin.EthGetTransactionReceiptLimited` RPC methods on some blocks.
 
+- [#5213](https://github.com/ChainSafe/forest/issues/5213) Fix incorrect results for the `Filecoin.EthGetLogs` RPC method on ranges that include null tipsets.
+
 ## Forest v.0.23.3 "Plumber"
 
 Mandatory release for calibnet node operators. It fixes a sync error at epoch 2281645.

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -2,8 +2,6 @@
 # They should be considered bugged, and not used until the root cause is resolved.
 # Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619017774/job/23623141130?pr=4170
 !Filecoin.MpoolGetNonce
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/5213
-!Filecoin.EthGetLogs
 # TODO: https://github.com/ChainSafe/forest/issues/4996
 !Filecoin.EthGetTransactionReceipt
 !Filecoin.EthGetTransactionReceiptLimited

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -2,4 +2,3 @@
 # They should be considered bugged, and not used until the root cause is resolved.
 # Internal Server Error on Lotus: https://github.com/ChainSafe/forest/actions/runs/8619017774/job/23623141130?pr=4170
 !Filecoin.MpoolGetNonce
-

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -21,8 +21,6 @@
 !Filecoin.F3GetCertificate
 !Filecoin.F3GetOrRenewParticipationTicket
 !Filecoin.F3GetF3PowerTable
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/5213
-!Filecoin.EthGetLogs
 # CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/actions/runs/9593268587/job/26453560366
 !Filecoin.StateCall
 # These methods don't make sense in the context of an offline node

--- a/src/rpc/methods/eth/filter/mod.rs
+++ b/src/rpc/methods/eth/filter/mod.rs
@@ -387,7 +387,6 @@ impl EthEventHandler {
                     *range.end()
                 };
 
-                let num_tipsets = (range.end() - range.start()) + 1;
                 let max_tipset = ctx.chain_store().chain_index.tipset_by_height(
                     max_height,
                     ctx.chain_store().heaviest_tipset(),
@@ -397,7 +396,7 @@ impl EthEventHandler {
                     .as_ref()
                     .clone()
                     .chain(&ctx.store())
-                    .take(num_tipsets as usize)
+                    .take_while(|ts| ts.epoch() >= *range.start())
                 {
                     let tipset = Arc::new(tipset);
                     Self::collect_events(ctx, &tipset, Some(&spec), &mut collected_events).await?;

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -1669,7 +1669,8 @@ fn eth_tests_with_tipset<DB: Blockstore>(store: &Arc<DB>, shared_tipset: &Tipset
                 block_hash: None,
             },))
             .unwrap(),
-        ),
+        )
+        .sort_policy(SortPolicy::All),
         RpcTest::identity(
             EthGetLogs::request((EthFilterSpec {
                 from_block: Some(format!("0x{:x}", shared_tipset.epoch() - 100)),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fix range tipset lookups that were not taking null rounds into account.

```bash
forest-tool api compare --lotus /ip4/127.0.0.1/tcp/1234/http --forest /ip4/127.0.0.1/tcp/2345/http forest_snapshot_calibnet_2025-01-30_height_2364216.forest.car.zst --filter EthGetLogs -n 900
| RPC Method                 | Forest | Lotus |
|----------------------------|--------|-------|
| Filecoin.EthGetLogs (1800) | Valid  | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5213

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
