### PR TITLE
chore(ci): run docker jobs on ubuntu-24.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   build-ubuntu-amd64:
     name: Build forest binaries on Linux AMD64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Run the job only if the PR is not a draft.
     # This is done to limit the runner cost.
     if: github.event.pull_request.draft == false
@@ -76,7 +76,7 @@ jobs:
   
   build-ubuntu-arm64:
     name: Build forest binaries on Ubuntu ARM64
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     # Run the job only if the PR is not a draft.
     # This is done to limit the runner cost.
     if: github.event.pull_request.draft == false
@@ -121,7 +121,7 @@ jobs:
 
   build-and-push-docker-image:
     name: Build images and push to GHCR
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Run the job only if the PR is not a draft.
     # This is done to limit the runner cost.
     if: github.event.pull_request.draft == false

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -16,7 +16,7 @@
 # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#cached-docker-images
 ##
 # A slim image contains only forest binaries
-FROM ubuntu:22.04 AS slim-image
+FROM ubuntu:24.04 AS slim-image
 
 # export TARGETPLATFORM TARGETOS and TARGETARCH
 ARG TARGETPLATFORM


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Previously, we used ubuntu 22.04 because buildjet does not support 24.04, now since we moved to GH hosted arm runners, we could just switch to 24.04

Changes introduced in this pull request:

- run docker jobs on ubuntu-24.04

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
