### PR TITLE
fix: favor fractional FIL amounts over a larger number of a smaller unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 ### Changed
 
+- [#5237](https://github.com/ChainSafe/forest/pull/5237) Stylistic changes to FIL pretty printing.
+
 ### Removed
 
 ### Fixed

--- a/src/cli/humantoken.rs
+++ b/src/cli/humantoken.rs
@@ -361,7 +361,7 @@ mod print {
             .iter()
             .filter(|prefix| prefix.exponent > 0)
         {
-            let scaled = n.clone() * prefix.multiplier().inverse();
+            let scaled = (n.clone() * prefix.multiplier().inverse()).normalized();
             if scaled >= BigDecimal::one() {
                 return (scaled, Some(*prefix));
             }
@@ -375,7 +375,7 @@ mod print {
             .iter()
             .filter(|prefix| prefix.exponent < 0)
         {
-            let scaled = n.clone() * prefix.multiplier().inverse();
+            let scaled = (n.clone() * prefix.multiplier().inverse()).normalized();
             if scaled >= BigDecimal::one() {
                 return (scaled, Some(*prefix));
             }
@@ -416,7 +416,7 @@ mod print {
         /// let amount = TokenAmount::from_nano(1500);
         ///
         /// // Defaults to precise, with SI prefix
-        /// assert_eq!("1500 nanoFIL", format!("{}", amount.pretty()));
+        /// assert_eq!("1.5 microFIL", format!("{}", amount.pretty()));
         ///
         /// // Rounded to 1 s.f
         /// assert_eq!("~2 microFIL", format!("{:.1}", amount.pretty()));
@@ -428,7 +428,7 @@ mod print {
         /// assert_eq!("~0.000002 FIL", format!("{:#.1}", amount.pretty()));
         ///
         /// // We only indicate lost precision when relevant
-        /// assert_eq!("1500 nanoFIL", format!("{:.2}", amount.pretty()));
+        /// assert_eq!("1.5 microFIL", format!("{:.2}", amount.pretty()));
         /// ```
         ///
         /// # Formatting
@@ -511,6 +511,7 @@ mod print {
             test_scale(&one_thousanth_of_a_quecto, "0.001", si::quecto);
         }
 
+        #[track_caller]
         fn test_scale(
             input: &str,
             expected_value: &str,
@@ -539,9 +540,9 @@ mod print {
         }
         #[test]
         fn trailing_one() {
-            test_scale("10001000", "10001", si::kilo);
-            test_scale("10001", "10001", None);
-            test_scale("1000.1", "1000100", si::milli);
+            test_scale("10001000", "10.001", si::mega);
+            test_scale("10001", "10.001", si::kilo);
+            test_scale("1000.1", "1.0001", si::kilo);
         }
 
         fn attos(input: &str) -> TokenAmount {

--- a/src/cli/humantoken.rs
+++ b/src/cli/humantoken.rs
@@ -352,7 +352,7 @@ mod print {
 
     use crate::shim::econ::TokenAmount;
     use bigdecimal::BigDecimal;
-    use num::{BigInt, Zero as _};
+    use num::{BigInt, One as _, Zero as _};
 
     use super::si;
 
@@ -362,12 +362,12 @@ mod print {
             .filter(|prefix| prefix.exponent > 0)
         {
             let scaled = n.clone() / prefix.multiplier();
-            if scaled.is_integer() {
+            if scaled >= BigDecimal::one() {
                 return (scaled, Some(*prefix));
             }
         }
 
-        if n.is_integer() {
+        if n >= BigDecimal::one() {
             return (n, None);
         }
 
@@ -376,7 +376,7 @@ mod print {
             .filter(|prefix| prefix.exponent < 0)
         {
             let scaled = n.clone() / prefix.multiplier();
-            if scaled.is_integer() {
+            if scaled >= BigDecimal::one() {
                 return (scaled, Some(*prefix));
             }
         }
@@ -562,7 +562,7 @@ mod print {
 
             // We select the right suffix
             assert_eq!("1 femtoFIL", format!("{}", attos("1000").pretty()));
-            assert_eq!("1001 attoFIL", format!("{}", attos("1001").pretty()));
+            assert_eq!("1.001 femtoFIL", format!("{}", attos("1001").pretty()));
 
             // If you ask for 0 precision, you get it
             assert_eq!("~0 FIL", format!("{:.0}", attos("1001").pretty()));
@@ -588,15 +588,15 @@ mod print {
             assert_eq!("~1 femtoFIL", format!("{:.1}", attos("1001").pretty()));
             assert_eq!("~1 femtoFIL", format!("{:.2}", attos("1001").pretty()));
             assert_eq!("~1 femtoFIL", format!("{:.3}", attos("1001").pretty()));
-            assert_eq!("1001 attoFIL", format!("{:.4}", attos("1001").pretty()));
-            assert_eq!("1001 attoFIL", format!("{:.5}", attos("1001").pretty()));
+            assert_eq!("1.001 femtoFIL", format!("{:.4}", attos("1001").pretty()));
+            assert_eq!("1.001 femtoFIL", format!("{:.5}", attos("1001").pretty()));
 
             // Small numbers with trailing numbers are rounded down
             assert_eq!("~1 femtoFIL", format!("{:.1}", attos("1234").pretty()));
-            assert_eq!("~1200 attoFIL", format!("{:.2}", attos("1234").pretty()));
-            assert_eq!("~1230 attoFIL", format!("{:.3}", attos("1234").pretty()));
-            assert_eq!("1234 attoFIL", format!("{:.4}", attos("1234").pretty()));
-            assert_eq!("1234 attoFIL", format!("{:.5}", attos("1234").pretty()));
+            assert_eq!("~1.2 femtoFIL", format!("{:.2}", attos("1234").pretty()));
+            assert_eq!("~1.23 femtoFIL", format!("{:.3}", attos("1234").pretty()));
+            assert_eq!("1.234 femtoFIL", format!("{:.4}", attos("1234").pretty()));
+            assert_eq!("1.234 femtoFIL", format!("{:.5}", attos("1234").pretty()));
 
             // Small numbers are rounded appropriately
             assert_eq!("~2 femtoFIL", format!("{:.1}", attos("1900").pretty()));
@@ -607,15 +607,15 @@ mod print {
             assert_eq!("~1 kiloFIL", format!("{:.1}", fils("1001").pretty()));
             assert_eq!("~1 kiloFIL", format!("{:.2}", fils("1001").pretty()));
             assert_eq!("~1 kiloFIL", format!("{:.3}", fils("1001").pretty()));
-            assert_eq!("1001 FIL", format!("{:.4}", fils("1001").pretty()));
-            assert_eq!("1001 FIL", format!("{:.5}", fils("1001").pretty()));
+            assert_eq!("1.001 kiloFIL", format!("{:.4}", fils("1001").pretty()));
+            assert_eq!("1.001 kiloFIL", format!("{:.5}", fils("1001").pretty()));
 
             // Big numbers with trailing numbers are rounded down
             assert_eq!("~1 kiloFIL", format!("{:.1}", fils("1234").pretty()));
-            assert_eq!("~1200 FIL", format!("{:.2}", fils("1234").pretty()));
-            assert_eq!("~1230 FIL", format!("{:.3}", fils("1234").pretty()));
-            assert_eq!("1234 FIL", format!("{:.4}", fils("1234").pretty()));
-            assert_eq!("1234 FIL", format!("{:.5}", fils("1234").pretty()));
+            assert_eq!("~1.2 kiloFIL", format!("{:.2}", fils("1234").pretty()));
+            assert_eq!("~1.23 kiloFIL", format!("{:.3}", fils("1234").pretty()));
+            assert_eq!("1.234 kiloFIL", format!("{:.4}", fils("1234").pretty()));
+            assert_eq!("1.234 kiloFIL", format!("{:.5}", fils("1234").pretty()));
 
             // Big numbers are rounded appropriately
             assert_eq!("~2 kiloFIL", format!("{:.1}", fils("1900").pretty()));

--- a/src/cli/humantoken.rs
+++ b/src/cli/humantoken.rs
@@ -361,7 +361,7 @@ mod print {
             .iter()
             .filter(|prefix| prefix.exponent > 0)
         {
-            let scaled = n.clone() / prefix.multiplier();
+            let scaled = n.clone() * prefix.multiplier().inverse();
             if scaled >= BigDecimal::one() {
                 return (scaled, Some(*prefix));
             }
@@ -375,14 +375,17 @@ mod print {
             .iter()
             .filter(|prefix| prefix.exponent < 0)
         {
-            let scaled = n.clone() / prefix.multiplier();
+            let scaled = n.clone() * prefix.multiplier().inverse();
             if scaled >= BigDecimal::one() {
                 return (scaled, Some(*prefix));
             }
         }
 
         let smallest_prefix = si::SUPPORTED_PREFIXES.last().unwrap();
-        (n / smallest_prefix.multiplier(), Some(*smallest_prefix))
+        (
+            n * smallest_prefix.multiplier().inverse(),
+            Some(*smallest_prefix),
+        )
     }
 
     pub struct Pretty {


### PR DESCRIPTION
205.4 FIL over 205400 milliFIL.

## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- This PR changes the behaviour of the FIL pretty-printer. It's a change in behaviour rather than a bug fix.
- Previously, the pretty-printer tried to find the biggest prefix that yielded a non-fractional number. Eg. `1001 milliFIL` over `1.001 FIL`. This PR changes the behaviour to find the biggest prefix that yields a number greater than 1.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #4951

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
