### PR TITLE
feat(cli): more healthcheck subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ### Added
 
+- [#5244](https://github.com/ChainSafe/forest/issues/5244) Add `live` and `healthy` subcommands to `forest-cli healthcheck`.
+
 - [#4708](https://github.com/ChainSafe/forest/issues/4708) Add support for the
   `Filecoin.EthTraceBlock` RPC method.
 

--- a/documentation/src/offline-forest.md
+++ b/documentation/src/offline-forest.md
@@ -9,7 +9,9 @@ chain's archive state without syncing, and various testing scenarios.
 ```bash
 forest-tool api serve --help
 ```
+
 Sample output (may vary depending on the version):
+
 ```console
 Usage: forest-tool api serve [OPTIONS] [SNAPSHOT_FILES]...
 
@@ -45,7 +47,9 @@ height: 1859736.
 ```bash
 forest-tool api serve --chain calibnet ~/Downloads/forest_snapshot_calibnet_2024-08-08_height_1859736.forest.car.zst
 ```
+
 Sample output:
+
 ```console
 2024-08-12T12:29:16.624698Z  INFO forest::tool::offline_server::server: Configuring Offline RPC Server
 2024-08-12T12:29:16.640402Z  INFO forest::tool::offline_server::server: Using chain config for calibnet
@@ -63,7 +67,9 @@ curl --silent -X POST -H "Content-Type: application/json" \
              --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.ChainHead","param":"null"}' \
              "http://127.0.0.1:2345/rpc/v0" | jq
 ```
+
 Sample output:
+
 ```json
 {
   "jsonrpc": "2.0",
@@ -101,7 +107,9 @@ curl --silent -X POST -H "Content-Type: application/json" \
              --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.StateGetNetworkParams","param":"null"}' \
              "http://127.0.0.1:2345/rpc/v0" | jq
 ```
+
 Sample output:
+
 ```json
 {
   "jsonrpc": "2.0",

--- a/src/cli/subcommands/healthcheck_cmd.rs
+++ b/src/cli/subcommands/healthcheck_cmd.rs
@@ -23,6 +23,24 @@ pub enum HealthcheckCommand {
         #[arg(long, default_value_t=DEFAULT_HEALTHCHECK_PORT)]
         healthcheck_port: u16,
     },
+    /// Display live status
+    Live {
+        /// Don't exit until node is ready
+        #[arg(long)]
+        wait: bool,
+        /// Healthcheck port
+        #[arg(long, default_value_t=DEFAULT_HEALTHCHECK_PORT)]
+        healthcheck_port: u16,
+    },
+    /// Display live status
+    Healthy {
+        /// Don't exit until node is ready
+        #[arg(long)]
+        wait: bool,
+        /// Healthcheck port
+        #[arg(long, default_value_t=DEFAULT_HEALTHCHECK_PORT)]
+        healthcheck_port: u16,
+    },
 }
 
 impl HealthcheckCommand {
@@ -31,42 +49,56 @@ impl HealthcheckCommand {
             Self::Ready {
                 wait,
                 healthcheck_port,
-            } => {
-                let ticker = Ticker::new(0.., Duration::from_secs(1));
-                let mut stdout = stdout();
+            } => Self::check(&client, "readyz", healthcheck_port, wait).await,
+            Self::Live {
+                wait,
+                healthcheck_port,
+            } => Self::check(&client, "livez", healthcheck_port, wait).await,
+            Self::Healthy {
+                wait,
+                healthcheck_port,
+            } => Self::check(&client, "healthz", healthcheck_port, wait).await,
+        }
+    }
 
-                let url = format!(
-                    "http://{}:{}/readyz?verbose",
-                    client.base_url().host_str().unwrap_or("localhost"),
-                    healthcheck_port,
-                );
+    async fn check(
+        client: &rpc::Client,
+        endpoint: &str,
+        healthcheck_port: u16,
+        wait: bool,
+    ) -> anyhow::Result<()> {
+        let ticker = Ticker::new(0.., Duration::from_secs(1));
+        let mut stdout = stdout();
 
-                for _ in ticker {
-                    let response = reqwest::get(&url).await?;
-                    let status = response.status();
-                    let text = response.text().await?;
+        let url = format!(
+            "http://{}:{healthcheck_port}/{endpoint}?verbose",
+            client.base_url().host_str().unwrap_or("localhost"),
+        );
 
-                    println!("{}", text);
+        for _ in ticker {
+            let response = reqwest::get(&url).await?;
+            let status = response.status();
+            let text = response.text().await?;
 
-                    if !wait {
-                        break;
-                    }
-                    if status == StatusCode::OK {
-                        println!("Done!");
-                        break;
-                    }
+            println!("{}", text);
 
-                    for _ in 0..(text.matches('\n').count() + 1) {
-                        write!(
-                            stdout,
-                            "\r{}{}",
-                            anes::MoveCursorUp(1),
-                            anes::ClearLine::All,
-                        )?;
-                    }
-                }
-                Ok(())
+            if !wait {
+                break;
+            }
+            if status == StatusCode::OK {
+                println!("Done!");
+                break;
+            }
+
+            for _ in 0..(text.matches('\n').count() + 1) {
+                write!(
+                    stdout,
+                    "\r{}{}",
+                    anes::MoveCursorUp(1),
+                    anes::ClearLine::All,
+                )?;
             }
         }
+        Ok(())
     }
 }

--- a/src/health/endpoints.rs
+++ b/src/health/endpoints.rs
@@ -18,6 +18,7 @@ const VERBOSE_PARAM: &str = "verbose";
 /// In our case, we require:
 /// - The node is not in an error state (i.e., boot-looping)
 /// - At least 1 peer is connected (without peers, the node is isolated and cannot sync)
+/// - The RPC server is running if not disabled
 ///
 /// If any of these conditions are not met, the node is **not** healthy. If this happens for a prolonged period of time, the application should be restarted.
 pub(crate) async fn livez(
@@ -29,6 +30,7 @@ pub(crate) async fn livez(
     let mut lively = true;
     lively &= check_sync_state_not_error(&state, &mut acc);
     lively &= check_peers_connected(&state, &mut acc);
+    lively &= check_rpc_server_running(&state, &mut acc).await;
 
     if lively {
         Ok(acc.result_ok())
@@ -42,7 +44,7 @@ pub(crate) async fn livez(
 /// In our case, we require:
 /// - The node is in sync with the network
 /// - The current epoch of the node is not too far behind the network
-/// - The RPC server is running
+/// - The RPC server is running if not disabled
 /// - The Ethereum mapping is up to date
 /// - The F3 side car is running if enabled
 ///

--- a/src/health/mod.rs
+++ b/src/health/mod.rs
@@ -154,6 +154,7 @@ mod test {
     #[tokio::test]
     async fn test_check_livez() {
         let healthcheck_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+        let rpc_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
 
         let sync_state = Arc::new(RwLock::new(SyncState::default()));
         let peer_manager = Arc::new(PeerManager::default());
@@ -162,6 +163,7 @@ mod test {
             config: Config {
                 client: Client {
                     healthcheck_address,
+                    rpc_address: rpc_listener.local_addr().unwrap(),
                     ..Default::default()
                 },
                 ..Default::default()


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Currently, we have 3 health check endpoints, namely, `readyz`, `livez` and `healthz` but only 1 CLI command `forest-cli healthcheck ready`. This PR extends the CLI subcommand to support all 3 endpoints

Changes introduced in this pull request:

- impl `forest-cli healthcheck live`
- impl `forest-cli healthcheck healthy`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #5246

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
