### PR TITLE
feat: cache actor bundle files locally to speed up forest-tool actor-bundle commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ libp2p = { workspace = true, features = [
 ] }
 libsecp256k1 = "0.7"
 lru = "0.13"
+md5 = { package = "md-5", version = "0.10" }
 memmap2 = "0.9"
 memory-stats = "1"
 multiaddr = "0.18"
@@ -241,7 +242,6 @@ glob = "0.3"
 http-range-header = "0.4"
 insta = { version = "1", features = ["yaml"] }
 libp2p-swarm-test = { workspace = true }
-md5 = { package = "md-5", version = "0.10" }
 num-bigint = { version = "0.4", features = ['quickcheck'] }
 petgraph = "0.7"
 predicates = "3"

--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -1,19 +1,19 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use crate::daemon::db_util::download_file_with_cache;
 use crate::db::PersistentStore;
 use crate::{
     networks::{ActorBundleInfo, NetworkChain, ACTOR_BUNDLES},
-    utils::{
-        db::car_stream::{CarBlock, CarStream},
-        net::http_get,
-    },
+    utils::db::car_stream::{CarBlock, CarStream},
 };
 use ahash::HashSet;
-use anyhow::ensure;
 use cid::Cid;
+use directories::ProjectDirs;
 use futures::{stream::FuturesUnordered, TryStreamExt};
+use once_cell::sync::Lazy;
 use std::mem::discriminant;
+use std::path::PathBuf;
 use std::{io::Cursor, path::Path};
 use tokio::io::BufReader;
 use tracing::{info, warn};
@@ -74,6 +74,14 @@ pub async fn load_actor_bundles_from_path(
     Ok(())
 }
 
+pub static ACTOR_BUNDLE_CACHE_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    let project_dir = ProjectDirs::from("com", "ChainSafe", "Forest");
+    project_dir
+        .map(|d| d.cache_dir().to_path_buf())
+        .unwrap_or_else(std::env::temp_dir)
+        .join("actor-bundles")
+});
+
 /// Loads the missing actor bundle, returns the CIDs of the loaded bundles.
 pub async fn load_actor_bundles_from_server(
     db: &impl PersistentStore,
@@ -94,26 +102,28 @@ pub async fn load_actor_bundles_from_server(
                      manifest: root,
                      url,
                      alt_url,
-                     network: _,
-                     version: _,
+                     network,
+                     version,
                  }| async move {
-                    let response = if let Ok(response) = http_get(url).await {
+                    let result = if let Ok(response) =
+                        download_file_with_cache(url, &ACTOR_BUNDLE_CACHE_DIR).await
+                    {
                         response
                     } else {
-                        warn!("failed to download bundle from primary URL, trying alternative URL");
-                        http_get(alt_url).await?
+                        warn!("failed to download bundle {network}-{version} from primary URL, trying alternative URL");
+                        download_file_with_cache(alt_url, &ACTOR_BUNDLE_CACHE_DIR).await?
                     };
-                    let bytes = response.bytes().await?;
 
+                    let bytes = std::fs::read(&result.path)?;
                     let mut stream = CarStream::new(BufReader::new(Cursor::new(bytes))).await?;
                     while let Some(block) = stream.try_next().await? {
                         db.put_keyed_persistent(&block.cid, &block.data)?;
                     }
                     let header = stream.header;
-                    ensure!(header.roots.len() == 1);
-                    ensure!(header.roots.first() == root);
+                    anyhow::ensure!(header.roots.len() == 1);
+                    anyhow::ensure!(header.roots.first() == root);
                     Ok(*header.roots.first())
-                },
+                }
             ),
     )
     .try_collect::<Vec<_>>()

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -9,14 +9,19 @@ use crate::networks::Height;
 use crate::state_manager::StateManager;
 use crate::utils::db::car_stream::CarStream;
 use crate::utils::io::EitherMmapOrRandomAccessFile;
+use crate::utils::net::global_http_client;
 use anyhow::{bail, Context};
+use backon::{ExponentialBuilder, Retryable as _};
+use base64::{prelude::BASE64_STANDARD, Engine};
 use futures::TryStreamExt;
+use md5::{Digest as _, Md5};
 use serde::{Deserialize, Serialize};
-use std::ffi::OsStr;
-use std::fs;
 use std::{
+    ffi::OsStr,
+    fs,
     path::{Path, PathBuf},
     time,
+    time::Duration,
 };
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, info};
@@ -212,6 +217,110 @@ pub async fn download_to(url: &Url, destination: &Path) -> anyhow::Result<()> {
     .await?;
 
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct DownloadFileResult {
+    pub path: PathBuf,
+    #[allow(dead_code)]
+    pub cache_hit: bool,
+}
+
+pub async fn download_file_with_cache(
+    url: &Url,
+    cache_dir: &Path,
+) -> anyhow::Result<DownloadFileResult> {
+    let cache_file_path =
+        cache_dir.join(url.path().strip_prefix('/').unwrap_or_else(|| url.path()));
+    if let Some(cache_file_dir) = cache_file_path.parent() {
+        if !cache_file_dir.is_dir() {
+            std::fs::create_dir_all(cache_file_dir)?;
+        }
+    }
+
+    let cache_hit = match get_file_md5_hash(&cache_file_path) {
+        Some(file_md5) => match get_content_md5_hash_from_url(url.clone()).await? {
+            Some(url_md5) => {
+                if file_md5 == url_md5 {
+                    true
+                } else {
+                    println!(
+                        "md5 hash mismatch, url: {url}, local: {}, remote: {}",
+                        hex::encode(&file_md5),
+                        hex::encode(&url_md5)
+                    );
+                    false
+                }
+            }
+            None => {
+                anyhow::bail!("failed to extract md5 content hash from remote url {url}");
+            }
+        },
+        None => false,
+    };
+
+    if !cache_hit {
+        snapshot::download_file_with_retry(
+            url,
+            cache_file_path.parent().unwrap_or_else(|| Path::new(".")),
+            cache_file_path
+                .file_name()
+                .and_then(OsStr::to_str)
+                .with_context(|| {
+                    format!(
+                        "Error getting the file name of {}",
+                        cache_file_path.display()
+                    )
+                })?,
+        )
+        .await?;
+    }
+
+    Ok(DownloadFileResult {
+        path: cache_file_path,
+        cache_hit,
+    })
+}
+
+fn get_file_md5_hash(path: &Path) -> Option<Vec<u8>> {
+    std::fs::read(path).ok().map(|bytes| {
+        let mut hasher = Md5::new();
+        hasher.update(bytes.as_slice());
+        hasher.finalize().to_vec()
+    })
+}
+
+async fn get_content_md5_hash_from_url(url: Url) -> anyhow::Result<Option<Vec<u8>>> {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+    let response = (|| {
+        global_http_client()
+            .head(url.clone())
+            .timeout(TIMEOUT)
+            .send()
+    })
+    .retry(ExponentialBuilder::default())
+    .await?;
+    let headers = response.headers();
+    // Github release assets
+    if let Some(ms_blob_md5) = headers.get("x-ms-blob-content-md5") {
+        return Ok(Some(BASE64_STANDARD.decode(ms_blob_md5)?));
+    }
+
+    static HOSTS_WITH_MD5_ETAG: [&str; 2] =
+        ["filecoin-actors.chainsafe.dev", ".digitaloceanspaces.com"];
+    if url
+        .host_str()
+        .map(|h| HOSTS_WITH_MD5_ETAG.iter().any(|h_part| h.contains(h_part)))
+        .unwrap_or_default()
+    {
+        let md5 = headers
+            .get("etag")
+            .and_then(|v| v.to_str().ok().map(|v| hex::decode(v.replace('"', ""))))
+            .transpose()?;
+        Ok(md5)
+    } else {
+        anyhow::bail!("unsupported host, register in HOSTS_WITH_MD5_ETAG if it's known to use md5 as etag algorithm. url: {url}")
+    }
 }
 
 fn move_or_copy_file(from: &Path, to: &Path, import_mode: ImportMode) -> anyhow::Result<()> {
@@ -424,5 +533,39 @@ mod test {
         }
         assert!(ts.epoch() > 0);
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_content_md5_hash_from_url_1() {
+        let url = "https://filecoin-actors.chainsafe.dev/v15.0.0/builtin-actors-mainnet.car";
+        let md5 = get_content_md5_hash_from_url(url.try_into().unwrap())
+            .await
+            .unwrap()
+            .map(hex::encode);
+        assert_eq!(md5, Some("676b41e3dd1dc94430084bde84849701".into()))
+    }
+
+    #[tokio::test]
+    async fn test_get_content_md5_hash_from_url_2() {
+        let url = "https://github.com/filecoin-project/builtin-actors/releases/download/v15.0.0/builtin-actors-mainnet.car";
+        let md5 = get_content_md5_hash_from_url(url.try_into().unwrap())
+            .await
+            .unwrap()
+            .map(hex::encode);
+        assert_eq!(md5, Some("676b41e3dd1dc94430084bde84849701".into()))
+    }
+
+    #[tokio::test]
+    async fn test_download_file_with_cache() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let url = "https://forest-snapshots.fra1.cdn.digitaloceanspaces.com/genesis/butterflynet-bafy2bzacecm7xklkq3hkc2kgm5wnb5shlxmffino6lzhh7lte5acytb7sssr4.car.zst".try_into().unwrap();
+        let result = download_file_with_cache(&url, temp_dir.path())
+            .await
+            .unwrap();
+        assert!(!result.cache_hit);
+        let result = download_file_with_cache(&url, temp_dir.path())
+            .await
+            .unwrap();
+        assert!(result.cache_hit);
     }
 }

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -20,10 +20,10 @@ use serde_with::{serde_as, DisplayFromStr};
 use tokio::fs::File;
 use tracing::warn;
 
-use crate::daemon::bundle::load_actor_bundles_from_server;
+use crate::daemon::bundle::{load_actor_bundles_from_server, ACTOR_BUNDLE_CACHE_DIR};
+use crate::daemon::db_util::download_file_with_cache;
 use crate::shim::machine::BuiltinActorManifest;
 use crate::utils::db::car_stream::{CarStream, CarWriter};
-use crate::utils::net::http_get;
 
 use std::str::FromStr;
 
@@ -170,16 +170,21 @@ pub async fn generate_actor_bundle(output: &Path) -> anyhow::Result<()> {
              manifest: root,
              url,
              alt_url,
-             network: _,
-             version: _,
+             network,
+             version,
          }| async move {
-            let response = if let Ok(response) = http_get(url).await {
+            let result = if let Ok(response) =
+                download_file_with_cache(url, &ACTOR_BUNDLE_CACHE_DIR).await
+            {
                 response
             } else {
-                warn!("failed to download bundle from primary URL, trying alternative URL");
-                http_get(alt_url).await?
+                warn!(
+                    "failed to download bundle {network}-{version} from primary URL, trying alternative URL"
+                );
+                download_file_with_cache(alt_url, &ACTOR_BUNDLE_CACHE_DIR).await?
             };
-            let bytes = response.bytes().await?;
+
+            let bytes = std::fs::read(&result.path)?;
             let car = CarStream::new(Cursor::new(bytes)).await?;
             ensure!(car.header.version == 1);
             ensure!(car.header.roots.len() == 1);

--- a/src/tool/subcommands/api_cmd/test_snapshot.rs
+++ b/src/tool/subcommands/api_cmd/test_snapshot.rs
@@ -142,16 +142,13 @@ async fn ctx(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{daemon::db_util::download_to, utils::net::global_http_client};
-    use backon::{ExponentialBuilder, Retryable as _};
+    use crate::daemon::db_util::download_file_with_cache;
     use directories::ProjectDirs;
     use futures::{stream::FuturesUnordered, StreamExt};
     use itertools::Itertools as _;
-    use md5::{Digest as _, Md5};
-    use std::time::Duration;
     use url::Url;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn rpc_regression_tests() {
         // Skip for debug build on CI as the downloading is slow and flaky
         if crate::utils::is_ci() && crate::utils::is_debug_build() {
@@ -174,61 +171,18 @@ mod tests {
             .collect_vec();
         let project_dir = ProjectDirs::from("com", "ChainSafe", "Forest").unwrap();
         let cache_dir = project_dir.cache_dir().join("test").join("rpc-snapshots");
-        let mut tasks = FuturesUnordered::from_iter(urls.iter().map(|(filename, url)| {
-            let cached_file_path = cache_dir.join(filename);
+        let mut tasks = FuturesUnordered::from_iter(urls.into_iter().map(|(filename, url)| {
+            let cache_dir = cache_dir.clone();
             async move {
-                let is_file_cached = match get_file_md5_etag(&cached_file_path) {
-                    Some(file_etag) => {
-                        let url_etag = get_digital_ocean_space_url_etag(url.clone()).await.unwrap();
-                        if Some(&file_etag) == url_etag.as_ref() {
-                            true
-                        } else {
-                            println!(
-                                "etag mismatch, file: {filename}, local: {file_etag}, remote: {}",
-                                url_etag.unwrap_or_default()
-                            );
-                            false
-                        }
-                    }
-                    None => false,
-                };
-                if !is_file_cached {
-                    println!("Downloading from {url} to {}", cached_file_path.display());
-                    download_to(url, &cached_file_path).await.unwrap();
-                }
-                (filename, cached_file_path)
+                let result = download_file_with_cache(&url, &cache_dir).await.unwrap();
+                (filename, result.path)
             }
         }));
 
-        while let Some((filename, cached_file_path)) = tasks.next().await {
+        while let Some((filename, file_path)) = tasks.next().await {
             print!("Testing {filename} ...");
-            run_test_from_snapshot(&cached_file_path).await.unwrap();
+            run_test_from_snapshot(&file_path).await.unwrap();
             println!("  succeeded.");
         }
-    }
-
-    async fn get_digital_ocean_space_url_etag(url: Url) -> anyhow::Result<Option<String>> {
-        const TIMEOUT: Duration = Duration::from_secs(5);
-        let response = (|| {
-            global_http_client()
-                .head(url.clone())
-                .timeout(TIMEOUT)
-                .send()
-        })
-        .retry(ExponentialBuilder::default())
-        .await?;
-        Ok(response
-            .headers()
-            .get("etag")
-            .and_then(|v| v.to_str().ok().map(|v| v.replace('"', "").to_string())))
-    }
-
-    fn get_file_md5_etag(path: &Path) -> Option<String> {
-        std::fs::read(path).ok().map(|bytes| {
-            let mut hasher = Md5::new();
-            hasher.update(bytes.as_slice());
-            let hash = hasher.finalize();
-            format!("{hash:x}")
-        })
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- cache actor bundle files locally to speed up `forest-tool state-migration generate-actors-metadata` and `forest-tool state-migration actor-bundle` commands

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
