### PR TITLE
Revert "fix(db): fallback to CAR DB head when HEAD_KEY not set (#5223)"

### DIFF
--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -185,10 +185,9 @@ pub async fn import_chain_as_forest_car(
 
     let ts = ForestCar::try_from(forest_car_db_path.as_path())?.heaviest_tipset()?;
     info!(
-        "Imported snapshot in: {}s, heaviest tipset epoch: {}, key: {}",
+        "Imported snapshot in: {}s, heaviest tipset epoch: {}",
         stopwatch.elapsed().as_secs(),
-        ts.epoch(),
-        ts.key()
+        ts.epoch()
     );
 
     Ok((forest_car_db_path, ts))

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -20,7 +20,6 @@ use crate::daemon::db_util::{
 };
 use crate::db::car::ManyCar;
 use crate::db::db_engine::{db_root, open_db};
-use crate::db::SettingsStore;
 use crate::db::{ttl::EthMappingCollector, MarkAndSweep, MemoryDB, SettingsExt, CAR_DB_DIR_NAME};
 use crate::genesis::{get_network_name_from_genesis, read_genesis_header};
 use crate::key_management::{
@@ -145,7 +144,7 @@ const GC_INTERVAL: Duration = Duration::from_secs(60 * 60 * 10);
 /// Starts daemon process
 pub(super) async fn start(
     opts: CliOpts,
-    mut config: Config,
+    config: Config,
     shutdown_send: mpsc::Sender<()>,
 ) -> anyhow::Result<()> {
     if opts.detach {
@@ -246,76 +245,11 @@ pub(super) async fn start(
     // Initialize ChainStore
     let chain_store = Arc::new(ChainStore::new(
         Arc::clone(&db),
-        Arc::new(db.clone()),
+        db.writer().clone(),
         db.writer().clone(),
         chain_config.clone(),
         genesis_header.clone(),
     )?);
-
-    // Initialize StateManager
-    let state_manager = Arc::new(StateManager::new(
-        Arc::clone(&chain_store),
-        Arc::clone(&chain_config),
-        Arc::new(config.sync.clone()),
-    )?);
-
-    let network_name = get_network_name_from_genesis(&genesis_header, &state_manager)?;
-
-    info!("Using network :: {}", get_actual_chain_name(&network_name));
-    utils::misc::display_chain_logo(config.chain());
-
-    // Sets proof parameter file download path early, the files will be checked and
-    // downloaded later right after snapshot import step
-    crate::utils::proofs_api::set_proofs_parameter_cache_dir_env(&config.client.data_dir);
-
-    if !opts.exit_after_init {
-        // Sets the latest snapshot if needed for downloading later
-        if config.client.snapshot_path.is_none() && !opts.stateless {
-            set_snapshot_path_if_needed(
-                &mut config,
-                &chain_config,
-                chain_store.heaviest_tipset().epoch(),
-                opts.auto_download_snapshot,
-                &db_root_dir,
-            )
-            .await?;
-        }
-
-        // Import chain if needed
-        if !opts.skip_load.unwrap_or_default() {
-            if let Some(path) = &config.client.snapshot_path {
-                let (car_db_path, _ts) =
-                    import_chain_as_forest_car(path, &forest_car_db_dir, config.client.import_mode)
-                        .await?;
-                db.read_only_files(std::iter::once(car_db_path.clone()))?;
-                debug!("Loaded car DB at {}", car_db_path.display());
-            }
-        }
-
-        if let Some(validate_from) = config.client.snapshot_height {
-            // We've been provided a snapshot and asked to validate it
-            ensure_params_downloaded().await?;
-            // Use the specified HEAD, otherwise take the current HEAD.
-            let current_height = config
-                .client
-                .snapshot_head
-                .unwrap_or_else(|| state_manager.chain_store().heaviest_tipset().epoch());
-            assert!(current_height.is_positive());
-            match validate_from.is_negative() {
-                // allow --height=-1000 to scroll back from the current head
-                true => state_manager
-                    .validate_range((current_height + validate_from)..=current_height)?,
-                false => state_manager.validate_range(validate_from..=current_height)?,
-            }
-        }
-
-        // Halt
-        if opts.halt_after_import {
-            // Cancel all async services
-            services.shutdown().await;
-            return Ok(());
-        }
-    }
 
     if !opts.no_gc {
         let mut db_garbage_collector = {
@@ -355,6 +289,19 @@ pub(super) async fn start(
 
     let publisher = chain_store.publisher();
 
+    // Initialize StateManager
+    let sm = StateManager::new(
+        Arc::clone(&chain_store),
+        Arc::clone(&chain_config),
+        Arc::new(config.sync.clone()),
+    )?;
+
+    let state_manager = Arc::new(sm);
+
+    let network_name = get_network_name_from_genesis(&genesis_header, &state_manager)?;
+
+    info!("Using network :: {}", get_actual_chain_name(&network_name));
+    utils::misc::display_chain_logo(config.chain());
     let (tipset_sender, tipset_receiver) = flume::bounded(20);
 
     // if bootstrap peers are not set, set them
@@ -375,6 +322,8 @@ pub(super) async fn start(
     if opts.exit_after_init {
         return Ok(());
     }
+
+    let epoch = chain_store.heaviest_tipset().epoch();
 
     let peer_manager = Arc::new(PeerManager::default());
     services.spawn(peer_manager.clone().peer_operation_event_loop_task());
@@ -430,7 +379,7 @@ pub(super) async fn start(
             genesis_timestamp: genesis_header.timestamp,
             sync_state: sync_state.clone(),
             peer_manager,
-            settings_store: db.writer().clone(),
+            settings_store: chain_store.settings(),
         };
 
         let listener =
@@ -518,11 +467,67 @@ pub(super) async fn start(
         unblock_parent_process()?;
     }
 
+    // Sets proof parameter file download path early, the files will be checked and
+    // downloaded later right after snapshot import step
+    crate::utils::proofs_api::set_proofs_parameter_cache_dir_env(&config.client.data_dir);
+
+    // Sets the latest snapshot if needed for downloading later
+    let mut config = config;
+    if config.client.snapshot_path.is_none() && !opts.stateless {
+        set_snapshot_path_if_needed(
+            &mut config,
+            &chain_config,
+            epoch,
+            opts.auto_download_snapshot,
+            &db_root_dir,
+        )
+        .await?;
+    }
+
+    // Import chain if needed
+    if !opts.skip_load.unwrap_or_default() {
+        if let Some(path) = &config.client.snapshot_path {
+            let (car_db_path, ts) =
+                import_chain_as_forest_car(path, &forest_car_db_dir, config.client.import_mode)
+                    .await?;
+            db.read_only_files(std::iter::once(car_db_path.clone()))?;
+            debug!("Loaded car DB at {}", car_db_path.display());
+            state_manager
+                .chain_store()
+                .set_heaviest_tipset(Arc::new(ts.clone()))?;
+        }
+    }
+
+    if let Some(validate_from) = config.client.snapshot_height {
+        // We've been provided a snapshot and asked to validate it
+        ensure_params_downloaded().await?;
+        // Use the specified HEAD, otherwise take the current HEAD.
+        let current_height = config
+            .client
+            .snapshot_head
+            .unwrap_or(state_manager.chain_store().heaviest_tipset().epoch());
+        assert!(current_height.is_positive());
+        match validate_from.is_negative() {
+            // allow --height=-1000 to scroll back from the current head
+            true => {
+                state_manager.validate_range((current_height + validate_from)..=current_height)?
+            }
+            false => state_manager.validate_range(validate_from..=current_height)?,
+        }
+    }
+
+    // Halt
+    if opts.halt_after_import {
+        // Cancel all async services
+        services.shutdown().await;
+        return Ok(());
+    }
+
     // Populate task
     if !opts.stateless && !chain_config.is_devnet() {
         let state_manager = Arc::clone(&state_manager);
         services.spawn(async move {
-            if let Err(err) = init_ethereum_mapping(state_manager, db.writer(), &config) {
+            if let Err(err) = init_ethereum_mapping(state_manager, &config) {
                 tracing::warn!("Init Ethereum mapping failed: {}", err)
             }
             Ok(())
@@ -806,10 +811,13 @@ fn create_password(prompt: &str) -> dialoguer::Result<String> {
 
 fn init_ethereum_mapping<DB: Blockstore>(
     state_manager: Arc<StateManager<DB>>,
-    settings: &impl SettingsStore,
     config: &Config,
 ) -> anyhow::Result<()> {
-    match settings.eth_mapping_up_to_date()? {
+    match state_manager
+        .chain_store()
+        .settings()
+        .eth_mapping_up_to_date()?
+    {
         Some(false) | None => {
             let car_db_path = car_db_path(config)?;
             let db: Arc<ManyCar<MemoryDB>> = Arc::default();
@@ -818,7 +826,10 @@ fn init_ethereum_mapping<DB: Blockstore>(
 
             populate_eth_mappings(&state_manager, &ts)?;
 
-            settings.set_eth_mapping_up_to_date()
+            state_manager
+                .chain_store()
+                .settings()
+                .set_eth_mapping_up_to_date()
         }
         Some(true) => {
             tracing::info!("Ethereum mapping up to date");

--- a/src/db/car/any.rs
+++ b/src/db/car/any.rs
@@ -9,7 +9,7 @@
 //! CARv2 is not supported yet.
 
 use super::{CacheKey, RandomAccessFileReader, ZstdFrameCache};
-use crate::blocks::{Tipset, TipsetKey};
+use crate::blocks::Tipset;
 use crate::db::PersistentStore;
 use crate::utils::io::EitherMmapOrRandomAccessFile;
 use cid::Cid;
@@ -50,14 +50,6 @@ impl<ReaderT: RandomAccessFileReader> AnyCar<ReaderT> {
             ErrorKind::InvalidData,
             "input not recognized as any kind of CAR data (.car, .car.zst, .forest.car)",
         ))
-    }
-
-    pub fn heaviest_tipset_key(&self) -> TipsetKey {
-        match self {
-            AnyCar::Forest(forest) => forest.heaviest_tipset_key(),
-            AnyCar::Plain(plain) => plain.heaviest_tipset_key(),
-            AnyCar::Memory(mem) => mem.heaviest_tipset_key(),
-        }
     }
 
     /// Filecoin archives are tagged with the heaviest tipset. This call may

--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -143,12 +143,8 @@ impl<ReaderT: super::RandomAccessFileReader> ForestCar<ReaderT> {
         &self.roots
     }
 
-    pub fn heaviest_tipset_key(&self) -> TipsetKey {
-        TipsetKey::from(self.roots().clone())
-    }
-
     pub fn heaviest_tipset(&self) -> anyhow::Result<Tipset> {
-        Tipset::load_required(self, &self.heaviest_tipset_key())
+        Tipset::load_required(self, &TipsetKey::from(self.roots().clone()))
     }
 
     pub fn into_dyn(self) -> ForestCar<Box<dyn super::RandomAccessFileReader>> {

--- a/src/db/car/plain.rs
+++ b/src/db/car/plain.rs
@@ -180,12 +180,8 @@ impl<ReaderT: super::RandomAccessFileReader> PlainCar<ReaderT> {
         self.version
     }
 
-    pub fn heaviest_tipset_key(&self) -> TipsetKey {
-        TipsetKey::from(self.roots().clone())
-    }
-
     pub fn heaviest_tipset(&self) -> anyhow::Result<Tipset> {
-        Tipset::load_required(self, &self.heaviest_tipset_key())
+        Tipset::load_required(self, &TipsetKey::from(self.roots().clone()))
     }
 
     /// In an arbitrary order

--- a/src/db/memory.rs
+++ b/src/db/memory.rs
@@ -175,17 +175,6 @@ impl BitswapStoreReadWrite for MemoryDB {
     }
 }
 
-impl super::HeaviestTipsetKeyProvider for MemoryDB {
-    fn heaviest_tipset_key(&self) -> anyhow::Result<TipsetKey> {
-        SettingsStoreExt::read_obj::<TipsetKey>(self, crate::db::setting_keys::HEAD_KEY)?
-            .context("head key not found")
-    }
-
-    fn set_heaviest_tipset_key(&self, tsk: &TipsetKey) -> anyhow::Result<()> {
-        SettingsStoreExt::write_obj(self, crate::db::setting_keys::HEAD_KEY, tsk)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -14,7 +14,6 @@ use setting_keys::ETH_MAPPING_UP_TO_DATE_KEY;
 mod db_mode;
 pub mod migration;
 
-use crate::blocks::TipsetKey;
 use crate::rpc::eth::types::EthHash;
 use anyhow::Context as _;
 use cid::Cid;
@@ -77,7 +76,6 @@ pub trait SettingsStoreExt {
     fn read_obj<V: DeserializeOwned>(&self, key: &str) -> anyhow::Result<Option<V>>;
     fn write_obj<V: Serialize>(&self, key: &str, value: &V) -> anyhow::Result<()>;
 
-    #[allow(dead_code)]
     /// Same as [`SettingsStoreExt::read_obj`], but returns an error if the key does not exist.
     fn require_obj<V: DeserializeOwned>(&self, key: &str) -> anyhow::Result<V>;
 }
@@ -240,24 +238,6 @@ impl<T: PersistentStore> PersistentStore for Arc<T> {
 impl<T: PersistentStore> PersistentStore for &Arc<T> {
     fn put_keyed_persistent(&self, k: &Cid, block: &[u8]) -> anyhow::Result<()> {
         PersistentStore::put_keyed_persistent(self.as_ref(), k, block)
-    }
-}
-
-pub trait HeaviestTipsetKeyProvider {
-    /// Returns the currently tracked heaviest tipset.
-    fn heaviest_tipset_key(&self) -> anyhow::Result<TipsetKey>;
-
-    /// Sets heaviest tipset.
-    fn set_heaviest_tipset_key(&self, tsk: &TipsetKey) -> anyhow::Result<()>;
-}
-
-impl<T: HeaviestTipsetKeyProvider> HeaviestTipsetKeyProvider for Arc<T> {
-    fn heaviest_tipset_key(&self) -> anyhow::Result<TipsetKey> {
-        self.as_ref().heaviest_tipset_key()
-    }
-
-    fn set_heaviest_tipset_key(&self, tsk: &TipsetKey) -> anyhow::Result<()> {
-        self.as_ref().set_heaviest_tipset_key(tsk)
     }
 }
 

--- a/src/tool/offline_server/server.rs
+++ b/src/tool/offline_server/server.rs
@@ -82,6 +82,10 @@ pub async fn start_offline_server(
     )?);
     let head_ts = Arc::new(db.heaviest_tipset()?);
 
+    state_manager
+        .chain_store()
+        .set_heaviest_tipset(head_ts.clone())?;
+
     populate_eth_mappings(&state_manager, &head_ts)?;
 
     let (network_send, _) = flume::bounded(5);

--- a/src/tool/subcommands/api_cmd/generate_test_snapshot.rs
+++ b/src/tool/subcommands/api_cmd/generate_test_snapshot.rs
@@ -3,13 +3,13 @@
 
 use super::*;
 use crate::{
-    blocks::TipsetKey,
+    blocks::{CachingBlockHeader, TipsetKey},
     chain::ChainStore,
     chain_sync::{network_context::SyncNetworkContext, SyncConfig, SyncStage},
     daemon::db_util::load_all_forest_cars,
     db::{
-        db_engine::open_db, parity_db::ParityDb, EthMappingsStore, HeaviestTipsetKeyProvider,
-        MemoryDB, SettingsStore, SettingsStoreExt, CAR_DB_DIR_NAME,
+        db_engine::open_db, parity_db::ParityDb, EthMappingsStore, MemoryDB, SettingsStore,
+        SettingsStoreExt, CAR_DB_DIR_NAME,
     },
     genesis::{get_network_name_from_genesis, read_genesis_header},
     libp2p::{NetworkMessage, PeerManager},
@@ -134,27 +134,6 @@ pub struct ReadOpsTrackingStore<T> {
 
 impl<T> ReadOpsTrackingStore<T>
 where
-    T: Blockstore + SettingsStore + HeaviestTipsetKeyProvider,
-{
-    fn is_chain_head_tracked(&self) -> anyhow::Result<bool> {
-        SettingsStore::exists(&self.tracker, crate::db::setting_keys::HEAD_KEY)
-    }
-
-    pub fn ensure_chain_head_is_tracked(&self) -> anyhow::Result<()> {
-        if !self.is_chain_head_tracked()? {
-            SettingsStoreExt::write_obj(
-                &self.tracker,
-                crate::db::setting_keys::HEAD_KEY,
-                &self.inner.heaviest_tipset_key()?,
-            )?;
-        }
-
-        Ok(())
-    }
-}
-
-impl<T> ReadOpsTrackingStore<T>
-where
     T: Blockstore + SettingsStore,
 {
     pub fn new(inner: T) -> Self {
@@ -164,21 +143,32 @@ where
         }
     }
 
+    pub fn ensure_chain_head_is_tracked(&self) -> anyhow::Result<()> {
+        if !self.is_chain_head_tracked()? {
+            let _ =
+                SettingsStoreExt::read_obj::<TipsetKey>(self, crate::db::setting_keys::HEAD_KEY)?
+                    .context("HEAD_KEY not found")?
+                    .into_cids()
+                    .into_iter()
+                    .map(|key| CachingBlockHeader::load(self, key))
+                    .collect::<anyhow::Result<Option<Vec<_>>>>()?
+                    .map(Tipset::new)
+                    .transpose()?
+                    .context("failed to load tipset")?;
+        }
+
+        Ok(())
+    }
+
+    fn is_chain_head_tracked(&self) -> anyhow::Result<bool> {
+        SettingsStore::exists(&self.tracker, crate::db::setting_keys::HEAD_KEY)
+    }
+
     pub async fn export_forest_car<W: tokio::io::AsyncWrite + Unpin>(
         &self,
         writer: &mut W,
     ) -> anyhow::Result<()> {
         self.tracker.export_forest_car(writer).await
-    }
-}
-
-impl<T: HeaviestTipsetKeyProvider> HeaviestTipsetKeyProvider for ReadOpsTrackingStore<T> {
-    fn heaviest_tipset_key(&self) -> anyhow::Result<TipsetKey> {
-        self.inner.heaviest_tipset_key()
-    }
-
-    fn set_heaviest_tipset_key(&self, tsk: &TipsetKey) -> anyhow::Result<()> {
-        self.inner.set_heaviest_tipset_key(tsk)
     }
 }
 

--- a/src/tool/subcommands/api_cmd/test_snapshot.rs
+++ b/src/tool/subcommands/api_cmd/test_snapshot.rs
@@ -104,6 +104,7 @@ async fn ctx(
         )
         .unwrap(),
     );
+    chain_store.set_heaviest_tipset(db.heaviest_tipset()?.into())?;
     let state_manager =
         Arc::new(StateManager::new(chain_store.clone(), chain_config, sync_config).unwrap());
     let network_name = get_network_name_from_genesis(&genesis_header, &state_manager)?;


### PR DESCRIPTION
This reverts commit d9e76f613470ef50e1fd32e28f289e99719161e9.

## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The HEAD changes (d9e76f613470ef50e1fd32e28f289e99719161e9) are causing Forest to always require a snapshot. For example, running `❯ forest --chain calibnet --encrypt-keystore false --import-snapshot ../snapshots/calibnet` , exiting and then `❯ forest --chain calibnet --encrypt-keystore false` will result in download snapshot prompt.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
