### PR TITLE
chore: remove scheduled Forest builds

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -17,8 +17,7 @@ concurrency:
     paths-ignore:
       - 'docs/**'
       - '.github/workflows/docs-*.yml'
-  schedule:
-    - cron: 0 0 * * *
+
 env:
   CI: 1
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -20,8 +20,6 @@ on:
     paths:
       - '**/*.rs'
       - '.github/workflows/rust-lint.yml'
-  schedule:
-    - cron: "0 0 * * *"
 
 env:
   CI: 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,8 +23,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '.github/workflows/docs-*.yml'
-  schedule:
-    - cron: "0 0 * * *"
 
 env:
   CI: 1


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- removed scheduled Forest builds. Nobody checks them anyway and we do plenty of builds, outside of weekends.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
