### PR TITLE
fix(ci): no cache for generating manifest json

### DIFF
--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::db::PersistentStore;
-use crate::utils::net::{download_file_with_cache, DownloadFileOption};
+use crate::utils::net::http_get;
 use crate::{
     networks::{ActorBundleInfo, NetworkChain, ACTOR_BUNDLES},
     utils::db::car_stream::{CarBlock, CarStream},
@@ -14,9 +14,7 @@ use futures::{stream::FuturesUnordered, TryStreamExt};
 use once_cell::sync::Lazy;
 use std::mem::discriminant;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::{io::Cursor, path::Path};
-use tokio::sync::Semaphore;
 use tracing::{info, warn};
 
 /// Tries to load the missing actor bundles to the blockstore. If the bundle is
@@ -89,7 +87,6 @@ pub async fn load_actor_bundles_from_server(
     network: &NetworkChain,
     bundles: &[ActorBundleInfo],
 ) -> anyhow::Result<Vec<Cid>> {
-    let semaphore = Arc::new(Semaphore::new(4));
     FuturesUnordered::from_iter(
         bundles
             .iter()
@@ -107,19 +104,17 @@ pub async fn load_actor_bundles_from_server(
                      network,
                      version,
                  }| {
-                    let semaphore = semaphore.clone();
                     async move {
-                        let _permit = semaphore.acquire().await?;
-                        let result = if let Ok(response) =
-                            download_file_with_cache(url, &ACTOR_BUNDLE_CACHE_DIR, DownloadFileOption::NonResumable).await
+                        let response = if let Ok(response) =
+                            http_get(url).await
                         {
                             response
                         } else {
                             warn!("failed to download bundle {network}-{version} from primary URL, trying alternative URL");
-                            download_file_with_cache(alt_url, &ACTOR_BUNDLE_CACHE_DIR, DownloadFileOption::NonResumable).await?
+                            http_get(alt_url).await?
                         };
 
-                        let bytes = std::fs::read(&result.path)?;
+                        let bytes = response.bytes().await?;
                         let mut stream = CarStream::new(Cursor::new(bytes)).await?;
                         while let Some(block) = stream.try_next().await? {
                             db.put_keyed_persistent(&block.cid, &block.data)?;

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -87,7 +87,7 @@ pub async fn reader(
                     (Left(Left(stream)), content_length)
                 }
                 DownloadFileOption::NonResumable => {
-                    let resp = reqwest::get(url).await?;
+                    let resp = global_http_client().get(url).send().await?;
                     let content_length = resp.content_length().unwrap_or_default();
                     let stream = resp
                         .bytes_stream()


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

The `state_migration_generate_actors_metadata` test has been flaky. Revert the manifest json generation logic for now.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
