### PR TITLE
feat(shed): add forest-tool shed f3 check-activation-raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@
 
 - [#4751](https://github.com/ChainSafe/forest/issues/4751) Add support for `Filecoin.GetActorEventsRaw` RPC method.
 
+- [#5309](https://github.com/ChainSafe/forest/issues/5309) Add `forest-tool shed f3 check-activation-raw` command.
+
 - [#5242](https://github.com/ChainSafe/forest/issues/5242) Fix existing signature verification and add `delegated` signature
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
 dependencies = [
  "fastrand",
  "gloo-timers",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -3013,6 +3013,7 @@ dependencies = [
  "fil_actor_system_state",
  "fil_actor_verifreg_state",
  "fil_actors_shared",
+ "flate2",
  "flume 0.11.1",
  "fs_extra",
  "futures",
@@ -3919,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -9540,9 +9541,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -9614,9 +9615,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-properties"
@@ -9724,9 +9725,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "8c1f41ffb7cf259f1ecc2876861a17e7142e63ead296f671f81f6ae85903e0d6"
 dependencies = [
  "getrandom 0.3.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ fil_actor_reward_state = { version = "19" }
 fil_actor_system_state = { version = "19" }
 fil_actor_verifreg_state = { version = "19" }
 fil_actors_shared = { version = "19", features = ["json"] }
+flate2 = "1"
 flume = { workspace = true }
 fs_extra = "1"
 futures = { workspace = true }

--- a/scripts/tests/calibnet_no_discovery_check.sh
+++ b/scripts/tests/calibnet_no_discovery_check.sh
@@ -12,6 +12,8 @@ FOREST_NODE_PID=$!
 FULLNODE_API_INFO="$(cat admin_token):/ip4/127.0.0.1/tcp/2345/http"
 export FULLNODE_API_INFO
 
+forest_wait_api
+
 # Verify that one of the seed nodes has been connected to
 until $FOREST_CLI_PATH net peers | grep "calib"; do
     sleep 1s;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -14,7 +14,6 @@ use crate::cli_shared::{
     chain_path,
     cli::{CliOpts, Config},
 };
-
 use crate::daemon::db_util::{
     import_chain_as_forest_car, load_all_forest_cars, populate_eth_mappings,
 };

--- a/src/rpc/methods/eth/types.rs
+++ b/src/rpc/methods/eth/types.rs
@@ -281,7 +281,7 @@ pub struct GasReward {
     pub premium: TokenAmount,
 }
 
-#[derive(PartialEq, Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(PartialEq, Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EthCallMessage {
     pub from: Option<EthAddress>,

--- a/src/rpc/methods/f3/types.rs
+++ b/src/rpc/methods/f3/types.rs
@@ -279,7 +279,7 @@ pub struct F3Manifest {
     pub ignore_ec_power: bool,
     #[schemars(with = "String")]
     #[serde(with = "crate::lotus_json")]
-    pub initial_power_table: Cid,
+    pub initial_power_table: Option<Cid>,
     pub committee_lookback: u64,
     #[schemars(with = "u64")]
     #[serde(with = "crate::lotus_json")]

--- a/src/tool/subcommands/shed_cmd.rs
+++ b/src/tool/subcommands/shed_cmd.rs
@@ -1,6 +1,9 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+mod f3;
+use f3::*;
+
 use std::path::PathBuf;
 
 use crate::{
@@ -58,6 +61,9 @@ pub enum ShedCommands {
         #[arg(long)]
         path: ApiPath,
     },
+    /// F3 related commands.
+    #[command(subcommand)]
+    F3(F3Commands),
 }
 
 impl ShedCommands {
@@ -137,8 +143,9 @@ impl ShedCommands {
                     _ => std::cmp::Ordering::Equal,
                 });
 
-                println!("{}", serde_json::to_string_pretty(&openrpc_doc).unwrap());
+                println!("{}", serde_json::to_string_pretty(&openrpc_doc)?);
             }
+            ShedCommands::F3(cmd) => cmd.run(client).await?,
         }
         Ok(())
     }

--- a/src/tool/subcommands/shed_cmd/f3.rs
+++ b/src/tool/subcommands/shed_cmd/f3.rs
@@ -20,14 +20,14 @@ const MAX_PAYLOAD_LEN: usize = 4 << 10;
 #[derive(Debug, Subcommand)]
 pub enum F3Commands {
     CheckActivation {
-        /// Contract address
+        /// Contract eth address
         #[arg(long, required = true)]
-        contract: String,
+        contract: EthAddress,
     },
     CheckActivationRaw {
-        /// Contract address
+        /// Contract eth address
         #[arg(long, required = true)]
-        contract: String,
+        contract: EthAddress,
     },
 }
 
@@ -40,7 +40,7 @@ impl F3Commands {
             }
             Self::CheckActivationRaw { contract } => {
                 let eth_call_message = EthCallMessage {
-                    to: Some(EthAddress::from_str(&contract)?),
+                    to: Some(contract),
                     data: EthBytes::from_str("0x2587660d")?, // method ID of activationInformation()
                     ..Default::default()
                 };
@@ -48,7 +48,7 @@ impl F3Commands {
                 let api_invoc_result =
                     StateCall::call(&client, (filecoin_message, None.into())).await?;
                 let Some(message_receipt) = api_invoc_result.msg_rct else {
-                    anyhow::bail!("No message receipt")
+                    anyhow::bail!("No message receipt");
                 };
                 anyhow::ensure!(
                     message_receipt.exit_code().is_success(),

--- a/src/tool/subcommands/shed_cmd/f3.rs
+++ b/src/tool/subcommands/shed_cmd/f3.rs
@@ -1,0 +1,111 @@
+// Copyright 2019-2025 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::{
+    rpc::{
+        self,
+        eth::types::{EthAddress, EthBytes, EthCallMessage},
+        f3::F3Manifest,
+        state::StateCall,
+        RpcMethodExt,
+    },
+    shim::message::Message,
+};
+use clap::Subcommand;
+use flate2::read::DeflateDecoder;
+use std::{io::Read, str::FromStr as _};
+
+const MAX_PAYLOAD_LEN: usize = 4 << 10;
+
+#[derive(Debug, Subcommand)]
+pub enum F3Commands {
+    CheckActivation {
+        /// Contract address
+        #[arg(long, required = true)]
+        contract: String,
+    },
+    CheckActivationRaw {
+        /// Contract address
+        #[arg(long, required = true)]
+        contract: String,
+    },
+}
+
+impl F3Commands {
+    #[allow(clippy::indexing_slicing)]
+    pub async fn run(self, client: rpc::Client) -> anyhow::Result<()> {
+        match self {
+            Self::CheckActivation { contract: _ } => {
+                unimplemented!("Will be done in a subsequent PR");
+            }
+            Self::CheckActivationRaw { contract } => {
+                let eth_call_message = EthCallMessage {
+                    to: Some(EthAddress::from_str(&contract)?),
+                    data: EthBytes::from_str("0x2587660d")?, // method ID of activationInformation()
+                    ..Default::default()
+                };
+                let filecoin_message = Message::try_from(eth_call_message)?;
+                let api_invoc_result =
+                    StateCall::call(&client, (filecoin_message, None.into())).await?;
+                let Some(message_receipt) = api_invoc_result.msg_rct else {
+                    anyhow::bail!("No message receipt")
+                };
+                anyhow::ensure!(
+                    message_receipt.exit_code().is_success(),
+                    "unsuccessful exit code {}",
+                    message_receipt.exit_code()
+                );
+                let return_data = message_receipt.return_data();
+                let eth_return =
+                    fvm_ipld_encoding::from_slice::<fvm_ipld_encoding::BytesDe>(&return_data)?.0;
+                println!("Raw data: {}", hex::encode(eth_return.as_slice()));
+                // 3*32 because there should be 3 slots minimum
+                anyhow::ensure!(eth_return.len() >= 3 * 32, "no activation information");
+                let mut activation_epoch_bytes: [u8; 8] = [0; 8];
+                activation_epoch_bytes.copy_from_slice(&eth_return[24..32]);
+                let activation_epoch = u64::from_be_bytes(activation_epoch_bytes);
+                for (i, &v) in eth_return[32..63].iter().enumerate() {
+                    anyhow::ensure!(
+                        v == 0,
+                        "wrong value for offset (padding): slot[{i}] = 0x{v:x} != 0x00"
+                    );
+                }
+                anyhow::ensure!(
+                    eth_return[63] == 0x40,
+                    "wrong value for offest : slot[31] = 0x{:x} != 0x40",
+                    eth_return[63]
+                );
+                let mut payload_len_bytes: [u8; 8] = [0; 8];
+                payload_len_bytes.copy_from_slice(&eth_return[88..96]);
+                let payload_len = u64::from_be_bytes(payload_len_bytes) as usize;
+                anyhow::ensure!(
+                    payload_len <= MAX_PAYLOAD_LEN,
+                    "too long declared payload: {payload_len} > {MAX_PAYLOAD_LEN}"
+                );
+                let payload_bytes = &eth_return[96..];
+                anyhow::ensure!(
+                    payload_len <= payload_bytes.len(),
+                    "not enough remaining bytes: {payload_len} > {}",
+                    payload_bytes.len()
+                );
+                anyhow::ensure!(
+                    activation_epoch < u64::MAX && payload_len > 0,
+                    "no active activation"
+                );
+                let compressed_manifest_bytes = &payload_bytes[..payload_len];
+                let mut deflater = DeflateDecoder::new(compressed_manifest_bytes);
+                let mut manifest_bytes = vec![];
+                deflater.read_to_end(&mut manifest_bytes)?;
+                let manifest: F3Manifest = serde_json::from_slice(&manifest_bytes)?;
+                anyhow::ensure!(
+                    manifest.bootstrap_epoch >= 0
+                        && manifest.bootstrap_epoch as u64 == activation_epoch,
+                    "bootstrap epoch does not match: {} != {activation_epoch}",
+                    manifest.bootstrap_epoch
+                );
+                println!("{}", serde_json::to_string_pretty(&manifest)?);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/tool/subcommands/shed_cmd/f3.rs
+++ b/src/tool/subcommands/shed_cmd/f3.rs
@@ -24,6 +24,7 @@ pub enum F3Commands {
         #[arg(long, required = true)]
         contract: EthAddress,
     },
+    /// Queries F3 parameters contract using raw logic
     CheckActivationRaw {
         /// Contract eth address
         #[arg(long, required = true)]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Part of https://github.com/ChainSafe/forest/issues/5307

Changes introduced in this pull request:

-

Lotus code:
```go
var f3CheckActivationRaw = &cli.Command{
	Name:  "check-activation-raw",
	Usage: "queries f3 parameters contract using raw logic",

	Flags: []cli.Flag{
		&cli.StringFlag{
			Name:  "contract",
			Usage: "address contract to query",
		},
	},
	Action: func(cctx *cli.Context) error {
		// this code is raw logic for cross-checking
		// the cleaner code is in chain/lf3/manifest.go
		address, err := ethtypes.ParseEthAddress(cctx.String("contract"))
		if err != nil {
			return fmt.Errorf("trying to parse contract address: %s: %w", cctx.String("contract"), err)
		}

		ethCall := ethtypes.EthCall{
			To:   &address,
			Data: must.One(ethtypes.DecodeHexString("0x2587660d")), // method ID of activationInformation()
		}
		fMessage, err := ethCall.ToFilecoinMessage()
		if err != nil {
			return fmt.Errorf("converting to filecoin message: %w", err)
		}

		ctx := cliutil.ReqContext(cctx)
		api, closer, err := cliutil.GetFullNodeAPIV1(cctx)
		if err != nil {
			return fmt.Errorf("getting api: %w", err)
		}
		defer closer()

		msgRes, err := api.StateCall(ctx, fMessage, types.EmptyTSK)
		if err != nil {
			return fmt.Errorf("state call error: %w", err)
		}
		if msgRes.MsgRct.ExitCode != 0 {
			return fmt.Errorf("message returned exit code: %v", msgRes.MsgRct.ExitCode)
		}

		var ethReturn abi.CborBytes
		err = ethReturn.UnmarshalCBOR(bytes.NewReader(msgRes.MsgRct.Return))
		if err != nil {
			return fmt.Errorf("could not decode return value: %w", err)
		}
		fmt.Printf("Raw data: %X\n", ethReturn)
		slot, retBytes := []byte{}, []byte(ethReturn)
		_ = slot
		// 3*32 because there should be 3 slots minimum
		if len(retBytes) < 3*32 {
			return fmt.Errorf("no activation information")
		}

		// split off first slot
		slot, retBytes = retBytes[:32], retBytes[32:]
		// it is uint64 so we want the last 8 bytes
		slot = slot[24:32]
		activationEpoch := binary.BigEndian.Uint64(slot)
		_ = activationEpoch

		slot, retBytes = retBytes[:32], retBytes[32:]
		for i := 0; i < 31; i++ {
			if slot[i] != 0 {
				return fmt.Errorf("wrong value for offest (padding): slot[%d] = 0x%x != 0x00", i, slot[i])
			}
		}
		if slot[31] != 0x40 {
			return fmt.Errorf("wrong value for offest : slot[31] = 0x%x != 0x40", slot[31])
		}
		slot, retBytes = retBytes[:32], retBytes[32:]
		slot = slot[24:32]
		pLen := binary.BigEndian.Uint64(slot)
		if pLen > 4<<10 {
			return fmt.Errorf("too long declared payload: %d > %d", pLen, 4<<10)
		}
		payloadLength := int(pLen)

		if payloadLength > len(retBytes) {
			return fmt.Errorf("not enough remaining bytes: %d > %d", payloadLength, retBytes)
		}

		if activationEpoch == math.MaxUint64 || payloadLength == 0 {
			fmt.Printf("no active activation")
		} else {
			compressedManifest := retBytes[:payloadLength]
			reader := io.LimitReader(flate.NewReader(bytes.NewReader(compressedManifest)), 1<<20)
			var m manifest.Manifest
			err = json.NewDecoder(reader).Decode(&m)
			if err != nil {
				return fmt.Errorf("got error while decoding manifest: %w", err)
			}

			if m.BootstrapEpoch < 0 || uint64(m.BootstrapEpoch) != activationEpoch {
				return fmt.Errorf("bootstrap epoch does not match: %d != %d", m.BootstrapEpoch, activationEpoch)
			}
			_, _ = io.Copy(os.Stdout, flate.NewReader(bytes.NewReader(compressedManifest)))
			fmt.Println()
		}
		return nil
	},
}
```

Output:
```
➜  lotus git:(master) ✗ ./lotus-shed f3 check-activation-raw --contract 0x476AC9256b9921C9C6a0fC237B7fE05fe9874F50
Raw data: 00000000000000000000000000000000000000000000000000000000004C4B400000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000023D8554C172DA3014BCF3150CE78E079B06486FC1D0363321A590B6874E0FB2FC8C35C8922BC90D6926FFDE27D9C27620539F9EB52B7977DF939F07C3E168432A0DA30FC38C700DEFDC8A924652C9BF83D24C0AC4AEDCFAAD6086117E2BB42182DA3D63B7BE90D268A348B92A25CD2D7DEC1E07DE837994EA704F0ABB6194310E54323172E0EA58724699D9C84750088B8AF3FA537B2115AC620FB4E21A110E78200987EEB65816053306E04ECA4342E801C1B0D6111343F36FE50D677B5180301669747AA99FCA24B3EBCFF882AF4BE086E0EBB4C7F2C0024FFF9265E8408AFAB8A881BF568433F3E458EB8A1B861E9D89B021ACC9D1EA233990742B2B916A1FB1D5991326B003A5D490DE81D89BDC99F01FDF42A2244929D1C64A9059B620AE7F6732CF991DB161307993B62B152AB3ED0DC2374968A2F7D131125FEAA6C66D861B504CDAA326E3D7F23E32E17242F0BA1B2D79EA85E653B52E9740999DC846826FFF4FC718B69E6C39BDF67514446D399FFA7A12CC425FBF0FE6A7ADD3209AF97A165CB9EA5723E233E6D219ADBE95BF568B51159C9288411996314A0CAC8E3427620F6D34311A14660BBF2BD0E68115202B5377FA55503B507F409D11A767C43513ACA88A8DE478470DEE22FC62F2D8BA0BBC30BAD0CB4D95ECAAA4235A16381CDA3661256CFCA9BF9CAD693BC0E776F1184D152B8DED5F9565A076756293A895E5F65E187A84FC5FE774734E57BBC6974C53893941EA0ED138799D1F55D873FF83A0EDFFF13A23DF4929BA10A6ED099E509437CEF0BC17E3E065F00F000000
{
  "Pause": false,
  "ProtocolVersion": 5,
  "InitialInstance": 0,
  "BootstrapEpoch": 5000000,
  "NetworkName": "filecoin",
  "ExplicitPower": null,
  "IgnoreECPower": false,
  "InitialPowerTable": null,
  "CommitteeLookback": 10,
  "CatchUpAlignment": 15000000000,
  "Gpbft": {
    "Delta": 6000000000,
    "DeltaBackOffExponent": 2,
    "QualityDeltaMultiplier": 1,
    "MaxLookaheadRounds": 5,
    "ChainProposedLength": 100,
    "RebroadcastBackoffBase": 6000000000,
    "RebroadcastBackoffExponent": 1.3,
    "RebroadcastBackoffSpread": 0.1,
    "RebroadcastBackoffMax": 60000000000
  },
  "EC": {
    "Period": 30000000000,
    "Finality": 900,
    "DelayMultiplier": 2,
    "BaseDecisionBackoffTable": [
      1.3,
      1.69,
      2.2,
      2.86,
      3.71,
      4.83,
      6.27,
      7.5
    ],
    "HeadLookback": 0,
    "Finalize": true
  },
  "CertificateExchange": {
    "ClientRequestTimeout": 10000000000,
    "ServerRequestTimeout": 60000000000,
    "MinimumPollInterval": 30000000000,
    "MaximumPollInterval": 120000000000
  },
  "PubSub": {
    "CompressionEnabled": false
  },
  "ChainExchange": {
    "SubscriptionBufferSize": 32,
    "MaxChainLength": 100,
    "MaxInstanceLookahead": 10,
    "MaxDiscoveredChainsPerInstance": 1000,
    "MaxWantedChainsPerInstance": 1000,
    "RebroadcastInterval": 2000000000,
    "MaxTimestampAge": 8000000000
  }
}
```

```
➜  lotus git:(master) forest-tool shed f3 check-activation-raw --contract 0x476AC9256b9921C9C6a0fC237B7fE05fe9874F50
Raw data: 00000000000000000000000000000000000000000000000000000000004c4b400000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000023d8554c172da3014bcf3150ce78e079b06486fc1d0363321a590b6874e0fb2fc8c35c8922bc90d6926ffde27d9c27620539f9eb52b7977df939f07c3e168432a0da30fc38c700defdc8a924652c9bf83d24c0ac4aedcfaad6086117e2bb42182da3d63b7be90d268a348b92a25cd2d7dec1e07de837994ea704f0abb6194310e54323172e0ea58724699d9c84750088b8af3fa537b2115ac620fb4e21a110e78200987eeb65816053306e04eca4342e801c1b0d6111343f36fe50d677b5180301669747aa99fca24b3ebcff882af4be086e0ebb4c7f2c0024fff9265e8408afab8a881bf568433f3e458eb8a1b861e9d89b021acc9d1ea233990742b2b916a1fb1d5991326b003a5d490de81d89bdc99f01fdf42a2244929d1c64a9059b620ae7f6732cf991db161307993b62b152ab3ed0dc2374968a2f7d131125feaa6c66d861b504cdaa326e3d7f23e32e17242f0ba1b2d79ea85e653b52e9740999dc846826fff4fc718b69e6c39bdf67514446d399ffa7a12cc425fbf0fe6a7add3209af97a165cb9ea5723e233e6d219adbe95bf568b51159c9288411996314a0cac8e3427620f6d34311a14660bbf2bd0e68115202b5377fa55503b507f409d11a767c43513aca88a8de478470dee22fc62f2d8ba0bbc30bad0cb4d95ecaaa4235a16381cda3661256cfca9bf9cad693bc0e776f1184d152b8ded5f9565a076756293a895e5f65e187a84fc5fe774734e57bbc6974c53893941ea0ed138799d1f55d873ff83a0edfff13a23df4929ba10a6ed099e509437cef0bc17e3e065f00f000000
{
  "ProtocolVersion": 5,
  "Pause": false,
  "InitialInstance": 0,
  "BootstrapEpoch": 5000000,
  "NetworkName": "filecoin",
  "ExplicitPower": null,
  "IgnoreECPower": false,
  "InitialPowerTable": null,
  "CommitteeLookback": 10,
  "CatchUpAlignment": 15000000000,
  "Gpbft": {
    "Delta": 6000000000,
    "DeltaBackOffExponent": 2.0,
    "QualityDeltaMultiplier": 1.0,
    "MaxLookaheadRounds": 5,
    "ChainProposedLength": 100,
    "RebroadcastBackoffBase": 6000000000,
    "RebroadcastBackoffExponent": 1.3,
    "RebroadcastBackoffSpread": 0.1,
    "RebroadcastBackoffMax": 60000000000
  },
  "EC": {
    "Period": 30000000000,
    "Finality": 900,
    "DelayMultiplier": 2.0,
    "BaseDecisionBackoffTable": [
      1.3,
      1.69,
      2.2,
      2.86,
      3.71,
      4.83,
      6.27,
      7.5
    ],
    "HeadLookback": 0,
    "Finalize": true
  },
  "CertificateExchange": {
    "ClientRequestTimeout": 10000000000,
    "ServerRequestTimeout": 60000000000,
    "MinimumPollInterval": 30000000000,
    "MaximumPollInterval": 120000000000
  },
  "PubSub": {
    "CompressionEnabled": false
  },
  "ChainExchange": {
    "SubscriptionBufferSize": 32,
    "MaxChainLength": 100,
    "MaxInstanceLookahead": 10,
    "MaxDiscoveredChainsPerInstance": 1000,
    "MaxWantedChainsPerInstance": 1000,
    "RebroadcastInterval": 2000000000,
    "MaxTimestampAge": 8000000000
  }
}
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
