### PR TITLE
fix: map RPC aliases to what Lotus uses + agent name in client version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 - [#4261](https://github.com/ChainSafe/forest/issues/4261) Remove the short flags from `forest-wallet list` and `forest-wallet balance` commands.
 
+- [#5329](https://github.com/ChainSafe/forest/pull/5329) Changed JSON-RPC alias for `Filecoin.NetListening`, `Filecoin.NetVersion`, `Filecoin.EthTraceBlock`, `Filecoin.EthTraceReplayBlockTransactions` to adhere to Lotus API.
+
 ### Added
 
 - [#5244](https://github.com/ChainSafe/forest/issues/5244) Add `live` and `healthy` subcommands to `forest-cli healthcheck`.
@@ -76,6 +78,8 @@
 ### Changed
 
 - [#5237](https://github.com/ChainSafe/forest/pull/5237) Stylistic changes to FIL pretty printing.
+
+- [#5329](https://github.com/ChainSafe/forest/pull/5329) `Filecoin.Web3ClientVersion` now returns the name of the node and its version, e.g., `forest/0.23.3+git.32a34e92`.
 
 ### Removed
 

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -656,7 +656,10 @@ impl RpcMethod<0> for Web3ClientVersion {
         _: Ctx<impl Blockstore + Send + Sync + 'static>,
         (): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        Ok(crate::utils::version::FOREST_VERSION_STRING.clone())
+        Ok(format!(
+            "forest/{}",
+            *crate::utils::version::FOREST_VERSION_STRING
+        ))
     }
 }
 
@@ -2842,7 +2845,7 @@ impl RpcMethod<1> for EthGetFilterLogs {
 pub enum EthTraceBlock {}
 impl RpcMethod<1> for EthTraceBlock {
     const NAME: &'static str = "Filecoin.EthTraceBlock";
-    const NAME_ALIAS: Option<&'static str> = Some("eth_traceBlock");
+    const NAME_ALIAS: Option<&'static str> = Some("trace_block");
     const N_REQUIRED_PARAMS: usize = 1;
     const PARAM_NAMES: [&'static str; 1] = ["block_param"];
     const API_PATHS: ApiPaths = ApiPaths::V1;
@@ -2912,7 +2915,7 @@ pub enum EthTraceReplayBlockTransactions {}
 impl RpcMethod<2> for EthTraceReplayBlockTransactions {
     const N_REQUIRED_PARAMS: usize = 2;
     const NAME: &'static str = "Filecoin.EthTraceReplayBlockTransactions";
-    const NAME_ALIAS: Option<&'static str> = Some("eth_traceReplayBlockTransactions");
+    const NAME_ALIAS: Option<&'static str> = Some("trace_replayBlockTransactions");
     const PARAM_NAMES: [&'static str; 2] = ["block_param", "trace_types"];
     const API_PATHS: ApiPaths = ApiPaths::V1;
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/net.rs
+++ b/src/rpc/methods/net.rs
@@ -103,6 +103,7 @@ impl RpcMethod<0> for NetListening {
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: ApiPaths = ApiPaths::V1;
     const PERMISSION: Permission = Permission::Read;
+    const NAME_ALIAS: Option<&'static str> = Some("net_listening");
 
     type Params = ();
     type Ok = bool;
@@ -249,6 +250,7 @@ impl RpcMethod<0> for NetVersion {
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: ApiPaths = ApiPaths::V1;
     const PERMISSION: Permission = Permission::Read;
+    const NAME_ALIAS: Option<&'static str> = Some("net_version");
 
     type Params = ();
     type Ok = String;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- use Lotus's aliases as outlined in https://github.com/filecoin-project/lotus/blob/a9718c841e1fced8afc6e9fee2db2a2b565acc42/api/eth_aliases.go (discrepancy reported by @AlexeyKrasnoperov)
- added agent type to `Filecoin.Web3ClientVersion`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
