### PR TITLE
feat: allow non-lists for address lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
 
 - [#5319](https://github.com/ChainSafe/forest/pull/5319) Improve the ergonomics of the `forest-tool api generate-test-snapshot` subcommand.
 
+- [#5342](https://github.com/ChainSafe/forest/pull/5342) Improved the ergonomics of handling addresses in the `Filecoin.EthGetLogs` and `Filecoin.EthNewFilter` to accept both single addresses and arrays of addresses. This conforms to the Ethereum RPC API.
+
 ### Changed
 
 - [#5237](https://github.com/ChainSafe/forest/pull/5237) Stylistic changes to FIL pretty printing.

--- a/src/rpc/methods/eth/filter/mod.rs
+++ b/src/rpc/methods/eth/filter/mod.rs
@@ -739,9 +739,9 @@ mod tests {
             to_block: Some("latest".into()),
             address: vec![
                 EthAddress::from_str("0xff38c072f286e3b20b3954ca9f99c05fbecc64aa").unwrap(),
-            ],
-            topics: None,
-            block_hash: None,
+            ]
+            .into(),
+            ..Default::default()
         };
 
         let chain_height = 50;
@@ -759,9 +759,9 @@ mod tests {
             to_block: Some("invalid".into()),
             address: vec![
                 EthAddress::from_str("0xff38c072f286e3b20b3954ca9f99c05fbecc64aa").unwrap(),
-            ],
-            topics: None,
-            block_hash: None,
+            ]
+            .into(),
+            ..Default::default()
         };
 
         let chain_height = 50;
@@ -876,9 +876,9 @@ mod tests {
             to_block: Some("latest".into()),
             address: vec![
                 EthAddress::from_str("0xff38c072f286e3b20b3954ca9f99c05fbecc64aa").unwrap(),
-            ],
-            topics: None,
-            block_hash: None,
+            ]
+            .into(),
+            ..Default::default()
         };
 
         let chain_height = 50;
@@ -911,13 +911,11 @@ mod tests {
         let event_handler = EthEventHandler::new();
         let mut filter_ids = Vec::new();
         let filter_spec = EthFilterSpec {
-            from_block: None,
-            to_block: None,
             address: vec![
                 EthAddress::from_str("0xff38c072f286e3b20b3954ca9f99c05fbecc64aa").unwrap(),
-            ],
-            topics: None,
-            block_hash: None,
+            ]
+            .into(),
+            ..Default::default()
         };
 
         let filter_id = event_handler.eth_new_filter(&filter_spec, 0).unwrap();
@@ -941,13 +939,7 @@ mod tests {
 
     #[test]
     fn test_do_match_address() {
-        let empty_spec = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
-            topics: None,
-            block_hash: None,
-        };
+        let empty_spec = EthFilterSpec::default();
 
         let addr0 = Address::from_str("t410f744ma4xsq3r3eczzktfj7goal67myzfkusna2hy").unwrap();
         let eth_addr0 = EthAddress::from_str("0xff38c072f286e3b20b3954ca9f99c05fbecc64aa").unwrap();
@@ -993,11 +985,8 @@ mod tests {
 
         // Matching the given address 0
         let spec0 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![eth_addr0.clone()],
-            topics: None,
-            block_hash: None,
+            address: vec![eth_addr0.clone()].into(),
+            ..Default::default()
         };
 
         assert!(spec0.matches(&addr0, &[]).unwrap());
@@ -1006,11 +995,8 @@ mod tests {
 
         // Matching the given address 0 or 1
         let spec1 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![eth_addr0.clone(), eth_addr1.clone()],
-            topics: None,
-            block_hash: None,
+            address: vec![eth_addr0.clone(), eth_addr1.clone()].into(),
+            ..Default::default()
         };
 
         assert!(spec1.matches(&addr0, &[]).unwrap());
@@ -1070,111 +1056,84 @@ mod tests {
                 .unwrap();
 
         let spec1 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![EthHashList::Single(None)])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(spec1.matches(&addr0, &entries0).unwrap());
 
         let spec2 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![
                 EthHashList::Single(None),
                 EthHashList::Single(None),
             ])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(spec2.matches(&addr0, &entries0).unwrap());
 
         let spec2 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![EthHashList::Single(Some(
                 topic0.clone(),
             ))])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(spec2.matches(&addr0, &entries0).unwrap());
 
         let spec3 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![EthHashList::List(vec![topic0.clone()])])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(spec3.matches(&addr0, &entries0).unwrap());
 
         let spec4 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![EthHashList::List(vec![
                 topic1.clone(),
                 topic0.clone(),
             ])])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(spec4.matches(&addr0, &entries0).unwrap());
 
         let spec5 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![EthHashList::Single(Some(
                 topic1.clone(),
             ))])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(!spec5.matches(&addr0, &entries0).unwrap());
 
         let spec6 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![EthHashList::List(vec![
                 topic2.clone(),
                 topic3.clone(),
             ])])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(!spec6.matches(&addr0, &entries0).unwrap());
 
         let spec7 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![
                 EthHashList::Single(Some(topic1.clone())),
                 EthHashList::Single(Some(topic1.clone())),
             ])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(!spec7.matches(&addr0, &entries0).unwrap());
 
         let spec8 = EthFilterSpec {
-            from_block: None,
-            to_block: None,
-            address: vec![],
             topics: Some(EthTopicSpec(vec![
                 EthHashList::Single(Some(topic0.clone())),
                 EthHashList::Single(Some(topic1.clone())),
                 EthHashList::Single(Some(topic3.clone())),
             ])),
-            block_hash: None,
+            ..Default::default()
         };
 
         assert!(!spec8.matches(&addr0, &entries0).unwrap());

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -1232,22 +1232,29 @@ fn eth_tests() -> Vec<RpcTest> {
                 .unwrap(),
             ));
         }
-        tests.push(RpcTest::basic(
-            EthNewFilter::request_with_alias(
-                (EthFilterSpec {
-                    from_block: None,
-                    to_block: None,
-                    address: vec![EthAddress::from_str(
-                        "0xff38c072f286e3b20b3954ca9f99c05fbecc64aa",
-                    )
-                    .unwrap()],
-                    topics: None,
-                    block_hash: None,
-                },),
-                use_alias,
-            )
-            .unwrap(),
-        ));
+
+        let cases = [
+            EthAddressList::List(vec![
+                EthAddress::from_str("0x0c1d86d34e469770339b53613f3a2343accd62cb").unwrap(),
+                EthAddress::from_str("0x89beb26addec4bc7e9f475aacfd084300d6de719").unwrap(),
+            ]),
+            EthAddressList::Single(
+                EthAddress::from_str("0x0c1d86d34e469770339b53613f3a2343accd62cb").unwrap(),
+            ),
+        ];
+
+        for address in cases {
+            tests.push(RpcTest::basic(
+                EthNewFilter::request_with_alias(
+                    (EthFilterSpec {
+                        address,
+                        ..Default::default()
+                    },),
+                    use_alias,
+                )
+                .unwrap(),
+            ));
+        }
         tests.push(RpcTest::basic(
             EthNewPendingTransactionFilter::request_with_alias((), use_alias).unwrap(),
         ));
@@ -1576,7 +1583,7 @@ fn eth_tests_with_tipset<DB: Blockstore>(store: &Arc<DB>, shared_tipset: &Tipset
             EthGetLogs::request((EthFilterSpec {
                 from_block: Some(format!("0x{:x}", shared_tipset.epoch())),
                 to_block: Some(format!("0x{:x}", shared_tipset.epoch())),
-                address: vec![],
+                address: Default::default(),
                 topics: None,
                 block_hash: None,
             },))
@@ -1587,7 +1594,7 @@ fn eth_tests_with_tipset<DB: Blockstore>(store: &Arc<DB>, shared_tipset: &Tipset
             EthGetLogs::request((EthFilterSpec {
                 from_block: Some(format!("0x{:x}", shared_tipset.epoch() - 100)),
                 to_block: Some(format!("0x{:x}", shared_tipset.epoch())),
-                address: vec![],
+                address: Default::default(),
                 topics: None,
                 block_hash: None,
             },))

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -1234,6 +1234,7 @@ fn eth_tests() -> Vec<RpcTest> {
         }
 
         let cases = [
+            EthAddressList::List(vec![]),
             EthAddressList::List(vec![
                 EthAddress::from_str("0x0c1d86d34e469770339b53613f3a2343accd62cb").unwrap(),
                 EthAddress::from_str("0x89beb26addec4bc7e9f475aacfd084300d6de719").unwrap(),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- allows addresses in the `EthFilterSpec` accept non-lists as well, thus conforming to Lotus and Eth API,
- tests for the above,
- simplified some calls of the `EthFilterSpec`,
- this fixes the usage of `EthGetLogs` and `EthNewFilter`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

```
❯ curl --silent -X POST -H "Content-Type: application/json" \
             --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.EthNewFilter","params": [{ "fromBlock": "latest", "toBlock": "latest", "address": ["0x0000000000000000000000000000000000000000"] }] }' \
             "http://127.0.0.1:2345/rpc/v1"
{"jsonrpc":"2.0","id":2,"result":"0x9c8f633445fa4c3ea11d2667bf5e821700000000000000000000000000000000"}⏎

❯ curl --silent -X POST -H "Content-Type: application/json" \
             --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.EthNewFilter","params": [{ "fromBlock": "latest", "toBlock": "latest", "address": "0x0000000000000000000000000000000000000000" }] }' \
             "http://127.0.0.1:2345/rpc/v1"
{"jsonrpc":"2.0","id":2,"result":"0x77d5b6b8e3b141b594b9669f8806868000000000000000000000000000000000"}⏎

```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
