### PR TITLE
chore: remove deprecated JS attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
 
 ### Removed
 
+- [#5344](https://github.com/ChainSafe/forest/pull/5344) Removed the last traces of the `forest-cli attach` command.
+
 ### Fixed
 
 - [#5111](https://github.com/ChainSafe/forest/issues/5111) Make F3 work when the node Kademlia is disabled.

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -7,7 +7,6 @@ use crate::cli_shared::logger;
 use crate::daemon::get_actual_chain_name;
 use crate::rpc::{self, prelude::*};
 use crate::shim::address::{CurrentNetwork, Network};
-use anyhow::bail;
 use clap::Parser;
 use std::ffi::OsString;
 
@@ -45,7 +44,6 @@ where
                 Subcommand::Send(cmd) => cmd.run(client).await,
                 Subcommand::Info(cmd) => cmd.run(client).await,
                 Subcommand::Snapshot(cmd) => cmd.run(client).await,
-                Subcommand::Attach { .. } => bail!("the `attach` subcommand has been removed. Please raise an issue if this breaks a workflow for you"),
                 Subcommand::Shutdown(cmd) => cmd.run(client).await,
                 Subcommand::Healthcheck(cmd) => cmd.run(client).await,
                 Subcommand::F3(cmd) => cmd.run(client).await,

--- a/src/cli/subcommands/mod.rs
+++ b/src/cli/subcommands/mod.rs
@@ -93,9 +93,6 @@ pub enum Subcommand {
     #[command(subcommand)]
     Info(InfoCommand),
 
-    /// `[REMOVED]` Attach to daemon via a JavaScript console
-    Attach { _ignored: Vec<String> },
-
     /// Shutdown Forest
     Shutdown(ShutdownCommand),
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- remove the last remnant of the JavaScript console. It shall forever live in our `git` history. :candle: 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
