### PR TITLE
feat: accept block params instead of block hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
 
 - [#5342](https://github.com/ChainSafe/forest/pull/5342) Improved the ergonomics of handling addresses in the `Filecoin.EthGetLogs` and `Filecoin.EthNewFilter` to accept both single addresses and arrays of addresses. This conforms to the Ethereum RPC API.
 
+- [#5346](https://github.com/ChainSafe/forest/pull/5346) `Filecoin.EthGetBlockReceipts` and `Filecoin.EthGetBlockReceiptsLimited` now accepts predefined block parameters on top of the block hash, e.g., `latest`, `earliest`, `pending`.
+
 ### Changed
 
 - [#5237](https://github.com/ChainSafe/forest/pull/5237) Stylistic changes to FIL pretty printing.

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1409,11 +1409,11 @@ impl RpcMethod<2> for EthGetBlockByNumber {
 
 async fn get_block_receipts<DB: Blockstore + Send + Sync + 'static>(
     ctx: &Ctx<DB>,
-    block_hash: EthHash,
+    block_param: BlockNumberOrHash,
     // TODO(forest): https://github.com/ChainSafe/forest/issues/5177
     _limit: Option<usize>,
 ) -> Result<Vec<EthTxReceipt>, ServerError> {
-    let ts = get_tipset_from_hash(ctx.chain_store(), &block_hash)?;
+    let ts = tipset_by_block_number_or_hash(ctx.chain_store(), block_param)?;
     let ts_ref = Arc::new(ts);
     let ts_key = ts_ref.key();
 
@@ -1444,17 +1444,17 @@ pub enum EthGetBlockReceipts {}
 impl RpcMethod<1> for EthGetBlockReceipts {
     const NAME: &'static str = "Filecoin.EthGetBlockReceipts";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getBlockReceipts");
-    const PARAM_NAMES: [&'static str; 1] = ["block_hash"];
+    const PARAM_NAMES: [&'static str; 1] = ["block_param"];
     const API_PATHS: ApiPaths = ApiPaths::V1;
     const PERMISSION: Permission = Permission::Read;
-    type Params = (EthHash,);
+    type Params = (BlockNumberOrHash,);
     type Ok = Vec<EthTxReceipt>;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
-        (block_hash,): Self::Params,
+        (block_param,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        get_block_receipts(&ctx, block_hash, None).await
+        get_block_receipts(&ctx, block_param, None).await
     }
 }
 
@@ -1462,17 +1462,17 @@ pub enum EthGetBlockReceiptsLimited {}
 impl RpcMethod<2> for EthGetBlockReceiptsLimited {
     const NAME: &'static str = "Filecoin.EthGetBlockReceiptsLimited";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getBlockReceiptsLimited");
-    const PARAM_NAMES: [&'static str; 2] = ["block_hash", "limit"];
+    const PARAM_NAMES: [&'static str; 2] = ["block_param", "limit"];
     const API_PATHS: ApiPaths = ApiPaths::V1;
     const PERMISSION: Permission = Permission::Read;
-    type Params = (EthHash, ChainEpoch);
+    type Params = (BlockNumberOrHash, ChainEpoch);
     type Ok = Vec<EthTxReceipt>;
 
     async fn handle(
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
-        (block_hash, limit): Self::Params,
+        (block_param, limit): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        get_block_receipts(&ctx, block_hash, Some(limit as usize)).await
+        get_block_receipts(&ctx, block_param, Some(limit as usize)).await
     }
 }
 

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -1395,6 +1395,13 @@ fn eth_tests_with_tipset<DB: Blockstore>(store: &Arc<DB>, shared_tipset: &Tipset
             ),))
             .unwrap(),
         ),
+        // Nodes might be synced to different epochs, so we can't assert the exact result here.
+        // Regardless, we want to check if the node returns a valid response and accepts predefined
+        // values.
+        RpcTest::basic(
+            EthGetBlockReceipts::request((BlockNumberOrHash::from_predefined(Predefined::Latest),))
+                .unwrap(),
+        ),
         RpcTest::identity(
             EthGetBlockTransactionCountByHash::request((block_hash.clone(),)).unwrap(),
         ),

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -1388,11 +1388,23 @@ fn eth_tests_with_tipset<DB: Blockstore>(store: &Arc<DB>, shared_tipset: &Tipset
             ))
             .unwrap(),
         ),
-        RpcTest::identity(EthGetBlockReceipts::request((block_hash.clone(),)).unwrap()),
+        RpcTest::identity(
+            EthGetBlockReceipts::request((BlockNumberOrHash::from_block_hash_object(
+                block_hash.clone(),
+                true,
+            ),))
+            .unwrap(),
+        ),
         RpcTest::identity(
             EthGetBlockTransactionCountByHash::request((block_hash.clone(),)).unwrap(),
         ),
-        RpcTest::identity(EthGetBlockReceiptsLimited::request((block_hash.clone(), 800)).unwrap()),
+        RpcTest::identity(
+            EthGetBlockReceiptsLimited::request((
+                BlockNumberOrHash::from_block_hash_object(block_hash.clone(), true),
+                800,
+            ))
+            .unwrap(),
+        ),
         RpcTest::identity(
             EthGetBlockTransactionCountByNumber::request((EthInt64(shared_tipset.epoch()),))
                 .unwrap(),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `Filecoin.EthGetBlockReceipts` and `Filecoin.EthGetBlockReceiptsLimited` now accepts predefined block parameters on top of the block hash, e.g., `latest`, `earliest`, `pending`.

```
❯ curl --silent -X POST -H "Content-Type: application/json" \
             --data '{"jsonrpc":"2.0","id":2,"method":"Filecoin.EthGetBlockReceipts","params": ["latest"]}' \
             "http://127.0.0.1:2345/rpc/v1"
{"jsonrpc":"2.0","id":2,"result":[{"transactionHash":"0xac21fb8074a7d39008538ae066aa3d54aa036f7eaf61877cceb51af153f7601a","transactionIndex":"0x0","blockHash":"0x665d2d7d35038cdde374fd4694e62822aa1c1ed6061e6a3261e9de8264a85b53","blockNumber":"0x25424a","from":"0x908fdd9ef6db0b4f8c3a60640f2d6b3c2a7a4f3b","to":"0x58b1b601ee88044f5a7f56b3abec45faa7e7681b","root":"0x0000000000000000000000000000000000000000000000000000000000000000","status":"0x1","contractAddress":null,"cumulativeGasUsed":"0x0","gasUsed":"0x8f83670","effectiveGasPrice":"0x4a7fe90d","logsBloom":"0x00000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000001000000000000000000000000000000000000000000040000000000000000000000000004000000000000000000000008000000000000000000000000000000000000001000000801000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400020800000000000000000000000000000000001000000000000000000000000000000000010000000000000000000000","logs":[{"address":"0x58b1b601ee88044f5a7f56b3abec45faa7e7681b","data":"0x00000000000000000000000000000000000000000000000000000002dfd1f8cc0000000000000000000000000000000000000000000000000000000012bd37d0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8","topics":["0x928bbf5188022bf8b9a0e59f5e81e179d0a4c729bdba2856ac971af2063fbf2b","0x0000000000000000000000000000000000000000000000000000000000000005"],"removed":false,"logIndex":"0x0","transactionIndex":"0x0","transactionHash":"0xac21fb8074a7d39008538ae066aa3d54aa036f7eaf61877cceb51af153f7601a","blockHash":"0x665d2d7d35038cdde374fd4694e62822aa1c1ed6061e6a3261e9de8264a85b53","blockNumber":"0x25424a"},{"address":"0xb1b1df5c1eb5338e32a7ee6b5e47980fb892bb9f","data":"0x000000000000000000000000000000000000000000000000000000000025424a0000000000000000000000000000000000000000000000000000000000000005","topics":["0xb3bcc997e36eca7b534a754795c8c1277f79fb6b97ac09855fb2c3f58a83cd3a","0x0000000000000000000000000000000000000000000000000000000000000005"],"removed":false,"logIndex":"0x1","transactionIndex":"0x0","transactionHash":"0xac21fb8074a7d39008538ae066aa3d54aa036f7eaf61877cceb51af153f7601a","blockHash":"0x665d2d7d35038cdde374fd4694e62822aa1c1ed6061e6a3261e9de8264a85b53","blockNumber":"0x25424a"}],"type":"0x0"}]}⏎
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
