### PR TITLE
fix(test): update drand test on quicknet to unblock CI

### DIFF
--- a/src/networks/drand.rs
+++ b/src/networks/drand.rs
@@ -142,9 +142,21 @@ mod tests {
             .await
         };
 
+        let mut remote_chain_info_list = vec![];
         for server in &config.servers {
-            let remote_chain_info = get_remote_chain_info(server).await.unwrap();
-            assert_eq!(&config.chain_info, &remote_chain_info);
+            if let Ok(remote_chain_info) = get_remote_chain_info(server).await {
+                remote_chain_info_list.push(remote_chain_info);
+            }
         }
+        assert!(
+            !remote_chain_info_list.is_empty(),
+            "all drand servers on the list are down"
+        );
+        assert!(
+            remote_chain_info_list
+                .iter()
+                .all(|i| i == &config.chain_info),
+            "some servers on the list serve different networks"
+        );
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Update failing drand unit test to unblock CI. The failing test ensures all the servers on the list serve the correct network with known network parameters. The beacon fetching logic with fallback is tested elsewhere and passing. 

https://filecoinproject.slack.com/archives/C05P37R9KQD/p1740782510773029
> FYI, the League of Entropy quicknet network used by Filecoin is currently in a somewhat degraded state because the Cloudflare HTTP relays are unable to server the quicknet beacons since Tuesday and they most likely won't be able to until next Tuesday. This should not affect Filecoin SPs since Filecoin relies on the drand OptimizingClient and on all 4 HTTP relays (the other 3 are still up) as well as on the Gossipsub relays (which are also still up)

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
