### PR TITLE
fix: don't load bundles in snapshot tests

### DIFF
--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -399,6 +399,7 @@ mod test {
         let temp_db_dir = tempfile::Builder::new().tempdir()?;
         let cfg = Config {
             client: Client {
+                load_actors: false,
                 encrypt_keystore: false,
                 data_dir: PathBuf::from(temp_db_dir.path()),
                 ..Default::default()


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- https://github.com/ChainSafe/forest/pull/5368 introduced an `AppContext` which does a bit too much in certain scenarios, especially in tests. This makes snapshot tests timeout due to actor bundles being downloaded multiple times. This change skips it.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
