### PR TITLE
fix: incorrect placement of forest var in lotus

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
       - FULLNODE_API_INFO=/dns/forest/tcp/${FOREST_RPC_PORT}/http
+      - FOREST_CHAIN_INDEXER_ENABLED=1
     entrypoint: [ "/bin/bash", "-c" ]
     user: 0:0
     command:
@@ -145,7 +146,6 @@ services:
       - LOTUS_CHAININDEXER_ENABLEINDEXER=1
       - LOTUS_CHAINSTORE_ENABLESPLITSTORE=false
       - LOTUS_SYNC_BOOTSTRAP_PEERS=1
-      - FOREST_CHAIN_INDEXER_ENABLED=1
       - FULLNODE_API_INFO=/dns/lotus/tcp/${LOTUS_RPC_PORT}/http
     entrypoint: [ "/bin/bash", "-c" ]
     command:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- the forest variable was incorrectly placed in the lotus service, causing failures:

```
  | Filecoin.EthGetMessageCidByTransactionHash (8)      | Rejected("indexer disabled, enable with chain_indexer.enable_indexer / FOREST_CHAIN_INDEXER_ENABLED") | Valid                                                                                                                                                                                                                                                                |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5426

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
