### PR TITLE
feat(tool): add forest-tool shed migrate state command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Added
 
+- [#5461](https://github.com/ChainSafe/forest/pull/5461) Add `forest-tool shed migrate-state` command.
+
 ### Changed
 
 - [#5452](https://github.com/ChainSafe/forest/pull/5452) Speed up void database migration.

--- a/docs/docs/developers/guides/network_upgrades.md
+++ b/docs/docs/developers/guides/network_upgrades.md
@@ -46,7 +46,7 @@ This provides the base for the state migrations and network-aware node changes. 
 State migrations are described in detail in the relevant FIPs, including the steps required to perform them. Note that naive state migrations might take a significant amount of time and resources. It is up to the implementation team to decide whether to optimize them.
 
 :::note
-Testing the state migration on a relevant network is crucial before the upgrade epoch. This is done by changing the upgrade epoch in both Lotus and Forest and ensuring both migrations produce the same state root. This is done locally, but it might be facilitated in the future.
+Testing the state migration on a relevant network is crucial before the upgrade epoch. This could be done by either changing the upgrade epoch in both Lotus and Forest and ensuring both migrations produce the same state root, or comparing the output of `forest-tool shed migrate-state` and `lotus-shed migrate-state` commands.
 
 This also allows for assessing the duration of the state migration and determining whether it is feasible to perform it on the mainnet.
 :::

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -504,7 +504,7 @@ impl FullTipset {
     pub fn parent_state(&self) -> &Cid {
         &self.first_block().header().state_root
     }
-    /// Returns the state root for the tipset parent.
+    /// Returns the keys of the parents of the blocks in the tipset.
     pub fn parents(&self) -> &TipsetKey {
         &self.first_block().header().parents
     }

--- a/src/shim/version.rs
+++ b/src/shim/version.rs
@@ -1,6 +1,8 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
+use std::fmt;
 use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
 
 use crate::lotus_json::lotus_json_with_self;
 
@@ -118,6 +120,21 @@ impl From<NetworkVersion> for NetworkVersion_v3 {
 impl From<NetworkVersion> for NetworkVersion_v4 {
     fn from(other: NetworkVersion) -> Self {
         other.0
+    }
+}
+
+impl FromStr for NetworkVersion {
+    type Err = <u32 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v: u32 = s.parse()?;
+        Ok(v.into())
+    }
+}
+
+impl fmt::Display for NetworkVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/src/state_migration/nv25/migration.rs
+++ b/src/state_migration/nv25/migration.rs
@@ -66,7 +66,6 @@ impl<BS: Blockstore> StateMigration<BS> {
 }
 
 /// Runs the migration for `NV25`. Returns the new state root.
-#[allow(dead_code)]
 pub fn run_migration<DB>(
     chain_config: &ChainConfig,
     blockstore: &Arc<DB>,

--- a/src/tool/subcommands/shed_cmd.rs
+++ b/src/tool/subcommands/shed_cmd.rs
@@ -3,6 +3,8 @@
 
 mod f3;
 use f3::*;
+mod migration;
+use migration::*;
 
 use crate::{
     libp2p::keypair::get_keypair,
@@ -67,6 +69,8 @@ pub enum ShedCommands {
     /// F3 related commands.
     #[command(subcommand)]
     F3(F3Commands),
+    /// Run a network upgrade migration
+    MigrateState(MigrateStateCommand),
 }
 
 #[derive(Debug, Clone, ValueEnum, PartialEq)]
@@ -171,6 +175,7 @@ impl ShedCommands {
                 println!("{}", serde_json::to_string_pretty(&openrpc_doc)?);
             }
             ShedCommands::F3(cmd) => cmd.run(client).await?,
+            ShedCommands::MigrateState(cmd) => cmd.run(client).await?,
         }
         Ok(())
     }

--- a/src/tool/subcommands/shed_cmd/migration.rs
+++ b/src/tool/subcommands/shed_cmd/migration.rs
@@ -1,0 +1,93 @@
+// Copyright 2019-2025 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use cid::Cid;
+use clap::Args;
+use itertools::Itertools;
+
+use crate::utils::db::CborStoreExt;
+use crate::{
+    blocks::CachingBlockHeader,
+    cli_shared::{chain_path, read_config},
+    daemon::db_util::load_all_forest_cars,
+    db::{
+        car::ManyCar,
+        db_engine::{db_root, open_db},
+        parity_db::ParityDb,
+        CAR_DB_DIR_NAME,
+    },
+    networks::{ChainConfig, NetworkChain},
+    shim::version::NetworkVersion,
+};
+
+#[derive(Debug, Args)]
+pub struct MigrateStateCommand {
+    /// Target network version
+    network_version: NetworkVersion,
+    /// Block to look back from
+    block_to_look_back: Cid,
+    /// Path to the Forest database folder
+    #[arg(long)]
+    db: Option<PathBuf>,
+    /// Filecoin network chain
+    #[arg(long, required = true)]
+    chain: NetworkChain,
+}
+
+impl MigrateStateCommand {
+    pub async fn run(self, _: crate::rpc::Client) -> anyhow::Result<()> {
+        let Self {
+            network_version,
+            block_to_look_back,
+            db,
+            chain,
+        } = self;
+        let db = {
+            let db = if let Some(db) = db {
+                db
+            } else {
+                let (_, config) = read_config(None, Some(chain.clone()))?;
+                db_root(&chain_path(&config))?
+            };
+            load_db(&db)?
+        };
+        let block: CachingBlockHeader = db.get_cbor_required(&block_to_look_back)?;
+        let chain_config = Arc::new(ChainConfig::from_chain(&chain));
+        let mut state_root = block.state_root;
+        let epoch = block.epoch - 1;
+        let migrations = crate::state_migration::get_migrations(&chain)
+            .into_iter()
+            .filter(|(h, _)| {
+                let nv: NetworkVersion = (*h).into();
+                network_version == nv
+            })
+            .collect_vec();
+        anyhow::ensure!(
+            !migrations.is_empty(),
+            "No migration found for network version {network_version} on {chain}"
+        );
+        for (_, migrate) in migrations {
+            println!("Migrating... state_root: {state_root}, epoch: {epoch}");
+            let start = Instant::now();
+            let new_state = migrate(&chain_config, &db, &state_root, epoch)?;
+            println!(
+                "Done. old_state: {state_root}, new_state: {new_state}, took: {}",
+                humantime::format_duration(start.elapsed())
+            );
+            state_root = new_state;
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn load_db(db_root: &Path) -> anyhow::Result<Arc<ManyCar<ParityDb>>> {
+    let db_writer = open_db(db_root.into(), Default::default())?;
+    let db = ManyCar::new(db_writer);
+    let forest_car_db_dir = db_root.join(CAR_DB_DIR_NAME);
+    load_all_forest_cars(&db, &forest_car_db_dir)?;
+    Ok(Arc::new(db))
+}


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR ports `lotus shed migrate-state` tool into Forest

Changes introduced in this pull request:

-

```
➜  forest git:(main) ✗ forest-tool shed migrate-state --chain calibnet 25 bafy2bzaceb2pqqnclk6hptttsuxtcfhzzfewfizk4c6lonrvq7vesddasxkbo
Migrating... state_root: bafy2bzaceaftms6pagbrvjqmhmehjuxuvicbmyjaz4rfe2rke5xnloc4x3v6e, epoch: 2519400
2025-03-26T09:01:57.696451Z  INFO forest::state_migration::common::state_migration: Processed 100000 actors
2025-03-26T09:02:01.296881Z  INFO forest::state_migration::common::state_migration: Processing deferred migrations
2025-03-26T09:02:01.322608Z  INFO forest::state_migration::common::state_migration: Processed 158974 deferred migrations
Done. old_state: bafy2bzaceaftms6pagbrvjqmhmehjuxuvicbmyjaz4rfe2rke5xnloc4x3v6e, new_state: bafy2bzacec42jz3abzw6zn4gp4wtz2yo6fndqo7uhenpuwcgz3ku54aiyltiy, took: 9s 737ms 522us 710ns
```

```
➜  lotus git:(master) ./lotus-shed migrate-state 25 bafy2bzaceb2pqqnclk6hptttsuxtcfhzzfewfizk4c6lonrvq7vesddasxkbo
REMINDER: If you are running this, you likely want to ALSO run the continuity testing tool!
2025-03-26T17:02:37.876+0800    INFO    bundle  bundle/bundle.go:60     manifest cid: bafy2bzacebc7zpsrihpyd2jdcvmegbbk6yhzkifre3hxtoul5wdxxklbwitry
2025-03-26T17:02:37.917+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Creating migration jobs
2025-03-26T17:02:37.917+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Started 17 workers
2025-03-26T17:02:37.918+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Result writer started
2025-03-26T17:02:39.918+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Performing migration: 44944 of 44945 jobs processed (22463/s) [2s elapsed]
2025-03-26T17:02:41.918+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Performing migration: 112121 of 112123 jobs processed (28024/s) [4s elapsed]
2025-03-26T17:02:43.228+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Done creating 158974 migration jobs after 5.3s
2025-03-26T17:02:43.228+0800    INFO    fil-consensus   filcns/upgrades.go:3016 All workers done after 5.3s
2025-03-26T17:02:43.228+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Result writer wrote 158974 results to state tree after 5.3s
2025-03-26T17:02:43.228+0800    INFO    fil-consensus   filcns/upgrades.go:3016 All 158974 done after 5.3s (29930/s)
migration height  2519400
old cid  bafy2bzaceaftms6pagbrvjqmhmehjuxuvicbmyjaz4rfe2rke5xnloc4x3v6e
new cid  bafy2bzacec42jz3abzw6zn4gp4wtz2yo6fndqo7uhenpuwcgz3ku54aiyltiy
completed round actual (without cache), took  5.981188017s
2025-03-26T17:02:44.056+0800    INFO    bundle  bundle/bundle.go:60     manifest cid: bafy2bzacebc7zpsrihpyd2jdcvmegbbk6yhzkifre3hxtoul5wdxxklbwitry
2025-03-26T17:02:44.057+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Started 10 workers
2025-03-26T17:02:44.057+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Result writer started
2025-03-26T17:02:44.057+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Creating migration jobs
2025-03-26T17:02:43.091+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Done creating 158940 migration jobs after 1.5s
2025-03-26T17:02:43.091+0800    INFO    fil-consensus   filcns/upgrades.go:3016 All workers done after 1.5s
2025-03-26T17:02:43.091+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Result writer wrote 158940 results to state tree after 1.5s
2025-03-26T17:02:43.091+0800    INFO    fil-consensus   filcns/upgrades.go:3016 All 158940 done after 1.5s (104335/s)
completed premigration, took  1.89159788s
2025-03-26T17:02:43.290+0800    INFO    bundle  bundle/bundle.go:60     manifest cid: bafy2bzacebc7zpsrihpyd2jdcvmegbbk6yhzkifre3hxtoul5wdxxklbwitry
2025-03-26T17:02:43.290+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Creating migration jobs
2025-03-26T17:02:43.290+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Started 17 workers
2025-03-26T17:02:43.291+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Result writer started
2025-03-26T17:02:43.719+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Done creating 158974 migration jobs after 400ms
2025-03-26T17:02:43.719+0800    INFO    fil-consensus   filcns/upgrades.go:3016 All workers done after 400ms
2025-03-26T17:02:43.719+0800    INFO    fil-consensus   filcns/upgrades.go:3016 Result writer wrote 158974 results to state tree after 400ms
2025-03-26T17:02:43.719+0800    INFO    fil-consensus   filcns/upgrades.go:3016 All 158974 done after 400ms (371033/s)
completed round actual (with cache), took  521.446447ms
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
