### PR TITLE
feat: allow rpcsnaps with failing cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Breaking
 
+- [#5464](https://github.com/ChainSafe/forest/pull/5464) Changed the `allow_response_mismatch` flag to `use_response_from` in the `forest-tool api generate-test-snapshot` subcommand. This allows specifying the source of the response to use when generating test snapshots and creating failing tests.
+
 ### Added
 
 ### Changed

--- a/src/tool/subcommands/api_cmd.rs
+++ b/src/tool/subcommands/api_cmd.rs
@@ -31,6 +31,12 @@ use std::{
 };
 use test_snapshot::RpcTestSnapshot;
 
+#[derive(Debug, Copy, Clone, PartialEq, ValueEnum)]
+pub enum NodeType {
+    Forest,
+    Lotus,
+}
+
 #[derive(Debug, Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum ApiCommands {
@@ -130,9 +136,11 @@ pub enum ApiCommands {
         /// Folder into which test snapshots are dumped
         out_dir: PathBuf,
         /// Allow generating snapshot even if Lotus generated a different response. This is useful
-        /// when the response is not deterministic.
+        /// when the response is not deterministic or a failing test is expected.
+        /// If generating a failing test, use `Lotus` as the argument to ensure the test passes
+        /// only when the response from Forest is fixed and matches the response from Lotus.
         #[arg(long)]
-        allow_response_mismatch: bool,
+        use_response_from: Option<NodeType>,
     },
     DumpTests {
         #[command(flatten)]
@@ -220,7 +228,7 @@ impl ApiCommands {
                 db,
                 chain,
                 out_dir,
-                allow_response_mismatch,
+                use_response_from,
             } => {
                 std::env::set_var("FOREST_TIPSET_CACHE_DISABLED", "1");
                 if !out_dir.is_dir() {
@@ -239,6 +247,7 @@ impl ApiCommands {
                         .with_extension("rpcsnap.json");
                     let test_dump = serde_json::from_reader(std::fs::File::open(&test_dump_file)?)?;
                     print!("Generating RPC snapshot at {} ...", out_path.display());
+                    let allow_response_mismatch = use_response_from.is_some();
                     match generate_test_snapshot::run_test_with_dump(
                         &test_dump,
                         tracking_db.clone(),
@@ -258,7 +267,10 @@ impl ApiCommands {
                                     chain: chain.clone(),
                                     name: test_dump.request.method_name.to_string(),
                                     params: test_dump.request.params,
-                                    response: test_dump.forest_response,
+                                    response: match use_response_from {
+                                        Some(NodeType::Forest) | None => test_dump.forest_response,
+                                        Some(NodeType::Lotus) => test_dump.lotus_response,
+                                    },
                                     index,
                                     db,
                                 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Changed the `allow_response_mismatch` flag to `use_response_from` in the `forest-tool api generate-test-snapshot` subcommand. This allows specifying the source of the response to use when generating test snapshots and creating failing tests.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
