### PR TITLE
chore: set nv25 upgrade epoch for mainnet

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -2594,7 +2594,7 @@
     "network": {
       "type": "mainnet"
     },
-    "version": "v16.0.0-rc3",
+    "version": "v16.0.0",
     "bundle_cid": "bafy2bzaceaj3s3rrfbibikplap264uw74qor5yl35mqwokv4lwst4plpwry36",
     "manifest": {
       "actors": [

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -100,7 +100,7 @@ pub static ACTOR_BUNDLES: Lazy<Box<[ActorBundleInfo]>> = Lazy::new(|| {
         "bafy2bzacecdhvfmtirtojwhw2tyciu4jkbpsbk5g53oe24br27oy62sn4dc4e" @ "v13.0.0" for "mainnet",
         "bafy2bzacecbueuzsropvqawsri27owo7isa5gp2qtluhrfsto2qg7wpgxnkba" @ "v14.0.0" for "mainnet",
         "bafy2bzaceakwje2hyinucrhgtsfo44p54iw4g6otbv5ghov65vajhxgntr53u" @ "v15.0.0" for "mainnet",
-        "bafy2bzaceaj3s3rrfbibikplap264uw74qor5yl35mqwokv4lwst4plpwry36" @ "v16.0.0-rc3" for "mainnet",
+        "bafy2bzaceaj3s3rrfbibikplap264uw74qor5yl35mqwokv4lwst4plpwry36" @ "v16.0.0" for "mainnet",
     ])
 });
 

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -4,7 +4,10 @@
 use crate::{
     eth::EthChainId,
     make_height,
-    shim::{clock::ChainEpoch, version::NetworkVersion},
+    shim::{
+        clock::{ChainEpoch, EPOCHS_IN_DAY},
+        version::NetworkVersion,
+    },
 };
 use ahash::HashMap;
 use cid::Cid;
@@ -75,9 +78,11 @@ pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
         make_height!(Waffle, 4_154_640, get_bundle_cid("v14.0.0")),
         // Wed 20 Nov 23:00:00 UTC 2024
         make_height!(TukTuk, 4_461_240, get_bundle_cid("v15.0.0")),
-        // TODO(forest): https://github.com/ChainSafe/forest/issues/5041
-        make_height!(Teep, i64::MAX, get_bundle_cid("v16.0.0-rc3")),
-        make_height!(Tock, i64::MAX),
+        // Thu 10 Apr 23:00:00 UTC 2025
+        make_height!(Teep, 4_867_320, get_bundle_cid("v16.0.0")),
+        // This epoch, 90 days after Teep is the completion of FIP-0100 where actors will start applying
+        // the new daily fee to pre-Teep sectors being extended.
+        make_height!(Tock, 4_867_320 + EPOCHS_IN_DAY * 90),
     ])
 });
 

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -275,7 +275,7 @@ impl ChainConfig {
             f3_bootstrap_epoch: -1,
             f3_initial_power_table: None,
             f3_contract_address: Some(
-                EthAddress::from_str("0x476AC9256b9921C9C6a0fC237B7fE05fe9874F50")
+                EthAddress::from_str("0xA19080A1Bcb82Bb61bcb9691EC94653Eb5315716")
                     .expect("invalid f3 contract eth address"),
             ),
             f3_contract_poll_interval: DEFAULT_F3_CONTRACT_POLL_INTERVAL,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
