### PR TITLE
fix: speed up rpc snapshot tests by using shared MultiEngine

### DIFF
--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -327,11 +327,10 @@ where
                 Arc::clone(&chain_index),
                 Arc::clone(&chain_config),
                 beacon,
-                // Creating new WASM engines is expensive (takes seconds to
-                // minutes). It's only acceptable here because this situation is
-                // so rare (may happen in dev-networks, doesn't happen in
-                // calibnet or mainnet.)
-                &crate::shim::machine::MultiEngine::default(),
+                // Using shared WASM engine here as creating new WASM engines is expensive
+                // (takes seconds to minutes). It's only acceptable here because this situation is
+                // so rare (may happen in dev-networks, doesn't happen in calibnet or mainnet.)
+                &crate::shim::machine::GLOBAL_MULTI_ENGINE,
                 Arc::clone(&heaviest_tipset),
                 crate::state_manager::NO_CALLBACK,
                 VMTrace::NotTraced,

--- a/src/shim/machine/mod.rs
+++ b/src/shim/machine/mod.rs
@@ -1,11 +1,16 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+mod manifest;
+pub use manifest::{BuiltinActor, BuiltinActorManifest};
+
 use fvm2::machine::MultiEngine as MultiEngine_v2;
 use fvm3::engine::MultiEngine as MultiEngine_v3;
 use fvm4::engine::MultiEngine as MultiEngine_v4;
-pub use manifest::{BuiltinActor, BuiltinActorManifest};
-mod manifest;
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+pub static GLOBAL_MULTI_ENGINE: Lazy<Arc<MultiEngine>> = Lazy::new(Default::default);
 
 pub struct MultiEngine {
     pub v2: MultiEngine_v2,

--- a/src/tool/subcommands/archive_cmd.rs
+++ b/src/tool/subcommands/archive_cmd.rs
@@ -41,7 +41,7 @@ use crate::networks::{butterflynet, calibnet, mainnet, ChainConfig, NetworkChain
 use crate::shim::address::CurrentNetwork;
 use crate::shim::clock::{ChainEpoch, EPOCHS_IN_DAY, EPOCH_DURATION_SECONDS};
 use crate::shim::fvm_shared_latest::address::Network;
-use crate::shim::machine::MultiEngine;
+use crate::shim::machine::GLOBAL_MULTI_ENGINE;
 use crate::state_manager::{apply_block_messages, StateOutput, NO_CALLBACK};
 use anyhow::{bail, Context as _};
 use chrono::DateTime;
@@ -551,7 +551,7 @@ async fn show_tipset_diff(
         Arc::new(chain_index),
         Arc::new(chain_config),
         beacon,
-        &MultiEngine::default(),
+        &GLOBAL_MULTI_ENGINE,
         tipset,
         NO_CALLBACK,
         VMTrace::NotTraced,

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -15,7 +15,7 @@ use crate::networks::{butterflynet, calibnet, mainnet, ChainConfig, NetworkChain
 use crate::shim::address::CurrentNetwork;
 use crate::shim::clock::ChainEpoch;
 use crate::shim::fvm_shared_latest::address::Network;
-use crate::shim::machine::MultiEngine;
+use crate::shim::machine::GLOBAL_MULTI_ENGINE;
 use crate::state_manager::{apply_block_messages, StateOutput};
 use crate::utils::db::car_stream::CarStream;
 use crate::utils::proofs_api::ensure_proof_params_downloaded;
@@ -439,7 +439,7 @@ where
         chain_index.clone(),
         chain_config,
         beacon,
-        &MultiEngine::default(),
+        &GLOBAL_MULTI_ENGINE,
         tipsets,
     )?;
 
@@ -487,7 +487,7 @@ fn print_computed_state(snapshot: PathBuf, epoch: ChainEpoch, json: bool) -> any
         Arc::new(chain_index),
         Arc::new(chain_config),
         beacon,
-        &MultiEngine::default(),
+        &GLOBAL_MULTI_ENGINE,
         tipset,
         if json {
             Some(|ctx: MessageCallbackCtx<'_>| {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Currently, RPC snapshot tests create a new `MultiEngine` for each test case. This PR tries to use a shared MultiEngine for all tests to reduce engine initialization time.

```
# Now
PASS [  29.958s] forest-filecoin tool::subcommands::api_cmd::test_snapshot::tests::rpc_regression_tests
# Before
PASS [ 145.529s] forest-filecoin tool::subcommands::api_cmd::test_snapshot::tests::rpc_regression_tests
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
