### PR TITLE
fix: improve fork enumeration, delete invalid short-cut

### DIFF
--- a/src/blocks/chain4u.rs
+++ b/src/blocks/chain4u.rs
@@ -271,7 +271,7 @@ impl Chain4UInner {
         // ensure consistency
         for it in [epoch_from_user, epoch_from_parents, epoch_from_siblings] {
             match it {
-                Some(it) if it == epoch => {}
+                Some(it) if it <= epoch => {}
                 Some(it) => panic!("inconsistent epoch: {} vs {}", it, epoch),
                 None => {}
             }

--- a/src/chain_sync/bad_block_cache.rs
+++ b/src/chain_sync/bad_block_cache.rs
@@ -8,8 +8,6 @@ use lru::LruCache;
 use nonzero_ext::nonzero;
 use parking_lot::Mutex;
 
-use crate::blocks::TipsetKey;
-
 /// Thread-safe cache for tracking bad blocks.
 /// This cache is checked before validating a block, to ensure no duplicate
 /// work.
@@ -40,17 +38,5 @@ impl BadBlockCache {
     /// This function does not update the head position of the `Cid` key.
     pub fn peek(&self, c: &Cid) -> Option<String> {
         self.cache.lock().peek(c).cloned()
-    }
-
-    /// Returns `Some` with the reason if there are any known bad blocks in the tipset.
-    /// This function does not update the head position of the `Cid` key.
-    pub fn peek_tipset_key(&self, tipset_key: &TipsetKey) -> Option<String> {
-        let cache = self.cache.lock();
-        for block in tipset_key.iter() {
-            if let Some(reason) = cache.peek(&block) {
-                return Some(reason.clone());
-            }
-        }
-        None
     }
 }

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -575,12 +575,13 @@ impl<DB: Blockstore> SyncStateMachine<DB> {
             let mut chain = Vec::new();
             let mut current = Some(heaviest);
 
-            while let Some(tipset) = current {
-                chain.push(tipset.clone());
+            while let Some(tipset) = current.take() {
                 remaining_tipsets.remove(tipset.key());
 
                 // Find parent in tipsets map
                 current = self.tipsets.get(tipset.parents()).cloned();
+
+                chain.push(tipset);
             }
             chain.reverse();
             chains.push(chain);

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -579,8 +579,8 @@ impl<DB: Blockstore> SyncStateMachine<DB> {
                 chain.push(tipset.clone());
                 remaining_tipsets.remove(tipset.key());
 
-                // Find parent in remaining tipsets
-                current = remaining_tipsets.get(tipset.parents()).cloned();
+                // Find parent in tipsets map
+                current = self.tipsets.get(tipset.parents()).cloned();
             }
             chain.reverse();
             chains.push(chain);
@@ -822,10 +822,6 @@ impl SyncTask {
                 }
             }
             SyncTask::FetchTipset(key, _epoch) => {
-                if let Some(reason) = bad_block_cache.peek_tipset_key(&key) {
-                    debug!("Skipping fetch of bad tipset: {}", reason);
-                    return None;
-                }
                 if let Ok(parents) =
                     get_full_tipset_batch(network.clone(), cs.clone(), None, key).await
                 {

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -278,7 +278,6 @@ pub async fn chain_follower<DB: Blockstore + Sync + Send + 'static>(
                         let action = task.clone().execute(
                             network.clone(),
                             state_manager.clone(),
-                            bad_block_cache.clone(),
                             stateless_mode,
                         );
                         tokio::spawn({
@@ -802,7 +801,6 @@ impl SyncTask {
         self,
         network: SyncNetworkContext<DB>,
         state_manager: Arc<StateManager<DB>>,
-        bad_block_cache: Arc<BadBlockCache>,
         stateless_mode: bool,
     ) -> Option<SyncEvent> {
         let cs = state_manager.chain_store();

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -845,6 +845,7 @@ mod tests {
     use crate::utils::db::CborStoreExt as _;
     use fil_actors_shared::fvm_ipld_amt::Amtv0 as Amt;
     use num_bigint::BigInt;
+    use num_traits::ToPrimitive;
     use std::sync::Arc;
 
     #[test]
@@ -948,5 +949,92 @@ mod tests {
 
         // We expect validation tasks for epochs 1 through 5 in order
         assert_eq!(validation_tasks, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_sync_state_machine_chain_fragments() {
+        // Initialize test logger
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::from_default_env()
+                    .add_directive(tracing::Level::TRACE.into()),
+            )
+            .try_init()
+            .unwrap();
+
+        // Create a test environment
+        let db = Arc::new(MemoryDB::default());
+
+        let chain_config = Arc::new(ChainConfig::default());
+        let bad_block_cache = Arc::new(BadBlockCache::default());
+        // Populate DB with message roots used by chain4u
+        {
+            let empty_amt = Amt::<Cid, _>::new(&db).flush().unwrap();
+            db.put_cbor_default(&crate::blocks::TxMeta {
+                bls_message_root: empty_amt,
+                secp_message_root: empty_amt,
+            })
+            .unwrap();
+        }
+        let dummy_state = |i| db.put_cbor_default(&i).unwrap();
+        let dummy_node = |i: ChainEpoch| HeaderBuilder {
+            state_root: dummy_state(i).into(),
+            weight: BigInt::from(i).into(),
+            epoch: i.into(),
+            ..Default::default()
+        };
+
+        // Create a forked chain
+        // genesis -> a -> b
+        //            \--> d
+        let c4u = Chain4U::with_blockstore(db.clone());
+        chain4u! {
+            in c4u;
+            [genesis_header = dummy_node(0)]
+            -> [a = dummy_node(1)] -> [b = dummy_node(2)]
+        };
+        chain4u! {
+            from [a] in c4u;
+            [c = dummy_node(3)]
+        };
+
+        let cs = Arc::new(
+            ChainStore::new(
+                db.clone(),
+                db.clone(),
+                db.clone(),
+                chain_config.clone(),
+                genesis_header.clone().into(),
+            )
+            .unwrap(),
+        );
+
+        let genesis_tipset = Arc::new(genesis_header.clone().into());
+        cs.set_heaviest_tipset(genesis_tipset).unwrap();
+
+        // Create the state machine
+        let mut state_machine = SyncStateMachine::new(cs, chain_config, bad_block_cache, false);
+
+        // Convert each block into a FullTipset and add it to the state machine
+        for block in [a, b, c] {
+            let full_tipset = FullTipset::new(vec![Block {
+                header: block.clone().into(),
+                bls_messages: vec![],
+                secp_messages: vec![],
+            }])
+            .unwrap();
+            state_machine.update(SyncEvent::NewFullTipsets(vec![Arc::new(full_tipset)]));
+        }
+
+        let chains = state_machine
+            .chains()
+            .into_iter()
+            .map(|v| {
+                v.into_iter()
+                    .map(|ts| ts.weight().to_i64().unwrap_or(0))
+                    .collect()
+            })
+            .collect::<Vec<Vec<_>>>();
+        assert_eq!(chains, vec![vec![1, 3], vec![1, 2]]);
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fix the calculation of available chain fragments. This avoids a situation where Forest repeatedly and unnecessarily loads the same tipset from the DB.
- Remove an invalid short-cut when querying known-bad tipsets. The short-cut would prevent the tipset from being marked as bad and removed from the set of known tipsets.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
