### PR TITLE
fix: readyz returns 503

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     command:
       - |
         set -euxo pipefail
+        # Print forest version
+        forest --version
         # fetch parameter files
         forest-tool fetch-params --keys
         # if there are some files in the data directory, then we don't need to fetch the snapshot

--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     command:
       - |
         set -euxo pipefail
-        # Print forest version
         forest --version
         # fetch parameter files
         forest-tool fetch-params --keys

--- a/scripts/tests/calibnet_eth_mapping_check.sh
+++ b/scripts/tests/calibnet_eth_mapping_check.sh
@@ -6,7 +6,6 @@ set -eu
 
 source "$(dirname "$0")/harness.sh"
 
-export FOREST_CHAIN_INDEXER_ENABLED=1
 forest_init
 
 FOREST_URL='http://127.0.0.1:2345/rpc/v1'

--- a/scripts/tests/calibnet_other_check.sh
+++ b/scripts/tests/calibnet_other_check.sh
@@ -41,3 +41,12 @@ echo "Test subcommand: net info"
 $FOREST_CLI_PATH net info
 
 $FOREST_CLI_PATH sync wait # allow the node to re-sync
+
+echo "Test subcommand: healthcheck live"
+$FOREST_CLI_PATH healthcheck live --wait
+
+echo "Test subcommand: healthcheck healthy"
+$FOREST_CLI_PATH healthcheck healthy --wait
+
+echo "Test subcommand: healthcheck ready"
+$FOREST_CLI_PATH healthcheck ready --wait

--- a/scripts/tests/harness.sh
+++ b/scripts/tests/harness.sh
@@ -3,17 +3,18 @@
 # the Forest tests. It is meant to be sourced by other scripts and not
 # executed directly.
 
-FOREST_PATH="forest"
-FOREST_CLI_PATH="forest-cli"
-FOREST_WALLET_PATH="forest-wallet"
-FOREST_TOOL_PATH="forest-tool"
+export FOREST_CHAIN_INDEXER_ENABLED="1"
+
+export FOREST_PATH="forest"
+export FOREST_CLI_PATH="forest-cli"
+export FOREST_WALLET_PATH="forest-wallet"
+export FOREST_TOOL_PATH="forest-tool"
 
 TMP_DIR=$(mktemp --directory)
 LOG_DIRECTORY=$TMP_DIR/logs
 
 export TMP_DIR
 export LOG_DIRECTORY
-export FOREST_WALLET_PATH
 
 function forest_import_non_calibnet_snapshot {
   echo "Importing a non calibnet snapshot"

--- a/src/cli/subcommands/healthcheck_cmd.rs
+++ b/src/cli/subcommands/healthcheck_cmd.rs
@@ -82,23 +82,16 @@ impl HealthcheckCommand {
                         let status = response.status();
                         let text = match response.text().await {
                             Ok(t) => t,
-                            Err(e) => {
-                                if !wait {
-                                    anyhow::bail!("{e}");
-                                }
-                                e.to_string()
-                            }
+                            Err(e) if wait => e.to_string(),
+                            Err(e) => anyhow::bail!("{e}"),
                         };
                         (status, text)
                     }
-                    Err(e) => {
-                        if !wait {
-                            anyhow::bail!("{e}");
-                        }
-
+                    Err(e) if wait => {
                         eprintln!("{e}");
                         (http::StatusCode::INTERNAL_SERVER_ERROR, "".into())
                     }
+                    Err(e) => anyhow::bail!("{e}"),
                 }
             };
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -387,13 +387,16 @@ async fn maybe_start_health_check_service(
             peer_manager: p2p_service.peer_manager().clone(),
             settings_store: ctx.db.writer().clone(),
         };
-        let listener =
-            tokio::net::TcpListener::bind(forest_state.config.client.healthcheck_address).await?;
+        let healthcheck_address = forest_state.config.client.healthcheck_address;
+        info!("Healthcheck endpoint will listen at {healthcheck_address}");
+        let listener = tokio::net::TcpListener::bind(healthcheck_address).await?;
         services.spawn(async move {
             crate::health::init_healthcheck_server(forest_state, listener)
                 .await
                 .context("Failed to initiate healthcheck server")
         });
+    } else {
+        info!("Healthcheck service is disabled");
     }
     Ok(())
 }

--- a/src/health/endpoints.rs
+++ b/src/health/endpoints.rs
@@ -165,15 +165,20 @@ fn check_peers_connected(state: &ForestState, acc: &mut MessageAccumulator) -> b
 }
 
 fn check_eth_mappings_up_to_date(state: &ForestState, acc: &mut MessageAccumulator) -> bool {
-    match state.settings_store.eth_mapping_up_to_date() {
-        Ok(Some(true)) => {
-            acc.push_ok("eth mappings up to date");
-            true
+    if state.config.chain_indexer.enable_indexer {
+        match state.settings_store.eth_mapping_up_to_date() {
+            Ok(Some(true)) => {
+                acc.push_ok("eth mappings up to date");
+                true
+            }
+            Ok(None) | Ok(Some(false)) | Err(_) => {
+                acc.push_err("no eth mappings");
+                false
+            }
         }
-        Ok(None) | Ok(Some(false)) | Err(_) => {
-            acc.push_err("no eth mappings");
-            false
-        }
+    } else {
+        acc.push_err("eth mappings disabled");
+        true
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

`forest-cli healthcheck ready --wait` throws an error on CI because the endpoint is not available when `forest` container becomes healthy, which might be caused by the recent `sync wait` logic change. 

This PR mitigates the issue while the actual bug is tracked in https://github.com/ChainSafe/forest/issues/5517

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5513

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
