### PR TITLE
fix: auto update branch name conflict

### DIFF
--- a/.github/workflows/docs-auto-update.yml
+++ b/.github/workflows/docs-auto-update.yml
@@ -25,6 +25,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           base: main
+          branch: leshy/update-forest-docs
           token: ${{ secrets.ACTIONS_PAT }}
           commit-message: Update Forest CLI docs
           title: "[automated] Update Forest CLI docs"

--- a/.github/workflows/lotus-api-bump.yml
+++ b/.github/workflows/lotus-api-bump.yml
@@ -32,6 +32,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           base: main
+          branch: leshy/update-lotus-version
           token: ${{ secrets.ACTIONS_PAT }}
           commit-message: Update Lotus dependency
           title: "[automated] Update Lotus version in API tests"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes an issue where we have two automated bumps simultaneously, e.g., CLI docs and Lotus version. They would use the default `create-pull-request/patch`, causing a race which in turn might result in, e.g., empty PRs https://github.com/ChainSafe/forest/pull/5525 (re-run was successful https://github.com/ChainSafe/forest/pull/5526). Consecutive commits for the same category will still update the same branch.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
