### PR TITLE
fix: cpu architecture mismatch in CI

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -61,7 +61,7 @@ jobs:
           command: |
             sudo apt-get install -y libclang-dev # required dep for cargo-spellcheck
       - name: Install Lint tools
-        run: make install-lint-tools-ci-arm
+        run: make install-lint-tools-ci
         env:
           RUSTFLAGS: "-Cstrip=symbols"
       - run: make lint-all

--- a/Makefile
+++ b/Makefile
@@ -32,19 +32,22 @@ install-lint-tools:
 	cargo install --locked cargo-deny
 	cargo install --locked cargo-spellcheck
 
+# Denotes the architecture of the machine. This is required for direct binary downloads.
+# Note that some repositories might use different names for the same architecture.
+CPU_ARCH := $(shell \
+  ARCH=$$(uname -m); \
+  if [ "$$ARCH" = "arm64" ]; then \
+    ARCH="aarch64"; \
+  fi; \
+  echo "$$ARCH" \
+)
+
 install-cargo-binstall:
-	wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
-	tar xzf cargo-binstall-x86_64-unknown-linux-musl.tgz
+	wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$(CPU_ARCH)-unknown-linux-musl.tgz
+	tar xzf cargo-binstall-$(CPU_ARCH)-unknown-linux-musl.tgz
 	cp cargo-binstall ~/.cargo/bin/cargo-binstall
 
 install-lint-tools-ci: install-cargo-binstall
-	cargo binstall --no-confirm taplo-cli cargo-spellcheck cargo-deny
-
-install-lint-tools-ci-arm:
-	wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-aarch64-unknown-linux-musl.tgz
-	tar xzf cargo-binstall-aarch64-unknown-linux-musl.tgz
-	cp cargo-binstall ~/.cargo/bin/cargo-binstall
-
 	cargo binstall --no-confirm taplo-cli cargo-spellcheck cargo-deny
 
 clean:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- this makes the installation procedure smarter by figuring out the CPU architecture of the host and downloading the correct binary. Additional translation layers might be introduced in the future for more exotic architectures.
- fixes CPU architecture mismatch https://github.com/ChainSafe/forest/actions/runs/14345905509/job/40215502924 where we downloaded `x86_64` binary for an ARM runner.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5542

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
