### PR TITLE
fix(ci): run RPC checks on CI only when PR is tagged with `RPC`

### DIFF
--- a/.github/workflows/docs-required-override.yml
+++ b/.github/workflows/docs-required-override.yml
@@ -58,6 +58,16 @@ jobs:
                     - '!**.md'
                     - '!.github/workflows/docs-*.yml'
 
+  override_calibnet_rpc_checks:
+    name: Calibnet RPC checks
+    runs-on: ubuntu-24.04-arm
+    needs:
+      - changes-docs
+      - changes-not-docs
+    if: ${{ (needs.changes-docs.outputs.changesFound == 'true') && (needs.changes-not-docs.outputs.otherChangesFound == 'false') }}
+    steps:
+      - run: echo "No-op job to trigger the required checks."
+
   override_integration_tests:
     name: Integration tests status
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - main
+    # This needs to be declared explicitly so that the RPC checks job is actually
+    # run when PR is labeled.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'docs/**'
       - '.github/workflows/docs-*.yml'
@@ -505,6 +508,54 @@ jobs:
       - name: Dump docker logs
         if: always()
         uses: jwalton/gh-docker-logs@v2
+  calibnet-rpc-checks-no-ops:
+    name: Calibnet RPC checks
+    runs-on: ubuntu-24.04-arm
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'RPC') }}
+    steps:
+      - run: echo "No-op job to trigger the required calibnet RPC checks."
+  calibnet-rpc-checks:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'RPC') }}
+    needs:
+      - build-ubuntu
+    name: Calibnet RPC checks
+    runs-on: ubuntu-24.04
+    env:
+      # We use a custom Dockerfile for CI to speed up the build process.
+      FOREST_DOCKERFILE_OVERRIDE: scripts/devnet/forest_ci.dockerfile
+    steps:
+      # Remove some unnecessary software to free up space. This should free up around 15-20 GB.
+      # This is required because of the limited space on the runner,
+      # and disk space-hungry snapshots used in the setup.
+      # This is taken from:
+      # https://github.com/easimon/maximize-build-space/blob/fc881a613ad2a34aca9c9624518214ebc21dfc0c/action.yml#L121-L136
+      # Using the action directly is not feasible as it does some more modifications that break the setup in our case.
+      -   name: Remove unnecessary software
+          run: |
+              echo "Disk space before cleanup"
+              df -h
+              sudo rm -rf /usr/share/dotnet
+              sudo rm -rf /usr/local/lib/android
+              sudo rm -rf /opt/ghc
+              sudo rm -rf /opt/hostedtoolcache/CodeQL
+              echo "Disk space after cleanup"
+              df -h
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: 'forest-${{ runner.os }}'
+      - name: Run api compare tests
+        run: ./scripts/tests/api_compare/setup.sh
+        timeout-minutes: '${{ fromJSON(env.SCRIPT_TIMEOUT_MINUTES) }}'
+      - name: Dump docker logs
+        if: always()
+        uses: jwalton/gh-docker-logs@v2
+      - name: Dump Docker usage
+        if: always()
+        run: |
+          docker system df
+          docker system df --verbose
+          df -h
   # Umbrella job to aggregate all integration tests and get their status
   integration-tests-status:
     needs:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- run RPC checks on CI only when PR is tagged with `RPC`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
