### PR TITLE
fix(ci): speed up RPC parity tests by symbol-linking docker volumes instead of removing unnecessary software

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -524,6 +524,12 @@ jobs:
       # We use a custom Dockerfile for CI to speed up the build process.
       FOREST_DOCKERFILE_OVERRIDE: scripts/devnet/forest_ci.dockerfile
     steps:
+      - name: Relocate docker volumes folder
+        run: |
+          sudo ls /var/lib/docker/volumes
+          sudo mv /var/lib/docker/volumes /mnt/docker-volumes
+          sudo ln -sf /mnt/docker-volumes /var/lib/docker/volumes
+          sudo ls /var/lib/docker/volumes
       # Remove some unnecessary software to free up space. This should free up around 15-20 GB.
       # This is required because of the limited space on the runner,
       # and disk space-hungry snapshots used in the setup.
@@ -553,6 +559,7 @@ jobs:
       - name: Dump Docker usage
         if: always()
         run: |
+          sudo ls /var/lib/docker/volumes
           docker system df
           docker system df --verbose
           df -h

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -530,22 +530,7 @@ jobs:
           sudo mv /var/lib/docker/volumes /mnt/docker-volumes
           sudo ln -sf /mnt/docker-volumes /var/lib/docker/volumes
           sudo ls /var/lib/docker/volumes
-      # Remove some unnecessary software to free up space. This should free up around 15-20 GB.
-      # This is required because of the limited space on the runner,
-      # and disk space-hungry snapshots used in the setup.
-      # This is taken from:
-      # https://github.com/easimon/maximize-build-space/blob/fc881a613ad2a34aca9c9624518214ebc21dfc0c/action.yml#L121-L136
-      # Using the action directly is not feasible as it does some more modifications that break the setup in our case.
-      -   name: Remove unnecessary software
-          run: |
-              echo "Disk space before cleanup"
-              df -h
-              sudo rm -rf /usr/share/dotnet
-              sudo rm -rf /usr/local/lib/android
-              sudo rm -rf /opt/ghc
-              sudo rm -rf /opt/hostedtoolcache/CodeQL
-              echo "Disk space after cleanup"
-              df -h
+          df -h
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -526,6 +526,7 @@ jobs:
     steps:
       - name: Relocate docker volumes folder
         run: |
+          # move docker volumes folder to under `/mnt` which has 60GB+ free space
           sudo ls /var/lib/docker/volumes
           sudo mv /var/lib/docker/volumes /mnt/docker-volumes
           sudo ln -sf /mnt/docker-volumes /var/lib/docker/volumes

--- a/.github/workflows/rpc-parity.yml
+++ b/.github/workflows/rpc-parity.yml
@@ -8,6 +8,12 @@ jobs:
     name: RPC parity tests
     runs-on: ubuntu-24.04
     steps:
+      - name: Relocate docker volumes folder
+        run: |
+          sudo ls /var/lib/docker/volumes
+          sudo mv /var/lib/docker/volumes /mnt/docker-volumes
+          sudo ln -sf /mnt/docker-volumes /var/lib/docker/volumes
+          sudo ls /var/lib/docker/volumes
       # Remove some unnecessary software to free up space. This should free up around 15-20 GB.
       # This is required because of the limited space on the runner,
       # and disk space-hungry snapshots used in the setup.
@@ -42,6 +48,7 @@ jobs:
       - name: Dump Docker usage
         if: always()
         run: |
+          sudo ls /var/lib/docker/volumes
           docker system df
           docker system df --verbose
           df -h

--- a/.github/workflows/rpc-parity.yml
+++ b/.github/workflows/rpc-parity.yml
@@ -14,22 +14,7 @@ jobs:
           sudo mv /var/lib/docker/volumes /mnt/docker-volumes
           sudo ln -sf /mnt/docker-volumes /var/lib/docker/volumes
           sudo ls /var/lib/docker/volumes
-      # Remove some unnecessary software to free up space. This should free up around 15-20 GB.
-      # This is required because of the limited space on the runner,
-      # and disk space-hungry snapshots used in the setup.
-      # This is taken from:
-      # https://github.com/easimon/maximize-build-space/blob/fc881a613ad2a34aca9c9624518214ebc21dfc0c/action.yml#L121-L136
-      # Using the action directly is not feasible as it does some more modifications that break the setup in our case.
-      - name: Remove unnecessary software
-        run: |
-            echo "Disk space before cleanup"
-            df -h
-            sudo rm -rf /usr/share/dotnet
-            sudo rm -rf /usr/local/lib/android
-            sudo rm -rf /opt/ghc
-            sudo rm -rf /opt/hostedtoolcache/CodeQL
-            echo "Disk space after cleanup"
-            df -h
+          df -h
       - uses: actions/checkout@v4
       - name: Run api compare tests on calibnet
         shell: bash

--- a/.github/workflows/rpc-parity.yml
+++ b/.github/workflows/rpc-parity.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - name: Relocate docker volumes folder
         run: |
+          # move docker volumes folder to under `/mnt` which has 60GB+ free space
           sudo ls /var/lib/docker/volumes
           sudo mv /var/lib/docker/volumes /mnt/docker-volumes
           sudo ln -sf /mnt/docker-volumes /var/lib/docker/volumes


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

The only RPC failure is fixed by https://github.com/ChainSafe/forest/pull/5553

Changes introduced in this pull request:

- move docker volumes folder to under `/mnt` which has 60GB+ free space
- remove `Remove unnecessary software` step as it's no longer necessary but takes 1min - [5min](https://github.com/ChainSafe/forest/actions/runs/14403141690/job/40393612129?pr=5530)

```
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          9         9         2.313GB   667.6MB (28%)
Containers      10        3         588.8MB   0B (0%)
Local Volumes   9         9         16.21GB   0B (0%)
Build Cache     11        0         586.5MB   586.5MB


Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   37G   35G  52% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.4M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   59M  761M   8% /boot
/dev/sdb15      105M  6.1M   99M   6% /boot/efi
/dev/sda1        74G   20G   51G  28% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
