### PR TITLE
fix(rpc): EthFeeHistory failure on CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -68,6 +68,11 @@ impl TipsetKey {
         self.0.len()
     }
 
+    // To suppress `#[warn(clippy::len_without_is_empty)]`
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
     /// Terse representation of the tipset key.
     /// `bafy2bzaceaqrqoasufr7gdwrbhvlfy2xmc4e5sdzekjgyha2kldxigu73gilo`
     /// becomes `eaq...ilo`. The `bafy2bzac` prefix is removed.

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -955,16 +955,11 @@ async fn execute_tipset<DB: Blockstore + Send + Sync + 'static>(
 ) -> Result<(Cid, Vec<(ChainMessage, Receipt)>)> {
     let msgs = data.chain_store().messages_for_tipset(tipset)?;
 
-    let (state_root, receipts) = data
-        .state_manager
-        .tipset_state_and_message_receipts(tipset)
-        .await?;
+    let (state_root, _) = data.state_manager.tipset_state(tipset).await?;
+    let receipts = data.state_manager.tipset_message_receipts(tipset).await?;
 
     if msgs.len() != receipts.len() {
-        bail!(
-            "receipts and message array lengths didn't match for tipset: {:?}",
-            tipset
-        )
+        bail!("receipts and message array lengths didn't match for tipset: {tipset:?}")
     }
 
     Ok((

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -955,9 +955,10 @@ async fn execute_tipset<DB: Blockstore + Send + Sync + 'static>(
 ) -> Result<(Cid, Vec<(ChainMessage, Receipt)>)> {
     let msgs = data.chain_store().messages_for_tipset(tipset)?;
 
-    let (state_root, receipt_root) = data.state_manager.tipset_state(tipset).await?;
-
-    let receipts = Receipt::get_receipts(data.store(), receipt_root)?;
+    let (state_root, receipts) = data
+        .state_manager
+        .tipset_state_and_message_receipts(tipset)
+        .await?;
 
     if msgs.len() != receipts.len() {
         bail!(

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -273,6 +273,8 @@ pub struct StateManager<DB> {
     cache: TipsetStateCache<StateOutputValue>,
     /// This is a cache dedicated to tipset events.
     events_cache: TipsetStateCache<StateEvents>,
+    /// This is a cache dedicated to message receipts.
+    receipt_cache: TipsetStateCache<Vec<Receipt>>,
     // Beacon can be cheaply crated from the `chain_config`. The only reason we
     // store it here is because it has a look-up cache.
     beacon: Arc<crate::beacon::BeaconSchedule>,
@@ -306,6 +308,7 @@ where
             cs,
             cache: TipsetStateCache::new(),
             events_cache: TipsetStateCache::with_size(DEFAULT_EVENT_CACHE_SIZE),
+            receipt_cache: TipsetStateCache::with_size(DEFAULT_EVENT_CACHE_SIZE),
             beacon,
             chain_config,
             engine,
@@ -501,44 +504,23 @@ where
             state_root,
             receipt_root,
             ..
-        } = self.tipset_state_output(tipset, false).await?;
+        } = self.tipset_state_output(tipset).await?;
         Ok((state_root, receipt_root))
-    }
-
-    pub async fn tipset_state_and_message_receipts(
-        self: &Arc<Self>,
-        tipset: &Arc<Tipset>,
-    ) -> anyhow::Result<(Cid, Vec<Receipt>)> {
-        let StateOutput {
-            state_root,
-            receipt_root,
-            ..
-        } = self.tipset_state_output(tipset, true).await?;
-        let receipts = Receipt::get_receipts(self.blockstore(), receipt_root)?;
-        Ok((state_root, receipts))
     }
 
     pub async fn tipset_state_output(
         self: &Arc<Self>,
         tipset: &Arc<Tipset>,
-        check_state_tree_and_message_receipts: bool,
     ) -> anyhow::Result<StateOutput> {
         let key = tipset.key();
-        Ok(match self.cache.get(key) {
-            Some(s)
-                if !check_state_tree_and_message_receipts
-                    || (self.blockstore().has(&s.state_root)?
-                        && self.blockstore().has(&s.receipt_root)?) =>
-            {
-                s
-            }
-            _ => {
+        self.cache
+            .get_or_else(key, || async move {
                 info!(
                     "Evaluating tipset: EPOCH = {}, blocks = {}",
                     tipset.epoch(),
                     tipset.len(),
                 );
-                let ts_state: StateOutputValue = self
+                let ts_state = self
                     .compute_tipset_state(
                         Arc::clone(tipset),
                         NO_CALLBACK,
@@ -548,11 +530,34 @@ where
                     .await?
                     .into();
                 trace!("Completed tipset state calculation {:?}", tipset.cids());
-                self.cache.insert(key.clone(), ts_state.clone());
-                ts_state
-            }
-        }
-        .into())
+                // We missed the opportunity to update `self.events_cache` and `self.receipt_cache` here, to be refactored.
+                Ok(ts_state)
+            })
+            .await
+            .map(StateOutput::from)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn tipset_message_receipts(
+        self: &Arc<Self>,
+        tipset: &Arc<Tipset>,
+    ) -> anyhow::Result<Vec<Receipt>> {
+        let key = tipset.key();
+        self.receipt_cache
+            .get_or_else(key, || async move {
+                let StateOutput { receipt_root, .. } = self
+                    .compute_tipset_state(
+                        Arc::clone(tipset),
+                        NO_CALLBACK,
+                        VMTrace::NotTraced,
+                        VMEvent::Pushed,
+                    )
+                    .await?;
+                trace!("Completed tipset state calculation {:?}", tipset.cids());
+                // We missed the opportunity to update `self.cache` here, to be refactored.
+                Receipt::get_receipts(self.blockstore(), receipt_root)
+            })
+            .await
     }
 
     #[instrument(skip(self))]
@@ -572,6 +577,7 @@ where
                     )
                     .await?;
                 trace!("Completed tipset state calculation {:?}", tipset.cids());
+                // We missed the opportunity to update `self.cache` here, to be refactored.
                 Ok(StateEvents {
                     events: ts_state.events,
                 })


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR fixes `EthFeeHistory` failure on CI, by re-computing tipset state when the output is cached but underlying state tree and message receipts are missing (likely introduced by https://github.com/ChainSafe/forest/pull/5540)

RPC tests passed on CI: https://github.com/ChainSafe/forest/actions/runs/14378406720/job/40316604127?pr=5553

It also fixed a few warnings:
```
warning: package `crossbeam-channel v0.5.14` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked

  --> src/blocks/tipset.rs:67:5
   |
67 |     pub fn len(&self) -> usize {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_without_is_empty
   = note: `#[warn(clippy::len_without_is_empty)]` on by default
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5549
Closes https://github.com/ChainSafe/forest/issues/5554

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
