### PR TITLE
fix: change Filecoin.ChainGetMinBaseFee to internal API with read access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ## Forest unreleased
 
 ### Breaking
+- [#5559](https://github.com/ChainSafe/forest/pull/5559) Change `Filecoin.ChainGetMinBaseFee` to `Forest.ChainGetMinBaseFee` with read access.
 
 ### Added
 
@@ -44,7 +45,6 @@ This is a non-mandatory, but highly recommended, release targeting the mainnet n
 - [#5512](https://github.com/ChainSafe/forest/pull/5512) Fixed `Filecoin.EthTraceFilter` RPC method.
 - [#5517](https://github.com/ChainSafe/forest/issues/5517) Fix the `forest-cli sync wait` issue
 - [#5540](https://github.com/ChainSafe/forest/pull/5540) Avoid duplicate migrations.
-- [#5559](https://github.com/ChainSafe/forest/pull/5559) Change `Filecoin.ChainGetMinBaseFee` to `Forest.ChainGetMinBaseFee` with read access
 
 ## Forest v0.25.2 "Fool of a Took"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This is a non-mandatory, but highly recommended, release targeting the mainnet n
 - [#5512](https://github.com/ChainSafe/forest/pull/5512) Fixed `Filecoin.EthTraceFilter` RPC method.
 - [#5517](https://github.com/ChainSafe/forest/issues/5517) Fix the `forest-cli sync wait` issue
 - [#5540](https://github.com/ChainSafe/forest/pull/5540) Avoid duplicate migrations.
+- [#5559](https://github.com/ChainSafe/forest/pull/5559) Change `Filecoin.ChainGetMinBaseFee` to `Forest.ChainGetMinBaseFee` with read access
 
 ## Forest v0.25.2 "Fool of a Took"
 

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -625,10 +625,10 @@ impl RpcMethod<1> for ChainSetHead {
 
 pub enum ChainGetMinBaseFee {}
 impl RpcMethod<1> for ChainGetMinBaseFee {
-    const NAME: &'static str = "Filecoin.ChainGetMinBaseFee";
+    const NAME: &'static str = "Forest.ChainGetMinBaseFee";
     const PARAM_NAMES: [&'static str; 1] = ["lookback"];
     const API_PATHS: ApiPaths = ApiPaths::V1;
-    const PERMISSION: Permission = Permission::Admin;
+    const PERMISSION: Permission = Permission::Read;
 
     type Params = (u32,);
     type Ok = String;

--- a/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
+++ b/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
@@ -12,7 +12,6 @@ Filecoin.AuthNew
 Filecoin.AuthVerify
 Filecoin.ChainExport
 Filecoin.ChainGetEvents
-Filecoin.ChainGetMinBaseFee
 Filecoin.ChainSetHead
 Filecoin.EthEstimateGas
 Filecoin.EthGetFilterChanges
@@ -83,3 +82,4 @@ Forest.NetInfo
 Forest.StateCompute
 Forest.StateFetchRoot
 Forest.SyncSnapshotProgress
+Forest.ChainGetMinBaseFee


### PR DESCRIPTION
## Summary of changes

This PR changes:
 - `Filecoin.ChainGetMinBaseFee` -> `Forest.ChainGetMinBaseFee`
 - Change `Admin` to `Read` permission

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes: #5558 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
