### PR TITLE
chore: update crossbeam-channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

```
 error[vulnerability]: crossbeam-channel: double free on Drop
    ┌─ /home/runner/work/forest/forest/Cargo.lock:153:1
    │
153 │ crossbeam-channel 0.5.14 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
    │
    ├ ID: RUSTSEC-2025-0024
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0024
    ├ The internal `Channel` type's `Drop` method has a race
      which could, in some circumstances, lead to a double-free.
      This could result in memory corruption.
      
      Quoting from the
      [upstream description in merge request \#1187](https://github.com/crossbeam-rs/crossbeam/pull/1187#issue-2980761131):
      
      > The problem lies in the fact that `dicard_all_messages` contained two paths that could lead to `head.block` being read but only one of them would swap the value. This meant that `dicard_all_messages` could end up observing a non-null block pointer (and therefore attempting to free it) without setting `head.block` to null. This would then lead to `Channel::drop` making a second attempt at dropping the same pointer.
      
      The bug was introduced while fixing a memory leak, in
      upstream [MR \#1084](https://github.com/crossbeam-rs/crossbeam/pull/1084),
      first published in 0.5.12.
      
      The fix is in
      upstream [MR \#1187](https://github.com/crossbeam-rs/crossbeam/pull/1187)
      and has been published in 0.5.15
    ├ Announcement: https://github.com/crossbeam-rs/crossbeam/pull/1187
    ├ Solution: Upgrade to >=0.5.15 (try `cargo update -p crossbeam-channel`)
```
## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5560

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
