### PR TITLE
fix(ci): transient error in F3GetCertificate

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -196,6 +196,10 @@ services:
         lotus sync wait
         # After the sync is done, import the wallet for signing blocks. It might be already there, which will return an error. We ignore it.
         echo $MINER_WORKER_KEY | lotus wallet import || true
+        # Wait until F3 certificate instance 100 is available
+        until lotus f3 c get 100; do
+            sleep 5s;
+        done
   api-compare:
     depends_on:
       lotus-sync-wait:

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -1822,7 +1822,7 @@ fn f3_tests() -> anyhow::Result<Vec<RpcTest>> {
         ))?),
         RpcTest::identity(F3IsRunning::request(())?),
         RpcTest::identity(F3GetCertificate::request((0,))?),
-        RpcTest::identity(F3GetCertificate::request((1000,))?),
+        RpcTest::identity(F3GetCertificate::request((100,))?),
         RpcTest::identity(F3GetManifest::request(())?),
     ])
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Lotus node should only be considered ready when F3 certificates are available. This becomes an issue since Forest eth mapping generation logic has been made much faster in https://github.com/ChainSafe/forest/pull/5360

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5576
Closes https://github.com/ChainSafe/forest/issues/5577
Closes https://github.com/ChainSafe/forest/issues/5578
 
## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
