### PR TITLE
[automated] Update Forest CLI docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ## Forest unreleased
 
 ### Breaking
+
 - [#5559](https://github.com/ChainSafe/forest/pull/5559) Change `Filecoin.ChainGetMinBaseFee` to `Forest.ChainGetMinBaseFee` with read access.
 
 ### Added


### PR DESCRIPTION
### Changes
- Updates Forest CLI docs to the latest commit in the `main` branch.