### PR TITLE
Fix `Filecoin.ChainGetEvents` method

### DIFF
--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -2,5 +2,3 @@
 # They should be considered bugged, and not used until the root cause is resolved.
 # Disable until next Lotus release with go-f3 0.8.0
 !Filecoin.F3GetManifest
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/5579
-!Filecoin.ChainGetEvents

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -27,5 +27,3 @@
 !Filecoin.EthGetBlockByNumber
 !eth_getBlockByNumber
 !Filecoin.ChainSetHead
-# CustomCheckFailed in Forest: https://github.com/ChainSafe/forest/issues/5579
-!Filecoin.ChainGetEvents

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -325,12 +325,10 @@ where
         let state_output = state_manager
             .compute_tipset_state(Arc::new(ts), NO_CALLBACK, VMTrace::NotTraced)
             .await?;
-        for events_root in state_output.events_roots.iter() {
-            if let Some(cid) = events_root {
-                println!("Indexing events root @{}: {}", epoch, cid);
+        for events_root in state_output.events_roots.iter().flatten() {
+            println!("Indexing events root @{}: {}", epoch, events_root);
 
-                state_manager.chain_store().put_index(cid, &tsk)?;
-            }
+            state_manager.chain_store().put_index(events_root, &tsk)?;
         }
     }
 

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -326,9 +326,11 @@ where
             .compute_tipset_state(Arc::new(ts), NO_CALLBACK, VMTrace::NotTraced)
             .await?;
         for events_root in state_output.events_roots.iter() {
-            println!("Indexing events root @{}: {}", epoch, events_root);
+            if let Some(cid) = events_root {
+                println!("Indexing events root @{}: {}", epoch, cid);
 
-            state_manager.chain_store().put_index(events_root, &tsk)?;
+                state_manager.chain_store().put_index(cid, &tsk)?;
+            }
         }
     }
 

--- a/src/rpc/methods/eth/filter/mod.rs
+++ b/src/rpc/methods/eth/filter/mod.rs
@@ -374,11 +374,13 @@ impl EthEventHandler {
             .tipset_state_events(tipset, Some(events_root))
             .await?;
 
+        ensure!(state_events.roots.len() == state_events.events.len());
+
         let filtered_events = state_events
             .roots
             .into_iter()
             .zip(state_events.events)
-            .filter(|(cid, _)| cid == events_root)
+            .filter(|(cid, _)| cid.as_ref() == Some(&events_root))
             .map(|(_, v)| v);
 
         let mut chain_events = vec![];

--- a/src/rpc/methods/eth/filter/mod.rs
+++ b/src/rpc/methods/eth/filter/mod.rs
@@ -380,7 +380,7 @@ impl EthEventHandler {
             .roots
             .into_iter()
             .zip(state_events.events)
-            .filter(|(cid, _)| cid.as_ref() == Some(&events_root))
+            .filter(|(cid, _)| cid.as_ref() == Some(events_root))
             .map(|(_, v)| v);
 
         let mut chain_events = vec![];

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -529,12 +529,10 @@ where
                 let state_output = self
                     .compute_tipset_state(Arc::clone(tipset), NO_CALLBACK, VMTrace::NotTraced)
                     .await?;
-                for events_root in state_output.events_roots.iter() {
-                    if let Some(cid) = events_root {
-                        trace!("Indexing events root @{}: {}", tipset.epoch(), cid);
+                for events_root in state_output.events_roots.iter().flatten() {
+                    trace!("Indexing events root @{}: {}", tipset.epoch(), events_root);
 
-                        self.chain_store().put_index(cid, key)?;
-                    }
+                    self.chain_store().put_index(events_root, key)?;
                 }
                 let ts_state = state_output.into();
                 trace!("Completed tipset state calculation {:?}", tipset.cids());

--- a/src/tool/subcommands/index_cmd.rs
+++ b/src/tool/subcommands/index_cmd.rs
@@ -96,12 +96,10 @@ impl IndexCommands {
                     let state_output = state_manager
                         .compute_tipset_state(Arc::new(ts), NO_CALLBACK, VMTrace::NotTraced)
                         .await?;
-                    for events_root in state_output.events_roots.iter() {
-                        if let Some(cid) = events_root {
-                            println!("Indexing events root @{}: {}", epoch, cid);
+                    for events_root in state_output.events_roots.iter().flatten() {
+                        println!("Indexing events root @{}: {}", epoch, events_root);
 
-                            chain_store.put_index(cid, &tsk)?;
-                        }
+                        chain_store.put_index(events_root, &tsk)?;
                     }
                 }
 

--- a/src/tool/subcommands/index_cmd.rs
+++ b/src/tool/subcommands/index_cmd.rs
@@ -97,9 +97,11 @@ impl IndexCommands {
                         .compute_tipset_state(Arc::new(ts), NO_CALLBACK, VMTrace::NotTraced)
                         .await?;
                     for events_root in state_output.events_roots.iter() {
-                        println!("Indexing events root @{}: {}", epoch, events_root);
+                        if let Some(cid) = events_root {
+                            println!("Indexing events root @{}: {}", epoch, cid);
 
-                        chain_store.put_index(events_root, &tsk)?;
+                            chain_store.put_index(cid, &tsk)?;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fix `apply_block_messages` function
- Remove RPC method from filter lists

```bash
forest-tool api compare --lotus /ip4/127.0.0.1/tcp/1234/http --forest /ip4/127.0.0.1/tcp/2345/http forest_snapshot_calibnet_2025-04-22_height_2599416.forest.car.zst --filter ChainGetEvents -n 200
| RPC Method                    | Forest | Lotus |
|-------------------------------|--------|-------|
| Filecoin.ChainGetEvents (254) | Valid  | Valid |
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #5579

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
