### PR TITLE
fix: fix parameters cache handling

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -225,6 +225,7 @@ services:
     environment:
       - RUST_LOG=info,forest::tool::subcommands=debug
       - FOREST_RPC_DEFAULT_TIMEOUT=120
+      - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
     entrypoint: [ "/bin/bash", "-c" ]
     user: 0:0
     command:
@@ -260,6 +261,7 @@ services:
     environment:
       - RUST_LOG=info,forest::tool::subcommands=debug
       - FOREST_RPC_DEFAULT_TIMEOUT=120
+      - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
     entrypoint: [ "/bin/bash", "-c" ]
     user: 0:0
     command:

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -144,7 +144,7 @@ fn startup_init(opts: &CliOpts, config: &Config) -> anyhow::Result<()> {
     maybe_increase_fd_limit()?;
     // Sets proof parameter file download path early, the files will be checked and
     // downloaded later right after snapshot import step
-    crate::utils::proofs_api::set_proofs_parameter_cache_dir_env(&config.client.data_dir);
+    crate::utils::proofs_api::maybe_set_proofs_parameter_cache_dir_env(&config.client.data_dir);
     info!(
         "Starting Forest daemon, version {}",
         FOREST_VERSION_STRING.as_str()

--- a/src/tool/subcommands/api_cmd/test_snapshot.rs
+++ b/src/tool/subcommands/api_cmd/test_snapshot.rs
@@ -193,7 +193,7 @@ mod tests {
             return;
         }
         // Set proof parameter data dir and make sure the proofs are available
-        crate::utils::proofs_api::set_proofs_parameter_cache_dir_env(
+        crate::utils::proofs_api::maybe_set_proofs_parameter_cache_dir_env(
             &Config::default().client.data_dir,
         );
         ensure_proof_params_downloaded().await.unwrap();

--- a/src/tool/subcommands/snapshot_cmd.rs
+++ b/src/tool/subcommands/snapshot_cmd.rs
@@ -414,7 +414,7 @@ where
     load_actor_bundles(&db, &network).await?;
 
     // Set proof parameter data dir and make sure the proofs are available
-    crate::utils::proofs_api::set_proofs_parameter_cache_dir_env(
+    crate::utils::proofs_api::maybe_set_proofs_parameter_cache_dir_env(
         &Config::default().client.data_dir,
     );
 

--- a/src/utils/proofs_api/mod.rs
+++ b/src/utils/proofs_api/mod.rs
@@ -4,5 +4,5 @@
 mod parameters;
 mod paramfetch;
 
-pub use parameters::set_proofs_parameter_cache_dir_env;
+pub use parameters::maybe_set_proofs_parameter_cache_dir_env;
 pub use paramfetch::{SectorSizeOpt, ensure_proof_params_downloaded, get_params_default};

--- a/src/utils/proofs_api/parameters.rs
+++ b/src/utils/proofs_api/parameters.rs
@@ -105,8 +105,16 @@ pub(super) fn param_dir(data_dir: &Path) -> PathBuf {
 /// variable is updated before the parameters are downloaded.
 ///
 /// More information available [here](https://github.com/filecoin-project/rust-fil-proofs/blob/8f5bd86be36a55e33b9b293ba22ea13ca1f28163/README.md?plain=1#L219-L235).
-pub fn set_proofs_parameter_cache_dir_env(data_dir: &Path) {
+fn set_proofs_parameter_cache_dir_env(data_dir: &Path) {
     unsafe { std::env::set_var(PROOFS_PARAMETER_CACHE_ENV, param_dir(data_dir)) };
+}
+
+/// Optionally set the proofs parameter cache directory environment variable if it is not already
+/// set. See [`set_proofs_parameter_cache_dir_env`] for more details.
+pub fn maybe_set_proofs_parameter_cache_dir_env(data_dir: &Path) {
+    if std::env::var(PROOFS_PARAMETER_CACHE_ENV).is_err() {
+        set_proofs_parameter_cache_dir_env(data_dir);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- this PR fixes inconsistent proof params cache overriding. There isn't a super clean way to do it, given https://crates.io/crates/filecoin-proofs is a pretty invasive library, creating directories on its own and expecting certain environment variables to be available for the process.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
