### PR TITLE
fix: eth syncing API 

### DIFF
--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1672,6 +1672,11 @@ impl RpcMethod<0> for EthSyncing {
         let sync_status: crate::chain_sync::SyncStatusReport =
             crate::rpc::sync::SyncStatus::handle(ctx, ()).await?;
         match sync_status.status {
+            NodeSyncStatus::Synced => Ok(EthSyncingResult {
+                done_sync: true,
+                // Once the node is synced, other fields are not relevant for the API
+                ..Default::default()
+            }),
             NodeSyncStatus::Syncing => {
                 let starting_block = match sync_status.get_min_starting_block() {
                     Some(e) => Ok(e),
@@ -1688,7 +1693,7 @@ impl RpcMethod<0> for EthSyncing {
                     highest_block: sync_status.network_head_epoch,
                 })
             }
-            _ => Err(ServerError::internal_error("sync status not found", None)),
+            _ => Err(ServerError::internal_error("node is not syncing", None)),
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Set done_sync to true if the Node sync status is Synced
- This will return false in RPC response which indicates (node is synced)


## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes: #5602 

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
