### PR TITLE
fix(f3): wrong mainnet network name for joining KAD network

### DIFF
--- a/f3-sidecar/api.go
+++ b/f3-sidecar/api.go
@@ -12,6 +12,7 @@ import (
 )
 
 type F3Api struct {
+	GetRawNetworkName        func(context.Context) (string, error)
 	GetTipsetByEpoch         func(context.Context, int64) (TipSet, error)
 	GetTipset                func(context.Context, gpbft.TipSetKey) (TipSet, error)
 	GetHead                  func(context.Context) (TipSet, error)
@@ -26,7 +27,6 @@ type F3Api struct {
 
 type FilecoinApi struct {
 	Version          func(context.Context) (VersionInfo, error)
-	StateNetworkName func(context.Context) (string, error)
 	NetAddrsListen   func(context.Context) (peer.AddrInfo, error)
 }
 

--- a/f3-sidecar/run.go
+++ b/f3-sidecar/run.go
@@ -26,9 +26,15 @@ func run(ctx context.Context, rpcEndpoint string, jwt string, f3RpcEndpoint stri
 		return err
 	}
 	defer closer()
-	var network string
+
+	ec, err := NewForestEC(rpcEndpoint, jwt)
+	if err != nil {
+		return err
+	}
+
+	var rawNetwork string
 	for {
-		network, err = api.StateNetworkName(ctx)
+		rawNetwork, err = ec.f3api.GetRawNetworkName(ctx)
 		if err == nil {
 			logger.Infoln("Forest RPC server is online")
 			break
@@ -42,11 +48,7 @@ func run(ctx context.Context, rpcEndpoint string, jwt string, f3RpcEndpoint stri
 		return err
 	}
 
-	p2p, err := createP2PHost(ctx, network)
-	if err != nil {
-		return err
-	}
-	ec, err := NewForestEC(rpcEndpoint, jwt)
+	p2p, err := createP2PHost(ctx, rawNetwork)
 	if err != nil {
 		return err
 	}
@@ -72,7 +74,13 @@ func run(ctx context.Context, rpcEndpoint string, jwt string, f3RpcEndpoint stri
 		logger.Warn("InitialPowerTable is undefined")
 		m.InitialPowerTable = cid.Undef
 	}
-	m.NetworkName = gpbft.NetworkName(network)
+	// Use "filecoin" as the network name on mainnet, otherwise use the network name. Yes,
+	// mainnet is called testnetnet in state.
+	if rawNetwork == "testnetnet" {
+		m.NetworkName = "filecoin"
+	} else {
+		m.NetworkName = gpbft.NetworkName(rawNetwork)
+	}
 	versionInfo, err := api.Version(ctx)
 	if err != nil {
 		return err

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -276,7 +276,11 @@ impl ChainConfig {
             f3_enabled: true,
             f3_consensus: true,
             f3_bootstrap_epoch: -1,
-            f3_initial_power_table: None,
+            f3_initial_power_table: Some(
+                "bafy2bzacecklgxd2eksmodvhgurqvorkg3wamgqkrunir3al2gchv2cikgmbu"
+                    .parse()
+                    .expect("invalid f3_initial_power_table"),
+            ),
             f3_contract_address: Some(
                 EthAddress::from_str("0xA19080A1Bcb82Bb61bcb9691EC94653Eb5315716")
                     .expect("invalid f3 contract eth address"),

--- a/src/rpc/methods/f3.rs
+++ b/src/rpc/methods/f3.rs
@@ -59,6 +59,22 @@ use std::{borrow::Cow, fmt::Display, num::NonZeroU64, str::FromStr as _, sync::A
 
 pub static F3_LEASE_MANAGER: OnceCell<F3LeaseManager> = OnceCell::new();
 
+pub enum GetRawNetworkName {}
+
+impl RpcMethod<0> for GetRawNetworkName {
+    const NAME: &'static str = "F3.GetRawNetworkName";
+    const PARAM_NAMES: [&'static str; 0] = [];
+    const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
+    const PERMISSION: Permission = Permission::Read;
+
+    type Params = ();
+    type Ok = String;
+
+    async fn handle(ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
+        Ok(ctx.network_name.clone())
+    }
+}
+
 pub enum GetTipsetByEpoch {}
 impl RpcMethod<1> for GetTipsetByEpoch {
     const NAME: &'static str = "F3.GetTipsetByEpoch";

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -7,7 +7,6 @@ pub use types::*;
 use crate::blocks::{Tipset, TipsetKey};
 use crate::chain::index::ResolveNullTipset;
 use crate::cid_collections::CidHashSet;
-use crate::daemon::get_actual_chain_name;
 use crate::eth::EthChainId;
 use crate::interpreter::{MessageCallbackCtx, VMTrace};
 use crate::libp2p::NetworkMessage;
@@ -2830,7 +2829,7 @@ impl RpcMethod<0> for StateGetNetworkParams {
         let policy = &config.policy;
 
         let params = NetworkParams {
-            network_name: get_actual_chain_name(&ctx.network_name).to_string(),
+            network_name: ctx.network_name.clone(),
             block_delay_secs: config.block_delay_secs as u64,
             consensus_miner_min_power: policy.minimum_consensus_power.clone(),
             pre_commit_challenge_delay: policy.pre_commit_challenge_delay,

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -7,6 +7,7 @@ pub use types::*;
 use crate::blocks::{Tipset, TipsetKey};
 use crate::chain::index::ResolveNullTipset;
 use crate::cid_collections::CidHashSet;
+use crate::daemon::get_actual_chain_name;
 use crate::eth::EthChainId;
 use crate::interpreter::{MessageCallbackCtx, VMTrace};
 use crate::libp2p::NetworkMessage;
@@ -2829,7 +2830,7 @@ impl RpcMethod<0> for StateGetNetworkParams {
         let policy = &config.policy;
 
         let params = NetworkParams {
-            network_name: ctx.network_name.clone(),
+            network_name: get_actual_chain_name(&ctx.network_name).to_string(),
             block_delay_secs: config.block_delay_secs as u64,
             consensus_miner_min_power: policy.minimum_consensus_power.clone(),
             pre_commit_challenge_delay: policy.pre_commit_challenge_delay,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -258,6 +258,7 @@ macro_rules! for_each_rpc_method {
         $callback!($crate::rpc::wallet::WalletVerify);
 
         // f3
+        $callback!($crate::rpc::f3::GetRawNetworkName);
         $callback!($crate::rpc::f3::F3GetCertificate);
         $callback!($crate::rpc::f3::F3GetECPowerTable);
         $callback!($crate::rpc::f3::F3GetF3PowerTable);

--- a/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
+++ b/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
@@ -4,6 +4,7 @@ F3.GetManifestFromContract
 F3.GetParent
 F3.GetParticipatingMinerIDs
 F3.GetPowerTable
+F3.GetRawNetworkName
 F3.GetTipset
 F3.GetTipsetByEpoch
 F3.ProtectPeer


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- use `testnetnet` for joining mainnet Kademlia
- use `filecoin` as mainnet F3 network name in static manifest (Not yet effective until we set F3 activation epoch in code or env var to bypass contract manifest)
- fix mainnet network name in `Filecoin.StateGetNetworkParams` RPC method
- set F3 initial power table on mainnet 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
