### PR TITLE
feat: (daemon) saves default RPC token and (CLI) consumes it automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 -[#5598](https://github.com/ChainSafe/forest/pull/5598) Add `forest-cli chain prune snap` command for garbage collecting the database with a new snapshot garbage collector.
 
+-[#5629](https://github.com/ChainSafe/forest/pull/5629) Save default RPC token and consume it automatically.
+
 ### Changed
 
 -[#5616](https://github.com/ChainSafe/forest/pull/5616) Remove the initial background task for populating Ethereum mappings. Use `forest-tool index backfill` to perform this operation offline instead.

--- a/README.md
+++ b/README.md
@@ -236,13 +236,14 @@ without any prompts.
 
 ### Interacting with Forest via CLI
 
-When the Forest daemon is started, an admin token will be displayed
-(alternatively, use `--save-token <token>` flag to save it on disk). You will
-need this for commands that require a higher level of authorization (like a
+When the Forest daemon is started, an admin token will be displayed and saved to
+data directory by default. (alternatively, use `--save-token <token>` flag to save it on disk).
+You will need this for commands that require a higher level of authorization (like a
 password). Forest, as mentioned above, uses multiaddresses for networking. This
 is no different in the CLI. To set the host and the port to use, if not using
 the default port or using a remote host, set the `FULLNODE_API_INFO` environment
-variable. This is also where you can set a token for authentication.
+variable. This is also where you can set a token for authentication. Note that the token is
+automatically set for CLI if it is invoked on the same host of the daemon.
 
 ```
 FULLNODE_API_INFO="<token goes here>:/ip4/<host>/tcp/<port>/http

--- a/docs/docs/users/knowledge_base/jwt_handling.md
+++ b/docs/docs/users/knowledge_base/jwt_handling.md
@@ -63,7 +63,7 @@ The admin token is assumed to be stored in `/tmp/token` for the following exampl
 
 ### via `forest-cli`
 
-The most straightforward way to use tokens is to pass them to the `forest-cli` tool. This can be done either by passing it via the `--token` flag or by setting the `FULLNODE_API_INFO` environment variable.
+The most straightforward way to use tokens is to pass them to the `forest-cli` tool. This can be done either by passing it via the `--token` flag or by setting the `FULLNODE_API_INFO` environment variable. Note that the token is automatically set for CLI if it is invoked on the same host of the daemon.
 
 ```bash
 forest-cli --token $(cat /tmp/token) shutdown

--- a/scripts/tests/calibnet_no_discovery_check.sh
+++ b/scripts/tests/calibnet_no_discovery_check.sh
@@ -11,12 +11,9 @@ function shutdown {
 
 trap shutdown EXIT
 
-$FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --save-token ./admin_token --exit-after-init
+$FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --exit-after-init
 $FOREST_PATH --chain calibnet --encrypt-keystore false --mdns false --kademlia false --auto-download-snapshot --log-dir "$LOG_DIRECTORY" &
 FOREST_NODE_PID=$!
-
-FULLNODE_API_INFO="$(cat admin_token):/ip4/127.0.0.1/tcp/2345/http"
-export FULLNODE_API_INFO
 
 forest_wait_api
 

--- a/scripts/tests/calibnet_other_check.sh
+++ b/scripts/tests/calibnet_other_check.sh
@@ -26,7 +26,7 @@ fi
 
 forest_check_db_stats
 echo "Run snapshot GC"
-forest_run_snap_gc
+$FOREST_CLI_PATH chain prune snap
 forest_wait_api
 echo "Wait the node to sync"
 forest_wait_for_sync

--- a/scripts/tests/calibnet_stateless_rpc_check.sh
+++ b/scripts/tests/calibnet_stateless_rpc_check.sh
@@ -10,13 +10,7 @@ function forest_run_node_stateless_detached_with_filter_list {
   pkill -9 forest || true
   local filter_list=$1
 
-  $FOREST_PATH --detach --chain calibnet --encrypt-keystore false --log-dir "$LOG_DIRECTORY" --save-token ./admin_token --skip-load-actors --stateless --rpc-filter-list "$filter_list"
-
-  ADMIN_TOKEN=$(cat admin_token)
-  FULLNODE_API_INFO="$ADMIN_TOKEN:/ip4/127.0.0.1/tcp/2345/http"
-
-  export ADMIN_TOKEN
-  export FULLNODE_API_INFO
+  $FOREST_PATH --detach --chain calibnet --encrypt-keystore false --log-dir "$LOG_DIRECTORY" --skip-load-actors --stateless --rpc-filter-list "$filter_list"
 }
 
 # Tests the RPC method `Filecoin.ChainHead` and checks if the status code matches the expected code.

--- a/scripts/tests/harness.sh
+++ b/scripts/tests/harness.sh
@@ -69,7 +69,7 @@ function forest_query_format {
 
 function forest_run_node_detached {
   echo "Running forest in detached mode"
-  $FOREST_PATH --chain calibnet --encrypt-keystore false --log-dir "$LOG_DIRECTORY" --detach --save-token ./admin_token --track-peak-rss
+  $FOREST_PATH --chain calibnet --encrypt-keystore false --log-dir "$LOG_DIRECTORY" --detach --track-peak-rss
 }
 
 function forest_run_node_stateless_detached {
@@ -111,12 +111,6 @@ function forest_init {
 
   forest_check_db_stats
   forest_run_node_detached
-
-  ADMIN_TOKEN=$(cat admin_token)
-  FULLNODE_API_INFO="$ADMIN_TOKEN:/ip4/127.0.0.1/tcp/2345/http"
-
-  export ADMIN_TOKEN
-  export FULLNODE_API_INFO
 
   forest_wait_api
   forest_wait_for_sync

--- a/scripts/tests/harness.sh
+++ b/scripts/tests/harness.sh
@@ -133,12 +133,6 @@ function forest_init_stateless {
   export FULLNODE_API_INFO
 }
 
-function forest_run_snap_gc {
-  ADMIN_TOKEN=$(cat admin_token)
-  FULLNODE_API_INFO="$ADMIN_TOKEN:/ip4/127.0.0.1/tcp/2345/http"
-  $FOREST_CLI_PATH chain prune snap
-}
-
 function forest_print_logs_and_metrics {
   echo "Get and print metrics"
   wget -O metrics.log http://localhost:6116/metrics

--- a/src/cli_shared/cli/client.rs
+++ b/src/cli_shared/cli/client.rs
@@ -97,3 +97,9 @@ impl Default for Client {
         }
     }
 }
+
+impl Client {
+    pub fn default_rpc_token_path(&self) -> PathBuf {
+        self.data_dir.join("token")
+    }
+}

--- a/src/daemon/context.rs
+++ b/src/daemon/context.rs
@@ -1,5 +1,6 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
+
 use crate::auth::{ADMIN, create_token, generate_priv_key};
 use crate::chain::ChainStore;
 use crate::cli_shared::chain_path;
@@ -157,7 +158,7 @@ async fn load_or_create_keystore_and_configure_jwt(
     if keystore.get(JWT_IDENTIFIER).is_err() {
         keystore.put(JWT_IDENTIFIER, generate_priv_key())?;
     }
-    let admin_jwt = handle_admin_token(opts, &keystore)?;
+    let admin_jwt = handle_admin_token(opts, config, &keystore)?;
     let keystore = Arc::new(RwLock::new(keystore));
     Ok((keystore, admin_jwt))
 }
@@ -315,7 +316,11 @@ fn create_password(prompt: &str) -> dialoguer::Result<String> {
 
 /// Generates, prints and optionally writes to a file the administrator JWT
 /// token.
-fn handle_admin_token(opts: &CliOpts, keystore: &KeyStore) -> anyhow::Result<String> {
+fn handle_admin_token(
+    opts: &CliOpts,
+    config: &Config,
+    keystore: &KeyStore,
+) -> anyhow::Result<String> {
     let ki = keystore.get(JWT_IDENTIFIER)?;
     // Lotus admin tokens do not expire but Forest requires all JWT tokens to
     // have an expiration date. So we set the expiration date to 100 years in
@@ -327,6 +332,10 @@ fn handle_admin_token(opts: &CliOpts, keystore: &KeyStore) -> anyhow::Result<Str
         token_exp,
     )?;
     info!("Admin token: {token}");
+    let default_token_path = config.client.default_rpc_token_path();
+    if let Err(e) = std::fs::write(&default_token_path, &token) {
+        tracing::warn!("Failed to save the default admin token file: {e}");
+    }
     if let Some(path) = opts.save_token.as_ref() {
         if let Some(dir) = path.parent() {
             if !dir.is_dir() {

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -55,6 +55,22 @@ impl Client {
         if token.is_some() && base_url.set_password(token).is_err() {
             bail!("couldn't set override password")
         }
+        // Set default token if not provided
+        if token.is_none() && base_url.password().is_none() {
+            let client_config = crate::cli_shared::cli::Client::default();
+            let default_token_path = client_config.default_rpc_token_path();
+            if default_token_path.is_file() {
+                if let Ok(token) = std::fs::read_to_string(&default_token_path) {
+                    if base_url.set_password(Some(token.trim())).is_ok() {
+                        tracing::info!("Loaded the default RPC token");
+                    } else {
+                        tracing::warn!("Failed to set the default RPC token");
+                    }
+                } else {
+                    tracing::warn!("Failed to load the default token file");
+                }
+            }
+        }
         Ok(Self::from_url(base_url))
     }
     pub fn from_url(mut base_url: Url) -> Self {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- update daemon to save RPC token to {data_dir}/token by default, to align with Lotus
- update CLI to consume the default token

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/4745

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
