### PR TITLE
fix: allow same errors on `EthTraceFilter`

### DIFF
--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -1711,7 +1711,10 @@ fn eth_tests_with_tipset<DB: Blockstore>(store: &Arc<DB>, shared_tipset: &Tipset
                 ..Default::default()
             },))
             .unwrap(),
-        ),
+        )
+        // both nodes could fail on, e.g., "too many results, maximum supported is 500, try paginating
+        // requests with After and Count"
+        .policy_on_rejected(PolicyOnRejected::PassWithIdenticalError),
     ];
 
     for block in shared_tipset.block_headers() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Both implementations return the same result on a certain condition. It's the same error so it should not fail the workflow.
```
  | Filecoin.EthTraceFilter (4)                         | Rejected("too many results, maximum supported is 500, try paginating requests with After and Count")                                                                                                                                                        | Rejected("too many results, maximum supported is 500, try paginating requests with After and Count")                                                                                                                                                          |
```

Changes introduced in this pull request:

- allow same the tests to pass on same errors in `EthTraceFilter`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5651
Closes https://github.com/ChainSafe/forest/issues/5655

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
