### PR TITLE
fix: highlight #5652 in changelog breaking section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Breaking
 
+-[#5652](https://github.com/ChainSafe/forest/pull/5652) Remove `--detach` flag from `forest`. Checkout the [migration guide](https://github.com/ChainSafe/forest#detaching-forest-process)
+
 ### Added
 
 -[#5598](https://github.com/ChainSafe/forest/pull/5598) Add `forest-cli chain prune snap` command for garbage collecting the database with a new snapshot garbage collector.
@@ -42,8 +44,6 @@
 -[#5662](https://github.com/ChainSafe/forest/pull/5662) Print index size when applicable in `forest-tool archive info`.
 
 ### Removed
-
--[#5652](https://github.com/ChainSafe/forest/pull/5652) Remove `--detach` flag from `forest`. Checkout the [migration guide](https://github.com/ChainSafe/forest#detaching-forest-process)
 
 ### Fixed
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

              I'd add it to the section of breaking changes for visibility.

_Originally posted by @LesnyRumcajs in https://github.com/ChainSafe/forest/pull/5652#discussion_r2111337265_
            

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
