### PR TITLE
fix: ignore index size diagnostic in snapshot parity tests

### DIFF
--- a/scripts/tests/snapshot_parity/docker-compose.yml
+++ b/scripts/tests/snapshot_parity/docker-compose.yml
@@ -97,8 +97,8 @@ services:
       - |
         set -euxo pipefail
         pushd /data/exported
-        # Skip the CAR format line
-        forest-tool archive info forest.car.zst | tail -n +2 > forest.txt
+        # Skip the CAR format line and the "Index size" line (only present in Forest snapshots)
+        forest-tool archive info forest.car.zst | tail -n +2 | grep -v "Index size" > forest.txt
         cat forest.txt
         # Skip the CAR format line
         forest-tool archive info lotus.car | tail -n +2 > lotus.txt


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Forest snapshots have an extra field in the `forest-tool archive info <snapshot>` which fail the diff in tests. This PR ignores this field as it's a diagnostic and irrelevant to snapshots being the same.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5683

## Other information and links

```
2025-06-02T08:26:42.593663Z  INFO forest::rpc::client: Loaded the default RPC token
Network:       calibnet
Epoch:         2717494
State-roots:   2000
Messages sets: 2000
Root CIDs:     bafy2bzacedjftzntkviejiah7dulhoir2j5u6snnovahp256id4buah4jxeyk
               bafy2bzacecjl7c7km6lj3xmhdug7yjcsvtm4jvziosq6734sqeeeav5wipfp4
               bafy2bzaceclev76betba4b2gcblmkcqujkvdfc2f7dl57er2g35oros4vvimk
> Index size:    199.1 MiB
```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
