### PR TITLE
fix(security): owner-only access admin token

### DIFF
--- a/src/daemon/context.rs
+++ b/src/daemon/context.rs
@@ -334,7 +334,9 @@ fn handle_admin_token(
     )?;
     info!("Admin token: {token}");
     let default_token_path = config.client.default_rpc_token_path();
-    if let Err(e) = std::fs::write(&default_token_path, &token) {
+    if let Err(e) =
+        crate::utils::io::write_new_sensitive_file(token.as_bytes(), &default_token_path)
+    {
         tracing::warn!("Failed to save the default admin token file: {e}");
     }
     if let Some(path) = opts.save_token.as_ref() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- This fixes a potential issue where non-owners of the JWT token could read it up. Likely not a huge deal unless someone customized their `data_dir` to be outside their home directory (which should have proper checks anyway).

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
