### PR TITLE
fix(gc): run GC scheduler after snapshot being imported

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -574,12 +574,11 @@ pub(super) async fn start_services(
     opts: &CliOpts,
     mut config: Config,
     shutdown_send: mpsc::Sender<()>,
-    on_app_context_initialized: impl Fn(&AppContext),
+    on_app_context_and_db_initialized: impl Fn(&AppContext),
 ) -> anyhow::Result<()> {
     let mut services = JoinSet::new();
     maybe_start_track_peak_rss_service(&mut services, opts);
     let ctx = AppContext::init(opts, &config).await?;
-    on_app_context_initialized(&ctx);
     info!(
         "Using network :: {}",
         get_actual_chain_name(&ctx.network_name)
@@ -613,6 +612,7 @@ pub(super) async fn start_services(
         services.shutdown().await;
         return Ok(());
     }
+    on_app_context_and_db_initialized(&ctx);
     ctx.state_manager.populate_cache();
     maybe_start_metrics_service(&mut services, &config, &ctx).await?;
     // maybe_start_mark_and_sweep_gc_service(&mut services, opts, &config, &ctx);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes an issue that GC is triggered right after snapshot is imported

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
