### PR TITLE
chore: use monotonic clock where applicable

### DIFF
--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -28,7 +28,7 @@ use fvm_ipld_blockstore::Blockstore;
 use itertools::Itertools;
 use libp2p::PeerId;
 use parking_lot::Mutex;
-use std::time::SystemTime;
+use std::time::Instant;
 use std::{ops::Deref as _, sync::Arc};
 use tokio::{sync::Notify, task::JoinSet};
 use tracing::{debug, error, info, trace, warn};
@@ -402,9 +402,7 @@ async fn handle_peer_connected_event<DB: Blockstore + Sync + Send + 'static>(
                 return;
             }
         };
-        let dur = SystemTime::now()
-            .duration_since(moment_sent)
-            .unwrap_or_default();
+        let dur = Instant::now().duration_since(moment_sent);
 
         // Update the peer metadata based on the response
         match response {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

I noticed we use quite extensively SystemTime and not Instant.  There is a subtle difference between them.

```
/// Distinct from the [Instant] type, this time measurement **is not
/// monotonic**. This means that you can save a file to the file system, then
/// save another file to the file system, **and the second file has a
/// SystemTime measurement earlier than the first**. In other words, an
/// operation that happens after another operation in real time may have an
/// earlier SystemTime!
///
/// Consequently, comparing two SystemTime instances to learn about the
/// duration between them returns a [Result] instead of an infallible [Duration]
/// to indicate that this sort of time drift may happen and needs to be handled.
````

The time measurement there is infallible in such cases. It seems more correct in measuring elapsed time and making the system less prone to host clock changes (though if host is playing with time then it's still pretty much UB).

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
