### PR TITLE
chore: demote token loading log to debug

### DIFF
--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -64,7 +64,7 @@ impl Client {
             if default_token_path.is_file() {
                 if let Ok(token) = std::fs::read_to_string(&default_token_path) {
                     if base_url.set_password(Some(token.trim())).is_ok() {
-                        tracing::info!("Loaded the default RPC token");
+                        tracing::debug!("Loaded the default RPC token");
                     } else {
                         tracing::warn!("Failed to set the default RPC token");
                     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- it doesn't seem to be a very useful information outside of debugging and it might fail unit tests locally.

```
thread 'export_empty_archive' panicked at /home/rumcajs/.rustup/toolchains/1.87.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5:
Unexpected stderr, failed var == "Error: input not recognized as any kind of CAR data (.car, .car.zst, .forest.car)"
├── var: "2025-06-06T12:57:50.028448Z  INFO forest::rpc::client: Loaded the default RPC token\nError: input not recognized as any kind of CAR data (.car, .car.zst, .forest.car)\n\nStack backtrace:\n   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from\n   1: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual\n   2: forest::db::car::many::ManyCar<WriterT>::read_only_files\n   3: forest::db::car::many::ManyCar<WriterT>::with_read_only_files\n   4: <forest::db::car::many::ManyCar as core::convert::TryFrom<alloc::vec::Vec<std::path::PathBuf>>>::try_from\n   5: forest::tool::subcommands::archive_cmd::ArchiveCommands::run::{{closure}}\n   6: forest::tool::main::main::{{closure}}\n   7: <core::pin::Pin<P> as core::future::future::Future>::poll\n   8: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll\n   9: tokio::runtime::park::CachedParkThread::block_on::{{closure}}\n  10: tokio::runtime::park::CachedParkThread::block_on\n  11: tokio::runtime::context::blocking::BlockingRegionGuard::block_on\n  12: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}\n  13: tokio::runtime::context::runtime::enter_runtime\n  14: tokio::runtime::scheduler::multi_thread::MultiThread::block_on\n  15: tokio::runtime::runtime::Runtime::block_on_inner\n  16: tokio::runtime::runtime::Runtime::block_on\n  17: forest::tool::main::main\n  18: forest_tool::main\n  19: core::ops::function::FnOnce::call_once\n  20: std::sys::backtrace::__rust_begin_short_backtrace\n  21: std::rt::lang_start::{{closure}}\n  22: std::rt::lang_start_internal\n  23: std::rt::lang_start\n  24: main\n  25: __libc_start_call_main\n  26: __libc_start_main_impl\n  27: _start\n"
└── var as str: 2025-06-06T12:57:50.028448Z  INFO forest::rpc::client: Loaded the default RPC token
    Error: input not recognized as any kind of CAR data (.car, .car.zst, .forest.car)
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
