### PR TITLE
feat: mpool msg limits

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,11 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 filter = 'test(state_migration_actor_bundle)'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
+# This test checks the limitations of the message pool, which can take a while.
+[[profile.default.overrides]]
+filter = 'test(message_pool::msgpool::selection::test_selection::message_selection_trimming_msgs_two_senders)'
+slow-timeout = { period = "120s", terminate-after = 3 }
+
 # This test downloads bundles from the network, which can take a while.
 # It is only run on CI, so we can afford to be more patient.
 [[profile.default.overrides]]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,6 +18,11 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 filter = 'test(message_pool::msgpool::selection::test_selection::message_selection_trimming_msgs_two_senders)'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
+# This test checks the limitations of the message pool, which can take a while.
+[[profile.default.overrides]]
+filter = 'test(message_pool::msgpool::selection::test_selection::message_selection_trimming_msgs_two_senders_complex)'
+slow-timeout = { period = "120s", terminate-after = 3 }
+
 # This test downloads bundles from the network, which can take a while.
 # It is only run on CI, so we can afford to be more patient.
 [[profile.default.overrides]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
 
 - [#5750](https://github.com/ChainSafe/forest/pull/5750) Fix regression causing the `Filecoin.ChainNotify` RPC endpoint to be unreachable.
 
+- [#5730](https://github.com/ChainSafe/forest/issues/5730) Fixed various bugs in the mempool selection logic, including gas overpricing and incorrect message chain pruning. Additional logic was added to limit the number of messages in the block.
+
 ## Forest v0.27.0 "Whisperer in Darkness"
 
 This is a non-mandatory but highly recommended release for all node operators. It introduces a fix for the forest node

--- a/src/message_pool/msg_chain.rs
+++ b/src/message_pool/msg_chain.rs
@@ -203,7 +203,7 @@ impl Chains {
 
         while i >= 0
             && (chain_node.gas_limit > gas_limit
-                || (chain_node.gas_perf < 0.0)
+                || chain_node.gas_perf < 0.0
                 || i >= msg_limit as i64)
         {
             #[allow(clippy::indexing_slicing)]
@@ -234,7 +234,7 @@ impl Chains {
             chain_node.msgs.clear();
             chain_node.valid = false;
         } else {
-            chain_node.msgs.drain(0..i as usize + 1);
+            chain_node.msgs.truncate(i as usize + 1);
         }
 
         let next = chain_node.next;

--- a/src/message_pool/msg_chain.rs
+++ b/src/message_pool/msg_chain.rs
@@ -335,14 +335,6 @@ impl MsgChainNode {
         self.eff_perf = eff_perf;
     }
 }
-/*
-    // move merged chains to the front so we can discard them earlier
-    return (mc.merged && !other.merged) ||
-        (mc.gasPerf >= 0 && other.gasPerf < 0) ||
-        mc.effPerf > other.effPerf ||
-        (mc.effPerf == other.effPerf && mc.gasPerf > other.gasPerf) ||
-        (mc.effPerf == other.effPerf && mc.gasPerf == other.gasPerf && mc.gasReward.Cmp(other.gasReward) > 0)
-*/
 
 impl MsgChainNode {
     pub(in crate::message_pool) fn cmp_effective(&self, other: &Self) -> Ordering {

--- a/src/message_pool/msg_chain.rs
+++ b/src/message_pool/msg_chain.rs
@@ -21,7 +21,7 @@ use crate::{
 use ahash::HashMap;
 use num_traits::Zero;
 use slotmap::{SlotMap, new_key_type};
-use tracing::{debug, warn};
+use tracing::warn;
 
 use super::errors::Error;
 use crate::message_pool::{
@@ -208,13 +208,6 @@ impl Chains {
             #[allow(clippy::indexing_slicing)]
             let msg = &chain_node.msgs[i as usize];
             let gas_reward = get_gas_reward(msg, base_fee);
-            debug!(
-                "chain node gas reward: {}, gas_reward: {}, chain node gas limit: {}, gas limit: {}",
-                chain_node.gas_reward,
-                gas_reward,
-                chain_node.gas_limit,
-                msg.gas_limit()
-            );
             chain_node.gas_reward -= gas_reward;
             chain_node.gas_limit = chain_node.gas_limit.saturating_sub(msg.gas_limit());
             if chain_node.gas_limit > 0 {

--- a/src/message_pool/msg_chain.rs
+++ b/src/message_pool/msg_chain.rs
@@ -7,13 +7,16 @@ use std::{
     ops::{Index, IndexMut},
 };
 
-use crate::blocks::{BLOCK_MESSAGE_LIMIT, Tipset};
 use crate::message::{Message, SignedMessage};
 use crate::networks::ChainConfig;
 use crate::shim::{
     address::Address,
     econ::TokenAmount,
     gas::{Gas, price_list_by_network_version},
+};
+use crate::{
+    blocks::{BLOCK_MESSAGE_LIMIT, Tipset},
+    shim::crypto::SignatureType,
 };
 use ahash::HashMap;
 use fvm_ipld_encoding::to_vec;
@@ -327,6 +330,7 @@ pub struct MsgChainNode {
     pub merged: bool,
     pub next: Option<NodeKey>,
     pub prev: Option<NodeKey>,
+    pub sig_type: SignatureType,
 }
 
 impl MsgChainNode {

--- a/src/message_pool/msg_chain.rs
+++ b/src/message_pool/msg_chain.rs
@@ -19,7 +19,6 @@ use crate::{
     shim::crypto::SignatureType,
 };
 use ahash::HashMap;
-use fvm_ipld_encoding::to_vec;
 use num_traits::Zero;
 use slotmap::{SlotMap, new_key_type};
 use tracing::{debug, warn};
@@ -447,7 +446,7 @@ where
         let network_version = chain_config.network_version(ts.epoch());
 
         let min_gas = price_list_by_network_version(network_version)
-            .on_chain_message(to_vec(m)?.len())
+            .on_chain_message(m.chain_length()?)
             .total();
 
         if Gas::new(m.gas_limit()) < min_gas {

--- a/src/message_pool/msg_chain.rs
+++ b/src/message_pool/msg_chain.rs
@@ -473,7 +473,7 @@ where
     }
 
     // check we have a sane set of messages to construct the chains
-    let msgs = if i > skip {
+    let mut msgs = if i > skip {
         #[allow(clippy::indexing_slicing)]
         msgs[skip..i].to_vec()
     } else {
@@ -481,14 +481,12 @@ where
     };
 
     // if we have more messages from this sender than can fit in a block, drop the extra ones
-    let msgs = if msgs.len() > BLOCK_MESSAGE_LIMIT {
+    if msgs.len() > BLOCK_MESSAGE_LIMIT {
         warn!(
             "dropping {} messages from {actor} as they exceed the block message limit of {BLOCK_MESSAGE_LIMIT}",
             msgs.len() - BLOCK_MESSAGE_LIMIT,
         );
-        msgs[..BLOCK_MESSAGE_LIMIT].to_vec()
-    } else {
-        msgs
+        msgs.truncate(BLOCK_MESSAGE_LIMIT);
     };
 
     let mut cur_chain = MsgChainNode::default();

--- a/src/message_pool/msgpool/mod.rs
+++ b/src/message_pool/msgpool/mod.rs
@@ -186,7 +186,7 @@ where
 
         // we can't fit the current chain but there is gas to spare
         // trim it and push it down
-        chains.trim_msgs_at(i, gas_limit, REPUB_MSG_LIMIT as i64, &base_fee);
+        chains.trim_msgs_at(i, gas_limit, REPUB_MSG_LIMIT, &base_fee);
         let mut j = i;
         while j < chains.len() - 1 {
             #[allow(clippy::indexing_slicing)]
@@ -196,6 +196,10 @@ where
             chains.key_vec.swap(i, i + 1);
             j += 1;
         }
+    }
+
+    if msgs.len() > REPUB_MSG_LIMIT {
+        msgs.truncate(REPUB_MSG_LIMIT);
     }
 
     Ok(msgs)

--- a/src/message_pool/msgpool/mod.rs
+++ b/src/message_pool/msgpool/mod.rs
@@ -186,7 +186,7 @@ where
 
         // we can't fit the current chain but there is gas to spare
         // trim it and push it down
-        chains.trim_msgs_at(i, gas_limit, &base_fee);
+        chains.trim_msgs_at(i, gas_limit, REPUB_MSG_LIMIT as i64, &base_fee);
         let mut j = i;
         while j < chains.len() - 1 {
             #[allow(clippy::indexing_slicing)]

--- a/src/message_pool/msgpool/selection.rs
+++ b/src/message_pool/msgpool/selection.rs
@@ -85,13 +85,13 @@ impl SelectedMessages {
         self.gas_limit = self.gas_limit.saturating_sub(gas);
     }
 
-    /// Reduces the BLS limit by the specified amount. It ensures that the BLS limit does not
+    /// Reduces the BLS limit by the specified amount. It ensures that the BLS message limit does not
     /// go below zero (which would cause a panic).
     fn reduce_bls_limit(&mut self, bls: u64) {
         self.bls_limit = self.bls_limit.saturating_sub(bls);
     }
 
-    /// Reduces the Secp256k1 limit by the specified amount. It ensures that the Secp256k1 limit
+    /// Reduces the `Secp256k1` limit by the specified amount. It ensures that the `Secp256k1` message limit
     /// does not go below zero (which would cause a panic).
     fn reduce_secp_limit(&mut self, secp: u64) {
         self.secp_limit = self.secp_limit.saturating_sub(secp);

--- a/src/message_pool/msgpool/selection.rs
+++ b/src/message_pool/msgpool/selection.rs
@@ -73,9 +73,7 @@ impl SelectedMessages {
 
     /// Truncates the selected messages to the specified length.
     fn truncate(&mut self, len: usize) {
-        if len < self.msgs.len() {
-            self.msgs.truncate(len);
-        }
+        self.msgs.truncate(len);
     }
 
     /// Reduces the gas limit by the specified amount. It ensures that the gas limit does not

--- a/src/message_pool/msgpool/selection.rs
+++ b/src/message_pool/msgpool/selection.rs
@@ -1228,6 +1228,106 @@ mod test_selection {
     }
 
     #[tokio::test]
+    async fn message_selection_trimming_msgs_two_senders_complex() {
+        let mut joinset = JoinSet::new();
+        let mut mpool = make_test_mpool(&mut joinset);
+        let ts = mock_tipset(&mut mpool).await;
+        let api = mpool.api.clone();
+
+        let keystore_1 = KeyStore::new(KeyStoreConfig::Memory).unwrap();
+        let mut wallet_1 = Wallet::new(keystore_1);
+        let address_1 = wallet_1.generate_addr(SignatureType::Secp256k1).unwrap();
+
+        let keystore_2 = KeyStore::new(KeyStoreConfig::Memory).unwrap();
+        let mut wallet_2 = Wallet::new(keystore_2);
+        let address_2 = wallet_2.generate_addr(SignatureType::Bls).unwrap();
+
+        api.set_state_balance_raw(&address_1, TokenAmount::from_whole(1));
+        api.set_state_balance_raw(&address_2, TokenAmount::from_whole(1));
+
+        // create two almost max-length chains of equal value
+        let mut counter = 0;
+        for i in 0..CBOR_GEN_LIMIT {
+            counter += 1;
+            let msg = create_smsg(
+                &address_2,
+                &address_1,
+                &mut wallet_1,
+                i as u64,
+                300_000,
+                100,
+            );
+            mpool.add(msg).unwrap();
+            // higher has price, those should be preferred and fill the block up to
+            // the [`CBOR_GEN_LIMIT`] messages.
+            let msg = create_smsg(
+                &address_1,
+                &address_2,
+                &mut wallet_2,
+                i as u64,
+                300_000,
+                100,
+            );
+            mpool.add(msg).unwrap();
+        }
+
+        // address_1 8192th message is worth more than address_2 8192th message
+        let msg = create_smsg(
+            &address_2,
+            &address_1,
+            &mut wallet_1,
+            counter as u64,
+            300_000,
+            1000,
+        );
+        mpool.add(msg).unwrap();
+
+        let msg = create_smsg(
+            &address_1,
+            &address_2,
+            &mut wallet_2,
+            counter as u64,
+            300_000,
+            100,
+        );
+        mpool.add(msg).unwrap();
+
+        counter += 1;
+
+        // address 2 (uneselectable) message is worth so much!
+        let msg = create_smsg(
+            &address_2,
+            &address_1,
+            &mut wallet_1,
+            counter as u64,
+            400_000,
+            1_000_000,
+        );
+        mpool.add(msg).unwrap();
+
+        let msgs = mpool.select_messages(&ts, 1.0).unwrap();
+        // check that the gas limit is not exceeded
+        let m_gas_limit = msgs.iter().map(|m| m.gas_limit()).sum::<u64>();
+        assert!(
+            m_gas_limit <= BLOCK_GAS_LIMIT,
+            "Selected messages gas limit {m_gas_limit} exceeds block gas limit {BLOCK_GAS_LIMIT}",
+        );
+        // We should have taken the SECP chain from address_1.
+        let secps_len = msgs.iter().filter(|m| m.is_secp256k1()).count();
+        assert_eq!(
+            CBOR_GEN_LIMIT, secps_len,
+            "Expected {CBOR_GEN_LIMIT} secp messages, got {secps_len}."
+        );
+        // The remaining messages should be BLS messages.
+        assert_eq!(
+            msgs.len(),
+            BLOCK_MESSAGE_LIMIT,
+            "Expected {BLOCK_MESSAGE_LIMIT} messages, got {}",
+            msgs.len()
+        );
+    }
+
+    #[tokio::test]
     async fn message_selection_priority() {
         let db = MemoryDB::default();
 

--- a/src/message_pool/msgpool/selection.rs
+++ b/src/message_pool/msgpool/selection.rs
@@ -344,14 +344,6 @@ where
     }
 
     #[allow(clippy::indexing_slicing)]
-    #[tracing::instrument(
-        name = "select_messages_optimal",
-        skip(self, cur_ts, target_tipset),
-        fields(
-            target_tipset = %target_tipset.key(),
-            ticket_quality = %ticket_quality,
-        )
-    )]
     fn select_messages_optimal(
         &self,
         cur_ts: &Tipset,

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -39,7 +39,7 @@ pub mod mainnet;
 pub mod metrics;
 
 /// Newest network version for all networks
-pub const NEWEST_NETWORK_VERSION: NetworkVersion = NetworkVersion::V17;
+pub const NEWEST_NETWORK_VERSION: NetworkVersion = NetworkVersion::V25;
 
 const ENV_FOREST_BLOCK_DELAY_SECS: &str = "FOREST_BLOCK_DELAY_SECS";
 const ENV_FOREST_PROPAGATION_DELAY_SECS: &str = "FOREST_PROPAGATION_DELAY_SECS";


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Follow up of https://github.com/ChainSafe/forest/pull/5729.

Changes introduced in this pull request:

- added block message limits (same as in Lotus - 8192 per message type and 10000 globally),
- migrated some refactoring that was made in the Lotus around adding different message chains,
- fixed a few random bugs that I uncovered while implementing the above,
- optimal selection now doesn't fail to pack a block.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5730

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
