### PR TITLE
fix: flaky sleep in snapshot parity tests

### DIFF
--- a/scripts/tests/snapshot_parity/docker-compose.yml
+++ b/scripts/tests/snapshot_parity/docker-compose.yml
@@ -45,7 +45,7 @@ services:
           --rpc-address 0.0.0.0:${FOREST_RPC_PORT} \
           --import-snapshot $(ls /data/*.car.zst | tail -n 1) \
           --import-mode=symlink &
-        sleep 15
+        forest-cli wait api
         forest-cli sync wait
         forest-cli snapshot export -t=$(ls /data/*.car.zst | tail -n 1 | grep -Eo '[0-9]+' | tail -n 1) -d=${EXPORT_EPOCHS} -o /data/exported/forest.car.zst
         kill -KILL $!


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- this _probably_ fixes flaky snapshot parity tests; the `sleep 15` is a bit unreliable given it might take the node some more time to start accepting requests, depending on the GH worker resources and network conditions.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5759
Closes https://github.com/ChainSafe/forest/issues/5758

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
