### PR TITLE
chore: replace `once_cell` utils with std equivalents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,7 +3123,6 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "nunny",
- "once_cell",
  "openrpc-types",
  "parity-db",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,6 @@ num-rational = "0.4"
 num-traits = "0.2"
 num_cpus = "1"
 nunny = { version = "0.2", features = ["serde", "quickcheck", "schemars1"] }
-once_cell = "1"
 openrpc-types = "0.5"
 parity-db = { version = "0.5", default-features = false }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }

--- a/src/blocks/election_proof.rs
+++ b/src/blocks/election_proof.rs
@@ -8,8 +8,8 @@ use num::{
     BigInt, Integer,
     bigint::{ParseBigIntError, Sign},
 };
-use once_cell::sync::Lazy;
 use serde_tuple::{self, Deserialize_tuple, Serialize_tuple};
+use std::sync::LazyLock;
 
 const PRECISION: u64 = 256;
 const MAX_WIN_COUNT: i64 = 3 * BLOCKS_PER_EPOCH as i64;
@@ -25,7 +25,7 @@ fn parse(strings: &[&str]) -> Result<Vec<BigInt>, ParseBigIntError> {
         .collect()
 }
 
-static EXP_NUM_COEF: Lazy<Vec<BigInt>> = Lazy::new(|| {
+static EXP_NUM_COEF: LazyLock<Vec<BigInt>> = LazyLock::new(|| {
     parse(&[
         "-648770010757830093818553637600",
         "67469480939593786226847644286976",
@@ -38,7 +38,7 @@ static EXP_NUM_COEF: Lazy<Vec<BigInt>> = Lazy::new(|| {
     ])
     .unwrap()
 });
-static EXP_DENO_COEF: Lazy<Vec<BigInt>> = Lazy::new(|| {
+static EXP_DENO_COEF: LazyLock<Vec<BigInt>> = LazyLock::new(|| {
     parse(&[
         "1225524182432722209606361",
         "114095592300906098243859450",

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -1,8 +1,10 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::sync::Arc;
-use std::{fmt, sync::OnceLock};
+use std::{
+    fmt,
+    sync::{Arc, OnceLock},
+};
 
 use crate::cid_collections::SmallCidNonEmptyVec;
 use crate::networks::{calibnet, mainnet};
@@ -16,7 +18,6 @@ use fvm_ipld_encoding::CborStore;
 use itertools::Itertools as _;
 use num::BigInt;
 use nunny::{Vec as NonEmpty, vec as nonempty};
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::info;
@@ -145,7 +146,7 @@ pub struct Tipset {
     /// Sorted
     headers: NonEmpty<CachingBlockHeader>,
     // key is lazily initialized via `fn key()`.
-    key: OnceCell<TipsetKey>,
+    key: OnceLock<TipsetKey>,
 }
 
 impl From<RawBlockHeader> for Tipset {
@@ -164,7 +165,7 @@ impl From<CachingBlockHeader> for Tipset {
     fn from(value: CachingBlockHeader) -> Self {
         Self {
             headers: nonempty![value],
-            key: OnceCell::new(),
+            key: OnceLock::new(),
         }
     }
 }
@@ -238,7 +239,7 @@ impl Tipset {
 
         Ok(Self {
             headers,
-            key: OnceCell::new(),
+            key: OnceLock::new(),
         })
     }
 
@@ -448,7 +449,7 @@ impl Tipset {
 pub struct FullTipset {
     blocks: NonEmpty<Block>,
     // key is lazily initialized via `fn key()`.
-    key: OnceCell<TipsetKey>,
+    key: OnceLock<TipsetKey>,
 }
 
 impl std::hash::Hash for FullTipset {
@@ -462,7 +463,7 @@ impl From<Block> for FullTipset {
     fn from(block: Block) -> Self {
         FullTipset {
             blocks: nonempty![block],
-            key: OnceCell::new(),
+            key: OnceLock::new(),
         }
     }
 }
@@ -489,7 +490,7 @@ impl FullTipset {
 
         Ok(Self {
             blocks,
-            key: OnceCell::new(),
+            key: OnceLock::new(),
         })
     }
     /// Returns the first block of the tipset.

--- a/src/chain_sync/metrics.rs
+++ b/src/chain_sync/metrics.rs
@@ -1,13 +1,13 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use once_cell::sync::Lazy;
 use prometheus_client::{
     encoding::{EncodeLabelKey, EncodeLabelSet, EncodeLabelValue, LabelSetEncoder},
     metrics::{counter::Counter, family::Family, gauge::Gauge, histogram::Histogram},
 };
+use std::sync::LazyLock;
 
-pub static TIPSET_PROCESSING_TIME: Lazy<Histogram> = Lazy::new(|| {
+pub static TIPSET_PROCESSING_TIME: LazyLock<Histogram> = LazyLock::new(|| {
     let metric = crate::metrics::default_histogram();
     crate::metrics::default_registry().register(
         "tipset_processing_time",
@@ -16,7 +16,7 @@ pub static TIPSET_PROCESSING_TIME: Lazy<Histogram> = Lazy::new(|| {
     );
     metric
 });
-pub static BLOCK_VALIDATION_TIME: Lazy<Histogram> = Lazy::new(|| {
+pub static BLOCK_VALIDATION_TIME: LazyLock<Histogram> = LazyLock::new(|| {
     let metric = crate::metrics::default_histogram();
     crate::metrics::default_registry().register(
         "block_validation_time",
@@ -25,16 +25,17 @@ pub static BLOCK_VALIDATION_TIME: Lazy<Histogram> = Lazy::new(|| {
     );
     metric
 });
-pub static LIBP2P_MESSAGE_TOTAL: Lazy<Family<Libp2pMessageKindLabel, Counter>> = Lazy::new(|| {
-    let metric = Family::default();
-    crate::metrics::default_registry().register(
-        "libp2p_messsage_total",
-        "Total number of libp2p messages by type",
-        metric.clone(),
-    );
-    metric
-});
-pub static INVALID_TIPSET_TOTAL: Lazy<Counter> = Lazy::new(|| {
+pub static LIBP2P_MESSAGE_TOTAL: LazyLock<Family<Libp2pMessageKindLabel, Counter>> =
+    LazyLock::new(|| {
+        let metric = Family::default();
+        crate::metrics::default_registry().register(
+            "libp2p_messsage_total",
+            "Total number of libp2p messages by type",
+            metric.clone(),
+        );
+        metric
+    });
+pub static INVALID_TIPSET_TOTAL: LazyLock<Counter> = LazyLock::new(|| {
     let metric = Counter::default();
     crate::metrics::default_registry().register(
         "invalid_tipset_total",
@@ -43,7 +44,7 @@ pub static INVALID_TIPSET_TOTAL: Lazy<Counter> = Lazy::new(|| {
     );
     metric
 });
-pub static HEAD_EPOCH: Lazy<Gauge> = Lazy::new(|| {
+pub static HEAD_EPOCH: LazyLock<Gauge> = LazyLock::new(|| {
     let metric = Gauge::default();
     crate::metrics::default_registry().register(
         "head_epoch",

--- a/src/chain_sync/network_context.rs
+++ b/src/chain_sync/network_context.rs
@@ -5,7 +5,7 @@ use std::{
     convert::TryFrom,
     num::NonZeroU64,
     sync::{
-        Arc,
+        Arc, LazyLock,
         atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -28,7 +28,6 @@ use crate::{
 };
 use anyhow::Context as _;
 use fvm_ipld_blockstore::Blockstore;
-use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use std::future::Future;
 use tokio::sync::Semaphore;
@@ -38,8 +37,8 @@ use tracing::{debug, trace};
 /// Timeout milliseconds for response from an RPC request
 // This value is automatically adapted in the range of [5, 60] for different network conditions,
 // being decreased on success and increased on failure
-static CHAIN_EXCHANGE_TIMEOUT_MILLIS: Lazy<ExponentialAdaptiveValueProvider<u64>> =
-    Lazy::new(|| ExponentialAdaptiveValueProvider::new(5000, 2000, 60000, false));
+static CHAIN_EXCHANGE_TIMEOUT_MILLIS: LazyLock<ExponentialAdaptiveValueProvider<u64>> =
+    LazyLock::new(|| ExponentialAdaptiveValueProvider::new(5000, 2000, 60000, false));
 
 /// Maximum number of concurrent chain exchange request being sent to the
 /// network.

--- a/src/cli/subcommands/f3_cmd.rs
+++ b/src/cli/subcommands/f3_cmd.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod tests;
 
-use std::{borrow::Cow, time::Duration};
+use std::{borrow::Cow, sync::LazyLock, time::Duration};
 
 use crate::{
     blocks::TipsetKey,
@@ -24,7 +24,6 @@ use anyhow::Context as _;
 use cid::Cid;
 use clap::{Subcommand, ValueEnum};
 use itertools::Itertools as _;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 use tera::Tera;
@@ -33,7 +32,7 @@ const MANIFEST_TEMPLATE_NAME: &str = "manifest.tpl";
 const CERTIFICATE_TEMPLATE_NAME: &str = "certificate.tpl";
 const PROGRESS_TEMPLATE_NAME: &str = "progress.tpl";
 
-static TEMPLATES: Lazy<Tera> = Lazy::new(|| {
+static TEMPLATES: LazyLock<Tera> = LazyLock::new(|| {
     let mut tera = Tera::default();
     tera.add_raw_template(MANIFEST_TEMPLATE_NAME, include_str!("f3_cmd/manifest.tpl"))
         .unwrap();

--- a/src/daemon/bundle.rs
+++ b/src/daemon/bundle.rs
@@ -11,9 +11,9 @@ use ahash::HashSet;
 use cid::Cid;
 use directories::ProjectDirs;
 use futures::{TryStreamExt, stream::FuturesUnordered};
-use once_cell::sync::Lazy;
 use std::mem::discriminant;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use std::{io::Cursor, path::Path};
 use tracing::{info, warn};
 
@@ -77,7 +77,7 @@ pub async fn load_actor_bundles_from_path(
     Ok(())
 }
 
-pub static ACTOR_BUNDLE_CACHE_DIR: Lazy<PathBuf> = Lazy::new(|| {
+pub static ACTOR_BUNDLE_CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
     let project_dir = ProjectDirs::from("com", "ChainSafe", "Forest");
     project_dir
         .map(|d| d.cache_dir().to_path_buf())

--- a/src/db/car/plain.rs
+++ b/src/db/car/plain.rs
@@ -493,8 +493,8 @@ mod tests {
     };
     use futures::{TryStreamExt as _, executor::block_on};
     use fvm_ipld_blockstore::{Blockstore, MemoryBlockstore};
-    use once_cell::sync::Lazy;
     use std::io::Cursor;
+    use std::sync::LazyLock;
     use tokio::io::{AsyncBufRead, AsyncSeek, BufReader};
 
     #[test]
@@ -571,7 +571,8 @@ mod tests {
     }
 
     fn chain4_car() -> &'static [u8] {
-        static CAR: Lazy<Vec<u8>> = Lazy::new(|| zstd::decode_all(chain4_car_zst()).unwrap());
+        static CAR: LazyLock<Vec<u8>> =
+            LazyLock::new(|| zstd::decode_all(chain4_car_zst()).unwrap());
         CAR.as_slice()
     }
 
@@ -580,7 +581,8 @@ mod tests {
     }
 
     fn carv2_car() -> &'static [u8] {
-        static CAR: Lazy<Vec<u8>> = Lazy::new(|| zstd::decode_all(carv2_car_zst()).unwrap());
+        static CAR: LazyLock<Vec<u8>> =
+            LazyLock::new(|| zstd::decode_all(carv2_car_zst()).unwrap());
         CAR.as_slice()
     }
 }

--- a/src/db/migration/migration_map.rs
+++ b/src/db/migration/migration_map.rs
@@ -4,7 +4,7 @@
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 use crate::Config;
@@ -14,7 +14,6 @@ use anyhow::Context as _;
 use anyhow::bail;
 use itertools::Itertools;
 use multimap::MultiMap;
-use once_cell::sync::Lazy;
 use semver::Version;
 use tracing::debug;
 
@@ -133,7 +132,7 @@ type MigrationsMap = MultiMap<Version, (Version, Migrator)>;
 /// `<FROM version> -> <TO version> @ <Migrator object>`
 macro_rules! create_migrations {
     ($($from:literal -> $to:literal @ $migration:tt),* $(,)?) => {
-pub(super) static MIGRATIONS: Lazy<MigrationsMap> = Lazy::new(|| {
+pub(super) static MIGRATIONS: LazyLock<MigrationsMap> = LazyLock::new(|| {
     MigrationsMap::from_iter(
         [
             $((

--- a/src/libp2p/behaviour.rs
+++ b/src/libp2p/behaviour.rs
@@ -1,7 +1,10 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, LazyLock},
+};
 
 use super::{
     PeerManager,
@@ -32,7 +35,6 @@ use libp2p::{
     ping, request_response,
     swarm::NetworkBehaviour,
 };
-use once_cell::sync::Lazy;
 use tracing::info;
 
 /// Libp2p behavior for the Forest node. This handles all sub protocols needed
@@ -74,15 +76,17 @@ impl ForestBehaviour {
         peer_manager: Arc<PeerManager>,
     ) -> anyhow::Result<Self> {
         const MAX_ESTABLISHED_PER_PEER: u32 = 4;
-        static MAX_CONCURRENT_REQUEST_RESPONSE_STREAMS_PER_PEER: Lazy<usize> = Lazy::new(|| {
-            std::env::var("FOREST_MAX_CONCURRENT_REQUEST_RESPONSE_STREAMS_PER_PEER")
+        static MAX_CONCURRENT_REQUEST_RESPONSE_STREAMS_PER_PEER: LazyLock<usize> = LazyLock::new(
+            || {
+                std::env::var("FOREST_MAX_CONCURRENT_REQUEST_RESPONSE_STREAMS_PER_PEER")
                 .ok()
                 .map(|it|
                     it.parse::<NonZeroUsize>()
                         .expect("Failed to parse the `FOREST_MAX_CONCURRENT_REQUEST_RESPONSE_STREAMS_PER_PEER` environment variable value, a positive integer is expected.")
                         .get())
                 .unwrap_or(10)
-        });
+            },
+        );
 
         let max_concurrent_request_response_streams = (config.target_peer_count as usize)
             .saturating_mul(*MAX_CONCURRENT_REQUEST_RESPONSE_STREAMS_PER_PEER);

--- a/src/libp2p/metrics.rs
+++ b/src/libp2p/metrics.rs
@@ -1,10 +1,10 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use once_cell::sync::Lazy;
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
+use std::sync::LazyLock;
 
-pub static PEER_FAILURE_TOTAL: Lazy<Counter> = Lazy::new(|| {
+pub static PEER_FAILURE_TOTAL: LazyLock<Counter> = LazyLock::new(|| {
     let metric = Counter::default();
     crate::metrics::default_registry().register(
         "peer_failure_total",
@@ -14,7 +14,7 @@ pub static PEER_FAILURE_TOTAL: Lazy<Counter> = Lazy::new(|| {
     metric
 });
 
-pub static FULL_PEERS: Lazy<Gauge> = Lazy::new(|| {
+pub static FULL_PEERS: LazyLock<Gauge> = LazyLock::new(|| {
     let metric = Gauge::default();
     crate::metrics::default_registry().register(
         "full_peers",
@@ -24,7 +24,7 @@ pub static FULL_PEERS: Lazy<Gauge> = Lazy::new(|| {
     metric
 });
 
-pub static BAD_PEERS: Lazy<Gauge> = Lazy::new(|| {
+pub static BAD_PEERS: LazyLock<Gauge> = LazyLock::new(|| {
     let metric = Gauge::default();
     crate::metrics::default_registry().register(
         "bad_peers",

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -52,13 +52,13 @@ use crate::libp2p::{
 };
 
 pub(in crate::libp2p) mod metrics {
-    use once_cell::sync::Lazy;
     use prometheus_client::metrics::{family::Family, gauge::Gauge};
+    use std::sync::LazyLock;
 
     use crate::metrics::KindLabel;
 
-    pub static NETWORK_CONTAINER_CAPACITIES: Lazy<Family<KindLabel, Gauge>> = {
-        Lazy::new(|| {
+    pub static NETWORK_CONTAINER_CAPACITIES: LazyLock<Family<KindLabel, Gauge>> = {
+        LazyLock::new(|| {
             let metric = Family::default();
             crate::metrics::default_registry().register(
                 "network_container_capacities",

--- a/src/libp2p_bitswap/metrics.rs
+++ b/src/libp2p_bitswap/metrics.rs
@@ -1,13 +1,13 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use once_cell::sync::Lazy;
 use parking_lot::MappedRwLockReadGuard;
 use prometheus_client::{
     encoding::EncodeLabelSet,
     metrics::{counter::Counter, family::Family, gauge::Gauge, histogram::Histogram},
     registry::Registry,
 };
+use std::sync::LazyLock;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct TypeLabel {
@@ -20,9 +20,9 @@ impl TypeLabel {
     }
 }
 
-static MESSAGE_COUNTER: Lazy<Family<TypeLabel, Counter>> = Lazy::new(Default::default);
-static CONTAINER_CAPACITIES: Lazy<Family<TypeLabel, Gauge>> = Lazy::new(Default::default);
-pub(in crate::libp2p_bitswap) static GET_BLOCK_TIME: Lazy<Histogram> = Lazy::new(|| {
+static MESSAGE_COUNTER: LazyLock<Family<TypeLabel, Counter>> = LazyLock::new(Default::default);
+static CONTAINER_CAPACITIES: LazyLock<Family<TypeLabel, Gauge>> = LazyLock::new(Default::default);
+pub(in crate::libp2p_bitswap) static GET_BLOCK_TIME: LazyLock<Histogram> = LazyLock::new(|| {
     Histogram::new([
         0.1, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
     ])

--- a/src/message_pool/msgpool/metrics.rs
+++ b/src/message_pool/msgpool/metrics.rs
@@ -1,10 +1,10 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use once_cell::sync::Lazy;
 use prometheus_client::metrics::gauge::Gauge;
+use std::sync::LazyLock;
 
-pub static MPOOL_MESSAGE_TOTAL: Lazy<Gauge> = Lazy::new(|| {
+pub static MPOOL_MESSAGE_TOTAL: LazyLock<Gauge> = LazyLock::new(|| {
     let metric = Gauge::default();
     crate::metrics::default_registry().register(
         "mpool_message_total",

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -5,7 +5,6 @@ pub mod db;
 
 use crate::db::DBStatistics;
 use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
-use once_cell::sync::Lazy;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use prometheus_client::{
     encoding::EncodeLabelSet,
@@ -15,27 +14,27 @@ use prometheus_client::{
         histogram::{Histogram, exponential_buckets},
     },
 };
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::{path::PathBuf, time::Instant};
 use tokio::net::TcpListener;
 use tower_http::compression::CompressionLayer;
 use tracing::warn;
 
-static DEFAULT_REGISTRY: Lazy<RwLock<prometheus_client::registry::Registry>> =
-    Lazy::new(Default::default);
+static DEFAULT_REGISTRY: LazyLock<RwLock<prometheus_client::registry::Registry>> =
+    LazyLock::new(Default::default);
 
 pub fn default_registry<'a>() -> RwLockWriteGuard<'a, prometheus_client::registry::Registry> {
     DEFAULT_REGISTRY.write()
 }
 
-pub static LRU_CACHE_HIT: Lazy<Family<KindLabel, Counter>> = Lazy::new(|| {
+pub static LRU_CACHE_HIT: LazyLock<Family<KindLabel, Counter>> = LazyLock::new(|| {
     let metric = Family::default();
     DEFAULT_REGISTRY
         .write()
         .register("lru_cache_hit", "Stats of lru cache hit", metric.clone());
     metric
 });
-pub static LRU_CACHE_MISS: Lazy<Family<KindLabel, Counter>> = Lazy::new(|| {
+pub static LRU_CACHE_MISS: LazyLock<Family<KindLabel, Counter>> = LazyLock::new(|| {
     let metric = Family::default();
     DEFAULT_REGISTRY
         .write()
@@ -43,7 +42,7 @@ pub static LRU_CACHE_MISS: Lazy<Family<KindLabel, Counter>> = Lazy::new(|| {
     metric
 });
 
-pub static RPC_METHOD_FAILURE: Lazy<Family<RpcMethodLabel, Counter>> = Lazy::new(|| {
+pub static RPC_METHOD_FAILURE: LazyLock<Family<RpcMethodLabel, Counter>> = LazyLock::new(|| {
     let metric = Family::default();
     DEFAULT_REGISTRY.write().register(
         "rpc_method_failure",
@@ -53,7 +52,7 @@ pub static RPC_METHOD_FAILURE: Lazy<Family<RpcMethodLabel, Counter>> = Lazy::new
     metric
 });
 
-pub static RPC_METHOD_TIME: Lazy<Family<RpcMethodLabel, Histogram>> = Lazy::new(|| {
+pub static RPC_METHOD_TIME: LazyLock<Family<RpcMethodLabel, Histogram>> = LazyLock::new(|| {
     let metric = Family::<RpcMethodLabel, Histogram>::new_with_constructor(|| {
         // Histogram with 5 buckets starting from 0.1ms going to 1s, each bucket 10 times as big as the last.
         Histogram::new(exponential_buckets(0.1, 10., 5))

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -3,6 +3,7 @@
 
 use std::io::{self, Cursor};
 use std::path::Path;
+use std::sync::LazyLock;
 
 use ahash::HashMap;
 use anyhow::ensure;
@@ -13,7 +14,6 @@ use futures::{StreamExt, TryStreamExt, stream};
 use fvm_ipld_blockstore::MemoryBlockstore;
 use itertools::Itertools;
 use nunny::Vec as NonEmpty;
-use once_cell::sync::Lazy;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
@@ -69,7 +69,7 @@ macro_rules! actor_bundle_info {
     }
 }
 
-pub static ACTOR_BUNDLES: Lazy<Box<[ActorBundleInfo]>> = Lazy::new(|| {
+pub static ACTOR_BUNDLES: LazyLock<Box<[ActorBundleInfo]>> = LazyLock::new(|| {
     Box::new(actor_bundle_info![
         "bafy2bzacedrdn6z3z7xz7lx4wll3tlgktirhllzqxb766dxpaqp3ukxsjfsba" @ "8.0.0-rc.1" for "calibrationnet",
         "bafy2bzacedbedgynklc4dgpyxippkxmba2mgtw7ecntoneclsvvl4klqwuyyy" @ "v9.0.3" for "calibrationnet",
@@ -129,7 +129,7 @@ impl ActorBundleMetadata {
 
 type ActorBundleMetadataMap = HashMap<(NetworkChain, String), ActorBundleMetadata>;
 
-pub static ACTOR_BUNDLES_METADATA: Lazy<ActorBundleMetadataMap> = Lazy::new(|| {
+pub static ACTOR_BUNDLES_METADATA: LazyLock<ActorBundleMetadataMap> = LazyLock::new(|| {
     let json: &str = include_str!("../../build/manifest.json");
     let metadata_vec: Vec<ActorBundleMetadata> =
         serde_json::from_str(json).expect("invalid manifest");

--- a/src/networks/butterflynet/mod.rs
+++ b/src/networks/butterflynet/mod.rs
@@ -4,8 +4,8 @@
 use ahash::HashMap;
 use cid::Cid;
 use libp2p::Multiaddr;
-use once_cell::sync::Lazy;
 use std::str::FromStr;
+use std::sync::LazyLock;
 use url::Url;
 
 use crate::{
@@ -45,12 +45,12 @@ pub async fn fetch_genesis<DB: SettingsStore>(db: &DB) -> anyhow::Result<Vec<u8>
 }
 
 /// Genesis CID
-pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| {
+pub static GENESIS_CID: LazyLock<Cid> = LazyLock::new(|| {
     Cid::from_str("bafy2bzacec4thmmboc5ye5lionzlyuvd4rfncggwdzrbbvqcepdrexny5qrx2").unwrap()
 });
 
 /// Compressed genesis file. It is compressed with zstd and cuts the download size by 80% (from 10 MB to 2 MB).
-static GENESIS_URL: Lazy<Url> = Lazy::new(|| {
+static GENESIS_URL: LazyLock<Url> = LazyLock::new(|| {
     "https://forest-snapshots.fra1.cdn.digitaloceanspaces.com/genesis/butterflynet-bafy2bzacec4thmmboc5ye5lionzlyuvd4rfncggwdzrbbvqcepdrexny5qrx2.car.zst"
         .parse()
         .expect("hard-coded URL must parse")
@@ -58,7 +58,7 @@ static GENESIS_URL: Lazy<Url> = Lazy::new(|| {
 
 /// Alternative URL for the genesis file. This is hosted on the `lotus` repository.
 /// `<https://github.com/filecoin-project/lotus/commit/c6068b60c526d44270bfc5d612045f0b27322dfb>`
-static GENESIS_URL_ALT: Lazy<Url> = Lazy::new(|| {
+static GENESIS_URL_ALT: LazyLock<Url> = LazyLock::new(|| {
     "https://github.com/filecoin-project/lotus/raw/c6068b60c526d44270bfc5d612045f0b27322dfb/build/genesis/butterflynet.car.zst".parse().expect("hard-coded URL must parse")
 });
 
@@ -67,8 +67,8 @@ pub(crate) const MINIMUM_VERIED_ALLOCATION: i64 = 1 << 20;
 pub(crate) const PRE_COMMIT_CHALLENGE_DELAY: i64 = 150;
 
 /// Default bootstrap peer ids.
-pub static DEFAULT_BOOTSTRAP: Lazy<Vec<Multiaddr>> =
-    Lazy::new(|| parse_bootstrap_peers(include_str!("../../../build/bootstrap/butterflynet")));
+pub static DEFAULT_BOOTSTRAP: LazyLock<Vec<Multiaddr>> =
+    LazyLock::new(|| parse_bootstrap_peers(include_str!("../../../build/bootstrap/butterflynet")));
 
 // https://github.com/ethereum-lists/chains/blob/4731f6713c6fc2bf2ae727388642954a6545b3a9/_data/chains/eip155-314159.json
 pub const ETH_CHAIN_ID: EthChainId = 3141592;
@@ -76,7 +76,7 @@ pub const ETH_CHAIN_ID: EthChainId = 3141592;
 pub const BREEZE_GAS_TAMPING_DURATION: i64 = 120;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
+pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|| {
     HashMap::from_iter([
         make_height!(Breeze, -50),
         make_height!(Smoke, -2),
@@ -118,7 +118,7 @@ fn get_bundle_cid(version: &str) -> Cid {
         .bundle_cid
 }
 
-pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 1]> = Lazy::new(|| {
+pub(super) static DRAND_SCHEDULE: LazyLock<[DrandPoint<'static>; 1]> = LazyLock::new(|| {
     [DrandPoint {
         height: 0,
         config: &DRAND_QUICKNET,

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -4,8 +4,8 @@
 use ahash::HashMap;
 use cid::Cid;
 use libp2p::Multiaddr;
-use once_cell::sync::Lazy;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use crate::{
     eth::EthChainId,
@@ -29,14 +29,14 @@ pub const NETWORK_GENESIS_NAME: &str = "calibrationnet";
 /// Default genesis car file bytes.
 pub const DEFAULT_GENESIS: &[u8] = include_bytes!("genesis.car");
 /// Genesis CID
-pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| {
+pub static GENESIS_CID: LazyLock<Cid> = LazyLock::new(|| {
     Cid::from_str("bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4").unwrap()
 });
 pub const GENESIS_NETWORK_VERSION: NetworkVersion = NetworkVersion::V0;
 
 /// Default bootstrap peer ids.
-pub static DEFAULT_BOOTSTRAP: Lazy<Vec<Multiaddr>> =
-    Lazy::new(|| parse_bootstrap_peers(include_str!("../../../build/bootstrap/calibnet")));
+pub static DEFAULT_BOOTSTRAP: LazyLock<Vec<Multiaddr>> =
+    LazyLock::new(|| parse_bootstrap_peers(include_str!("../../../build/bootstrap/calibnet")));
 
 const LIGHTNING_EPOCH: i64 = 489_094;
 
@@ -51,7 +51,7 @@ pub const ETH_CHAIN_ID: EthChainId = 314159;
 pub const BREEZE_GAS_TAMPING_DURATION: i64 = 120;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
+pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|| {
     HashMap::from_iter([
         make_height!(Breeze, -1),
         make_height!(Smoke, -2),
@@ -103,7 +103,7 @@ fn get_bundle_cid(version: &str) -> Cid {
         .bundle_cid
 }
 
-pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 2]> = Lazy::new(|| {
+pub(super) static DRAND_SCHEDULE: LazyLock<[DrandPoint<'static>; 2]> = LazyLock::new(|| {
     [
         DrandPoint {
             height: 0,

--- a/src/networks/devnet/mod.rs
+++ b/src/networks/devnet/mod.rs
@@ -3,7 +3,7 @@
 
 use ahash::HashMap;
 use cid::Cid;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use crate::{eth::EthChainId, make_height, shim::version::NetworkVersion};
 
@@ -17,7 +17,7 @@ pub const ETH_CHAIN_ID: EthChainId = 31415926;
 
 pub const BREEZE_GAS_TAMPING_DURATION: i64 = 0;
 
-pub static GENESIS_NETWORK_VERSION: Lazy<NetworkVersion> = Lazy::new(|| {
+pub static GENESIS_NETWORK_VERSION: LazyLock<NetworkVersion> = LazyLock::new(|| {
     if let Ok(version) = std::env::var("FOREST_GENESIS_NETWORK_VERSION") {
         NetworkVersion::from(
             version
@@ -32,7 +32,7 @@ pub static GENESIS_NETWORK_VERSION: Lazy<NetworkVersion> = Lazy::new(|| {
 /// Height epochs.
 /// Environment variable names follow
 /// <https://github.com/filecoin-project/lotus/blob/8f73f157933435f5020d7b8f23bee9e4ab71cb1c/build/params_2k.go#L108>
-pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
+pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|| {
     HashMap::from_iter([
         make_height!(
             Breeze,
@@ -174,7 +174,7 @@ fn get_bundle_cid(version: &str) -> Cid {
         .bundle_cid
 }
 
-pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 1]> = Lazy::new(|| {
+pub(super) static DRAND_SCHEDULE: LazyLock<[DrandPoint<'static>; 1]> = LazyLock::new(|| {
     [DrandPoint {
         height: 0,
         config: &DRAND_QUICKNET,

--- a/src/networks/drand.rs
+++ b/src/networks/drand.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::beacon::{ChainInfo, DrandConfig, DrandNetwork};
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
+use std::sync::LazyLock;
 
-pub(super) static DRAND_MAINNET: Lazy<DrandConfig<'static>> = Lazy::new(|| {
+pub(super) static DRAND_MAINNET: LazyLock<DrandConfig<'static>> = LazyLock::new(|| {
     let default = DrandConfig {
         // https://drand.love/developer/http-api/#public-endpoints
         servers: vec![
@@ -32,7 +32,7 @@ pub(super) static DRAND_MAINNET: Lazy<DrandConfig<'static>> = Lazy::new(|| {
     parse_drand_config_from_env_var("FOREST_DRAND_MAINNET_CONFIG").unwrap_or(default)
 });
 
-pub(super) static DRAND_QUICKNET: Lazy<DrandConfig<'static>> = Lazy::new(|| {
+pub(super) static DRAND_QUICKNET: LazyLock<DrandConfig<'static>> = LazyLock::new(|| {
     let default = DrandConfig {
         // https://drand.love/developer/http-api/#public-endpoints
         servers: vec![
@@ -59,7 +59,7 @@ pub(super) static DRAND_QUICKNET: Lazy<DrandConfig<'static>> = Lazy::new(|| {
     parse_drand_config_from_env_var("FOREST_DRAND_QUICKNET_CONFIG").unwrap_or(default)
 });
 
-pub(super) static DRAND_INCENTINET: Lazy<DrandConfig<'static>> = Lazy::new(|| {
+pub(super) static DRAND_INCENTINET: LazyLock<DrandConfig<'static>> = LazyLock::new(|| {
     let default = DrandConfig {
         // Note: This URL is no longer valid.
         // See <https://github.com/filecoin-project/lotus/pull/10476/files> and its related issues

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -12,8 +12,8 @@ use crate::{
 use ahash::HashMap;
 use cid::Cid;
 use libp2p::Multiaddr;
-use once_cell::sync::Lazy;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use super::{
     DrandPoint, Height, HeightInfo, NetworkChain,
@@ -33,13 +33,13 @@ pub const NETWORK_GENESIS_NAME: &str = "testnetnet";
 /// Default genesis car file bytes.
 pub const DEFAULT_GENESIS: &[u8] = include_bytes!("genesis.car");
 /// Genesis CID
-pub static GENESIS_CID: Lazy<Cid> = Lazy::new(|| {
+pub static GENESIS_CID: LazyLock<Cid> = LazyLock::new(|| {
     Cid::from_str("bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2").unwrap()
 });
 pub const GENESIS_NETWORK_VERSION: NetworkVersion = NetworkVersion::V0;
 
-pub static DEFAULT_BOOTSTRAP: Lazy<Vec<Multiaddr>> =
-    Lazy::new(|| parse_bootstrap_peers(include_str!("../../../build/bootstrap/mainnet")));
+pub static DEFAULT_BOOTSTRAP: LazyLock<Vec<Multiaddr>> =
+    LazyLock::new(|| parse_bootstrap_peers(include_str!("../../../build/bootstrap/mainnet")));
 
 // The rollover period is the duration between nv19 and nv20 which both old
 // proofs (v1) and the new proofs (v1_1) proofs will be accepted by the
@@ -52,7 +52,7 @@ pub const ETH_CHAIN_ID: EthChainId = 314;
 pub const BREEZE_GAS_TAMPING_DURATION: i64 = 120;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: Lazy<HashMap<Height, HeightInfo>> = Lazy::new(|| {
+pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|| {
     HashMap::from_iter([
         make_height!(Breeze, 41_280),
         make_height!(Smoke, SMOKE_HEIGHT),
@@ -100,7 +100,7 @@ fn get_bundle_cid(version: &str) -> Cid {
         .bundle_cid
 }
 
-pub(super) static DRAND_SCHEDULE: Lazy<[DrandPoint<'static>; 3]> = Lazy::new(|| {
+pub(super) static DRAND_SCHEDULE: LazyLock<[DrandPoint<'static>; 3]> = LazyLock::new(|| {
     [
         DrandPoint {
             height: 0,

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use ahash::HashMap;
 use cid::Cid;
 use fil_actors_shared::v13::runtime::Policy;
 use itertools::Itertools;
 use libp2p::Multiaddr;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 use tracing::warn;
@@ -49,7 +49,8 @@ const ENV_FOREST_BLOCK_DELAY_SECS: &str = "FOREST_BLOCK_DELAY_SECS";
 const ENV_FOREST_PROPAGATION_DELAY_SECS: &str = "FOREST_PROPAGATION_DELAY_SECS";
 const ENV_PLEDGE_RULE_RAMP: &str = "FOREST_PLEDGE_RULE_RAMP";
 
-static INITIAL_FIL_RESERVED: Lazy<TokenAmount> = Lazy::new(|| TokenAmount::from_whole(300_000_000));
+static INITIAL_FIL_RESERVED: LazyLock<TokenAmount> =
+    LazyLock::new(|| TokenAmount::from_whole(300_000_000));
 
 /// Forest builtin `filecoin` network chains. In general only `mainnet` and its
 /// chain information should be considered stable.
@@ -229,7 +230,7 @@ pub struct HeightInfo {
 #[derive(Clone)]
 struct DrandPoint<'a> {
     pub height: ChainEpoch,
-    pub config: &'a Lazy<DrandConfig<'a>>,
+    pub config: &'a LazyLock<DrandConfig<'a>>,
 }
 
 /// Defines all network configuration parameters.

--- a/src/rpc/auth_layer.rs
+++ b/src/rpc/auth_layer.rs
@@ -16,13 +16,12 @@ use jsonrpsee::core::middleware::{Batch, BatchEntry, BatchEntryErr, Notification
 use jsonrpsee::server::middleware::rpc::RpcServiceT;
 use jsonrpsee::types::Id;
 use jsonrpsee::types::{ErrorObject, error::ErrorCode};
-use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tower::Layer;
 use tracing::debug;
 
-static METHOD_NAME2REQUIRED_PERMISSION: Lazy<HashMap<&str, Permission>> = Lazy::new(|| {
+static METHOD_NAME2REQUIRED_PERMISSION: LazyLock<HashMap<&str, Permission>> = LazyLock::new(|| {
     let mut access = HashMap::new();
 
     macro_rules! insert {

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -11,6 +11,7 @@
 
 use std::env;
 use std::fmt::{self, Debug};
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use anyhow::{Context as _, bail};
@@ -21,7 +22,6 @@ use jsonrpsee::core::ClientError;
 use jsonrpsee::core::client::ClientT as _;
 use jsonrpsee::core::params::{ArrayParams, ObjectParams};
 use jsonrpsee::core::traits::ToRpcParams;
-use once_cell::sync::Lazy;
 use serde::de::DeserializeOwned;
 use tracing::{Instrument, Level, debug};
 use url::Url;
@@ -44,7 +44,7 @@ impl Client {
     ///
     /// If `token` is provided, use that over the token in either of the above.
     pub fn default_or_from_env(token: Option<&str>) -> anyhow::Result<Self> {
-        static DEFAULT: Lazy<Url> = Lazy::new(|| "http://127.0.0.1:2345/".parse().unwrap());
+        static DEFAULT: LazyLock<Url> = LazyLock::new(|| "http://127.0.0.1:2345/".parse().unwrap());
 
         let mut base_url = match env::var("FULLNODE_API_INFO") {
             Ok(it) => {

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -33,11 +33,14 @@ use ipld_core::ipld::Ipld;
 use jsonrpsee::types::Params;
 use jsonrpsee::types::error::ErrorObjectOwned;
 use num::BigInt;
-use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use std::{collections::VecDeque, path::PathBuf, sync::Arc};
+use std::{
+    collections::VecDeque,
+    path::PathBuf,
+    sync::{Arc, LazyLock},
+};
 use tokio::sync::{
     Mutex,
     broadcast::{self, Receiver as Subscriber},
@@ -242,7 +245,7 @@ impl RpcMethod<1> for ChainExport {
             dry_run,
         } = params;
 
-        static LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+        static LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
         let _locked = LOCK.try_lock();
         if _locked.is_err() {

--- a/src/rpc/methods/common.rs
+++ b/src/rpc/methods/common.rs
@@ -6,13 +6,13 @@ use crate::rpc::error::ServerError;
 use crate::rpc::{ApiPaths, Ctx, Permission, RpcMethod};
 use enumflags2::BitFlags;
 use fvm_ipld_blockstore::Blockstore;
-use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
+use std::sync::LazyLock;
 use uuid::Uuid;
 
-static SESSION_UUID: Lazy<Uuid> = Lazy::new(crate::utils::rand::new_uuid_v4);
+static SESSION_UUID: LazyLock<Uuid> = LazyLock::new(crate::utils::rand::new_uuid_v4);
 
 /// The returned session UUID uniquely identifies the API node.
 pub enum Session {}

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -65,17 +65,16 @@ use fvm_ipld_encoding::{CBOR, DAG_CBOR, IPLD_RAW, RawBytes};
 use ipld_core::ipld::Ipld;
 use itertools::Itertools;
 use num::{BigInt, Zero as _};
-use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tracing::log;
 use utils::{decode_payload, lookup_eth_address};
 
-static FOREST_TRACE_FILTER_MAX_RESULT: Lazy<u64> =
-    Lazy::new(|| env_or_default("FOREST_TRACE_FILTER_MAX_RESULT", 500));
+static FOREST_TRACE_FILTER_MAX_RESULT: LazyLock<u64> =
+    LazyLock::new(|| env_or_default("FOREST_TRACE_FILTER_MAX_RESULT", 500));
 
 const MASKED_ID_PREFIX: [u8; 12] = [0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 

--- a/src/rpc/methods/eth/utils.rs
+++ b/src/rpc/methods/eth/utils.rs
@@ -14,8 +14,8 @@ use cbor4ii::core::Value;
 use cbor4ii::core::dec::Decode as _;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::{CBOR, DAG_CBOR, IPLD_RAW, RawBytes};
-use once_cell::sync::Lazy;
 use serde::de;
+use std::sync::LazyLock;
 use tracing::log;
 
 pub fn lookup_eth_address<DB: Blockstore>(
@@ -121,7 +121,7 @@ const ERROR_FUNCTION_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0]; // keccak256(
 const PANIC_FUNCTION_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71]; // keccak256("Panic(uint256)") [first 4 bytes]
 
 // Lazily initialized HashMap for panic codes
-static PANIC_ERROR_CODES: Lazy<HashMap<u64, &'static str>> = Lazy::new(|| {
+static PANIC_ERROR_CODES: LazyLock<HashMap<u64, &'static str>> = LazyLock::new(|| {
     let mut m = HashMap::new();
     m.insert(0x00, "Panic()");
     m.insert(0x01, "Assert()");

--- a/src/rpc/methods/f3.rs
+++ b/src/rpc/methods/f3.rs
@@ -52,12 +52,15 @@ use jsonrpsee::core::{client::ClientT as _, params::ArrayParams};
 use libp2p::PeerId;
 use lru::LruCache;
 use num::Signed as _;
-use once_cell::sync::Lazy;
-use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
-use std::{borrow::Cow, fmt::Display, str::FromStr as _, sync::Arc};
+use std::{
+    borrow::Cow,
+    fmt::Display,
+    str::FromStr as _,
+    sync::{Arc, LazyLock, OnceLock},
+};
 
-pub static F3_LEASE_MANAGER: OnceCell<F3LeaseManager> = OnceCell::new();
+pub static F3_LEASE_MANAGER: OnceLock<F3LeaseManager> = OnceLock::new();
 
 pub enum GetRawNetworkName {}
 
@@ -163,7 +166,7 @@ impl GetPowerTable {
     ) -> anyhow::Result<Vec<F3PowerEntry>> {
         // The RAM overhead on mainnet is ~14MiB
         const BLOCKSTORE_CACHE_CAP: usize = 65536;
-        static BLOCKSTORE_CACHE: Lazy<Arc<LruBlockstoreReadCache>> = Lazy::new(|| {
+        static BLOCKSTORE_CACHE: LazyLock<Arc<LruBlockstoreReadCache>> = LazyLock::new(|| {
             Arc::new(LruBlockstoreReadCache::new(
                 BLOCKSTORE_CACHE_CAP.try_into().expect("Infallible"),
             ))
@@ -469,8 +472,8 @@ impl RpcMethod<1> for GetPowerTable {
         ctx: Ctx<impl Blockstore + Send + Sync + 'static>,
         (f3_tsk,): Self::Params,
     ) -> Result<Self::Ok, ServerError> {
-        static CACHE: Lazy<tokio::sync::Mutex<LruCache<TipsetKey, Vec<F3PowerEntry>>>> =
-            Lazy::new(|| {
+        static CACHE: LazyLock<tokio::sync::Mutex<LruCache<TipsetKey, Vec<F3PowerEntry>>>> =
+            LazyLock::new(|| {
                 tokio::sync::Mutex::new(LruCache::new(32.try_into().expect("Infallible")))
             });
         let tsk = f3_tsk.try_into()?;

--- a/src/rpc/methods/f3/types.rs
+++ b/src/rpc/methods/f3/types.rs
@@ -18,11 +18,11 @@ use fvm_shared4::ActorID;
 use itertools::Itertools as _;
 use libp2p::PeerId;
 use num::Zero as _;
-use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 use std::io::Read as _;
+use std::sync::LazyLock;
 use std::{cmp::Ordering, time::Duration};
 
 const MAX_LEASE_INSTANCES: u64 = 5;
@@ -53,7 +53,7 @@ impl TryFrom<F3TipSetKey> for TipsetKey {
     type Error = anyhow::Error;
 
     fn try_from(tsk: F3TipSetKey) -> Result<Self, Self::Error> {
-        static BLOCK_HEADER_CID_LEN: Lazy<usize> = Lazy::new(|| {
+        static BLOCK_HEADER_CID_LEN: LazyLock<usize> = LazyLock::new(|| {
             let buf = [0_u8; 256];
             let cid = Cid::new_v1(
                 fvm_ipld_encoding::DAG_CBOR,

--- a/src/rpc/methods/f3/util.rs
+++ b/src/rpc/methods/f3/util.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use super::*;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 const F3_PERMANENT_PARTICIPATING_MINER_IDS_ENV_KEY: &str =
     "FOREST_F3_PERMANENT_PARTICIPATING_MINER_ADDRESSES";
 
-pub static F3_PERMANENT_PARTICIPATING_MINER_IDS: Lazy<Option<HashSet<u64>>> =
-    Lazy::new(get_f3_permanent_participating_miner_ids);
+pub static F3_PERMANENT_PARTICIPATING_MINER_IDS: LazyLock<Option<HashSet<u64>>> =
+    LazyLock::new(get_f3_permanent_participating_miner_ids);
 
 /// loads f3 permanent participating miner IDs.
 /// Note that this environment variable should only be used for testing purpose.

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -410,11 +410,10 @@ use jsonrpsee::{
     core::middleware::RpcServiceBuilder,
     server::{RpcModule, Server, StopHandle, TowerServiceBuilder, stop_channel},
 };
-use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use std::env;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tower::Service;
@@ -425,7 +424,7 @@ use openrpc_types::{self, ParamStructure};
 pub const DEFAULT_PORT: u16 = 2345;
 
 /// Request timeout read from environment variables
-static DEFAULT_REQUEST_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
+static DEFAULT_REQUEST_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
     env::var("FOREST_RPC_DEFAULT_TIMEOUT")
         .ok()
         .and_then(|it| Duration::from_secs(it.parse().ok()?).into())

--- a/src/rpc/registry/actors_reg.rs
+++ b/src/rpc/registry/actors_reg.rs
@@ -14,8 +14,8 @@ use ahash::{HashMap, HashMapExt};
 use anyhow::{Context, Result, anyhow};
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use once_cell::sync::Lazy;
 use serde_json::Value;
+use std::sync::LazyLock;
 
 #[derive(Debug)]
 pub struct ActorRegistry {
@@ -48,7 +48,7 @@ impl ActorRegistry {
     }
 }
 
-pub(crate) static ACTOR_REGISTRY: Lazy<ActorRegistry> = Lazy::new(ActorRegistry::new);
+pub(crate) static ACTOR_REGISTRY: LazyLock<ActorRegistry> = LazyLock::new(ActorRegistry::new);
 
 pub fn get_actor_type_from_code(code_cid: &Cid) -> Result<(BuiltinActor, u64)> {
     ACTOR_REGISTRY

--- a/src/rpc/registry/methods_reg.rs
+++ b/src/rpc/registry/methods_reg.rs
@@ -7,14 +7,15 @@ use crate::shim::message::MethodNum;
 use ahash::{HashMap, HashMapExt};
 use anyhow::{Context, Result, bail};
 use cid::Cid;
-use once_cell::sync::Lazy;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use std::sync::LazyLock;
 
 use crate::rpc::registry::actors_reg::{ACTOR_REGISTRY, get_actor_type_from_code};
 
 // Global registry for method parameter deserialization
-static METHOD_REGISTRY: Lazy<MethodRegistry> = Lazy::new(MethodRegistry::with_known_methods);
+static METHOD_REGISTRY: LazyLock<MethodRegistry> =
+    LazyLock::new(MethodRegistry::with_known_methods);
 
 type ParamDeserializerFn = Box<dyn Fn(&[u8]) -> Result<Value> + Send + Sync>;
 

--- a/src/shim/actors/version.rs
+++ b/src/shim/actors/version.rs
@@ -3,14 +3,14 @@
 use crate::utils::multihash::prelude::*;
 use cid::Cid;
 use fil_actors_shared::v11::runtime::builtins::Type;
-use once_cell::sync::Lazy;
 use paste::paste;
+use std::sync::LazyLock;
 
 macro_rules! impl_actor_cids_type_actor {
     ($($actor_type:ident, $actor:ident),*) => {
         $(
 paste! {
-static [<$actor:upper _ACTOR_CIDS>]: Lazy<Vec<(u64, Cid)>> = Lazy::new(|| {
+static [<$actor:upper _ACTOR_CIDS>]: LazyLock<Vec<(u64, Cid)>> = LazyLock::new(|| {
     let mut actors: Vec<_> = crate::networks::ACTOR_BUNDLES_METADATA
         .values()
         .filter_map(|bundle| {

--- a/src/shim/address.rs
+++ b/src/shim/address.rs
@@ -16,15 +16,17 @@ use fvm_shared4::address::Address as Address_latest;
 pub use fvm_shared4::address::{Error, Network, PAYLOAD_HASH_LEN, Payload, Protocol};
 use integer_encoding::VarInt;
 use num_traits::FromPrimitive;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{
+    LazyLock,
+    atomic::{AtomicU8, Ordering},
+};
 
 /// Zero address used to avoid allowing it to be used for verification.
 /// This is intentionally disallowed because it is an edge case with Filecoin's BLS
 /// signature verification.
 // Copied from ref-fvm due to a bug in their definition.
-pub static ZERO_ADDRESS: Lazy<Address> = Lazy::new(|| {
+pub static ZERO_ADDRESS: LazyLock<Address> = LazyLock::new(|| {
     Network::Mainnet
         .parse_address(
             "f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a",

--- a/src/shim/econ.rs
+++ b/src/shim/econ.rs
@@ -4,6 +4,7 @@
 use std::{
     fmt,
     ops::{Add, AddAssign, Deref, DerefMut, Mul, MulAssign, Sub, SubAssign},
+    sync::LazyLock,
 };
 
 use super::fvm_shared_latest::econ::TokenAmount as TokenAmount_latest;
@@ -13,7 +14,6 @@ pub use fvm_shared3::{BLOCK_GAS_LIMIT, TOTAL_FILECOIN_BASE};
 use fvm_shared4::econ::TokenAmount as TokenAmount_v4;
 use num_bigint::BigInt;
 use num_traits::Zero;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use static_assertions::const_assert_eq;
 
@@ -21,8 +21,8 @@ const_assert_eq!(BLOCK_GAS_LIMIT, fvm_shared2::BLOCK_GAS_LIMIT as u64);
 const_assert_eq!(TOTAL_FILECOIN_BASE, fvm_shared2::TOTAL_FILECOIN_BASE);
 
 /// Total Filecoin available to the network.
-pub static TOTAL_FILECOIN: Lazy<TokenAmount> =
-    Lazy::new(|| TokenAmount::from_whole(TOTAL_FILECOIN_BASE));
+pub static TOTAL_FILECOIN: LazyLock<TokenAmount> =
+    LazyLock::new(|| TokenAmount::from_whole(TOTAL_FILECOIN_BASE));
 
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize, Default)]
 #[serde(transparent)]

--- a/src/shim/machine/mod.rs
+++ b/src/shim/machine/mod.rs
@@ -7,10 +7,9 @@ pub use manifest::{BuiltinActor, BuiltinActorManifest};
 use fvm2::machine::MultiEngine as MultiEngine_v2;
 use fvm3::engine::MultiEngine as MultiEngine_v3;
 use fvm4::engine::MultiEngine as MultiEngine_v4;
-use once_cell::sync::Lazy;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
-pub static GLOBAL_MULTI_ENGINE: Lazy<Arc<MultiEngine>> = Lazy::new(Default::default);
+pub static GLOBAL_MULTI_ENGINE: LazyLock<Arc<MultiEngine>> = LazyLock::new(Default::default);
 
 pub struct MultiEngine {
     pub v2: MultiEngine_v2,

--- a/src/state_migration/nv17/datacap.rs
+++ b/src/state_migration/nv17/datacap.rs
@@ -4,8 +4,6 @@
 //! This module contains the migration logic for the `NV17` upgrade for the `datacap`
 //! actor.
 
-use std::str::FromStr;
-
 use crate::shim::address::Address;
 use crate::shim::bigint::BigInt;
 use crate::shim::state_tree::{ActorState, StateTree};
@@ -17,13 +15,14 @@ use fil_actors_shared::frc46_token::token::state::TokenState;
 use fil_actors_shared::fvm_ipld_hamt::BytesKey;
 use fvm_ipld_blockstore::Blockstore;
 use num_traits::Zero;
-use once_cell::sync::Lazy;
 use std::ops::Deref;
+use std::str::FromStr;
+use std::sync::LazyLock;
 
 use super::util::hamt_addr_key_to_key;
 
 const DATA_CAP_GRANULARITY: u64 = TokenAmount::PRECISION;
-static INFINITE_ALLOWANCE: Lazy<StoragePower> = Lazy::new(|| {
+static INFINITE_ALLOWANCE: LazyLock<StoragePower> = LazyLock::new(|| {
     StoragePower::from_str("1000000000000000000000").expect("Failed to parse INFINITE_ALLOWANCE")
         * TokenAmount::PRECISION
 });

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -52,14 +52,18 @@ use itertools::Itertools as _;
 use jsonrpsee::types::ErrorCode;
 use libp2p::PeerId;
 use num_traits::Signed;
-use once_cell::sync::Lazy;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use similar::{ChangeTag, TextDiff};
 use std::path::Path;
 use std::time::Instant;
-use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 use tokio::sync::Semaphore;
 use tracing::debug;
 
@@ -67,7 +71,7 @@ const COLLECTION_SAMPLE_SIZE: usize = 5;
 
 /// This address has been funded by the calibnet faucet and the private keys
 /// has been discarded. It should always have a non-zero balance.
-static KNOWN_CALIBNET_ADDRESS: Lazy<Address> = Lazy::new(|| {
+static KNOWN_CALIBNET_ADDRESS: LazyLock<Address> = LazyLock::new(|| {
     crate::shim::address::Network::Testnet
         .parse_address("t1c4dkec3qhrnrsa4mccy7qntkyq2hhsma4sq7lui")
         .unwrap()

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -8,10 +8,9 @@ use crate::utils::io::WithProgress;
 use crate::utils::reqwest_resume;
 use cid::Cid;
 use futures::{AsyncWriteExt, TryStreamExt};
-use once_cell::sync::Lazy;
 use reqwest::Response;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tap::Pipe;
 use tokio::io::AsyncBufRead;
 use tokio_util::{
@@ -22,7 +21,7 @@ use tracing::info;
 use url::Url;
 
 pub fn global_http_client() -> reqwest::Client {
-    static CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);
+    static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
     CLIENT.clone()
 }
 

--- a/src/utils/reqwest_resume/tests.rs
+++ b/src/utils/reqwest_resume/tests.rs
@@ -7,10 +7,10 @@ use axum::response::IntoResponse;
 use bytes::Bytes;
 use futures::stream;
 use http_range_header::parse_range_header;
-use once_cell::sync::Lazy;
 use rand::Rng;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::ops::Range;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio_stream::StreamExt as _;
@@ -18,7 +18,7 @@ use tokio_stream::StreamExt as _;
 const CHUNK_LEN: usize = 2048;
 // `RANDOM_BYTES` size is arbitrarily chosen. We could use something smaller or bigger here.
 // The only constraint is that `CHUNK_LEN < RANDOM_BYTES.len()`.
-static RANDOM_BYTES: Lazy<Bytes> = Lazy::new(|| {
+static RANDOM_BYTES: LazyLock<Bytes> = LazyLock::new(|| {
     let mut rng = crate::utils::rand::forest_rng();
     (0..8192).map(|_| rng.r#gen()).collect()
 });

--- a/src/utils/version/mod.rs
+++ b/src/utils/version/mod.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use git_version::git_version;
-use once_cell::sync::Lazy;
 use prometheus_client::{
     collector::Collector,
     encoding::{DescriptorEncoder, EncodeLabelSet, EncodeMetric},
     metrics::{family::Family, gauge::Gauge},
 };
+use std::sync::LazyLock;
 
 /// Current git commit hash of the Forest repository.
 pub const GIT_HASH: &str =
@@ -15,11 +15,11 @@ pub const GIT_HASH: &str =
 
 /// Current version of the Forest repository with git hash embedded
 /// E.g., `0.8.0+git.e69baf3e4`
-pub static FOREST_VERSION_STRING: Lazy<String> =
-    Lazy::new(|| format!("{}+git.{}", env!("CARGO_PKG_VERSION"), GIT_HASH));
+pub static FOREST_VERSION_STRING: LazyLock<String> =
+    LazyLock::new(|| format!("{}+git.{}", env!("CARGO_PKG_VERSION"), GIT_HASH));
 
-pub static FOREST_VERSION: Lazy<semver::Version> =
-    Lazy::new(|| semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Invalid version"));
+pub static FOREST_VERSION: LazyLock<semver::Version> =
+    LazyLock::new(|| semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Invalid version"));
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct VersionLabel {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR favors std APIs over external ones since

> Parts of once_cell API are included into std https://github.com/rust-lang/rust/pull/105587

Changes introduced in this pull request:

- replace `once_cell::sync::Lazy` with `std::sync::LazyLock`
- replace `once_cell::sync::OnceCell` with `std::sync::OnceLock`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
