### PR TITLE
fix: size calculation for zstd frame cache

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -43,3 +43,7 @@ reason = """use `crate::utils::new_uuid_v4` instead."""
 [[disallowed-methods]]
 path = "tempfile::NamedTempFile::new"
 reason = """The temporary files created by this method are not persistable if the temporary directory lives on a different filesystem than the target directory. While it is valid in other contexts (if not persisting files), it was misused many times and so we are banning it. Consider using `tempfile::NamedTempFile::new_in` or `tempfile::NamedTempFile::Builder"""
+
+[[disallowed-methods]]
+path = "lru::LruCache::unbounded"
+reason = """Avoid unbounded lru cache for potential memory leak"""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Added
 
+- [#5859](https://github.com/ChainSafe/forest/pull/5859) Added size metrics for zstd frame cache and made max size configurable via `FOREST_ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE` environment variable.
+
 ### Changed
 
 ### Removed
@@ -36,6 +38,8 @@
 ### Fixed
 
 - [#5863](https://github.com/ChainSafe/forest/pull/5863) Fixed needless GC runs on a stateless node.
+
+- [#5859](https://github.com/ChainSafe/forest/pull/5859) Fixed size calculation for zstd frame cache.
 
 ## Forest v0.28.0 "Denethor's Folly"
 

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -117,3 +117,4 @@ V0
 V1
 VPS
 WIP
+zstd

--- a/docs/docs/users/reference/env_variables.md
+++ b/docs/docs/users/reference/env_variables.md
@@ -49,7 +49,7 @@ process.
 | `FOREST_SNAPSHOT_GC_INTERVAL_EPOCHS`                      | non-negative integer             | 20160                                          | 8000                                                          | The interval in epochs for scheduling snapshot GC                                                                     |
 | `FOREST_SNAPSHOT_GC_CHECK_INTERVAL_SECONDS`               | non-negative integer             | 300                                            | 60                                                            | The interval in seconds for checking if snapshot GC should run                                                        |
 | `FOREST_DISABLE_BAD_BLOCK_CACHE`                          | 1 or true                        | empty                                          | 1                                                             | Whether or not to disable bad block cache                                                                             |
-| `FOREST_ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE`                | positive integer                 | 1073741824                                     | 536870912                                                     | The default zstd frame cache max size in bytes                                                                        |
+| `FOREST_ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE`                | positive integer                 | 268435456                                      | 536870912                                                     | The default zstd frame cache max size in bytes                                                                        |
 
 ### `FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT`
 

--- a/docs/docs/users/reference/env_variables.md
+++ b/docs/docs/users/reference/env_variables.md
@@ -49,6 +49,7 @@ process.
 | `FOREST_SNAPSHOT_GC_INTERVAL_EPOCHS`                      | non-negative integer             | 20160                                          | 8000                                                          | The interval in epochs for scheduling snapshot GC                                                                     |
 | `FOREST_SNAPSHOT_GC_CHECK_INTERVAL_SECONDS`               | non-negative integer             | 300                                            | 60                                                            | The interval in seconds for checking if snapshot GC should run                                                        |
 | `FOREST_DISABLE_BAD_BLOCK_CACHE`                          | 1 or true                        | empty                                          | 1                                                             | Whether or not to disable bad block cache                                                                             |
+| `FOREST_ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE`                | positive integer                 | 1073741824                                     | 536870912                                                     | The default zstd frame cache max size in bytes                                                                        |
 
 ### `FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT`
 

--- a/src/db/car/any.rs
+++ b/src/db/car/any.rs
@@ -14,7 +14,6 @@ use crate::db::PersistentStore;
 use crate::utils::io::EitherMmapOrRandomAccessFile;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use parking_lot::Mutex;
 use positioned_io::ReadAt;
 use std::borrow::Cow;
 use std::io::{Error, ErrorKind, Result};
@@ -90,7 +89,7 @@ impl<ReaderT: RandomAccessFileReader> AnyCar<ReaderT> {
     }
 
     /// Set the z-frame cache of the inner CAR reader.
-    pub fn with_cache(self, cache: Arc<Mutex<ZstdFrameCache>>, key: CacheKey) -> Self {
+    pub fn with_cache(self, cache: Arc<ZstdFrameCache>, key: CacheKey) -> Self {
         match self {
             AnyCar::Forest(f) => AnyCar::Forest(f.with_cache(cache, key)),
             AnyCar::Plain(p) => AnyCar::Plain(p),

--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -229,9 +229,9 @@ where
                         UviBytes::<Bytes>::default().decode_eof(&mut zstd_frame)?
                     {
                         let CarBlock { cid, data } = CarBlock::from_bytes(block_frame)?;
-                        block_map.insert(cid, data);
+                        block_map.insert(cid.into(), data);
                     }
-                    let get_result = block_map.get(k).cloned();
+                    let get_result = block_map.get(&(*k).into()).cloned();
                     self.frame_cache
                         .lock()
                         .put(position, self.cache_key, block_map);

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -23,7 +23,7 @@ use crate::{blocks::Tipset, libp2p_bitswap::BitswapStoreRead};
 use anyhow::Context as _;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use std::cmp::Ord;
 use std::collections::BinaryHeap;
 use std::{path::PathBuf, sync::Arc};
@@ -64,7 +64,7 @@ impl PartialEq for WithHeaviestEpoch {
 }
 
 pub struct ManyCar<WriterT = MemoryDB> {
-    shared_cache: Arc<Mutex<ZstdFrameCache>>,
+    shared_cache: Arc<ZstdFrameCache>,
     read_only: Arc<RwLock<BinaryHeap<WithHeaviestEpoch>>>,
     writer: WriterT,
 }
@@ -72,7 +72,7 @@ pub struct ManyCar<WriterT = MemoryDB> {
 impl<WriterT> ManyCar<WriterT> {
     pub fn new(writer: WriterT) -> Self {
         ManyCar {
-            shared_cache: Arc::new(Mutex::new(ZstdFrameCache::default())),
+            shared_cache: Arc::new(ZstdFrameCache::default()),
             read_only: Arc::new(RwLock::new(BinaryHeap::default())),
             writer,
         }

--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -41,7 +41,7 @@ pub static ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE: LazyLock<usize> = LazyLock::new(||
             tracing::info!("zstd frame max size is set to {size} via {ENV_KEY}");
             return size;
         } else {
-            tracing::warn!("Failed to parse {ENV_KEY}={value}, value should be a positive integer");
+            tracing::error!("Failed to parse {ENV_KEY}={value}, value should be a positive integer");
         }
     }
     // 256 MiB

--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -7,6 +7,7 @@ pub mod plain;
 
 pub use any::AnyCar;
 pub use forest::ForestCar;
+use get_size2::GetSize as _;
 pub use many::ManyCar;
 pub use plain::PlainCar;
 
@@ -14,6 +15,9 @@ use ahash::HashMap;
 use cid::Cid;
 use lru::LruCache;
 use positioned_io::{ReadAt, Size};
+use std::{num::NonZeroUsize, sync::LazyLock};
+
+use crate::utils::get_size::CidWrapper;
 
 pub trait RandomAccessFileReader: ReadAt + Size + Send + Sync + 'static {}
 impl<X: ReadAt + Size + Send + Sync + 'static> RandomAccessFileReader for X {}
@@ -24,24 +28,37 @@ pub type CacheKey = u64;
 
 type FrameOffset = u64;
 
+// 1 GiB
+pub static ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE: LazyLock<usize> = LazyLock::new(|| {
+    const ENV_KEY: &str = "FOREST_ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE";
+    if let Ok(value) = std::env::var(ENV_KEY) {
+        if let Ok(size) = value.parse::<NonZeroUsize>() {
+            let size = size.get();
+            tracing::info!("zstd frame max size is set to {size} via {ENV_KEY}");
+            return size;
+        } else {
+            tracing::warn!("Failed to parse {ENV_KEY}={value}, value should be a positive integer");
+        }
+    }
+    // 1GiB
+    1024 * 1024 * 1024
+});
+
 pub struct ZstdFrameCache {
     /// Maximum size in bytes. Pages will be evicted if the total size of the
     /// cache exceeds this amount.
     pub max_size: usize,
     current_size: usize,
-    lru: LruCache<(FrameOffset, CacheKey), HashMap<Cid, Vec<u8>>>,
+    lru: LruCache<(FrameOffset, CacheKey), HashMap<CidWrapper, Vec<u8>>>,
 }
 
 impl Default for ZstdFrameCache {
     fn default() -> Self {
-        ZstdFrameCache::new(ZstdFrameCache::DEFAULT_SIZE)
+        ZstdFrameCache::new(*ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE)
     }
 }
 
 impl ZstdFrameCache {
-    // 1 GiB
-    pub const DEFAULT_SIZE: usize = 1024 * 1024 * 1024;
-
     pub fn new(max_size: usize) -> Self {
         ZstdFrameCache {
             max_size,
@@ -55,21 +72,32 @@ impl ZstdFrameCache {
     pub fn get(&mut self, offset: FrameOffset, key: CacheKey, cid: Cid) -> Option<Option<Vec<u8>>> {
         self.lru
             .get(&(offset, key))
-            .map(|index| index.get(&cid).cloned())
+            .map(|index| index.get(&cid.into()).cloned())
     }
 
     /// Insert entry into lru-cache and evict pages if `max_size` has been exceeded.
-    pub fn put(&mut self, offset: FrameOffset, key: CacheKey, index: HashMap<Cid, Vec<u8>>) {
-        fn size_of_entry(entry: &HashMap<Cid, Vec<u8>>) -> usize {
-            entry.values().map(Vec::len).sum::<usize>()
-        }
-        self.current_size += size_of_entry(&index);
-        if let Some(prev_entry) = self.lru.put((offset, key), index) {
-            self.current_size -= size_of_entry(&prev_entry);
+    pub fn put(&mut self, offset: FrameOffset, key: CacheKey, index: HashMap<CidWrapper, Vec<u8>>) {
+        let lru_key = (offset, key);
+        let lru_key_size = lru_key.get_size();
+        let entry_size = index.get_size();
+        if let Some((_, prev_entry)) = self.lru.push(lru_key, index) {
+            // keys are cancelled out
+            self.current_size = self
+                .current_size
+                .saturating_add(entry_size)
+                .saturating_sub(prev_entry.get_size());
+        } else {
+            self.current_size = self
+                .current_size
+                .saturating_add(entry_size)
+                .saturating_add(lru_key_size);
         }
         while self.current_size > self.max_size {
-            if let Some((_, entry)) = self.lru.pop_lru() {
-                self.current_size -= size_of_entry(&entry)
+            if let Some((prev_key, prev_entry)) = self.lru.pop_lru() {
+                self.current_size = self
+                    .current_size
+                    .saturating_sub(prev_key.get_size())
+                    .saturating_sub(prev_entry.get_size());
             } else {
                 break;
             }

--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -13,11 +13,16 @@ pub use plain::PlainCar;
 
 use ahash::HashMap;
 use cid::Cid;
-use lru::LruCache;
 use positioned_io::{ReadAt, Size};
-use std::{num::NonZeroUsize, sync::LazyLock};
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        LazyLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
-use crate::utils::get_size::CidWrapper;
+use crate::utils::{cache::SizeTrackingLruCache, get_size::CidWrapper};
 
 pub trait RandomAccessFileReader: ReadAt + Size + Send + Sync + 'static {}
 impl<X: ReadAt + Size + Send + Sync + 'static> RandomAccessFileReader for X {}
@@ -28,7 +33,6 @@ pub type CacheKey = u64;
 
 type FrameOffset = u64;
 
-// 1 GiB
 pub static ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE: LazyLock<usize> = LazyLock::new(|| {
     const ENV_KEY: &str = "FOREST_ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE";
     if let Ok(value) = std::env::var(ENV_KEY) {
@@ -48,8 +52,8 @@ pub struct ZstdFrameCache {
     /// Maximum size in bytes. Pages will be evicted if the total size of the
     /// cache exceeds this amount.
     pub max_size: usize,
-    current_size: usize,
-    lru: LruCache<(FrameOffset, CacheKey), HashMap<CidWrapper, Vec<u8>>>,
+    current_size: AtomicUsize,
+    lru: SizeTrackingLruCache<(FrameOffset, CacheKey), HashMap<CidWrapper, Vec<u8>>>,
 }
 
 impl Default for ZstdFrameCache {
@@ -62,42 +66,48 @@ impl ZstdFrameCache {
     pub fn new(max_size: usize) -> Self {
         ZstdFrameCache {
             max_size,
-            current_size: 0,
-            lru: LruCache::unbounded(),
+            current_size: AtomicUsize::new(0),
+            lru: SizeTrackingLruCache::unbounded_with_default_metrics_registry(
+                "zstd_frame_cache".into(),
+            ),
         }
     }
 
     /// Return a clone of the value associated with `cid`. If a value is found,
     /// the cache entry is moved to the top of the queue.
-    pub fn get(&mut self, offset: FrameOffset, key: CacheKey, cid: Cid) -> Option<Option<Vec<u8>>> {
+    pub fn get(&self, offset: FrameOffset, key: CacheKey, cid: Cid) -> Option<Option<Vec<u8>>> {
         self.lru
+            .cache()
+            .write()
             .get(&(offset, key))
             .map(|index| index.get(&cid.into()).cloned())
     }
 
     /// Insert entry into lru-cache and evict pages if `max_size` has been exceeded.
-    pub fn put(&mut self, offset: FrameOffset, key: CacheKey, index: HashMap<CidWrapper, Vec<u8>>) {
+    pub fn put(&self, offset: FrameOffset, key: CacheKey, index: HashMap<CidWrapper, Vec<u8>>) {
         let lru_key = (offset, key);
         let lru_key_size = lru_key.get_size();
         let entry_size = index.get_size();
+        // Skip large items
+        if entry_size.saturating_add(lru_key_size) >= self.max_size {
+            return;
+        }
+
         if let Some((_, prev_entry)) = self.lru.push(lru_key, index) {
             // keys are cancelled out
-            self.current_size = self
-                .current_size
-                .saturating_add(entry_size)
-                .saturating_sub(prev_entry.get_size());
+            self.current_size.fetch_add(entry_size, Ordering::Relaxed);
+            self.current_size
+                .fetch_sub(prev_entry.get_size(), Ordering::Relaxed);
         } else {
-            self.current_size = self
-                .current_size
-                .saturating_add(entry_size)
-                .saturating_add(lru_key_size);
+            self.current_size
+                .fetch_add(entry_size.saturating_add(lru_key_size), Ordering::Relaxed);
         }
-        while self.current_size > self.max_size {
+        while self.current_size.load(Ordering::Relaxed) > self.max_size {
             if let Some((prev_key, prev_entry)) = self.lru.pop_lru() {
-                self.current_size = self
-                    .current_size
-                    .saturating_sub(prev_key.get_size())
-                    .saturating_sub(prev_entry.get_size());
+                self.current_size.fetch_sub(
+                    prev_key.get_size().saturating_add(prev_entry.get_size()),
+                    Ordering::Relaxed,
+                );
             } else {
                 break;
             }

--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -44,8 +44,8 @@ pub static ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE: LazyLock<usize> = LazyLock::new(||
             tracing::warn!("Failed to parse {ENV_KEY}={value}, value should be a positive integer");
         }
     }
-    // 1GiB
-    1024 * 1024 * 1024
+    // 256 MiB
+    256 * 1024 * 1024
 });
 
 pub struct ZstdFrameCache {

--- a/src/utils/cache/lru.rs
+++ b/src/utils/cache/lru.rs
@@ -65,9 +65,11 @@ where
         Self {
             cache_id: ID_GENERATOR.fetch_add(1, Ordering::Relaxed),
             cache_name,
+            #[allow(clippy::disallowed_methods)]
             cache: Arc::new(RwLock::new(
                 capacity
                     .map(LruCache::new)
+                    // For constructing lru cache that is bounded by memory usage instead of length
                     .unwrap_or_else(LruCache::unbounded),
             )),
         }
@@ -150,7 +152,7 @@ where
         self.cache.read().cap().get()
     }
 
-    fn size_in_bytes(&self) -> usize {
+    pub(crate) fn size_in_bytes(&self) -> usize {
         let mut size = 0_usize;
         for (k, v) in self.cache.read().iter() {
             size = size


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fix size calculation for zstd frame cache
- make max size configurable via env var
- switch to `SizeTrackingLruCache`
- update default max size to 256MiB

cache size is ~120MiB after running Forest on mainnet for a while. How about changing the default max size to 512MiB or even 256MiB @LesnyRumcajs 

```
# HELP zstd_frame_cache_0_size_bytes Size of LruCache zstd_frame_cache_0 in bytes
# TYPE zstd_frame_cache_0_size_bytes gauge
# UNIT zstd_frame_cache_0_size_bytes bytes
zstd_frame_cache_0_size_bytes 125976889
# HELP zstd_frame_cache_0_len Length of LruCache zstd_frame_cache_0
# TYPE zstd_frame_cache_0_len gauge
zstd_frame_cache_0_len 5699
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5858

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added documentation for a new environment variable to configure the default maximum size of the zstd frame cache.

* **Documentation**
  * Updated glossary with the term "zstd".
  * Documented the `FOREST_ZSTD_FRAME_CACHE_DEFAULT_MAX_SIZE` environment variable, including its purpose, default, and example values.

* **Refactor**
  * Improved cache concurrency and performance by removing unnecessary locking (mutexes) from the zstd frame cache.
  * Enhanced cache size tracking with atomic operations and more accurate entry size accounting.
  * Introduced environment-based configuration for cache size limits.
  * Expanded cache utility with new methods for unbounded cache creation and LRU entry removal.

* **Chores**
  * Added a lint rule to disallow unbounded LRU cache creation to prevent potential memory leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->