### PR TITLE
feat: add reason for the API failure in compare cmd

### DIFF
--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
+
 use super::{CreateTestsArgs, ReportMode, RunIgnored, TestCriteriaOverride};
 use crate::blocks::{ElectionProof, Ticket, Tipset};
 use crate::chain::ChainStore;
@@ -59,7 +60,6 @@ use similar::{ChangeTag, TextDiff};
 use std::path::Path;
 use std::time::Instant;
 use std::{
-    fmt,
     path::PathBuf,
     str::FromStr,
     sync::{Arc, LazyLock},
@@ -88,7 +88,9 @@ const ACCOUNT_ADDRESS: Address = Address::new_id(1234); // account actor address
 const EVM_ADDRESS: &str = "t410fbqoynu2oi2lxam43knqt6ordiowm2ywlml27z4i";
 
 /// Brief description of a single method call against a single host
-#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, strum::Display,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum TestSummary {
     /// Server spoke JSON-RPC: no such method
@@ -107,22 +109,6 @@ pub enum TestSummary {
     Timeout,
     /// Server returned JSON-RPC, and it matched our schema, and passed validation
     Valid,
-}
-
-impl fmt::Display for TestSummary {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            TestSummary::MissingMethod => "MissingMethod",
-            TestSummary::Rejected(_) => "Rejected",
-            TestSummary::NotJsonRPC => "NotJsonRPC",
-            TestSummary::InfraError => "InfraError",
-            TestSummary::BadJson => "BadJson",
-            TestSummary::CustomCheckFailed => "CustomCheckFailed",
-            TestSummary::Timeout => "Timeout",
-            TestSummary::Valid => "Valid",
-        };
-        write!(f, "{s}")
-    }
 }
 
 impl TestSummary {

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -59,6 +59,7 @@ use similar::{ChangeTag, TextDiff};
 use std::path::Path;
 use std::time::Instant;
 use std::{
+    fmt,
     path::PathBuf,
     str::FromStr,
     sync::{Arc, LazyLock},
@@ -106,6 +107,22 @@ pub enum TestSummary {
     Timeout,
     /// Server returned JSON-RPC, and it matched our schema, and passed validation
     Valid,
+}
+
+impl fmt::Display for TestSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            TestSummary::MissingMethod => "MissingMethod",
+            TestSummary::Rejected(_) => "Rejected",
+            TestSummary::NotJsonRPC => "NotJsonRPC",
+            TestSummary::InfraError => "InfraError",
+            TestSummary::BadJson => "BadJson",
+            TestSummary::CustomCheckFailed => "CustomCheckFailed",
+            TestSummary::Timeout => "Timeout",
+            TestSummary::Valid => "Valid",
+        };
+        write!(f, "{s}")
+    }
 }
 
 impl TestSummary {

--- a/src/tool/subcommands/api_cmd/report.rs
+++ b/src/tool/subcommands/api_cmd/report.rs
@@ -7,6 +7,7 @@ use crate::rpc::{FilterList, Permission};
 use crate::tool::subcommands::api_cmd::api_compare_tests::TestSummary;
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use chrono::{DateTime, Utc};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, DurationMilliSeconds, DurationSeconds, serde_as};
 use similar::{ChangeTag, TextDiff};
@@ -325,11 +326,8 @@ impl ReportBuilder {
                             }
                         }
 
-                        let reasons_str = reasons
-                            .iter()
-                            .map(|s| s.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ");
+                        let reasons_str =
+                            reasons.iter().map(|s| s.as_str()).collect_vec().join(", ");
 
                         if *success_count == 0 {
                             format!("❌ All Failed ({reasons_str})")

--- a/src/tool/subcommands/api_cmd/report.rs
+++ b/src/tool/subcommands/api_cmd/report.rs
@@ -5,7 +5,7 @@ use super::ReportMode;
 use crate::rpc;
 use crate::rpc::{FilterList, Permission};
 use crate::tool::subcommands::api_cmd::api_compare_tests::TestSummary;
-use ahash::{HashMap, HashMapExt};
+use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, DurationMilliSeconds, DurationSeconds, serde_as};
@@ -313,18 +313,36 @@ impl ReportBuilder {
                     };
 
                     let status = if *failure_count == 0 {
-                        "✅ All Passed"
-                    } else if *success_count == 0 {
-                        "❌ All Failed"
+                        "✅ All Passed".into()
                     } else {
-                        "⚠️  Mixed Results"
+                        let mut reasons = HashSet::new();
+                        for failure in &report.failed_test_params {
+                            if failure.forest_status != TestSummary::Valid {
+                                reasons.insert(failure.forest_status.to_string());
+                            }
+                            if failure.lotus_status != TestSummary::Valid {
+                                reasons.insert(failure.lotus_status.to_string());
+                            }
+                        }
+
+                        let reasons_str = reasons
+                            .iter()
+                            .map(|s| s.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+
+                        if *success_count == 0 {
+                            format!("❌ All Failed ({reasons_str})")
+                        } else {
+                            format!("⚠️  Mixed Results ({reasons_str})")
+                        }
                     };
 
                     builder.push_record([
                         method_name.as_str(),
                         &format!("{success_count}/{total_count}"),
                         &format!("{success_count}/{total_count}"),
-                        status,
+                        &status,
                     ]);
                 }
                 MethodTestStatus::NotTested | MethodTestStatus::Filtered => {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Print the reason if the API is failing while running the `compare` cmd

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes: #5854 

## Other information and links
- Now we will get below response in the output if the API is failing
<img width="793" height="715" alt="Screenshot 2025-07-28 at 7 29 05 PM" src="https://github.com/user-attachments/assets/073436f4-f2f8-4568-9a14-1c6c52170c7d" />

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status messages in test reports now include specific failure reasons, providing more detailed feedback on failed or mixed test results.

* **Style**
  * Enhanced display formatting for test summary values, ensuring clearer and more consistent output in reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->