### PR TITLE
Potential fix for code scanning alert no. 58: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -1,4 +1,6 @@
 name: Integration tests
+permissions:
+  contents: read
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
Potential fix for [https://github.com/ChainSafe/forest/security/code-scanning/58](https://github.com/ChainSafe/forest/security/code-scanning/58)

To fix the problem, add a `permissions` block at the top level of the workflow file (just after the `name:` or before/after `on:`), specifying the minimum required permissions. If the workflow does not need to write to the repository or interact with issues or pull requests, set `permissions: contents: read`. This will apply to all jobs in the workflow unless overridden at the job level. No changes to existing functionality are required, and this change is backward-compatible and safe.

**Steps:**
- Edit `.github/workflows/forest.yml`.
- Insert the following block after the `name:` line (line 1), before `concurrency:` (line 2):

```yaml
permissions:
  contents: read
```

- No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
