### PR TITLE
chore: refactor cur_tipset in MessagePool to use RwLock instead Mutex

### DIFF
--- a/src/message_pool/msgpool/mod.rs
+++ b/src/message_pool/msgpool/mod.rs
@@ -21,7 +21,7 @@ use crate::utils::get_size::CidWrapper;
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use cid::Cid;
 use fvm_ipld_encoding::to_vec;
-use parking_lot::{Mutex, RwLock as SyncRwLock};
+use parking_lot::RwLock as SyncRwLock;
 use tracing::error;
 use utils::{get_base_fee_lower_bound, recover_sig};
 
@@ -57,7 +57,7 @@ async fn republish_pending_messages<T>(
     api: &T,
     network_sender: &flume::Sender<NetworkMessage>,
     pending: &SyncRwLock<HashMap<Address, MsgSet>>,
-    cur_tipset: &Mutex<Arc<Tipset>>,
+    cur_tipset: &SyncRwLock<Arc<Tipset>>,
     republished: &SyncRwLock<HashSet<Cid>>,
     local_addrs: &SyncRwLock<Vec<Address>>,
     chain_config: &ChainConfig,
@@ -65,7 +65,7 @@ async fn republish_pending_messages<T>(
 where
     T: Provider,
 {
-    let ts = cur_tipset.lock().clone();
+    let ts = cur_tipset.read().clone();
     let mut pending_map: HashMap<Address, HashMap<u64, SignedMessage>> = HashMap::new();
 
     republished.write().clear();
@@ -216,7 +216,7 @@ pub async fn head_change<T>(
     repub_trigger: Arc<flume::Sender<()>>,
     republished: &SyncRwLock<HashSet<Cid>>,
     pending: &SyncRwLock<HashMap<Address, MsgSet>>,
-    cur_tipset: &Mutex<Arc<Tipset>>,
+    cur_tipset: &SyncRwLock<Arc<Tipset>>,
     revert: Vec<Tipset>,
     apply: Vec<Tipset>,
 ) -> Result<(), Error>
@@ -227,7 +227,7 @@ where
     let mut rmsgs: HashMap<Address, HashMap<u64, SignedMessage>> = HashMap::new();
     for ts in revert {
         let pts = api.load_tipset(ts.parents())?;
-        *cur_tipset.lock() = pts;
+        *cur_tipset.write() = pts;
 
         let mut msgs: Vec<SignedMessage> = Vec::new();
         for block in ts.block_headers() {
@@ -266,7 +266,7 @@ where
                 }
             }
         }
-        *cur_tipset.lock() = Arc::new(ts);
+        *cur_tipset.write() = Arc::new(ts);
     }
     if repub {
         repub_trigger
@@ -276,7 +276,7 @@ where
     }
     for (_, hm) in rmsgs {
         for (_, msg) in hm {
-            let sequence = get_state_sequence(api, &msg.from(), &cur_tipset.lock().clone())?;
+            let sequence = get_state_sequence(api, &msg.from(), &cur_tipset.read().clone())?;
             if let Err(e) = add_helper(api, bls_sig_cache, pending, msg, sequence) {
                 error!("Failed to read message from reorg to mpool: {}", e);
             }
@@ -616,7 +616,7 @@ pub mod tests {
         // sleep allows for async block to update mpool's cur_tipset
         tokio::time::sleep(Duration::new(2, 0)).await;
 
-        let cur_ts = mpool.cur_tipset.lock().clone();
+        let cur_ts = mpool.current_tipset();
         assert_eq!(cur_ts.as_ref(), &tipset);
     }
 

--- a/src/message_pool/msgpool/selection.rs
+++ b/src/message_pool/msgpool/selection.rs
@@ -290,7 +290,7 @@ where
     /// for inclusion from the pool, given the ticket quality of a miner.
     /// This method selects messages for including in a block.
     pub fn select_messages(&self, ts: &Tipset, tq: f64) -> Result<Vec<SignedMessage>, Error> {
-        let cur_ts = self.cur_tipset.lock().clone();
+        let cur_ts = self.current_tipset();
         // if the ticket quality is high enough that the first block has higher
         // probability than any other block, then we don't bother with optimal
         // selection because the first block will always have higher effective

--- a/src/rpc/methods/gas.rs
+++ b/src/rpc/methods/gas.rs
@@ -221,7 +221,7 @@ impl GasEstimateGasLimit {
             .map(|s| s.into_iter().map(ChainMessage::Signed).collect::<Vec<_>>())
             .unwrap_or_default();
 
-        let ts = data.mpool.cur_tipset.lock().clone();
+        let ts = data.mpool.current_tipset();
         // Pretend that the message is signed. This has an influence on the gas
         // cost. We obviously can't generate a valid signature. Instead, we just
         // fill the signature with zeros. The validity is not checked.


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

During invetigating https://github.com/ChainSafe/forest/issues/5812 I made some refactoring to the `cur_tipset` in `MessagePool` to use `RwLock` instead `Mutex` since there're quite a few read-only operations.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved concurrent access to the current tipset by switching from exclusive locking to a read-write lock, allowing multiple readers at once.
  * Introduced a new method for retrieving the current tipset, streamlining access across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->