### PR TITLE
feat: tracking size of all LruCache with SizeTrackingLruCache

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -45,5 +45,9 @@ path = "tempfile::NamedTempFile::new"
 reason = """The temporary files created by this method are not persistable if the temporary directory lives on a different filesystem than the target directory. While it is valid in other contexts (if not persisting files), it was misused many times and so we are banning it. Consider using `tempfile::NamedTempFile::new_in` or `tempfile::NamedTempFile::Builder"""
 
 [[disallowed-methods]]
+path = "lru::LruCache::new"
+reason = """Use SizeTrackingLruCache instead."""
+
+[[disallowed-methods]]
 path = "lru::LruCache::unbounded"
-reason = """Avoid unbounded lru cache for potential memory leak"""
+reason = """Avoid unbounded lru cache for potential memory leak, use SizeTrackingLruCache instead."""

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -49,5 +49,13 @@ path = "lru::LruCache::new"
 reason = """Use SizeTrackingLruCache instead."""
 
 [[disallowed-methods]]
+path = "lru::LruCache::with_hasher"
+reason = """Use SizeTrackingLruCache instead."""
+
+[[disallowed-methods]]
 path = "lru::LruCache::unbounded"
+reason = """Avoid unbounded lru cache for potential memory leak, use SizeTrackingLruCache instead."""
+
+[[disallowed-methods]]
+path = "lru::LruCache::unbounded_with_hasher"
 reason = """Avoid unbounded lru cache for potential memory leak, use SizeTrackingLruCache instead."""

--- a/interop-tests/tests/dhat_get_size_beacon_entry.rs
+++ b/interop-tests/tests/dhat_get_size_beacon_entry.rs
@@ -49,7 +49,7 @@ fn test_get_size_beacon_entry() {
     assert_eq!(v.capacity(), v.len());
     dhat::assert_eq!(
         stats.curr_bytes,
-        size_of::<BeaconEntry>() * v.capacity() + 60
+        size_of::<BeaconEntry>() * v.capacity() + inner_bytes
     );
     dhat::assert_eq!(stats.curr_bytes, v.get_heap_size());
 }

--- a/src/beacon/drand.rs
+++ b/src/beacon/drand.rs
@@ -262,7 +262,7 @@ impl DrandBeacon {
             fil_round_time: interval,
             fil_gen_time: genesis_ts,
             verified_beacons: SizeTrackingLruCache::new_with_default_metrics_registry(
-                "verified_beacons_cache".into(),
+                "verified_beacons".into(),
                 NonZeroUsize::new(CACHE_SIZE).expect("Infallible"),
             ),
         }

--- a/src/blocks/election_proof.rs
+++ b/src/blocks/election_proof.rs
@@ -5,6 +5,7 @@ use crate::blocks::VRFProof;
 use crate::shim::clock::BLOCKS_PER_EPOCH;
 use crate::utils::encoding::blake2b_256;
 use fvm_ipld_encoding::tuple::*;
+use get_size2::GetSize;
 use num::{
     BigInt, Integer,
     bigint::{ParseBigIntError, Sign},
@@ -134,7 +135,17 @@ impl Poiss {
 /// This is generated from hashing a partial ticket and using the hash to
 /// generate a value.
 #[derive(
-    Clone, Debug, PartialEq, PartialOrd, Eq, Default, Ord, Serialize_tuple, Deserialize_tuple, Hash,
+    Clone,
+    Debug,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Default,
+    Ord,
+    Serialize_tuple,
+    Deserialize_tuple,
+    Hash,
+    GetSize,
 )]
 pub struct ElectionProof {
     pub win_count: i64,

--- a/src/blocks/ticket.rs
+++ b/src/blocks/ticket.rs
@@ -3,12 +3,23 @@
 
 use crate::blocks::VRFProof;
 use fvm_ipld_encoding::tuple::*;
+use get_size2::GetSize;
 
 /// A Ticket is a marker of a tick of the blockchain's clock.  It is the source
 /// of randomness for proofs of storage and leader election.  It is generated
 /// by the miner of a block using a `VRF` and a `VDF`.
 #[derive(
-    Clone, Debug, PartialEq, Eq, Default, Serialize_tuple, Deserialize_tuple, Hash, PartialOrd, Ord,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize_tuple,
+    Deserialize_tuple,
+    Hash,
+    PartialOrd,
+    Ord,
+    GetSize,
 )]
 pub struct Ticket {
     /// A proof output by running a `VRF` on the `VDFResult` of the parent

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -11,7 +11,7 @@ use crate::{
     cid_collections::SmallCidNonEmptyVec,
     networks::{calibnet, mainnet},
     shim::clock::ChainEpoch,
-    utils::cid::CidCborExt,
+    utils::{cid::CidCborExt, get_size::nunny_vec_heap_size_helper},
 };
 use ahash::HashMap;
 use anyhow::Context as _;
@@ -146,9 +146,10 @@ impl IntoIterator for TipsetKey {
 ///
 /// Represents non-null tipsets, see the documentation on [`crate::state_manager::apply_block_messages`]
 /// for more.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, GetSize)]
 pub struct Tipset {
     /// Sorted
+    #[get_size(size_fn = nunny_vec_heap_size_helper)]
     headers: NonEmpty<CachingBlockHeader>,
     // key is lazily initialized via `fn key()`.
     key: OnceLock<TipsetKey>,

--- a/src/blocks/vrf_proof.rs
+++ b/src/blocks/vrf_proof.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::utils::encoding::{blake2b_256, serde_byte_array};
+use get_size2::GetSize;
 use serde::{Deserialize, Serialize};
 
 /// The output from running a VRF proof.
@@ -23,5 +24,11 @@ impl VRFProof {
     /// Compute the `BLAKE2b256` digest of the proof.
     pub fn digest(&self) -> [u8; 32] {
         blake2b_256(&self.0)
+    }
+}
+
+impl GetSize for VRFProof {
+    fn get_heap_size(&self) -> usize {
+        self.0.get_heap_size()
     }
 }

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -6,7 +6,6 @@ use super::{
     index::{ChainIndex, ResolveNullTipset},
     tipset_tracker::TipsetTracker,
 };
-use crate::fil_cns;
 use crate::interpreter::{BlockMessages, VMTrace};
 use crate::libp2p_bitswap::{BitswapStoreRead, BitswapStoreReadWrite};
 use crate::message::{ChainMessage, Message as MessageTrait, SignedMessage};
@@ -27,6 +26,7 @@ use crate::{
     chain_sync::metrics,
     db::{EthMappingsStore, EthMappingsStoreExt, IndicesStore, IndicesStoreExt},
 };
+use crate::{fil_cns, utils::cache::SizeTrackingLruCache};
 use ahash::{HashMap, HashMapExt, HashSet};
 use anyhow::Context as _;
 use cid::Cid;
@@ -34,8 +34,7 @@ use fil_actors_shared::fvm_ipld_amt::Amtv0 as Amt;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::CborStore;
 use itertools::Itertools;
-use lru::LruCache;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use serde::{Serialize, de::DeserializeOwned};
 use std::{num::NonZeroUsize, sync::Arc};
 use tokio::sync::broadcast::{self, Sender as Publisher};
@@ -554,27 +553,28 @@ where
 /// use-cases. This cache is intended to be used with a complementary function;
 /// [`messages_for_tipset_with_cache`].
 pub struct MsgsInTipsetCache {
-    cache: RwLock<LruCache<TipsetKey, Vec<ChainMessage>>>,
+    cache: SizeTrackingLruCache<TipsetKey, Vec<ChainMessage>>,
 }
 
 impl MsgsInTipsetCache {
-    pub fn new(cap: usize) -> anyhow::Result<Self> {
-        Ok(Self {
-            cache: RwLock::new(LruCache::new(
-                NonZeroUsize::new(cap).context("cache capacity must be greater than 0")?,
-            )),
-        })
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            cache: SizeTrackingLruCache::new_with_default_metrics_registry(
+                "msg_in_tipset".into(),
+                capacity,
+            ),
+        }
     }
 
     pub fn get(&self, key: &TipsetKey) -> Option<Vec<ChainMessage>> {
-        self.cache.write().get(key).cloned()
+        self.cache.get_cloned(key)
     }
 
     pub fn get_or_insert_with<F>(&self, key: &TipsetKey, f: F) -> anyhow::Result<Vec<ChainMessage>>
     where
         F: FnOnce() -> anyhow::Result<Vec<ChainMessage>>,
     {
-        if self.cache.read().contains(key) {
+        if self.cache.contains(key) {
             Ok(self.get(key).expect("cache entry disappeared!"))
         } else {
             let v = f()?;
@@ -584,21 +584,23 @@ impl MsgsInTipsetCache {
     }
 
     pub fn insert(&self, key: TipsetKey, value: Vec<ChainMessage>) {
-        self.cache.write().put(key, value);
+        self.cache.push(key, value);
     }
 
     /// Reads the intended cache size for this process from the environment or uses the default.
-    fn read_cache_size() -> usize {
+    fn read_cache_size() -> NonZeroUsize {
+        // Arbitrary number, can be adjusted
+        const DEFAULT: NonZeroUsize = NonZeroUsize::new(100).expect("infallible");
         std::env::var("FOREST_MESSAGES_IN_TIPSET_CACHE_SIZE")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(100) // Arbitrary number, can be adjusted
+            .unwrap_or(DEFAULT)
     }
 }
 
 impl Default for MsgsInTipsetCache {
     fn default() -> Self {
-        Self::new(Self::read_cache_size()).expect("failed to create default cache")
+        Self::new(Self::read_cache_size())
     }
 }
 
@@ -796,7 +798,7 @@ mod tests {
 
     #[test]
     fn test_messages_in_tipset_cache() {
-        let cache = MsgsInTipsetCache::new(2).unwrap();
+        let cache = MsgsInTipsetCache::new(2.try_into().unwrap());
         let key1 = TipsetKey::from(nunny::vec![Cid::new_v1(
             DAG_CBOR,
             MultihashCode::Blake2b256.digest(&[1])

--- a/src/chain/store/index.rs
+++ b/src/chain/store/index.rs
@@ -39,7 +39,7 @@ pub enum ResolveNullTipset {
 impl<DB: Blockstore> ChainIndex<DB> {
     pub fn new(db: DB) -> Self {
         let ts_cache = SizeTrackingLruCache::new_with_default_metrics_registry(
-            "tipet".into(),
+            "tipset".into(),
             DEFAULT_TIPSET_CACHE_SIZE,
         );
         Self { ts_cache, db }

--- a/src/chain_sync/bad_block_cache.rs
+++ b/src/chain_sync/bad_block_cache.rs
@@ -25,10 +25,7 @@ impl Default for BadBlockCache {
 impl BadBlockCache {
     pub fn new(cap: NonZeroUsize) -> Self {
         Self {
-            cache: SizeTrackingLruCache::new_with_default_metrics_registry(
-                "bad_block_cache".into(),
-                cap,
-            ),
+            cache: SizeTrackingLruCache::new_with_default_metrics_registry("bad_block".into(), cap),
         }
     }
 

--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -72,9 +72,7 @@ impl ZstdFrameCache {
         ZstdFrameCache {
             max_size,
             current_size: AtomicUsize::new(0),
-            lru: SizeTrackingLruCache::unbounded_with_default_metrics_registry(
-                "zstd_frame_cache".into(),
-            ),
+            lru: SizeTrackingLruCache::unbounded_with_default_metrics_registry("zstd_frame".into()),
         }
     }
 

--- a/src/message/chain_message.rs
+++ b/src/message/chain_message.rs
@@ -1,17 +1,17 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use super::Message as MessageTrait;
+use crate::message::signed_message::SignedMessage;
 use crate::shim::message::MethodNum;
 use crate::shim::{address::Address, econ::TokenAmount, message::Message};
 use fvm_ipld_encoding::RawBytes;
+use get_size2::GetSize;
 use serde::{Deserialize, Serialize};
-
-use super::Message as MessageTrait;
-use crate::message::signed_message::SignedMessage;
 
 /// `Enum` to encapsulate signed and unsigned messages. Useful when working with
 /// both types
-#[derive(Clone, Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, Eq, PartialEq, GetSize)]
 #[serde(untagged)]
 pub enum ChainMessage {
     Unsigned(Message),

--- a/src/message/signed_message.rs
+++ b/src/message/signed_message.rs
@@ -12,10 +12,11 @@ use crate::shim::{
 };
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{RawBytes, to_vec};
+use get_size2::GetSize;
 
 /// Represents a wrapped message with signature bytes.
 #[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
-#[derive(PartialEq, Clone, Debug, Serialize_tuple, Deserialize_tuple, Hash, Eq)]
+#[derive(PartialEq, Clone, Debug, Serialize_tuple, Deserialize_tuple, Hash, Eq, GetSize)]
 pub struct SignedMessage {
     pub message: Message,
     pub signature: Signature,

--- a/src/message_pool/msgpool/msg_pool.rs
+++ b/src/message_pool/msgpool/msg_pool.rs
@@ -476,11 +476,11 @@ where
         let pending = Arc::new(SyncRwLock::new(HashMap::new()));
         let tipset = Arc::new(SyncRwLock::new(api.get_heaviest_tipset()));
         let bls_sig_cache = Arc::new(SizeTrackingLruCache::new_with_default_metrics_registry(
-            "bls_sig_cache".into(),
+            "bls_sig".into(),
             BLS_SIG_CACHE_SIZE,
         ));
         let sig_val_cache = Arc::new(SizeTrackingLruCache::new_with_default_metrics_registry(
-            "sig_val_cache".into(),
+            "sig_val".into(),
             SIG_VAL_CACHE_SIZE,
         ));
         let local_msgs = Arc::new(SyncRwLock::new(HashSet::new()));

--- a/src/shim/address.rs
+++ b/src/shim/address.rs
@@ -262,7 +262,7 @@ impl DerefMut for Address {
 
 impl GetSize for Address {
     fn get_heap_size(&self) -> usize {
-        0
+        0 // all variants of the internal payload are stack-allocated
     }
 }
 

--- a/src/shim/address.rs
+++ b/src/shim/address.rs
@@ -14,6 +14,7 @@ use fvm_shared3::address::Address as Address_v3;
 use fvm_shared4::address::Address as Address_v4;
 use fvm_shared4::address::Address as Address_latest;
 pub use fvm_shared4::address::{Error, Network, PAYLOAD_HASH_LEN, Payload, Protocol};
+use get_size2::GetSize;
 use integer_encoding::VarInt;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
@@ -256,6 +257,12 @@ impl Deref for Address {
 impl DerefMut for Address {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl GetSize for Address {
+    fn get_heap_size(&self) -> usize {
+        0
     }
 }
 

--- a/src/shim/econ.rs
+++ b/src/shim/econ.rs
@@ -8,10 +8,12 @@ use std::{
 };
 
 use super::fvm_shared_latest::econ::TokenAmount as TokenAmount_latest;
+use crate::utils::get_size::big_int_heap_size_helper;
 use fvm_shared2::econ::TokenAmount as TokenAmount_v2;
 use fvm_shared3::econ::TokenAmount as TokenAmount_v3;
 pub use fvm_shared3::{BLOCK_GAS_LIMIT, TOTAL_FILECOIN_BASE};
 use fvm_shared4::econ::TokenAmount as TokenAmount_v4;
+use get_size2::GetSize;
 use num_bigint::BigInt;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
@@ -31,6 +33,12 @@ pub struct TokenAmount(TokenAmount_latest);
 impl fmt::Debug for TokenAmount {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl GetSize for TokenAmount {
+    fn get_heap_size(&self) -> usize {
+        big_int_heap_size_helper(self.0.atto())
     }
 }
 

--- a/src/shim/sector.rs
+++ b/src/shim/sector.rs
@@ -19,6 +19,7 @@ pub use fvm_shared4::sector::{
     RegisteredSealProof as RegisteredSealProofV4, SectorInfo as SectorInfoV4,
     SectorSize as SectorSizeV4,
 };
+use get_size2::GetSize;
 use num_derive::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
@@ -374,6 +375,12 @@ impl From<PoStProofV2> for PoStProof {
             post_proof: *RegisteredPoStProof::from(value.post_proof),
             proof_bytes: value.proof_bytes,
         })
+    }
+}
+
+impl GetSize for PoStProof {
+    fn get_heap_size(&self) -> usize {
+        self.0.proof_bytes.get_heap_size()
     }
 }
 

--- a/src/state_manager/cache.rs
+++ b/src/state_manager/cache.rs
@@ -45,7 +45,7 @@ impl<V: LruValueConstraints> TipsetStateCacheInner<V> {
     fn cache_name() -> String {
         use convert_case::{Case, Casing as _};
         format!(
-            "tipset_state_cache_{}",
+            "tipset_state_{}",
             crate::utils::misc::short_type_name::<V>().to_case(Case::Snake)
         )
     }

--- a/src/state_migration/common/mod.rs
+++ b/src/state_migration/common/mod.rs
@@ -32,7 +32,7 @@ impl MigrationCache {
     pub fn new(size: NonZeroUsize) -> Self {
         Self {
             cache: Arc::new(SizeTrackingLruCache::new_with_default_metrics_registry(
-                "migration_cache".into(),
+                "migration".into(),
                 size,
             )),
         }

--- a/src/utils/cache/lru.rs
+++ b/src/utils/cache/lru.rs
@@ -124,6 +124,14 @@ where
         self.cache.write().push(k, v)
     }
 
+    pub fn contains<Q>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.cache.read().contains(k)
+    }
+
     pub fn get_cloned<Q>(&self, k: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -175,7 +183,7 @@ where
                 g.set(self.size_in_bytes() as _);
                 g
             };
-            let size_metric_name = format!("{}_{}_size", self.cache_name, self.cache_id);
+            let size_metric_name = format!("cache_{}_{}_size", self.cache_name, self.cache_id);
             let size_metric_help = format!(
                 "Size of LruCache {}_{} in bytes",
                 self.cache_name, self.cache_id

--- a/src/utils/get_size/mod.rs
+++ b/src/utils/get_size/mod.rs
@@ -5,6 +5,7 @@ use cid::Cid;
 use derive_more::{From, Into};
 // re-exports the trait
 pub use get_size2::GetSize;
+use num::BigInt;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, From, Into)]
 pub struct CidWrapper(pub Cid);
@@ -48,6 +49,12 @@ pub fn vec_heap_size_with_fn_helper<T>(v: &Vec<T>, get_heap_size: impl Fn(&T) ->
 
 pub fn nunny_vec_heap_size_helper<T: GetSize>(v: &nunny::Vec<T>) -> usize {
     impl_vec_alike_heap_size_helper!(v, T)
+}
+
+// This is a rough estimation. Use `b.allocation_size()`
+// once https://github.com/rust-num/num-bigint/pull/333 is accepted and released.
+pub fn big_int_heap_size_helper(b: &BigInt) -> usize {
+    b.bits().div_ceil(8) as usize
 }
 
 #[cfg(test)]

--- a/src/utils/get_size/mod.rs
+++ b/src/utils/get_size/mod.rs
@@ -5,7 +5,7 @@ use cid::Cid;
 use derive_more::{From, Into};
 // re-exports the trait
 pub use get_size2::GetSize;
-use num::BigInt;
+use num_bigint::BigInt;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, From, Into)]
 pub struct CidWrapper(pub Cid);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- replaces all the rest `LruCache` usages with `SizeTrackingLruCache`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added heap-size reporting across core types (headers, tipsets, tickets, proofs, messages, addresses, token amounts) for improved memory accounting.

- Refactor
  - Replaced lock-guarded LRU caches with size-tracking caches, requiring non-zero capacities and adjusting concurrency/access semantics.
  - Standardized cache metric names and prefixes for clearer observability.

- Chores
  - Updated lint/config to discourage legacy cache constructors.

- Tests
  - Updated tests to compute sizes dynamically instead of using hard-coded values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->