### PR TITLE
test: dhat test for lru and hashlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,8 +3295,10 @@ dependencies = [
  "forest-filecoin",
  "futures",
  "get-size2",
+ "hashlink 0.10.0",
  "libp2p",
  "libp2p-swarm-test",
+ "lru 0.16.0",
  "multihash-codetable",
  "rust2go",
  "tokio",
@@ -4126,6 +4128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5333,7 +5344,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.16",
- "hashlink",
+ "hashlink 0.9.1",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ dhat = "0.3"
 flume = "0.11"
 futures = "0.3"
 get-size2 = { version = "0.6", features = ["derive"] }
+hashlink = "0.10"
 libp2p = { version = "0.56", default-features = false }
 libp2p-swarm-test = { version = "0.6", default-features = false, features = ["tokio"] }
+lru = "0.16"
 multihash-codetable = { version = "0.1", features = ["blake2b", "blake2s", "blake3", "sha2", "sha3", "strobe"] }
 rust2go = "0.4"
 tokio = "1"
@@ -139,7 +141,7 @@ libp2p = { workspace = true, features = [
   'secp256k1',
 ] }
 libsecp256k1 = "0.7"
-lru = "0.16"
+lru = { workspace = true }
 md5 = { package = "md-5", version = "0.10" }
 memmap2 = "0.9"
 memory-stats = "1"

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -22,6 +22,7 @@ forest = { package = "forest-filecoin", path = "../", default-features = false, 
 ] }
 futures = { workspace = true }
 get-size2 = { workspace = true }
+hashlink = { workspace = true }
 libp2p = { workspace = true, features = [
   'kad',
   'identify',
@@ -37,6 +38,7 @@ libp2p = { workspace = true, features = [
   'secp256k1',
 ] }
 libp2p-swarm-test = { workspace = true }
+lru = { workspace = true }
 multihash-codetable = { workspace = true }
 rust2go = { workspace = true }
 tokio = { workspace = true, features = ['full'] }

--- a/interop-tests/tests/dhat_hashlink.rs
+++ b/interop-tests/tests/dhat_hashlink.rs
@@ -1,0 +1,18 @@
+// Copyright 2019-2025 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_hashlink() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let mut c = hashlink::LruCache::new(10000);
+    for i in 0..10 {
+        c.insert(i, format!("i"));
+    }
+
+    let stats = dhat::HeapStats::get();
+    assert_eq!(stats.curr_bytes, 698);
+}

--- a/interop-tests/tests/dhat_lru.rs
+++ b/interop-tests/tests/dhat_lru.rs
@@ -1,0 +1,18 @@
+// Copyright 2019-2025 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_lru() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let mut c = lru::LruCache::new(10000.try_into().unwrap());
+    for i in 0..10 {
+        c.push(i, format!("i"));
+    }
+
+    let stats = dhat::HeapStats::get();
+    assert_eq!(stats.curr_bytes, 279130);
+}


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR adds tests to prove that, `lru::LruCache` uses `hashbrown::HashMap` internally to hold the data thus its heap allocation is capacity bounded, while `hashlink::LruCache` uses a linked list internally thus its heap allocation is not capacity bounded. 

We should consider switching to `hashlink`

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
