### PR TITLE
fix: use hashlink::LruCache in SizeTrackingLruCache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,8 @@ dependencies = [
  "git-version",
  "glob",
  "group",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
  "hex",
  "hickory-resolver",
  "http",
@@ -3928,6 +3930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5697765925a05c9d401dd04a93dfd662d336cc25fdcc3301220385a1ffcfdde5"
 dependencies = [
  "get-size-derive2",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4126,6 +4129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5333,7 +5345,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.16",
- "hashlink",
+ "hashlink 0.9.1",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ cid = { version = "0.11", default-features = false, features = ["std"] }
 dhat = "0.3"
 flume = "0.11"
 futures = "0.3"
-get-size2 = { version = "0.6", features = ["derive"] }
+get-size2 = { version = "0.6", features = ["derive", "hashbrown"] }
+hashlink = "0.10"
 libp2p = { version = "0.56", default-features = false }
 libp2p-swarm-test = { version = "0.6", default-features = false, features = ["tokio"] }
 multihash-codetable = { version = "0.1", features = ["blake2b", "blake2s", "blake3", "sha2", "sha3", "strobe"] }
@@ -98,6 +99,8 @@ get-size2 = { workspace = true }
 gethostname = "1"
 git-version = "0.3"
 group = "0.13"
+hashbrown = "0.15"
+hashlink = { workspace = true }
 hex = { version = "0.4", features = ["serde"] }
 hickory-resolver = { version = "0.25", default-features = false, features = ["system-config", "tokio"] }
 http = "1"

--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -53,8 +53,8 @@ use crate::db::car::RandomAccessFileReader;
 use crate::db::car::plain::write_skip_frame_header_async;
 use crate::utils::db::car_stream::{CarBlock, CarV1Header};
 use crate::utils::encoding::from_slice_with_fallback;
+use crate::utils::get_size::CidWrapper;
 use crate::utils::io::EitherMmapOrRandomAccessFile;
-use ahash::{HashMap, HashMapExt};
 use byteorder::LittleEndian;
 use bytes::{BufMut as _, Bytes, BytesMut, buf::Writer};
 use cid::Cid;
@@ -241,14 +241,14 @@ where
                     let cursor = Cursor::new_pos(entire_file, position);
                     let mut zstd_frame = decode_zstd_single_frame(cursor)?;
                     // Parse all key-value pairs and insert them into a map
-                    let mut block_map = HashMap::new();
+                    let mut block_map = hashbrown::HashMap::new();
                     while let Some(block_frame) =
                         UviBytes::<Bytes>::default().decode_eof(&mut zstd_frame)?
                     {
                         let CarBlock { cid, data } = CarBlock::from_bytes(block_frame)?;
                         block_map.insert(cid.into(), data);
                     }
-                    let get_result = block_map.get(&(*k).into()).cloned();
+                    let get_result = block_map.get(&CidWrapper::from(*k)).cloned();
                     self.frame_cache.put(position, self.cache_key, block_map);
 
                     // This lookup only fails in case of a hash collision


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
