### PR TITLE
fix: remove excess vec capacity in caches

### DIFF
--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -241,7 +241,7 @@ impl Tipset {
     pub fn new<H: Into<CachingBlockHeader>>(
         headers: impl IntoIterator<Item = H>,
     ) -> Result<Self, CreateTipsetError> {
-        let headers = NonEmpty::new(
+        let mut headers = NonEmpty::new(
             headers
                 .into_iter()
                 .map(Into::<CachingBlockHeader>::into)
@@ -249,7 +249,7 @@ impl Tipset {
                 .collect(),
         )
         .map_err(|_| CreateTipsetError::Empty)?;
-
+        headers.shrink_to_fit();
         verify_block_headers(&headers)?;
 
         Ok(Self {

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -583,7 +583,8 @@ impl MsgsInTipsetCache {
         }
     }
 
-    pub fn insert(&self, key: TipsetKey, value: Vec<ChainMessage>) {
+    pub fn insert(&self, key: TipsetKey, mut value: Vec<ChainMessage>) {
+        value.shrink_to_fit();
         self.cache.push(key, value);
     }
 

--- a/src/state_manager/cache.rs
+++ b/src/state_manager/cache.rs
@@ -203,14 +203,17 @@ impl EnabledTipsetDataCache {
 }
 
 impl TipsetReceiptEventCacheHandler for EnabledTipsetDataCache {
-    fn insert_receipt(&self, key: &TipsetKey, receipts: Vec<Receipt>) {
+    fn insert_receipt(&self, key: &TipsetKey, mut receipts: Vec<Receipt>) {
         if !receipts.is_empty() {
+            receipts.shrink_to_fit();
             self.receipt_cache.insert(key.clone(), receipts);
         }
     }
 
-    fn insert_events(&self, key: &TipsetKey, events_data: StateEvents) {
+    fn insert_events(&self, key: &TipsetKey, mut events_data: StateEvents) {
         if !events_data.events.is_empty() {
+            events_data.events.shrink_to_fit();
+            events_data.roots.shrink_to_fit();
             self.events_cache.insert(key.clone(), events_data);
         }
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR tries to reduce potential excess Vec capacity in caches for lower memory usage

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory usage when building tipsets and caching messages, receipts, and events, leading to lower overhead during sync and querying.
* **Reliability**
  * Added stricter validation of block headers in tipset creation to ensure consistent parents, state roots, epochs, and unique miners, improving chain integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->