### PR TITLE
test: ci test for `forest-cli state compute`

### DIFF
--- a/scripts/tests/calibnet_other_check.sh
+++ b/scripts/tests/calibnet_other_check.sh
@@ -16,7 +16,7 @@ go test -v ./f3-sidecar
 echo "Verifying the non calibnet snapshot (./test-snapshots/chain4.car) is being served properly."
 $FOREST_CLI_PATH chain read-obj -c bafy2bzacedjrqan2fwfvhfopi64yickki7miiksecglpeiavf7xueytnzevlu
 
-echo "Test subcommand: state compute"
+echo "Test subcommand: state compute at epoch 0"
 cid=$($FOREST_CLI_PATH state compute --epoch 0)
 # Expected state root CID, same reported as in Lotus. This should break only if the network is reset.
 if [ "$cid" != "bafy2bzacecgqgzh3gxpariy3mzqb37y2vvxoaw5nwbrlzkhso6owus3zqckwe" ]; then
@@ -63,3 +63,6 @@ echo "Regression testing mempool select"
 gem install http --user-install
 $FOREST_CLI_PATH chain head --format json -n 1000 | scripts/mpool_select_killer.rb
 
+echo "Test subcommand: state compute (batch)"
+head=$($FOREST_CLI_PATH chain head | head -n 1 | jq ".[0]")
+$FOREST_CLI_PATH state compute --epoch $((head - 900)) -n 10 -v

--- a/scripts/tests/calibnet_other_check.sh
+++ b/scripts/tests/calibnet_other_check.sh
@@ -64,5 +64,10 @@ gem install http --user-install
 $FOREST_CLI_PATH chain head --format json -n 1000 | scripts/mpool_select_killer.rb
 
 echo "Test subcommand: state compute (batch)"
-head=$($FOREST_CLI_PATH chain head | head -n 1 | jq ".[0]")
-$FOREST_CLI_PATH state compute --epoch $((head - 900)) -n 10 -v
+head_epoch=$($FOREST_CLI_PATH chain head --format json | jq ".[0].epoch")
+if ! [[ "$head_epoch" =~ ^[0-9]+$ ]]; then
+  echo "Failed to parse numeric head epoch from 'chain head --format json': $head_epoch"
+  exit 1
+fi
+start_epoch=$(( head_epoch > 900 ? head_epoch - 900 : 0 ))
+$FOREST_CLI_PATH state compute --epoch "$start_epoch" -n 10 -v


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- CI test for `forest-cli state compute` with `--n-epochs` argument

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5953

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Clarified test output to indicate state compute at epoch 0.
  * Added explicit validation of state root CID with clear failure message on mismatch.
  * Added a batch state-compute test that selects a recent historical epoch (with a guard to avoid negative epochs), runs multiple iterations, and provides verbose output.
  * Preserved existing mempool/test flow; new batch test runs after it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->