### PR TITLE
fix: remove deprecated docs info

### DIFF
--- a/documentation/src/introduction.md
+++ b/documentation/src/introduction.md
@@ -1,19 +1,3 @@
-<p align="center">
-    <img height="269" src="./img/forest_logo.png">
-</p>
-
-<p align="center">
-    <a href="https://github.com/ChainSafe/forest/actions"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/ChainSafe/forest/forest.yml?style=for-the-badge"></a>
-    <a href="https://github.com/ChainSafe/forest/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/ChainSafe/forest?style=for-the-badge"></a>
-    <a href="https://docs.forest.chainsafe.io"><img alt="Docs" src="https://img.shields.io/badge/doc-user_guide-green?style=for-the-badge"></a>
-    <a href="https://docs.forest.chainsafe.io/rustdoc/"><img alt="Rust Docs" src="https://img.shields.io/badge/doc-rust_docs-green?style=for-the-badge"></a>
-</p>
- <p align="center">
-    <a href="https://github.com/ChainSafe/forest/blob/main/LICENSE-APACHE"><img alt="License Apache 2.0" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-    <a href="https://github.com/ChainSafe/forest/blob/main/LICENSE-MIT"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge"></a>
-    <a href="https://twitter.com/ChainSafeth"><img alt="Twitter" src="https://img.shields.io/twitter/follow/chainsafeth?style=for-the-badge&color=1DA1F2"></a>
-</p>
-
 # ⚠️ Documentation deprecated
 
 This documentation is deprecated and will be removed in the future. Please refer


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- these docs are depreacted and there's no point in maintaining the links there. This fixes a CI issue where the rustdoc link fails.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the introduction page: removed the top-of-page hero/header (logo, status/release/docs badges, license badges, and social link).
  * Added a prominent “Documentation deprecated” notice with a direct link to the new site at docs.forest.chainsafe.io.
  * Clarified navigation by directing readers to the new documentation location.
  * No functional changes to the app; this is a content-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->