### PR TITLE
fix: allow some flakiness for RPC tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -35,6 +35,9 @@ filter = 'binary(lint)'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
 # These tests download test snapshots from the network, which can take a while.
+# There might be some network issues, so we allow some retries with backoff.
+# Jitter is enabled to avoid [thundering herd issues](https://en.wikipedia.org/wiki/Thundering_herd_problem).
 [[profile.default.overrides]]
 filter = 'test(rpc_test_)'
-slow-timeout = { period = "120s", terminate-after = 3 }
+slow-timeout = { period = "60s", terminate-after = 2 }
+retries = { backoff = "exponential", count = 4, delay = "5s", jitter = true }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- allow for some flakiness in the RPC tests, given they were failing repeatedly, most likely due to network conditions (but maybe the worker was overwhelmed due to FVM init)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
