### PR TITLE
chore: deprecate `ticker` by favoring `tokio::time::interval`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,7 +3265,6 @@ dependencies = [
  "tera",
  "termios",
  "thiserror 2.0.15",
- "ticker",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
@@ -9107,12 +9106,6 @@ checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
 ]
-
-[[package]]
-name = "ticker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6821a2afe2700471d4572a25bcbfc091d6d596902a279ed41af139f350b76e"
 
 [[package]]
 name = "tikv-jemalloc-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,6 @@ tar = "0.4"
 tempfile = "3"
 tera = { version = "1", default-features = false }
 thiserror = "2"
-ticker = "0.1"
 tokio = { version = "1", features = ['full'] }
 tokio-stream = { version = "0.1", features = ["fs", "io-util"] }
 tokio-util = { version = "0.7", features = ["compat", "io-util"] }

--- a/src/cli/subcommands/healthcheck_cmd.rs
+++ b/src/cli/subcommands/healthcheck_cmd.rs
@@ -10,7 +10,6 @@ use crate::health::DEFAULT_HEALTHCHECK_PORT;
 use crate::rpc;
 use clap::Subcommand;
 use http::StatusCode;
-use ticker::Ticker;
 
 #[derive(Debug, Subcommand)]
 pub enum HealthcheckCommand {
@@ -67,7 +66,6 @@ impl HealthcheckCommand {
         healthcheck_port: u16,
         wait: bool,
     ) -> anyhow::Result<()> {
-        let ticker = Ticker::new(0.., Duration::from_secs(1));
         let mut stdout = stdout();
 
         let url = format!(
@@ -75,7 +73,9 @@ impl HealthcheckCommand {
             client.base_url().host_str().unwrap_or("localhost"),
         );
 
-        for _ in ticker {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        loop {
+            interval.tick().await;
             let (status, text) = {
                 match reqwest::get(&url).await {
                     Ok(response) => {

--- a/src/cli/subcommands/sync_cmd.rs
+++ b/src/cli/subcommands/sync_cmd.rs
@@ -12,7 +12,6 @@ use std::{
     io::{Write, stdout},
     time::Duration,
 };
-use ticker::Ticker;
 use tokio::time;
 use tokio::time::sleep;
 
@@ -44,13 +43,14 @@ impl SyncCommands {
     pub async fn run(self, client: rpc::Client) -> anyhow::Result<()> {
         match self {
             Self::Wait { watch } => {
-                let ticker = Ticker::new(0.., Duration::from_secs(1));
                 let mut stdout = stdout();
                 let mut lines_printed_last_iteration = 0;
 
                 handle_initial_snapshot_check(&client).await?;
 
-                for _ in ticker {
+                let mut interval = tokio::time::interval(Duration::from_secs(1));
+                loop {
+                    interval.tick().await;
                     let report = SyncStatus::call(&client, ())
                         .await
                         .context("Failed to get sync status")?;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

`ticker` crate is pretty old and was last updated 8 years ago. This PR replaces `ticker` with `tokio::time::interval` and removes `ticker` from dependency tree

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved periodic polling in health check and sync watch commands to deliver smoother, more reliable 1-second updates and better responsiveness during long-running operations.

- **Chores**
  - Removed an unused timing dependency to streamline the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->