### PR TITLE
chore: use more fitting ignore case method

### DIFF
--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -3084,7 +3084,7 @@ fn evaluate_test_success(
                 PolicyOnRejected::Pass => true,
                 PolicyOnRejected::PassWithIdenticalError => reason_forest == reason_lotus,
                 PolicyOnRejected::PassWithIdenticalErrorCaseInsensitive => {
-                    reason_forest.to_lowercase() == reason_lotus.to_lowercase()
+                    reason_forest.eq_ignore_ascii_case(reason_lotus)
                 }
                 PolicyOnRejected::PassWithQuasiIdenticalError => {
                     reason_lotus.contains(reason_forest) || reason_forest.contains(reason_lotus)


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- a completely meaningless improvement that saves maybe two allocations in the tests that are seldom invoked. Totally worth it.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved case-insensitive matching in API comparison tests by switching to ASCII-only comparison, reducing false positives/negatives when evaluating identical error messages that differ only by case. Enhances reliability and performance of test outcomes. No changes to public interfaces or user workflows, and no impact on runtime behavior—only test evaluation is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->