### PR TITLE
fix: print actual response in `forest-cli sync check-bad`

### DIFF
--- a/src/cli/subcommands/sync_cmd.rs
+++ b/src/cli/subcommands/sync_cmd.rs
@@ -96,7 +96,7 @@ impl SyncCommands {
                 if response.is_empty() {
                     println!("Block \"{cid}\" is not marked as a bad block");
                 } else {
-                    println!("response");
+                    println!("{response}");
                 }
                 Ok(())
             }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

(Came across this randomly)

Changes introduced in this pull request:

- print actual response in `forest-cli sync check-bad`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The sync check command now displays the actual response content when issues are detected, replacing the previous generic placeholder. This improves clarity of CLI output for diagnosing problems.
  * Behavior for empty responses is unchanged.
  * No changes to command behavior, options, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->