### PR TITLE
fix: link check on wikipedia

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -19,6 +19,8 @@ exclude = [
   "crates.io",
   # Bot protection / 403 Forbidden errors
   "linuxhint.com",
+  # Bot protection / 403 Forbidden errors
+  "wikipedia.org",
 ]
 timeout = 30
 max_retries = 6


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- it seems Wikipedia started using some bot protection, effectively causing the link check to fail there. I added the entire domain to exceptions.

https://github.com/ChainSafe/forest/actions/runs/17208198974/job/48813396939
>  [403] <https://en.wikipedia.org/wiki/Memory_paging#Swappiness> | Rejected status code (this depends on your "accept" configuration): Forbidden

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link-checking configuration to exclude wikipedia.org, reducing false positives caused by bot protection (403 errors) during automated link validation.
  * Improves CI reliability for link checks without affecting application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->