### PR TITLE
chore(release): prepare v0.29.0 "Fëanor"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@
 
 ### Breaking
 
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+## Forest v0.29.0 "Fëanor"
+
+Non-mandatory release. It introduces a couple of features around snapshot generation and inspection. It fully supports the new FRC-0108 Filecoin snapshot format. There is also a notable fix in `Filecoin.ChainNotify` RPC method that would cause issues with some clients.
+
+### Breaking
+
 - [#5946](https://github.com/ChainSafe/forest/pull/5946) Updated parameters and response of `Forest.StateCompute` RPC method to support new `forest-cli state compute` options.
 
 ### Added
@@ -59,13 +73,13 @@
 
 - [#5969](https://github.com/ChainSafe/forest/pull/5969) Updated `forest-tool snapshot validate` to print better error message for troubleshooting.
 
-### Removed
-
 ### Fixed
 
 - [#5863](https://github.com/ChainSafe/forest/pull/5863) Fixed needless GC runs on a stateless node.
 
 - [#5859](https://github.com/ChainSafe/forest/pull/5859) Fixed size calculation for zstd frame cache.
+
+- [#5975](https://github.com/ChainSafe/forest/issues/5975) Fixed JSON escaping in the `Filecoin.ChainNotify` RPC method.
 
 ## Forest v0.28.0 "Denethor's Folly"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,7 +3111,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "forest-filecoin"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "anes 0.2.1",
@@ -9637,7 +9637,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.15",
+ "thiserror 2.0.16",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forest-filecoin"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 repository = "https://github.com/ChainSafe/forest"
 edition = "2024"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- prepare v0.29.0 "Fëanor"

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Snapshot generation/inspection enhancements and support for FRC-0108 snapshot format.
- Bug Fixes
  - Corrected JSON escaping in ChainNotify notifications; reduced unnecessary GC; optimized zstd frame cache size.
- Changed
  - Updated state compute options (breaking change) to align CLI/RPC behavior.
- Documentation
  - Changelog reorganized with Unreleased and v0.29.0 sections; clearer snapshot validation messaging.
- Chores
  - Version bumped to 0.29.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->