### PR TITLE
fix: bug in fallback_de_ipld_dagcbor

### DIFF
--- a/src/utils/encoding/fallback_de_ipld_dagcbor.rs
+++ b/src/utils/encoding/fallback_de_ipld_dagcbor.rs
@@ -5,7 +5,6 @@
 // - strings are de-serialized as `BadStr`. This is a workaround for the historical
 // bug in Lotus where malformed UTF-8 strings were serialized as CBOR strings.
 // Allow everything so we don't stray from the original code too much.
-#![allow(clippy::all, warnings)]
 
 use self::cbor4ii_nonpub::*;
 use cbor4ii::core::dec::{self, Decode};
@@ -115,6 +114,7 @@ where
 /// let value: &str = de::from_reader(&v[..]).unwrap();
 /// assert_eq!(value, "foobar");
 /// ```
+#[allow(dead_code)]
 pub fn from_reader<T, R>(reader: R) -> Result<T, DecodeError<std::io::Error>>
 where
     T: de::DeserializeOwned,
@@ -159,8 +159,8 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     where
         V: Visitor<'de>,
     {
+        const CBOR_TAGS_CID: u64 = 42; // serde_ipld_dagcbor::CBOR_TAGS_CID
         let tag = dec::TagStart::decode(&mut self.reader)?;
-
         match tag.0 {
             CBOR_TAGS_CID => visitor.visit_newtype_struct(&mut CidDeserializer(self)),
             _ => Err(DecodeError::TypeMismatch {
@@ -198,7 +198,7 @@ macro_rules! deserialize_type {
     };
 }
 
-impl<'de, 'a, R: dec::Read<'de>> serde::Deserializer<'de> for &'a mut Deserializer<R> {
+impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
     type Error = DecodeError<R::Error>;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

`CBOR_TAGS_CID` is supposed to be a const but it's made a variable in the copy & pasted code. This should've been caught by clippy but clippy was disabled.

https://docs.rs/crate/serde_ipld_dagcbor/0.6.3/source/src/de.rs#214
```rust
        match tag.0 {
            CBOR_TAGS_CID => visitor.visit_newtype_struct(&mut CidDeserializer(self)),
            _ => Err(DecodeError::TypeMismatch {
                name: "CBOR tag",
                byte: tag.0 as u8,
            }),
        }
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CBOR deserialization internals for greater robustness and maintainability.
  * Standardized use of constants for tag handling to reduce ambiguity.
  * Tightened input requirements to use buffered readers, improving performance and reliability.

* **Chores**
  * Removed broad lint suppressions to surface meaningful warnings.
  * Adopted more modern Rust patterns for borrowed types and lifetimes.
  * Applied targeted allowances to keep builds clean without hiding issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->