### PR TITLE
fix: OOM in `forest-tool archive diff`

### DIFF
--- a/src/statediff/mod.rs
+++ b/src/statediff/mod.rs
@@ -89,18 +89,17 @@ fn try_print_actor_states<BS: Blockstore>(
     let state_tree = StateTree::new_from_root(bs.clone(), root)?;
 
     state_tree.for_each(|addr: Address, actor| {
-        let calc_pp = pp_actor_state(bs, actor, depth)?;
-
         if let Some(other) = e_state.remove(&addr) {
             if &other != actor {
-                let comma = ",";
+                const COMMA: &str = ",";
+                let calc_pp = pp_actor_state(bs, actor, depth)?;
                 let expected_pp = pp_actor_state(bs, &other, depth)?;
                 let expected = expected_pp
-                    .split(comma)
+                    .split(COMMA)
                     .map(|s| s.trim_start_matches('\n'))
                     .collect::<Vec<&str>>();
                 let calculated = calc_pp
-                    .split(comma)
+                    .split(COMMA)
                     .map(|s| s.trim_start_matches('\n'))
                     .collect::<Vec<&str>>();
                 let diffs = TextDiff::from_slices(&expected, &calculated);
@@ -110,6 +109,7 @@ fn try_print_actor_states<BS: Blockstore>(
                 print_diffs(&mut handle, diffs)?;
             }
         } else {
+            let calc_pp = pp_actor_state(bs, actor, depth)?;
             // Added actor, print out the json format actor state.
             println!("{}", format!("+ Address {addr}:\n{calc_pp}").green());
         }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR fixes OOM issue in running `forest-tool archive diff --epoch 2819795 forest_snapshot_mainnet_2023-05-01_height_2820000.forest.car.zst`

Output:
```
forest-tool archive diff --epoch 2819795 forest_snapshot_mainnet_2023-05-01_height_2820000.forest.car.zst

- Expected state hash: bafy2bzacedflaenehbgpwlzgeimnamtuuu45vy5zk3u6vp345h7zs4ybweerq
+ Computed state hash: bafy2bzacecyw2yay6jkkmyob53u4hobgsi57xiqdfla6uu437w2vriarb5nds
Address f04 changed: 
 ActorState(ActorState { code: Cid(bafk2bzaceaxgloxuzg35vu7l7tohdgaq2frsfp4ejmuo7tkoxjp5zqrze6sf4)
- state: Cid(bafy2bzacedabdkat4ikokbpmzkbmwjql63zqmj2mlqdbbuzscmo6jz7vhwpxi)
+ state: Cid(bafy2bzaceanjejlvqc5gwilc62xpmdvzkgfzcqgp4igcymywto2vm25wexnni)
  sequence: 0
  balance: TokenAmount(0.011)
  delegated_address: None })
V11(State { total_raw_byte_power: 14030677426019762176
  total_bytes_committed: 14030973057208680448
  total_quality_adj_power: 22832346608471441408
  total_qa_bytes_committed: 22833184005643042816
- total_pledge_collateral: TokenAmount(143269926.2652187083170961)
+ total_pledge_collateral: TokenAmount(143270003.413371965258963041)
  this_epoch_raw_byte_power: 14030677426019762176
  this_epoch_quality_adj_power: 22832346608471441408
- this_epoch_pledge_collateral: TokenAmount(143269926.2652187083170961)
+ this_epoch_pledge_collateral: TokenAmount(143270003.413371965258963041)
  this_epoch_qa_power_smoothed: FilterEstimate { position: 7788953586247045787797498918428003402915103487709779837094
  velocity: 30553465660375297517809812792028847344200527615729490 }
  miner_count: 597663
  miner_above_min_power_count: 3468
  cron_event_queue: Cid(bafy2bzaceblqrq7j5jz75xqtwkgm7h67chxyp443zy7agjzkf6dvcpthxbhmw)
  first_cron_epoch: 2819796
  claims: Cid(bafy2bzacecl7s52etztcf2aaj5ccilgrzovhr4zeitxcl4n35ti7eucxbfwdg)
  proof_validation_batch: None })
Address f099 changed: 
 ActorState(ActorState { code: Cid(bafk2bzacealnlr7st6lkwoh6wxpf2hnrlex5sknaopgmkr2tuhg7vmbfy45so)
  state: Cid(bafy2bzacedpuk5ggwoq3s2wixsyjjnexpsjstdlyntio76vs2lt2jvy3o6mau)
  sequence: 0
- balance: TokenAmount(36187969.358883641800996567)
+ balance: TokenAmount(36187896.068627543923907091)
  delegated_address: None })
V11(State { address: Address { payload: ID(99) } })
Address f094625 changed: 
 ActorState(ActorState { code: Cid(bafk2bzacec24okjqrp7c7rj3hbrs5ez5apvwah2ruka6haesgfngf37mhk6us)
- state: Cid(bafy2bzacebr6if6imx2olrhrb3gquzgfwd4zkn36cxinnikiz4lyngys3eeyk)
+ state: Cid(bafy2bzacedjrgrvkj4wopdyecsqviyzride2ae4itin3uzabxg5kqh4jrr5l6)
  sequence: 0
- balance: TokenAmount(49655.00241996624371334)
- delegated_address: None })
V11(State { info: Cid(bafy2bzacealxryywh3wxrpq2ydnv5p53mp64x5eniswhj5tdnd67lhee6tjua)
+ balance: TokenAmount(49732.150573223185580281)
+ delegated_address: None })
V11(State { info: Cid(bafy2bzaced5vr2epcy7ao63r6sbda6jberludtn77u2dg6xufeydtyazo3b4m)
  pre_commit_deposits: TokenAmount(0.0)
- locked_funds: TokenAmount(5036.123441842349323139)
- vesting_funds: Cid(bafy2bzacedo75tr7blox5i374yioa2fk3xpzyqes7tb4tmiuu7beuwounk4oa)
+ locked_funds: TokenAmount(5113.27159509929119008)
+ vesting_funds: Cid(bafy2bzaceayfqbja334jl3cjggp5jhdrnwb6k3l2ey7mz5qro56mptkwvprae)
  fee_debt: TokenAmount(0.0)
  initial_pledge: TokenAmount(35640.487189858427627691)
  pre_committed_sectors: Cid(bafy2bzaceamp42wmmgr2g2ymg46euououzfyck7szknvfacqscohrvaikwfay)
  pre_committed_sectors_cleanup: Cid(bafy2bzaceaa2jny7gkgdwnid4kuldau6bnvgyss5bszo4uy6uikrncvdu5mc2)
  allocated_sectors: Cid(bafy2bzaceagnnbswwvovpa4knbmqco7iweh62ffsm4jelgp5d2mmmopb4ix2e)
  sectors: Cid(bafy2bzaced4paoaja7y7inff55ua2jqanjsvjpyci2zpg4khy5zhhrdvyitzk)
  proving_period_start: 2817774
  current_deadline: 33
  deadlines: Cid(bafy2bzacebgwqhqu6momrtokexrgqgoyp7baswlne5jaqvlcxm6owygcbfdm2)
  early_terminations: BitField { ranges: []
  set: {}
  unset: {} }
  deadline_cron_active: true })
Address f01984106 changed: 
 ActorState(ActorState { code: Cid(bafk2bzacealnlr7st6lkwoh6wxpf2hnrlex5sknaopgmkr2tuhg7vmbfy45so)
  state: Cid(bafy2bzacebfeoet4rnxbdcsmnrmttjtylyf64zmt27tjoud52ettkvgscr3xo)
  sequence: 111
- balance: TokenAmount(51.096479311654039993)
+ balance: TokenAmount(47.238582152589262528)
  delegated_address: None })
V11(State { address: Address { payload: Secp256k1([78
  66
  50
  65
  69
  41
  115
  113
  158
  124
  128
  139
  119
  241
  247
  133
  197
  177
  154
  216]) } })
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.
- Performance
  - Reduced upfront processing when displaying actor state differences; computes details only for changed or added items, improving responsiveness with large diffs.
- Refactor
  - Streamlined preparation of state diff data and clarified internal constants. No changes to output format or public APIs. Behavior and results remain the same; only efficiency and maintainability improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->