### PR TITLE
chore(release): prepare v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,23 @@
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Fixed
+
+## Forest v0.30.0 "Eärendil"
+
+Mandatory release for calibration network node operators. It includes the NV27 _Golden Week_ network upgrade at epoch `3_007_294` which corresponds to `Wed 10 Sep 23:00:00 UTC 2025`. This release also includes a few breaking changes (removal of unused commands) and minor fixes.
+
+### Added
+
 - [#6006](https://github.com/ChainSafe/forest/issues/6006) More strict checks for the address arguments in the `forest-cli` subcommands.
 
 - [#5897](https://github.com/ChainSafe/forest/issues/5987) Added support for the NV27 _Golden Week_ network upgrade for devnets.
 
 - [#5897](https://github.com/ChainSafe/forest/issues/5987) Added support for the NV27 _Golden Week_ network upgrade for calibration network. The upgrade epoch is set to `3_007_294` (Wed 10 Sep 23:00:00 UTC 2025).
-
-### Changed
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,7 +3122,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "forest-filecoin"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "ahash",
  "anes 0.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forest-filecoin"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 repository = "https://github.com/ChainSafe/forest"
 edition = "2024"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- prepare release v0.30.0

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated release notes for Forest v0.30.0 “Eärendil,” highlighting:
    - Stricter validation for address arguments in CLI subcommands.
    - Support for the NV27 “Golden Week” network upgrade for devnets and the calibration network (epoch 3,007,294, Wed 10 Sep 23:00:00 UTC 2025).
    - Deprecation note: removed the legacy CLI send command; use wallet send instead.
  - Added placeholder sections for upcoming changes.
- Chores
  - Bumped application version to 0.30.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->