### PR TITLE
fix(ci): ignore `eth_newBlockFilter` test in `forest-tool api test-stateful`

### DIFF
--- a/src/tool/subcommands/api_cmd/stateful_tests.rs
+++ b/src/tool/subcommands/api_cmd/stateful_tests.rs
@@ -630,7 +630,9 @@ pub(super) async fn create_tests(tx: TestTransaction) -> Vec<RpcTestScenario> {
             EthUninstallFilter
         ),
         with_methods!(
-            eth_new_block_filter().name("eth_newBlockFilter works"),
+            eth_new_block_filter()
+                .name("eth_newBlockFilter works")
+                .ignore("https://github.com/ChainSafe/forest/issues/6069"),
             EthNewBlockFilter,
             EthGetFilterChanges,
             EthUninstallFilter


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Ignore `eth_newBlockFilter` test to unblock CI, see https://github.com/ChainSafe/forest/issues/6069

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test suite to temporarily skip a flaky network filter scenario due to a known issue, improving CI stability and reducing false negatives.
  * This change affects only internal test configuration; runtime behavior and feature set remain unchanged.
  * No public API or user-facing changes; builds and releases proceed as normal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->