### PR TITLE
fix: some metrics get duplicated after GC

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -55,3 +55,7 @@ reason = """Use SizeTrackingLruCache instead."""
 [[disallowed-methods]]
 path = "hashlink::LruCache::new_unbounded"
 reason = """Avoid unbounded lru cache for potential memory leak, use SizeTrackingLruCache instead."""
+
+[[disallowed-methods]]
+path = "prometheus_client::registry::Registry::register_collector"
+reason = """use crate::metrics::register_collector instead."""

--- a/src/beacon/drand.rs
+++ b/src/beacon/drand.rs
@@ -259,7 +259,7 @@ impl DrandBeacon {
             drand_gen_time: config.chain_info.genesis_time as u64,
             fil_round_time: interval,
             fil_gen_time: genesis_ts,
-            verified_beacons: SizeTrackingLruCache::new_with_default_metrics_registry(
+            verified_beacons: SizeTrackingLruCache::new_with_metrics(
                 "verified_beacons".into(),
                 NonZeroUsize::new(CACHE_SIZE).expect("Infallible"),
             ),

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -565,10 +565,7 @@ pub struct MsgsInTipsetCache {
 impl MsgsInTipsetCache {
     pub fn new(capacity: NonZeroUsize) -> Self {
         Self {
-            cache: SizeTrackingLruCache::new_with_default_metrics_registry(
-                "msg_in_tipset".into(),
-                capacity,
-            ),
+            cache: SizeTrackingLruCache::new_with_metrics("msg_in_tipset".into(), capacity),
         }
     }
 

--- a/src/chain/store/index.rs
+++ b/src/chain/store/index.rs
@@ -40,10 +40,8 @@ pub enum ResolveNullTipset {
 
 impl<DB: Blockstore> ChainIndex<DB> {
     pub fn new(db: DB) -> Self {
-        let ts_cache = SizeTrackingLruCache::new_with_default_metrics_registry(
-            "tipset".into(),
-            DEFAULT_TIPSET_CACHE_SIZE,
-        );
+        let ts_cache =
+            SizeTrackingLruCache::new_with_metrics("tipset".into(), DEFAULT_TIPSET_CACHE_SIZE);
         Self { ts_cache, db }
     }
 
@@ -125,7 +123,7 @@ impl<DB: Blockstore> ChainIndex<DB> {
         use crate::shim::policy::policy_constants::CHAIN_FINALITY;
 
         static CACHE: LazyLock<SizeTrackingLruCache<ChainEpoch, TipsetKey>> = LazyLock::new(|| {
-            SizeTrackingLruCache::new_with_default_metrics_registry(
+            SizeTrackingLruCache::new_with_metrics(
                 "tipset_by_height".into(),
                 4096.try_into().expect("infallible"),
             )

--- a/src/chain_sync/bad_block_cache.rs
+++ b/src/chain_sync/bad_block_cache.rs
@@ -25,7 +25,7 @@ impl Default for BadBlockCache {
 impl BadBlockCache {
     pub fn new(cap: NonZeroUsize) -> Self {
         Self {
-            cache: SizeTrackingLruCache::new_with_default_metrics_registry("bad_block".into(), cap),
+            cache: SizeTrackingLruCache::new_with_metrics("bad_block".into(), cap),
         }
     }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -208,7 +208,7 @@ async fn maybe_start_metrics_service(
                 .context("Failed to initiate prometheus server")
         });
 
-        crate::metrics::default_registry().register_collector(Box::new(
+        crate::metrics::register_collector(Box::new(
             networks::metrics::NetworkHeightCollector::new(
                 ctx.state_manager.chain_config().block_delay_secs,
                 ctx.state_manager
@@ -533,8 +533,8 @@ pub(super) async fn start_services(
     shutdown_send: mpsc::Sender<()>,
     on_app_context_and_db_initialized: impl Fn(&AppContext),
 ) -> anyhow::Result<()> {
-    // Cleanup the default prometheus metrics registry
-    *crate::metrics::default_registry() = Default::default();
+    // Cleanup the collector prometheus metrics registry on start
+    crate::metrics::reset_collector_registry();
     let mut services = JoinSet::new();
     let network = config.chain();
     let ctx = AppContext::init(opts, &config).await?;

--- a/src/db/car/mod.rs
+++ b/src/db/car/mod.rs
@@ -73,7 +73,7 @@ impl ZstdFrameCache {
         ZstdFrameCache {
             max_size,
             current_size: AtomicUsize::new(0),
-            lru: SizeTrackingLruCache::unbounded_with_default_metrics_registry("zstd_frame".into()),
+            lru: SizeTrackingLruCache::unbounded_with_metrics("zstd_frame".into()),
         }
     }
 

--- a/src/libp2p/behaviour.rs
+++ b/src/libp2p/behaviour.rs
@@ -123,7 +123,7 @@ impl ForestBehaviour {
             request_response::Config::default()
                 .with_max_concurrent_streams(max_concurrent_request_response_streams),
         );
-        crate::libp2p_bitswap::register_metrics(&mut crate::metrics::default_registry());
+        crate::libp2p_bitswap::register_metrics(&mut crate::metrics::collector_registry());
 
         let discovery = DiscoveryConfig::new(local_key.public(), network_name)
             .with_mdns(config.mdns)

--- a/src/libp2p/service.rs
+++ b/src/libp2p/service.rs
@@ -202,7 +202,7 @@ where
             )?
             .with_quic()
             .with_dns()?
-            .with_bandwidth_metrics(&mut crate::metrics::default_registry())
+            .with_bandwidth_metrics(&mut crate::metrics::collector_registry())
             .with_behaviour(|_| behaviour)?
             .with_swarm_config(|config| {
                 config
@@ -301,7 +301,7 @@ where
             bitswap_request_manager.outbound_request_stream().fuse();
         let mut peer_ops_rx_stream = self.peer_manager.peer_ops_rx().stream().fuse();
         let metrics = if libp2p_metrics_enabled() {
-            Some(Metrics::new(&mut crate::metrics::default_registry()))
+            Some(Metrics::new(&mut crate::metrics::collector_registry()))
         } else {
             None
         };

--- a/src/message_pool/msgpool/msg_pool.rs
+++ b/src/message_pool/msgpool/msg_pool.rs
@@ -475,11 +475,11 @@ where
         let local_addrs = Arc::new(SyncRwLock::new(Vec::new()));
         let pending = Arc::new(SyncRwLock::new(HashMap::new()));
         let tipset = Arc::new(SyncRwLock::new(api.get_heaviest_tipset()));
-        let bls_sig_cache = Arc::new(SizeTrackingLruCache::new_with_default_metrics_registry(
+        let bls_sig_cache = Arc::new(SizeTrackingLruCache::new_with_metrics(
             "bls_sig".into(),
             BLS_SIG_CACHE_SIZE,
         ));
-        let sig_val_cache = Arc::new(SizeTrackingLruCache::new_with_default_metrics_registry(
+        let sig_val_cache = Arc::new(SizeTrackingLruCache::new_with_metrics(
             "sig_val".into(),
             SIG_VAL_CACHE_SIZE,
         ));

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -7,6 +7,7 @@ use crate::db::DBStatistics;
 use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
 use parking_lot::{RwLock, RwLockWriteGuard};
 use prometheus_client::{
+    collector::Collector,
     encoding::EncodeLabelSet,
     metrics::{
         counter::Counter,
@@ -23,8 +24,24 @@ use tracing::warn;
 static DEFAULT_REGISTRY: LazyLock<RwLock<prometheus_client::registry::Registry>> =
     LazyLock::new(Default::default);
 
+static COLLECTOR_REGISTRY: LazyLock<RwLock<prometheus_client::registry::Registry>> =
+    LazyLock::new(Default::default);
+
 pub fn default_registry<'a>() -> RwLockWriteGuard<'a, prometheus_client::registry::Registry> {
     DEFAULT_REGISTRY.write()
+}
+
+pub fn collector_registry<'a>() -> RwLockWriteGuard<'a, prometheus_client::registry::Registry> {
+    COLLECTOR_REGISTRY.write()
+}
+
+pub fn register_collector(collector: Box<dyn Collector>) {
+    #[allow(clippy::disallowed_methods)]
+    collector_registry().register_collector(collector)
+}
+
+pub fn reset_collector_registry() {
+    *collector_registry() = Default::default();
 }
 
 pub static LRU_CACHE_HIT: LazyLock<Family<KindLabel, Counter>> = LazyLock::new(|| {
@@ -74,18 +91,16 @@ where
     DB: DBStatistics + Send + Sync + 'static,
 {
     // Add the process collector to the registry
-    if let Err(err) =
-        kubert_prometheus_process::register(default_registry().sub_registry_with_prefix("process"))
-    {
+    if let Err(err) = kubert_prometheus_process::register(
+        collector_registry().sub_registry_with_prefix("process"),
+    ) {
         warn!("Failed to register process metrics: {err}");
     }
 
-    DEFAULT_REGISTRY.write().register_collector(Box::new(
+    register_collector(Box::new(
         crate::utils::version::ForestVersionCollector::new(),
     ));
-    DEFAULT_REGISTRY
-        .write()
-        .register_collector(Box::new(crate::metrics::db::DBCollector::new(db_directory)));
+    register_collector(Box::new(crate::metrics::db::DBCollector::new(db_directory)));
 
     // Create an configure HTTP server
     let app = Router::new()
@@ -100,11 +115,19 @@ where
 
 async fn collect_prometheus_metrics() -> impl IntoResponse {
     let mut metrics = String::new();
-    match prometheus_client::encoding::text::encode(&mut metrics, &DEFAULT_REGISTRY.read()) {
-        Ok(()) => {}
-        Err(e) => warn!("{e}"),
+    if let Err(e) =
+        prometheus_client::encoding::text::encode_registry(&mut metrics, &DEFAULT_REGISTRY.read())
+    {
+        warn!("failed to encode the default metrics registry: {e}");
     };
-
+    if let Err(e) =
+        prometheus_client::encoding::text::encode_registry(&mut metrics, &COLLECTOR_REGISTRY.read())
+    {
+        warn!("failed to encode the collector metrics registry: {e}");
+    };
+    if let Err(e) = prometheus_client::encoding::text::encode_eof(&mut metrics) {
+        warn!("failed to encode metrics eof {e}");
+    };
     (
         StatusCode::OK,
         [("content-type", "text/plain; charset=utf-8")],

--- a/src/rpc/methods/f3.rs
+++ b/src/rpc/methods/f3.rs
@@ -164,7 +164,7 @@ impl GetPowerTable {
         // The RAM overhead on mainnet is ~14MiB
         const BLOCKSTORE_CACHE_CAP: usize = 65536;
         static BLOCKSTORE_CACHE: LazyLock<LruBlockstoreReadCache> = LazyLock::new(|| {
-            LruBlockstoreReadCache::new_with_default_metrics_registry(
+            LruBlockstoreReadCache::new_with_metrics(
                 "get_powertable".into(),
                 BLOCKSTORE_CACHE_CAP.try_into().expect("Infallible"),
             )

--- a/src/state_manager/cache.rs
+++ b/src/state_manager/cache.rs
@@ -20,7 +20,7 @@ struct TipsetStateCacheInner<V: LruValueConstraints> {
 impl<V: LruValueConstraints> TipsetStateCacheInner<V> {
     pub fn with_size(cache_identifier: &str, cache_size: NonZeroUsize) -> Self {
         Self {
-            values: SizeTrackingLruCache::new_with_default_metrics_registry(
+            values: SizeTrackingLruCache::new_with_metrics(
                 Self::cache_name(cache_identifier).into(),
                 cache_size,
             ),

--- a/src/state_migration/common/mod.rs
+++ b/src/state_migration/common/mod.rs
@@ -31,7 +31,7 @@ pub(in crate::state_migration) struct MigrationCache {
 impl MigrationCache {
     pub fn new(size: NonZeroUsize) -> Self {
         Self {
-            cache: Arc::new(SizeTrackingLruCache::new_with_default_metrics_registry(
+            cache: Arc::new(SizeTrackingLruCache::new_with_metrics(
                 "migration".into(),
                 size,
             )),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fix an issue that some metrics get duplicated (re-registered) after GC

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics are now cleanly reinitialized when the daemon starts, improving the reliability and consistency of Prometheus metrics after restarts. This standardizes metrics setup across services at launch and helps ensure accurate reporting from the outset. No configuration changes or user action are required; behavior is automatic on start-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->