### PR TITLE
feat: set nv27 mainnet upgrade epoch

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1154,7 +1154,7 @@
     "network": {
       "type": "calibnet"
     },
-    "version": "v17.0.0-rc1",
+    "version": "v17.0.0",
     "bundle_cid": "bafy2bzacecn64rlb52rjsvgopnidz6w42z3zobmjxqek5s4xqjh3ly47rcurg",
     "manifest": {
       "actors": [
@@ -1430,7 +1430,7 @@
     "network": {
       "type": "butterflynet"
     },
-    "version": "v17.0.0-rc1",
+    "version": "v17.0.0",
     "bundle_cid": "bafy2bzacedzjwguwuihh4tptzfkkwaj3naamrnklbaixn2wfzqh67twwp56pi",
     "manifest": {
       "actors": [
@@ -2247,7 +2247,7 @@
       "type": "devnet",
       "name": "devnet"
     },
-    "version": "v17.0.0-rc1",
+    "version": "v17.0.0",
     "bundle_cid": "bafy2bzaceasvgkke3j4cs3xsxnjswpcdmokkvkiehzxzcgfox3ozlehimbuqk",
     "manifest": {
       "actors": [
@@ -3049,6 +3049,98 @@
         ]
       ],
       "actor_list_cid": "bafy2bzaceavbltrvpskmmc4lmy3ur7ymigxqtnesdx3lld576puv63uolufks"
+    }
+  },
+  {
+    "network": {
+      "type": "mainnet"
+    },
+    "version": "v17.0.0",
+    "bundle_cid": "bafy2bzaceai74ppsvuxs3nvpzzeuptdr3wl7vmdpbphvtz4qt5hfq2qdfvz3e",
+    "manifest": {
+      "actors": [
+        [
+          "system",
+          1,
+          "bafk2bzacebf4et7elmttbioggwlpmsjhplcnzfxtmi4lnbtqr3f6tzuwsoj2a"
+        ],
+        [
+          "init",
+          2,
+          "bafk2bzacecp5go2numz52kerspigi2e3rygesaqeqhn4gegmfgr5xoon73sde"
+        ],
+        [
+          "cron",
+          3,
+          "bafk2bzacea74gcozu357t22lm6t7n7jxsv7buz2quurhtjzz6s7tkxyyfrve6"
+        ],
+        [
+          "account",
+          4,
+          "bafk2bzaceb4as5yyhjfkvxgooum37uvm5gbjr4dtbpxmqnpvvbjfpu5qouii4"
+        ],
+        [
+          "storagepower",
+          5,
+          "bafk2bzacedyhaec4jvpdmaas6pgtoj7zkdlmdpljz7yjwjqtkfmwv7yb5invw"
+        ],
+        [
+          "storageminer",
+          6,
+          "bafk2bzaceautzxqsrstcxerpxtykn4syogslbiwpsfoh562jex262vxeluc4w"
+        ],
+        [
+          "storagemarket",
+          7,
+          "bafk2bzacebsnn4nk5crrlrvhg5vdpaxsrs4r72etaofxdi7tucr72om22z6a4"
+        ],
+        [
+          "paymentchannel",
+          8,
+          "bafk2bzaceavlvljdoww4v3bp225p6lurcxtdsub4rg33ee6xhvhkyyysnenac"
+        ],
+        [
+          "multisig",
+          9,
+          "bafk2bzaceblf5vqw4dwjueoetgawhg7t6he7qhdnfy3shf7ufnfv4mkwchgbm"
+        ],
+        [
+          "reward",
+          10,
+          "bafk2bzacebezdh75otifygspbfymgeipv34v6feti5xylrxt7xetu77pisnym"
+        ],
+        [
+          "verifiedregistry",
+          11,
+          "bafk2bzaceak2iqpfy4hw6xyyrf7c4yfh7pl4copzm7t63mokecsxfcnybxnd2"
+        ],
+        [
+          "datacap",
+          12,
+          "bafk2bzaceakb5v267o4y6jq3vao4b5c63sjjk3sr2jgjoabtze7ygcvbpvc6i"
+        ],
+        [
+          "placeholder",
+          13,
+          "bafk2bzacedfvut2myeleyq67fljcrw4kkmn5pb5dpyozovj7jpoez5irnc3ro"
+        ],
+        [
+          "evm",
+          14,
+          "bafk2bzaced5i2jt5t4f5gplsfb5gogjl5tknvhvsssgyj75on3g6ds36yy45y"
+        ],
+        [
+          "eam",
+          15,
+          "bafk2bzacecp2lpiqfjeiulrgor7g6zx4boo2oobjuyuxvtoqya46ljm6gkgci"
+        ],
+        [
+          "ethaccount",
+          16,
+          "bafk2bzacedgl6zt7d2ointmeyqrdwkehpi5w5rk3smsemrwbf3v5gc2wx7qfy"
+        ]
+      ],
+      "actor_list_cid": "bafy2bzaceasz5pov3d4tyxxdcxj2qvvdnkdxihzycj5oos5t2xj5pznwvxvem"
     }
   }
 ]

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -84,10 +84,10 @@ pub static ACTOR_BUNDLES: LazyLock<Box<[ActorBundleInfo]>> = LazyLock::new(|| {
         "bafy2bzaceax5zkysst7vtyup4whdxwzlpnaya3qp34rnoi6gyt4pongps7obw" @ "v15.0.0" for "calibrationnet",
         "bafy2bzacebc7zpsrihpyd2jdcvmegbbk6yhzkifre3hxtoul5wdxxklbwitry" @ "v16.0.0-rc3" for "calibrationnet",
         "bafy2bzacecqtwq6hjhj2zy5gwjp76a4tpcg2lt7dps5ycenvynk2ijqqyo65e" @ "v16.0.1" for "calibrationnet",
-        "bafy2bzacecn64rlb52rjsvgopnidz6w42z3zobmjxqek5s4xqjh3ly47rcurg" @ "v17.0.0-rc1" for "calibrationnet",
+        "bafy2bzacecn64rlb52rjsvgopnidz6w42z3zobmjxqek5s4xqjh3ly47rcurg" @ "v17.0.0" for "calibrationnet",
         "bafy2bzacearjal5rsmzloz3ny7aoju2rgw66wgxdrydgg27thcsazbmf5qihq" @ "v15.0.0-rc1" for "butterflynet",
         "bafy2bzaceda5lc7qrwp2hdm6s6erppwuydsfqrhbgld7juixalk342inqimbo" @ "v16.0.1" for "butterflynet",
-        "bafy2bzacedzjwguwuihh4tptzfkkwaj3naamrnklbaixn2wfzqh67twwp56pi" @ "v17.0.0-rc1" for "butterflynet",
+        "bafy2bzacedzjwguwuihh4tptzfkkwaj3naamrnklbaixn2wfzqh67twwp56pi" @ "v17.0.0" for "butterflynet",
         "bafy2bzacedozk3jh2j4nobqotkbofodq4chbrabioxbfrygpldgoxs3zwgggk" @ "v9.0.3" for "devnet",
         "bafy2bzacebzz376j5kizfck56366kdz5aut6ktqrvqbi3efa2d4l2o2m653ts" @ "v10.0.0" for "devnet",
         "bafy2bzaceay35go4xbjb45km6o46e5bib3bi46panhovcbedrynzwmm3drr4i" @ "v11.0.0" for "devnet",
@@ -96,7 +96,7 @@ pub static ACTOR_BUNDLES: LazyLock<Box<[ActorBundleInfo]>> = LazyLock::new(|| {
         "bafy2bzacebwn7ymtozv5yz3x5hnxl4bds2grlgsk5kncyxjak3hqyhslb534m" @ "v14.0.0-rc.1" for "devnet",
         "bafy2bzacedlusqjwf7chvl2ve2fum5noyqrtjzcrzkhpbzpkg7puiru7dj4ug" @ "v15.0.0-rc1" for "devnet",
         "bafy2bzaceclp3wfrwdjgh6c3gee5smwj3zmmrhb4fdbc4yfchfaia6rlljx5o" @ "v16.0.1" for "devnet",
-        "bafy2bzaceasvgkke3j4cs3xsxnjswpcdmokkvkiehzxzcgfox3ozlehimbuqk" @ "v17.0.0-rc1" for "devnet",
+        "bafy2bzaceasvgkke3j4cs3xsxnjswpcdmokkvkiehzxzcgfox3ozlehimbuqk" @ "v17.0.0" for "devnet",
         "bafy2bzaceb6j6666h36xnhksu3ww4kxb6e25niayfgkdnifaqi6m6ooc66i6i" @ "v9.0.3" for "mainnet",
         "bafy2bzacecsuyf7mmvrhkx2evng5gnz5canlnz2fdlzu2lvcgptiq2pzuovos" @ "v10.0.0" for "mainnet",
         "bafy2bzacecnhaiwcrpyjvzl4uv4q3jzoif26okl3m66q3cijp3dfwlcxwztwo" @ "v11.0.0" for "mainnet",
@@ -105,6 +105,7 @@ pub static ACTOR_BUNDLES: LazyLock<Box<[ActorBundleInfo]>> = LazyLock::new(|| {
         "bafy2bzacecbueuzsropvqawsri27owo7isa5gp2qtluhrfsto2qg7wpgxnkba" @ "v14.0.0" for "mainnet",
         "bafy2bzaceakwje2hyinucrhgtsfo44p54iw4g6otbv5ghov65vajhxgntr53u" @ "v15.0.0" for "mainnet",
         "bafy2bzacecnepvsh4lw6pwljobvwm6zwu6mbwveatp7llhpuguvjhjiqz7o46" @ "v16.0.1" for "mainnet",
+        "bafy2bzaceai74ppsvuxs3nvpzzeuptdr3wl7vmdpbphvtz4qt5hfq2qdfvz3e" @ "v17.0.0" for "mainnet",
     ])
 });
 

--- a/src/networks/butterflynet/mod.rs
+++ b/src/networks/butterflynet/mod.rs
@@ -105,7 +105,7 @@ pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|
         make_height!(TukTuk, -27, get_bundle_cid("v15.0.0-rc1")),
         make_height!(Teep, 50, get_bundle_cid("v16.0.1")),
         make_height!(Tock, 100),
-        make_height!(GoldenWeek, 200, get_bundle_cid("v17.0.0-rc1")),
+        make_height!(GoldenWeek, 200, get_bundle_cid("v17.0.0")),
     ])
 });
 

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -94,7 +94,7 @@ pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|
         // Mon  7 Apr 23:00:00 UTC 2025
         make_height!(TockFix, 2_558_014, get_bundle_cid("v16.0.1")),
         // Wed 10 Sep 23:00:00 UTC 2025
-        make_height!(GoldenWeek, 3_007_294, get_bundle_cid("v17.0.0-rc1")),
+        make_height!(GoldenWeek, 3_007_294, get_bundle_cid("v17.0.0")),
     ])
 });
 

--- a/src/networks/devnet/mod.rs
+++ b/src/networks/devnet/mod.rs
@@ -162,7 +162,7 @@ pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|
         make_height!(
             GoldenWeek,
             get_upgrade_height_from_env("FOREST_GOLDEN_WEEK_HEIGHT").unwrap_or(9999999999),
-            get_bundle_cid("v17.0.0-rc1")
+            get_bundle_cid("v17.0.0")
         ),
     ])
 });

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -90,8 +90,8 @@ pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|
         // This epoch, 90 days after Teep is the completion of FIP-0100 where actors will start applying
         // the new daily fee to pre-Teep sectors being extended.
         make_height!(Tock, 4_878_840 + EPOCHS_IN_DAY * 90),
-        // TODO(forest): https://github.com/ChainSafe/forest/issues/5989
-        make_height!(GoldenWeek, i64::MAX, get_bundle_cid("v16.0.1")),
+        // Wed 24 Sep 23:00:00 UTC 2025
+        make_height!(GoldenWeek, 5_348_280, get_bundle_cid("v17.0.0")),
     ])
 });
 

--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -47,8 +47,7 @@ where
                 (Height::Waffle, nv23::run_migration::<DB>),
                 (Height::TukTuk, nv24::run_migration::<DB>),
                 (Height::Teep, nv25::run_migration::<DB>),
-                // TODO(forest): https://github.com/ChainSafe/forest/issues/5989
-                // (Height::GoldenWeek, nv27::run_migration::<DB>),
+                (Height::GoldenWeek, nv27::run_migration::<DB>),
             ]
         }
         NetworkChain::Calibnet => {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

https://github.com/filecoin-project/lotus/blob/v1.34.0/build/buildconstants/params_mainnet.go#L142

```go
// 2025-09-24T23:00:00Z
var UpgradeGoldenWeekHeight = abi.ChainEpoch(5348280)
```

Performed a dummy upgrade @ epoch 5325160, Lotus and Forest produces the same state tree (bafy2bzacebggqplsoqxtyobh5kct4hmegtylvtbedyn5auzuzadfooqp5ybjm)

Lotus:
```
2025-09-17T00:23:25.759+0200    WARN    chain   chain/sync.go:220       InformNewHead called on block marked as bad: bafy2bzacedfc5lopt53ht6ldephu4yvgnvecjgl3hf2xw5qmfqi6xs3la364u (reason: linked to bafy2bzaced6x2rg6knvgqxdb3egkinbvpvsxvkokp6ifhuc752xnheapmqrpu caused by: [bafy2bzaced6pqff54sr4xnyji7n5kz7fa3wgh6pacfmr2f2znhdnw3lwue3hc] 1 error occurred:
        * parent state root did not match computed state (bafy2bzacedopk6v2uf6xl46fs7cslkl7hjbzyqcpapbsbdzgqs4fniqp5e6gm != bafy2bzacebggqplsoqxtyobh5kct4hmegtylvtbedyn5auzuzadfooqp5ybjm):
    github.com/filecoin-project/lotus/chain/consensus.CommonBlkChecks.func3
        /home/hm/git/lotus/chain/consensus/common.go:119
```

Forest:
```
2025-09-16T22:26:27.455498Z  WARN forest::chain_sync::tipset_syncer: Validating block [CID = bafy2bzaced56aiiqmjjipth6ltx4eveex6455mo4d2kxejgvk24l77wmzxf7o] in EPOCH = 5325162 failed: Validation error: Validation error: Parent state root did not match computed state: bafy2bzacedopk6v2uf6xl46fs7cslkl7hjbzyqcpapbsbdzgqs4fniqp5e6gm (header), bafy2bzacebggqplsoqxtyobh5kct4hmegtylvtbedyn5auzuzadfooqp5ybjm (computed)
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #5989

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enable the GoldenWeek network upgrade on mainnet at height 5,348,280 (Wed 24 Sep 2025, 23:00 UTC), including automatic state migration.
  - Adopt actors v17.0.0 on mainnet with the standard 16-actor roster.

- Chores
  - Promote calibnet, butterflynet, and devnet actor bundles from v17.0.0-rc1 to v17.0.0.
  - Add a mainnet manifest entry for v17.0.0 and update associated bundle references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->