### PR TITLE
fix: CarStream should support large data blocks like F3 snap

### DIFF
--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -161,7 +161,12 @@ pub async fn import_chain_as_forest_car(
                 snapshot_progress_tracker.completed();
             } else {
                 snapshot_progress_tracker.not_required();
-                move_or_copy_file(from_path, &downloaded_car_temp_path, mode)?;
+                if ForestCar::is_valid(&EitherMmapOrRandomAccessFile::open(from_path)?) {
+                    move_or_copy_file(from_path, &downloaded_car_temp_path, mode)?;
+                } else {
+                    // For a local snapshot, we transcode directly instead of copying & transcoding.
+                    transcode_into_forest_car(from_path, &downloaded_car_temp_path).await?;
+                }
             }
 
             if ForestCar::is_valid(&EitherMmapOrRandomAccessFile::open(
@@ -292,6 +297,11 @@ fn move_or_copy_file(from: &Path, to: &Path, import_mode: ImportMode) -> anyhow:
 }
 
 async fn transcode_into_forest_car(from: &Path, to: &Path) -> anyhow::Result<()> {
+    tracing::info!(
+        from = %from.display(),
+        to = %to.display(),
+        "transcoding into forest car"
+    );
     let car_stream = CarStream::new(tokio::io::BufReader::new(
         tokio::fs::File::open(from).await?,
     ))

--- a/src/utils/db/car_stream.rs
+++ b/src/utils/db/car_stream.rs
@@ -172,7 +172,7 @@ impl<ReaderT: AsyncBufRead + Unpin> CarStream<ReaderT> {
             .as_ref()
             .map(|h| h.data_size as u64)
             .unwrap_or(u64::MAX);
-        let mut reader = FramedRead::new(reader.take(max_car_v1_bytes), UviBytes::default());
+        let mut reader = FramedRead::new(reader.take(max_car_v1_bytes), uvi_bytes());
         let header_v1 = read_v1_header(&mut reader)
             .await
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid v1 header block"))?;
@@ -283,7 +283,7 @@ impl<W: AsyncWrite> CarWriter<W> {
         let car_header = CarV1Header { roots, version: 1 };
 
         let mut header_uvi_frame = BytesMut::new();
-        UviBytes::default().encode(Bytes::from(to_vec(&car_header)?), &mut header_uvi_frame)?;
+        uvi_bytes().encode(Bytes::from(to_vec(&car_header)?), &mut header_uvi_frame)?;
 
         Ok(Self {
             inner: writer,
@@ -327,6 +327,12 @@ async fn read_v1_header<ReaderT: AsyncRead + Unpin>(
         return None;
     }
     Some(header)
+}
+
+pub fn uvi_bytes() -> UviBytes {
+    let mut decoder = UviBytes::default();
+    decoder.set_max_len(usize::MAX);
+    decoder
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR fixes an issue in transcoding a v2 plain CAR into ForestCAR by increasing `max_len` of `UviBytes` (default is `128MiB`)

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
