### PR TITLE
fix: drand verification failure on duplicate entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 
 ### Fixed
 
+- [#5055](https://github.com/ChainSafe/forest/issues/5055) Fixed an issue where Forest fails on duplicate drand entries. This would only happen on new devnets.
+
 ## Forest v0.30.1 "Laurelin"
 
 Mandatory release for mainnet node operators. It sets the NV27 _Golden Week_ network upgrade to epoch `5_348_280` which corresponds to `Wed 24 Sep 23:00:00 UTC 2025`. It also includes a few improvements that help with snapshot generation and inspection.

--- a/src/beacon/drand.rs
+++ b/src/beacon/drand.rs
@@ -289,7 +289,8 @@ impl Beacon for DrandBeacon {
             let mut signatures = vec![];
             let pk = PublicKeyOnG2::from_bytes(&self.public_key)?;
             {
-                for entry in entries.iter() {
+                // Deduplicate by round. See Lotus issue: https://github.com/filecoin-project/lotus/issues/13349
+                for entry in entries.iter().unique_by(|e| e.round()) {
                     if self.is_verified(entry) {
                         continue;
                     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes Forest failing continuously when a beacon has duplicate entries. See https://github.com/filecoin-project/lotus/issues/13349 for issue write-up.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5055

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved failures caused by duplicate drand beacon entries on new devnets. Verification now handles duplicate rounds correctly, improving reliability during startup and syncing.

- Documentation
  - Updated the changelog to record the fix under the unreleased section, including formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->