### PR TITLE
Fix test for eth_newFilter creation

### DIFF
--- a/src/tool/subcommands/api_cmd/stateful_tests.rs
+++ b/src/tool/subcommands/api_cmd/stateful_tests.rs
@@ -145,7 +145,10 @@ pub(super) async fn run_tests(
             Err(e) => {
                 if let Some(expected_msg) = test.should_fail_with {
                     let err_str = format!("{e:#}");
-                    if err_str.contains(expected_msg) {
+                    if err_str
+                        .to_lowercase()
+                        .contains(&expected_msg.to_lowercase())
+                    {
                         println!("ok");
                         passed += 1;
                     } else {
@@ -624,8 +627,7 @@ pub(super) async fn create_tests(tx: TestTransaction) -> Vec<RpcTestScenario> {
         with_methods!(
             create_eth_new_filter_limit_test(LOTUS_EVENTS_MAXFILTERS + 1)
                 .name("eth_newFilter over limit")
-                .should_fail_with("maximum number of filters registered")
-                .ignore("https://github.com/ChainSafe/forest/issues/5915"),
+                .should_fail_with("maximum number of filters registered"),
             EthNewFilter,
             EthUninstallFilter
         ),


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- We already have a filter creation limit, fixed test and re-enable `create_eth_new_filter_limit_test` 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #5915

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
