### PR TITLE
spec: Add `ChainGetFinalizedTipset` API

### DIFF
--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod types;
-use enumflags2::BitFlags;
+use enumflags2::{BitFlags, make_bitflags};
 use types::*;
 
 #[cfg(test)]
@@ -125,6 +125,28 @@ pub(crate) fn logs<DB: Blockstore + Sync + Send + 'static>(
     });
 
     (receiver, handle)
+}
+
+/// Returns the latest finalized tipset.
+/// It uses the current F3 instance to determine the finalized tipset.
+/// If F3 is operational and finalizing in this node. If not, it will fall back
+/// to the Expected Consensus (EC) finality definition of head - 900 epochs.
+pub enum ChainGetFinalizedTipset {}
+impl RpcMethod<0> for ChainGetFinalizedTipset {
+    const NAME: &'static str = "Filecoin.ChainGetFinalizedTipSet";
+    const PARAM_NAMES: [&'static str; 0] = [];
+    const API_PATHS: BitFlags<ApiPaths> = make_bitflags!(ApiPaths::V1);
+    const PERMISSION: Permission = Permission::Read;
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Returns the latest finalized tipset. It uses the f3 instance or Expected Consensus (EC) definition (head - 900 epochs) to get the finalized tipset.",
+    );
+
+    type Params = ();
+    type Ok = Tipset;
+
+    async fn handle(_ctx: Ctx<impl Blockstore>, (): Self::Params) -> Result<Self::Ok, ServerError> {
+        Err(anyhow::anyhow!("ChainGetFinalizedTipset is not yet implemented").into())
+    }
 }
 
 pub enum ChainGetMessage {}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -65,6 +65,7 @@ macro_rules! for_each_rpc_method {
         $callback!($crate::rpc::chain::ChainGetBlockMessages);
         $callback!($crate::rpc::chain::ChainGetEvents);
         $callback!($crate::rpc::chain::ChainGetGenesis);
+        $callback!($crate::rpc::chain::ChainGetFinalizedTipset);
         $callback!($crate::rpc::chain::ChainGetMessage);
         $callback!($crate::rpc::chain::ChainGetMessagesInTipset);
         $callback!($crate::rpc::chain::ChainGetMinBaseFee);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Adding `ChainGetFinalizedTipset` API
- The API is currently unimplemented only used as spec for `forest-tool` to generate API spec. It will be implemented in a follow up PR tracking here https://github.com/ChainSafe/forest/issues/6113

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
