### PR TITLE
fix: prefer JoinSet over FuturesUnordered

### DIFF
--- a/src/chain_sync/consensus.rs
+++ b/src/chain_sync/consensus.rs
@@ -1,16 +1,16 @@
 // Copyright 2019-2025 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use futures::{StreamExt, stream::FuturesUnordered};
 use nunny::Vec as NonEmpty;
+use tokio::task::JoinSet;
 
 /// Helper function to collect errors from async validations.
-pub async fn collect_errs<E>(
-    mut handles: FuturesUnordered<tokio::task::JoinHandle<Result<(), E>>>,
+pub async fn collect_errs<E: 'static>(
+    mut handles: JoinSet<Result<(), E>>,
 ) -> Result<(), NonEmpty<E>> {
     let mut errors = Vec::new();
 
-    while let Some(result) = handles.next().await {
+    while let Some(result) = handles.join_next().await {
         if let Ok(Err(e)) = result {
             errors.push(e);
         }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Prefer `tokio` native `JoinSet` over `futures::FuturesUnOrdered` to avoid calling `tokio::spawn` and `tokio::task::spawn_blocking` directly

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
