### PR TITLE
fix: ignore RUSTSEC-2025-0046

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,7 @@ ignore = [
   "RUSTSEC-2022-0061", # parity-wasm is deprecated
   "RUSTSEC-2024-0436", # paste is unmaintained
   "RUSTSEC-2025-0046", # wasmtime issue, this needs to be resolved in FVM
+  "RUSTSEC-2023-0071", # rsa issue. No patch is yet available, however work is underway to migrate to a fully constant-time implementation.
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Ignore [RUSTSEC-2025-0046](https://rustsec.org/advisories/RUSTSEC-2023-0071) for now.

Impact
Due to a non-constant-time implementation, information about the private key is leaked through timing information which is observable over the network. An attacker may be able to use that information to recover the key.

Patches
No patch is yet available, however work is underway to migrate to a fully constant-time implementation.

Workarounds
The only currently available workaround is to avoid using the rsa crate in settings where attackers are able to observe timing information, e.g. local use on a non-compromised computer is fine.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/6155

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security audit configuration to ignore a specific advisory, ensuring cleaner CI results.
  * No changes to application features, behavior, or performance.
  * Licensing and dependency ban configurations remain unchanged.
  * Build and release artifacts are unaffected.
  * No user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->