### PR TITLE
fix: ignore a few RUSTSECs

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,12 @@ ignore = [
   "RUSTSEC-2024-0436", # paste is unmaintained
   "RUSTSEC-2025-0046", # wasmtime issue, this needs to be resolved in FVM
   "RUSTSEC-2023-0071", # rsa issue. No patch is yet available, however work is underway to migrate to a fully constant-time implementation.
+  "RUSTSEC-2025-0098", # All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
+  "RUSTSEC-2025-0104", # All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
+  "RUSTSEC-2025-0074", # All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
+  "RUSTSEC-2025-0075", # All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
+  "RUSTSEC-2025-0080", # All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
+  "RUSTSEC-2025-0081", # All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

To fix `cargo deny check advisories` failures.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/6179

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency security advisory configuration to suppress six additional known advisories in the project's security tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->