### PR TITLE
fix: mute go-f3 dht/RtRefreshManager log

### DIFF
--- a/f3-sidecar/utils.go
+++ b/f3-sidecar/utils.go
@@ -61,7 +61,7 @@ func setLogLevels() error {
 		return err
 	}
 	// Always mute RtRefreshManager because it breaks terminals
-	if err := setLogLevel("dht/RtRefreshManager", "warn"); err != nil {
+	if err := setLogLevel("dht/RtRefreshManager", "fatal"); err != nil {
 		return err
 	}
 	if err := setLogLevel("f3/sidecar", "debug"); err != nil {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Adjust go log levels to match Lotus

https://github.com/filecoin-project/lotus/blob/v1.34.1/lib/lotuslog/levels.go#L22
```go
// Always mute RtRefreshManager because it breaks terminals
_ = logging.SetLogLevel("dht/RtRefreshManager", "FATAL")
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error logging severity for internal system components to enhance visibility of critical events. This adjustment may affect how system failures and certain error conditions are communicated in operational scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->