### PR TITLE
fix: improve export status output and CI

### DIFF
--- a/scripts/tests/calibnet_export_check.sh
+++ b/scripts/tests/calibnet_export_check.sh
@@ -11,7 +11,7 @@ source "$(dirname "$0")/harness.sh"
 
 forest_init "$@"
 
-retries=10
+retries=30
 sleep_interval=0.5
 
 echo "Cleaning up the initial snapshot"

--- a/src/cli/subcommands/snapshot_cmd.rs
+++ b/src/cli/subcommands/snapshot_cmd.rs
@@ -219,7 +219,7 @@ impl SnapshotCommands {
                 }
                 if wait {
                     let elapsed = chrono::Utc::now()
-                        .signed_duration_since(result.start_time)
+                        .signed_duration_since(result.start_time.unwrap_or_default())
                         .to_std()
                         .unwrap_or(Duration::ZERO);
                     let pb = ProgressBar::new(10000)

--- a/src/ipld/util.rs
+++ b/src/ipld/util.rs
@@ -26,7 +26,7 @@ pub struct ExportStatus {
     pub initial_epoch: i64,
     pub exporting: bool,
     pub cancelled: bool,
-    pub start_time: DateTime<Utc>,
+    pub start_time: Option<DateTime<Utc>>,
 }
 
 pub static CHAIN_EXPORT_STATUS: LazyLock<Mutex<ExportStatus>> =
@@ -46,7 +46,7 @@ pub fn start_export() {
     mutex.initial_epoch = 0;
     mutex.exporting = true;
     mutex.cancelled = false;
-    mutex.start_time = Utc::now();
+    mutex.start_time = Some(Utc::now());
 }
 
 pub fn end_export() {

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -523,6 +523,8 @@ impl RpcMethod<0> for ForestChainExportStatus {
                 0.0
             }
         };
+        // only two decimal places
+        let progress = (progress * 100.0).round() / 100.0;
 
         let status = ApiExportStatus {
             progress,

--- a/src/rpc/types/mod.rs
+++ b/src/rpc/types/mod.rs
@@ -568,7 +568,7 @@ pub struct ApiExportStatus {
     pub progress: f64,
     pub exporting: bool,
     pub cancelled: bool,
-    pub start_time: chrono::DateTime<Utc>,
+    pub start_time: Option<chrono::DateTime<Utc>>,
 }
 
 lotus_json_with_self!(ApiExportStatus);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixed an issue where export status would show unix time genesis on `forest-cli snapshot export-status --format json` on a rebooted node (where no prior export has taken place)
- progress `0.31231231353452` is weird; let's keep only to two decimal places
- v2 job seems to be constantly failing; I increased the number of retries.

on a fresh node it's now:
```
❯ forest-cli snapshot export-status --format json
{
  "progress": 0.0,
  "exporting": false,
  "cancelled": false,
  "start_time": null
}
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot export status handling by gracefully managing cases where start time is unavailable.
  * Progress bar values now display with consistent two decimal place precision.
  * Increased retry limit for snapshot export polling to reduce premature timeout occurrences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->