### PR TITLE
fix(rpc): method name of V0 only RPC methods

### DIFF
--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -1,4 +1,2 @@
 # This list contains potentially broken methods (or tests) that are ignored.
 # They should be considered bugged, and not used until the root cause is resolved.
-# Disable until next Lotus release with go-f3 0.8.6
-!Filecoin.F3GetManifest

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1109,7 +1109,7 @@ impl RpcMethod<2> for StateGetReceipt {
 pub enum StateWaitMsgV0 {}
 
 impl RpcMethod<2> for StateWaitMsgV0 {
-    const NAME: &'static str = "Filecoin.StateWaitMsgV0";
+    const NAME: &'static str = "Filecoin.StateWaitMsg";
     const PARAM_NAMES: [&'static str; 2] = ["messageCid", "confidence"];
     const API_PATHS: BitFlags<ApiPaths> = make_bitflags!(ApiPaths::V0); // Changed in V1
     const PERMISSION: Permission = Permission::Read;
@@ -2047,7 +2047,7 @@ impl RpcMethod<1> for StateGetBeaconEntry {
 pub enum StateSectorPreCommitInfoV0 {}
 
 impl RpcMethod<3> for StateSectorPreCommitInfoV0 {
-    const NAME: &'static str = "Filecoin.StateSectorPreCommitInfoV0";
+    const NAME: &'static str = "Filecoin.StateSectorPreCommitInfo";
     const PARAM_NAMES: [&'static str; 3] = ["minerAddress", "sectorNumber", "tipsetKey"];
     const API_PATHS: BitFlags<ApiPaths> = make_bitflags!(ApiPaths::V0); // Changed in V1
     const PERMISSION: Permission = Permission::Read;

--- a/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
+++ b/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
@@ -61,8 +61,6 @@ Filecoin.NodeStatus
 Filecoin.Shutdown
 Filecoin.StartTime
 Filecoin.StateGetReceipt
-Filecoin.StateSectorPreCommitInfoV0
-Filecoin.StateWaitMsgV0
 Filecoin.SyncCheckBad
 Filecoin.SyncMarkBad
 Filecoin.SyncSubmitBlock


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- remove the `V0` suffix in `Filecoin.StateWaitMsgV0` and `Filecoin.StateSectorPreCommitInfoV0` since the naming conflict issue between versions has been fixed by https://github.com/ChainSafe/forest/pull/6219
- re-enable `Filecoin.F3GetManifest` in RPC parity test

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified RPC method naming for state operations
  * Re-enabled Filecoin F3 manifest API method support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->