### PR TITLE
fix(rpc): avoid unecessarily cloning Tipset

### DIFF
--- a/src/cli/subcommands/chain_cmd.rs
+++ b/src/cli/subcommands/chain_cmd.rs
@@ -7,6 +7,7 @@ use list::ChainListCommand;
 mod prune;
 use prune::ChainPruneCommands;
 
+use super::print_pretty_lotus_json;
 use crate::blocks::{Tipset, TipsetKey};
 use crate::lotus_json::HasLotusJson;
 use crate::message::ChainMessage;
@@ -15,8 +16,7 @@ use anyhow::{bail, ensure};
 use cid::Cid;
 use clap::Subcommand;
 use nunny::Vec as NonEmpty;
-
-use super::print_pretty_lotus_json;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, clap::ValueEnum)]
 pub enum Format {
@@ -143,7 +143,7 @@ impl ChainCommands {
 async fn tipset_by_epoch_or_offset(
     client: &rpc::Client,
     epoch_or_offset: i64,
-) -> Result<Tipset, jsonrpsee::core::ClientError> {
+) -> Result<Arc<Tipset>, jsonrpsee::core::ClientError> {
     let current_head = ChainHead::call(client, ()).await?;
 
     let target_epoch = match epoch_or_offset.is_negative() {

--- a/src/cli/subcommands/f3_cmd.rs
+++ b/src/cli/subcommands/f3_cmd.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use std::{
     borrow::Cow,
-    sync::LazyLock,
+    sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
 
@@ -151,7 +151,7 @@ impl F3Commands {
 
                 async fn get_heads(
                     client: &rpc::Client,
-                ) -> anyhow::Result<(Tipset, FinalityCertificate)> {
+                ) -> anyhow::Result<(Arc<Tipset>, FinalityCertificate)> {
                     let cert_head = client.call(F3GetLatestCertificate::request(())?).await?;
                     let chain_head = client.call(ChainHead::request(())?).await?;
                     Ok((chain_head, cert_head))

--- a/src/lotus_json/arc.rs
+++ b/src/lotus_json/arc.rs
@@ -1,0 +1,25 @@
+// Copyright 2019-2025 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use super::*;
+use std::sync::Arc;
+
+impl<T: HasLotusJson + Clone> HasLotusJson for Arc<T> {
+    type LotusJson = T::LotusJson;
+
+    #[cfg(test)]
+    fn snapshots() -> Vec<(serde_json::Value, Self)> {
+        T::snapshots()
+            .into_iter()
+            .map(|(k, v)| (k, Arc::new(v)))
+            .collect()
+    }
+
+    fn into_lotus_json(self) -> Self::LotusJson {
+        (*self).clone().into_lotus_json()
+    }
+
+    fn from_lotus_json(lotus_json: Self::LotusJson) -> Self {
+        Arc::new(T::from_lotus_json(lotus_json))
+    }
+}

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -220,6 +220,7 @@ decl_and_test!(
 // but you MUST document any tech debt - the reason WHY it cannot be tested above.
 mod actors;
 mod allocation;
+mod arc;
 mod beneficiary_term; // fil_actor_miner_state::v12::BeneficiaryTerm: !quickcheck::Arbitrary
 mod bit_field; //  fil_actors_shared::fvm_ipld_bitfield::BitField: !quickcheck::Arbitrary
 mod bytecode_hash;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized memory handling in chain RPC methods (ChainHead, ChainGetTipSet, ChainGetTipSetByHeight, ChainGetTipSetAfterHeight, ChainGetFinalizedTipset, ChainGetTipSetV2) to reduce unnecessary data copying.
  * Extended internal trait implementations to support reference-counted types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->