### PR TITLE
fix: support `input` as param in eth_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 
 - [#6206](https://github.com/ChainSafe/forest/pull/6206) Fixed batch request error in RPC server.
 
+- [#6234](https://github.com/ChainSafe/forest/pull/6234) Support `input` as an alias for `data` in `eth_call` and `eth_estimateGas` RPC methods.
+
 ## Forest v0.30.2 "Garuda"
 
 This is a non-mandatory release that brings important enhancements to Forest's tooling capabilities, Ethereum RPC compatibility, and F3 integration.

--- a/src/rpc/methods/eth/types.rs
+++ b/src/rpc/methods/eth/types.rs
@@ -314,7 +314,8 @@ pub struct EthCallMessage {
     pub gas_price: Option<EthBigInt>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub value: Option<EthBigInt>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    // Some clients use `input`, others use `data`. We have to support both.
+    #[serde(alias = "input", skip_serializing_if = "Option::is_none", default)]
     pub data: Option<EthBytes>,
 }
 lotus_json_with_self!(EthCallMessage);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- as per [Lotus comment](https://github.com/filecoin-project/lotus/blob/081f2610437efee3a5c9964d19fb33258e0e3d17/chain/types/ethtypes/eth_types.go#L333-L334)
```
		// The field should be "input" by spec, but many clients use "data" so we support
		// both, but prefer "input".
```

JSON-RPC strictness at its finest.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Part of https://github.com/ChainSafe/forest/issues/6214. It still doesn't work, but there seem to be issues in the mempool, to be resolved in a separate PR.

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RPC methods `eth_call` and `eth_estimateGas` now accept "input" as an alternative parameter name in addition to "data" for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->