### PR TITLE
fix: avoid cloning block headers in `validate_block`

### DIFF
--- a/src/fil_cns/validation.rs
+++ b/src/fil_cns/validation.rs
@@ -99,11 +99,11 @@ pub(in crate::fil_cns) async fn validate_block<DB: Blockstore + Sync + Send + 's
     // Miner validations
     let v_state_manager = state_manager.clone();
     let v_base_tipset = base_tipset.clone();
-    let v_header = header.clone();
+    let v_block = block.clone();
     validations.spawn_blocking(move || {
         validate_miner(
             v_state_manager.as_ref(),
-            &v_header.miner_address,
+            &v_block.header.miner_address,
             v_base_tipset.parent_state(),
         )
     });
@@ -233,7 +233,7 @@ fn validate_miner<DB: Blockstore>(
         .map_err(|err| FilecoinConsensusError::MinerPowerUnavailable(err.to_string()))?;
 
     state
-        .miner_power(state_manager.blockstore(), &miner_addr.into())
+        .miner_power(state_manager.blockstore(), miner_addr)
         .map_err(|err| FilecoinConsensusError::MinerPowerUnavailable(err.to_string()))?;
 
     Ok(())

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1839,11 +1839,7 @@ impl RpcMethod<1> for StateListMiners {
     ) -> Result<Self::Ok, ServerError> {
         let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let state: power::State = ctx.state_manager.get_actor_state(&ts)?;
-        let miners = state
-            .list_all_miners(ctx.store())?
-            .iter()
-            .map(From::from)
-            .collect();
+        let miners = state.list_all_miners(ctx.store())?;
         Ok(miners)
     }
 }

--- a/src/shim/actors/builtin/power/mod.rs
+++ b/src/shim/actors/builtin/power/mod.rs
@@ -4,16 +4,17 @@
 pub mod ext;
 
 use crate::list_miners_for_state;
-use crate::shim::actors::FilterEstimate;
-use crate::shim::actors::Policy;
-use crate::shim::actors::convert::*;
+use crate::shim::{
+    actors::{FilterEstimate, Policy, convert::*},
+    address::Address,
+};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared2::{address::Address, econ::TokenAmount, sector::StoragePower};
+use fvm_shared2::{econ::TokenAmount, sector::StoragePower};
 use serde::{Deserialize, Serialize};
 
 /// Power actor address.
 // TODO(forest): https://github.com/ChainSafe/forest/issues/5011
-pub const ADDRESS: Address = Address::new_id(4);
+pub const ADDRESS: fvm_shared2::address::Address = fvm_shared2::address::Address::new_id(4);
 
 /// Power actor method.
 // TODO(forest): https://github.com/ChainSafe/forest/issues/5011
@@ -104,7 +105,7 @@ impl State {
                 let claims = st.load_claims(store)?;
                 let mut miners = Vec::new();
                 claims.for_each(|addr, _claim| {
-                    miners.push(from_address_v4_to_v2(addr));
+                    miners.push(addr.into());
                     Ok(())
                 })?;
                 Ok(miners)
@@ -113,7 +114,7 @@ impl State {
                 let claims = st.load_claims(store)?;
                 let mut miners = Vec::new();
                 claims.for_each(|addr, _claim| {
-                    miners.push(from_address_v4_to_v2(addr));
+                    miners.push(addr.into());
                     Ok(())
                 })?;
                 Ok(miners)
@@ -122,7 +123,7 @@ impl State {
                 let claims = st.load_claims(store)?;
                 let mut miners = Vec::new();
                 claims.for_each(|addr, _claim| {
-                    miners.push(from_address_v4_to_v2(addr));
+                    miners.push(addr.into());
                     Ok(())
                 })?;
                 Ok(miners)
@@ -131,7 +132,7 @@ impl State {
                 let claims = st.load_claims(store)?;
                 let mut miners = Vec::new();
                 claims.for_each(|addr, _claim| {
-                    miners.push(from_address_v4_to_v2(addr));
+                    miners.push(addr.into());
                     Ok(())
                 })?;
                 Ok(miners)
@@ -140,7 +141,7 @@ impl State {
                 let claims = st.load_claims(store)?;
                 let mut miners = Vec::new();
                 claims.for_each(|addr, _claim| {
-                    miners.push(from_address_v4_to_v2(addr));
+                    miners.push(addr.into());
                     Ok(())
                 })?;
                 Ok(miners)
@@ -149,7 +150,7 @@ impl State {
                 let claims = st.load_claims(store)?;
                 let mut miners = Vec::new();
                 claims.for_each(|addr, _claim| {
-                    miners.push(from_address_v4_to_v2(addr));
+                    miners.push(addr.into());
                     Ok(())
                 })?;
                 Ok(miners)
@@ -226,32 +227,16 @@ impl State {
         miner: &Address,
     ) -> anyhow::Result<Option<Claim>> {
         match self {
-            State::V8(st) => Ok(st.miner_power(&s, miner)?.map(From::from)),
-            State::V9(st) => Ok(st.miner_power(&s, miner)?.map(From::from)),
-            State::V10(st) => Ok(st
-                .miner_power(&s, &from_address_v2_to_v3(*miner))?
-                .map(From::from)),
-            State::V11(st) => Ok(st
-                .miner_power(&s, &from_address_v2_to_v3(*miner))?
-                .map(From::from)),
-            State::V12(st) => Ok(st
-                .miner_power(&s, &from_address_v2_to_v4(*miner))?
-                .map(From::from)),
-            State::V13(st) => Ok(st
-                .miner_power(&s, &from_address_v2_to_v4(*miner))?
-                .map(From::from)),
-            State::V14(st) => Ok(st
-                .miner_power(&s, &from_address_v2_to_v4(*miner))?
-                .map(From::from)),
-            State::V15(st) => Ok(st
-                .miner_power(&s, &from_address_v2_to_v4(*miner))?
-                .map(From::from)),
-            State::V16(st) => Ok(st
-                .miner_power(&s, &from_address_v2_to_v4(*miner))?
-                .map(From::from)),
-            State::V17(st) => Ok(st
-                .miner_power(&s, &from_address_v2_to_v4(*miner))?
-                .map(From::from)),
+            State::V8(st) => Ok(st.miner_power(&s, &miner.into())?.map(From::from)),
+            State::V9(st) => Ok(st.miner_power(&s, &miner.into())?.map(From::from)),
+            State::V10(st) => Ok(st.miner_power(&s, &miner.into())?.map(From::from)),
+            State::V11(st) => Ok(st.miner_power(&s, &miner.into())?.map(From::from)),
+            State::V12(st) => Ok(st.miner_power(&s, miner.into())?.map(From::from)),
+            State::V13(st) => Ok(st.miner_power(&s, miner.into())?.map(From::from)),
+            State::V14(st) => Ok(st.miner_power(&s, miner.into())?.map(From::from)),
+            State::V15(st) => Ok(st.miner_power(&s, miner.into())?.map(From::from)),
+            State::V16(st) => Ok(st.miner_power(&s, miner.into())?.map(From::from)),
+            State::V17(st) => Ok(st.miner_power(&s, miner.into())?.map(From::from)),
         }
     }
 
@@ -266,12 +251,12 @@ impl State {
             State::V8(st) => st.miner_nominal_power_meets_consensus_minimum(
                 &from_policy_v13_to_v9(policy),
                 &s,
-                miner,
+                &miner.into(),
             ),
             State::V9(st) => st.miner_nominal_power_meets_consensus_minimum(
                 &from_policy_v13_to_v9(policy),
                 &s,
-                miner,
+                &miner.into(),
             ),
             State::V10(st) => st
                 .miner_nominal_power_meets_consensus_minimum(

--- a/src/shim/address.rs
+++ b/src/shim/address.rs
@@ -343,6 +343,24 @@ impl From<&Address_v4> for Address {
     }
 }
 
+impl From<Address> for Address_v4 {
+    fn from(addr: Address) -> Self {
+        addr.0
+    }
+}
+
+impl From<&Address> for Address_v4 {
+    fn from(other: &Address) -> Self {
+        other.0
+    }
+}
+
+impl<'a> From<&'a Address> for &'a Address_v4 {
+    fn from(addr: &'a Address) -> Self {
+        &addr.0
+    }
+}
+
 impl From<&Address_v3> for Address {
     fn from(other: &Address_v3) -> Self {
         Address::from(
@@ -372,18 +390,6 @@ impl From<&Address_v2> for Address {
 impl From<Address_v2> for Address {
     fn from(other: Address_v2) -> Self {
         (&other).into()
-    }
-}
-
-impl From<Address> for Address_v4 {
-    fn from(other: Address) -> Address_v4 {
-        other.0
-    }
-}
-
-impl From<&Address> for Address_v4 {
-    fn from(other: &Address) -> Self {
-        other.0
     }
 }
 

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -391,7 +391,7 @@ where
 
         let spas = power::State::load(self.blockstore(), actor.code, actor.state)?;
 
-        Ok(spas.miner_power(self.blockstore(), &addr.into())?.is_none())
+        Ok(spas.miner_power(self.blockstore(), addr)?.is_none())
     }
 
     /// Returns raw work address of a miner given the state root.
@@ -421,13 +421,13 @@ where
 
         if let Some(maddr) = addr {
             let m_pow = spas
-                .miner_power(self.blockstore(), &maddr.into())?
+                .miner_power(self.blockstore(), maddr)?
                 .ok_or_else(|| Error::state(format!("Miner for address {maddr} not found")))?;
 
             let min_pow = spas.miner_nominal_power_meets_consensus_minimum(
                 &self.chain_config().policy,
                 self.blockstore(),
-                &maddr.into(),
+                maddr,
             )?;
             if min_pow {
                 return Ok(Some((m_pow, t_pow)));
@@ -857,7 +857,7 @@ where
 
         // Non-empty power claim.
         let claim = power_state
-            .miner_power(self.blockstore(), &address.into())?
+            .miner_power(self.blockstore(), address)?
             .ok_or_else(|| Error::Other("Could not get claim".to_string()))?;
         if claim.quality_adj_power <= BigInt::zero() {
             return Ok(false);
@@ -1522,7 +1522,7 @@ where
             .ok_or_else(|| Error::state("Power actor address could not be resolved"))?;
         let ps = power::State::load(self.blockstore(), actor.code, actor.state)?;
 
-        ps.miner_nominal_power_meets_consensus_minimum(policy, self.blockstore(), &addr.into())
+        ps.miner_nominal_power_meets_consensus_minimum(policy, self.blockstore(), addr)
     }
 
     /// Validates all tipsets at epoch `start..=end` behind the heaviest tipset.


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-  avoid cloning block headers in `validate_block`
-  avoid converting `Address`@fvm4 in `miner_power`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified address handling throughout the codebase for improved code consistency and maintainability.
  * Optimized miners retrieval logic to remove unnecessary conversion steps.
  * Unified address conversion mechanisms across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->