### PR TITLE
chore: fix `GetActorEventsRaw` tests

### DIFF
--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -654,7 +654,8 @@ fn node_tests() -> Vec<RpcTest> {
 fn event_tests_with_tipset<DB: Blockstore>(_store: &Arc<DB>, tipset: &Tipset) -> Vec<RpcTest> {
     let epoch = tipset.epoch();
     vec![
-        RpcTest::identity(GetActorEventsRaw::request((None,)).unwrap()),
+        RpcTest::identity(GetActorEventsRaw::request((None,)).unwrap())
+            .policy_on_rejected(PolicyOnRejected::PassWithQuasiIdenticalError),
         RpcTest::identity(
             GetActorEventsRaw::request((Some(ActorEventFilter {
                 addresses: vec![],
@@ -665,6 +666,7 @@ fn event_tests_with_tipset<DB: Blockstore>(_store: &Arc<DB>, tipset: &Tipset) ->
             }),))
             .unwrap(),
         )
+        .policy_on_rejected(PolicyOnRejected::PassWithQuasiIdenticalError)
         .sort_policy(SortPolicy::All),
         RpcTest::identity(
             GetActorEventsRaw::request((Some(ActorEventFilter {
@@ -676,6 +678,7 @@ fn event_tests_with_tipset<DB: Blockstore>(_store: &Arc<DB>, tipset: &Tipset) ->
             }),))
             .unwrap(),
         )
+        .policy_on_rejected(PolicyOnRejected::PassWithQuasiIdenticalError)
         .sort_policy(SortPolicy::All),
         RpcTest::identity(
             GetActorEventsRaw::request((Some(ActorEventFilter {
@@ -687,6 +690,7 @@ fn event_tests_with_tipset<DB: Blockstore>(_store: &Arc<DB>, tipset: &Tipset) ->
             }),))
             .unwrap(),
         )
+        .policy_on_rejected(PolicyOnRejected::PassWithQuasiIdenticalError)
         .sort_policy(SortPolicy::All),
         RpcTest::identity(
             GetActorEventsRaw::request((Some(ActorEventFilter {
@@ -702,6 +706,7 @@ fn event_tests_with_tipset<DB: Blockstore>(_store: &Arc<DB>, tipset: &Tipset) ->
             }),))
             .unwrap(),
         )
+        .policy_on_rejected(PolicyOnRejected::PassWithQuasiIdenticalError)
         .sort_policy(SortPolicy::All),
         {
             use std::collections::BTreeMap;
@@ -732,6 +737,7 @@ fn event_tests_with_tipset<DB: Blockstore>(_store: &Arc<DB>, tipset: &Tipset) ->
                 }),))
                 .unwrap(),
             )
+            .policy_on_rejected(PolicyOnRejected::PassWithQuasiIdenticalError)
             .sort_policy(SortPolicy::All)
         },
     ]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

RPC tests fail with:
```
2025-12-08T00:45:48.3212958Z           "forest_status": {
2025-12-08T00:45:48.3213172Z             "rejected": "filter matches too many events, try a more restricted filter"
2025-12-08T00:45:48.3213214Z           },
2025-12-08T00:45:48.3213261Z           "lotus_status": {
2025-12-08T00:45:48.3213468Z             "rejected": "get events for filter: failed to get events: filter matches too many events, try a more restricted filter"
2025-12-08T00:45:48.3213508Z           }
```
I guess Lotus added a bit of wrappers in the recent version. `PassWithQuasiIdenticalError` should resolve it (it makes the test pass if Forest error message is a substring of the Lotus error message).

Changes introduced in this pull request:

- relaxed requirements on `GetActorEventsRaw` tests to allow for sub-errors.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/6316

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved API comparison tests to more accurately recognize equivalent error responses across different client implementations. Quasi-identical errors are now properly validated during compatibility checks rather than being treated as failures. Updates applied to event query tests with various filters and configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->