### PR TITLE
fix(ci): deprecate quick cargo profile

### DIFF
--- a/.github/workflows/butterflynet.yml
+++ b/.github/workflows/butterflynet.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           # To minimize compile times: https://nnethercote.github.io/perf-book/build-configuration.html#minimizing-compile-times
           RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=lld"
-        run: make install-slim
+        run: make install-minimum-quick
       - name: Run butterflynet checks
         run: ./scripts/tests/butterflynet_check.sh
         timeout-minutes: ${{ fromJSON(env.SCRIPT_TIMEOUT_MINUTES) }}

--- a/.github/workflows/forest.yml
+++ b/.github/workflows/forest.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           # To minimize compile times: https://nnethercote.github.io/perf-book/build-configuration.html#minimizing-compile-times
           RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=lld"
-        run: make install-slim
+        run: make install-minimum-quick
       - uses: actions/upload-artifact@v6
         with:
           name: "forest-${{ runner.os }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,13 +303,11 @@ lto = "fat"
 # These should be refactored (probably removed) in #2984
 [features]
 default = ["jemalloc", "tokio-console", "tracing-loki", "tracing-chrome"]
-slim = ["rustalloc"]
 doctest-private = []                                                      # see lib.rs::doctest_private
 benchmark-private = ["dep:criterion"]                                     # see lib.rs::benchmark_private
 interop-tests-private = []                                                # see lib.rs::interop_tests_private
 
 # Allocator. Use at most one of these.
-rustalloc = []
 jemalloc = ["dep:tikv-jemallocator"]
 system-alloc = []                    # Use the platform allocator (for memory profiling).
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 install:
 	cargo install --locked --path . --force
 
-install-slim:
-	cargo install --no-default-features --features slim --locked --path . --force
-
 install-minimum:
 	cargo install --no-default-features --locked --path . --force
+
+install-minimum-quick:
+	cargo install --debug --no-default-features --locked --path . --force
 
 install-lto-fat:
 	cargo install --locked --force --profile release-lto-fat --path .
 
 # Installs Forest binaries with default rust global allocator
 install-with-rustalloc:
-	cargo install --locked --path . --force --no-default-features --features rustalloc
+	cargo install --locked --path . --force --no-default-features
 
 install-lint-tools:
 	cargo install --locked taplo-cli
@@ -58,7 +58,6 @@ lint: license clean lint-clippy
 # --quiet: don't show build logs
 lint-clippy:
 	cargo clippy --all-targets --quiet --no-deps -- --deny=warnings
-	cargo clippy --all-targets --no-default-features --features slim --quiet --no-deps -- --deny=warnings
 	cargo clippy --all-targets --no-default-features --quiet --no-deps -- --deny=warnings
 	cargo clippy --benches --features benchmark-private --quiet --no-deps -- --deny=warnings
 	# check docs.rs build

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = { workspace = true }
 cid = { workspace = true }
 flume = { workspace = true }
 forest = { package = "forest-filecoin", path = "../", default-features = false, features = [
-  "rustalloc",
   "interop-tests-private",
   "no-f3-sidecar",
 ] }

--- a/src/cli_shared/mod.rs
+++ b/src/cli_shared/mod.rs
@@ -10,8 +10,7 @@ use crate::utils::io::read_toml;
 use std::path::PathBuf;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "rustalloc")] {
-    } else if #[cfg(feature = "jemalloc")] {
+    if #[cfg(feature = "jemalloc")] {
         pub use tikv_jemallocator;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,7 @@
 )]
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "rustalloc")] {
-    } else if #[cfg(feature = "jemalloc")] {
+    if #[cfg(feature = "jemalloc")] {
         use crate::cli_shared::tikv_jemallocator::Jemalloc;
         #[global_allocator]
         static GLOBAL: Jemalloc = Jemalloc;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- use only `dev` profile in CI to better utilize sccache build cache

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed "quick" build profile and associated install targets, simplifying build options.
  * CI workflows updated to use the standard installation method instead of quick variants.
  * Test-release execution switched to the standard release profile.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->