### PR TITLE
feat(rpc): add `Forest.ChainGetTipsetByParentState` for trouble shooting state tree missing issues.

### DIFF
--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -1245,6 +1245,29 @@ impl RpcMethod<1> for ChainTipSetWeight {
     }
 }
 
+pub enum ChainGetTipsetByParentState {}
+impl RpcMethod<1> for ChainGetTipsetByParentState {
+    const NAME: &'static str = "Forest.ChainGetTipsetByParentState";
+    const PARAM_NAMES: [&'static str; 1] = ["parentState"];
+    const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
+    const PERMISSION: Permission = Permission::Read;
+
+    type Params = (Cid,);
+    type Ok = Option<Tipset>;
+
+    async fn handle(
+        ctx: Ctx<impl Blockstore>,
+        (parent_state,): Self::Params,
+    ) -> Result<Self::Ok, ServerError> {
+        Ok(ctx
+            .chain_store()
+            .heaviest_tipset()
+            .chain(ctx.store())
+            .find(|ts| ts.parent_state() == &parent_state)
+            .clone())
+    }
+}
+
 pub const CHAIN_NOTIFY: &str = "Filecoin.ChainNotify";
 pub(crate) fn chain_notify<DB: Blockstore>(
     _params: Params<'_>,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -88,6 +88,7 @@ macro_rules! for_each_rpc_method {
         $callback!($crate::rpc::chain::ForestChainExportDiff);
         $callback!($crate::rpc::chain::ForestChainExportStatus);
         $callback!($crate::rpc::chain::ForestChainExportCancel);
+        $callback!($crate::rpc::chain::ChainGetTipsetByParentState);
 
         // common vertical
         $callback!($crate::rpc::common::Session);

--- a/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
+++ b/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
@@ -81,6 +81,7 @@ Forest.ChainExportCancel
 Forest.ChainExportDiff
 Forest.ChainExportStatus
 Forest.ChainGetMinBaseFee
+Forest.ChainGetTipsetByParentState
 Forest.NetInfo
 Forest.SnapshotGC
 Forest.StateActorInfo


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- adds an RPC method to get tipset by its parent state tree root

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new chain RPC endpoint for querying tipsets by parent state, enabling enhanced blockchain state lookups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->