### PR TITLE
fix(f3): prepare for f3 network name change on calibnet

### DIFF
--- a/f3-sidecar/import.go
+++ b/f3-sidecar/import.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/filecoin-project/go-f3/certstore"
+	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/ipfs/go-datastore/namespace"
@@ -22,8 +23,8 @@ func importSnap(ctx context.Context, rpcEndpoint string, f3Root string, snapshot
 	}
 	defer closer()
 	rawNetworkName := waitRawNetworkName(ctx, &f3api)
-	networkName := getNetworkName(rawNetworkName)
-	m := Network2PredefinedManifestMappings[networkName]
+	networkName := gpbft.NetworkName(rawNetworkName)
+	m := RawNetwork2PredefinedManifestMappings[networkName]
 	if m == nil {
 		m2 := manifest.LocalDevnetManifest()
 		m = &m2

--- a/f3-sidecar/manifest.go
+++ b/f3-sidecar/manifest.go
@@ -8,13 +8,13 @@ import (
 	"github.com/filecoin-project/go-f3/manifest"
 )
 
-var Network2PredefinedManifestMappings map[gpbft.NetworkName]*manifest.Manifest = make(map[gpbft.NetworkName]*manifest.Manifest)
+var RawNetwork2PredefinedManifestMappings map[gpbft.NetworkName]*manifest.Manifest = make(map[gpbft.NetworkName]*manifest.Manifest)
 
 func init() {
-	for _, bytes := range [][]byte{F3ManifestBytes2K, F3ManifestBytesButterfly, F3ManifestBytesCalibnet, F3ManifestBytesMainnet} {
-		m := loadManifest(bytes)
-		Network2PredefinedManifestMappings[m.NetworkName] = m
-	}
+	RawNetwork2PredefinedManifestMappings["testnetnet"] = loadManifest(F3ManifestBytesMainnet)
+	RawNetwork2PredefinedManifestMappings["calibrationnet"] = loadManifest(F3ManifestBytesCalibnet)
+	RawNetwork2PredefinedManifestMappings["butterflynet"] = loadManifest(F3ManifestBytesButterfly)
+	RawNetwork2PredefinedManifestMappings["2k"] = loadManifest(F3ManifestBytes2K)
 }
 
 //go:embed f3manifest_2k.json

--- a/f3-sidecar/run.go
+++ b/f3-sidecar/run.go
@@ -58,8 +58,8 @@ func run(ctx context.Context, rpcEndpoint string, jwt string, f3RpcEndpoint stri
 		}
 	}()
 	verif := blssig.VerifierWithKeyOnG1()
-	networkName := getNetworkName(rawNetwork)
-	m := Network2PredefinedManifestMappings[networkName]
+	networkName := gpbft.NetworkName(rawNetwork)
+	m := RawNetwork2PredefinedManifestMappings[networkName]
 	if m == nil {
 		m2 := manifest.LocalDevnetManifest()
 		m = &m2

--- a/f3-sidecar/utils.go
+++ b/f3-sidecar/utils.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/ipfs/go-cid"
 	leveldb "github.com/ipfs/go-ds-leveldb"
 	logging "github.com/ipfs/go-log/v2"
@@ -37,17 +36,6 @@ func waitRawNetworkName(ctx context.Context, f3api *F3Api) string {
 		logger.Infoln("Forest RPC server is online")
 		return rawNetwork
 	}
-}
-
-func getNetworkName(rawNetworkName string) gpbft.NetworkName {
-	networkName := gpbft.NetworkName(rawNetworkName)
-	// See <https://github.com/filecoin-project/lotus/blob/v1.33.1/chain/lf3/config.go#L65>
-	// Use "filecoin" as the network name on mainnet, otherwise use the network name. Yes,
-	// mainnet is called testnetnet in state.
-	if networkName == "testnetnet" {
-		networkName = "filecoin"
-	}
-	return networkName
 }
 
 func setLogLevel(name string, level string) error {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

(Manually verified the change on both calibnet and mainnet)

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated network manifest initialization by simplifying how network identifiers are derived and looked up internally. This streamlines the network configuration process while maintaining existing functionality.

* **Chores**
  * Removed redundant utility functions to reduce internal code complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->