### PR TITLE
fix(ci): reduce logs in CI tests to speed up the jobs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,3 +41,11 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 filter = 'test(rpc_snapshot_test_)'
 slow-timeout = { period = "120s", terminate-after = 3 }
 retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true }
+
+# These tests download test snapshots from the network, which can take a while.
+# There might be some network issues, so we allow some retries with backoff.
+# Jitter is enabled to avoid [thundering herd issues](https://en.wikipedia.org/wiki/Thundering_herd_problem).
+[[profile.default.overrides]]
+filter = 'test(state_compute_)'
+slow-timeout = { period = "120s", terminate-after = 3 }
+retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true }

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,7 @@ env:
   CXX: sccache clang++
   # To minimize compile times: https://nnethercote.github.io/perf-book/build-configuration.html#minimizing-compile-times
   RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=lld"
+  RUST_LOG: error
 
 jobs:
   codecov:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,7 @@ env:
   RUSTC_WRAPPER: "sccache"
   CC: "sccache clang"
   CXX: "sccache clang++"
+  RUST_LOG: error
 
 jobs:
   tests-release:

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -884,13 +884,18 @@ mod tests {
     use num_bigint::BigInt;
     use num_traits::ToPrimitive;
     use std::sync::Arc;
+    use tracing::level_filters::LevelFilter;
+    use tracing_subscriber::EnvFilter;
 
     fn setup() -> (Arc<ChainStore<MemoryDB>>, Chain4U<Arc<MemoryDB>>) {
         // Initialize test logger
         let _ = tracing_subscriber::fmt()
+            .without_time()
             .with_env_filter(
-                tracing_subscriber::EnvFilter::from_default_env()
-                    .add_directive(tracing::Level::DEBUG.into()),
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::DEBUG.into())
+                    .from_env()
+                    .unwrap(),
             )
             .try_init();
 

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -45,13 +45,18 @@ use lints::{Lint, Violation};
 use proc_macro2::{LineColumn, Span};
 use syn::visit::Visit;
 use tracing::{debug, info, level_filters::LevelFilter};
-use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::{EnvFilter, util::SubscriberInitExt as _};
 
 #[test]
 fn lint() {
     let _guard = tracing_subscriber::fmt()
         .without_time()
-        .with_max_level(LevelFilter::DEBUG)
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::DEBUG.into())
+                .from_env()
+                .unwrap(),
+        )
         .set_default();
     LintRunner::new()
         .run::<lints::NoTestsWithReturn>()


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test logging configuration with improved environment-based filtering and timestamp handling.
  * Added retry mechanisms for compute-related tests with exponential backoff to improve test reliability.

* **Chores**
  * Updated CI/CD workflows to increase Rust logging verbosity for better diagnostic information during automated testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->