### PR TITLE
fix: warnings in `mise run install`

### DIFF
--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -41,19 +41,3 @@ tokio = { workspace = true, features = ['full'] }
 
 [build-dependencies]
 rust2go = { workspace = true, features = ["build"] }
-
-# https://doc.rust-lang.org/stable/cargo/guide/build-performance.html#reduce-amount-of-generated-debug-information
-[profile.dev]
-debug = "line-tables-only"
-split-debuginfo = "unpacked"
-
-[profile.dev.package."*"]
-# Avoid generating any debug information for dependencies
-debug = false
-# Speed up debug tests and codecov tests
-opt-level = 1
-
-[profile.dev.package."forest-filecoin"]
-debug = "line-tables-only"
-split-debuginfo = "unpacked"
-opt-level = 0


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/me/git/forest/interop-tests/Cargo.toml
workspace: /home/me/git/forest/Cargo.toml
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified development build configuration by removing debug profile settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->