### PR TITLE
fix: fix backfill with null tipsets present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 ### Fixed
 
+- [#6409](https://github.com/ChainSafe/forest/pull/6409) Fixed backfill issue when null tipsets are present.
+
 - [#6327](https://github.com/ChainSafe/forest/pull/6327) Fixed: Forest returns 404 for all invalid api paths.
 
 ## Forest v0.30.5 "Dulce de Leche"

--- a/src/tool/subcommands/index_cmd.rs
+++ b/src/tool/subcommands/index_cmd.rs
@@ -99,8 +99,11 @@ impl IndexCommands {
                 println!("Head epoch:    {}", head_ts.epoch());
 
                 let from_ts = if let Some(from) = from {
+                    // ensure from epoch is not greater than head epoch. This can happen if the
+                    // assumed head is actually a null tipset.
+                    let from = std::cmp::min(*from, head_ts.epoch());
                     chain_store.chain_index().tipset_by_height(
-                        *from,
+                        from,
                         head_ts,
                         ResolveNullTipset::TakeOlder,
                     )?


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fixed backfill issue when null tipsets are present. This occurred in https://github.com/ChainSafe/forest/actions/runs/20925172201/job/60123244129

```
❯ forest-tool index backfill --from 3363360 --n-tipsets 5 --chain calibnet
2026-01-12T17:57:17.696759Z  INFO forest::daemon::db_util: Loaded 18 CARs
2026-01-12T17:57:17.696783Z  INFO forest::tool::offline_server::server: Using chain config for calibnet
2026-01-12T17:57:17.699389Z  INFO forest::genesis: Initialized genesis: bafy2bzacecyaggy24wol5ruvs6qm73gjibs2l2iyhcqmvi7r7a4ph7zx3yqd4
Database path: /home/rumcajs/.local/share/forest/calibnet/0.30.5
From epoch:    3363360
Tipsets:       5
Head epoch:    3363359
Error: looking for tipset with height greater than start point, req: 3363360, head: 3363359
```

due to the null tipset https://calibration.filscan.io/en/height/3363360/

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed backfill issues with null tipsets by ensuring the starting epoch in indexing operations does not exceed the current head epoch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->