### PR TITLE
fix: add F3 pending activation status to healthcheck API

### DIFF
--- a/src/health/endpoints.rs
+++ b/src/health/endpoints.rs
@@ -166,6 +166,11 @@ async fn check_f3_running(state: &ForestState, acc: &mut MessageAccumulator) -> 
     } else if F3IsRunning::is_f3_running().await.unwrap_or_default() {
         acc.push_ok("f3 running");
         true
+    } else if crate::f3::get_f3_sidecar_params(&state.chain_config).bootstrap_epoch
+        > state.sync_status.read().network_head_epoch
+    {
+        acc.push_ok("f3 pending activation");
+        true
     } else {
         acc.push_err("f3 not running");
         false


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

To make `healthcheck` API work properly before the new calibnet F3 is activated.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved F3 health status reporting to correctly identify when F3 is in pending activation state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->