### PR TITLE
chore: makefile to mise in docs/

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -31,12 +31,8 @@ jobs:
         working-directory: ./docs
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          package-manager-cache: false
-      - run: corepack enable
-      - run: make format-spellcheck-dictionary-check
+      - uses: jdx/mise-action@v3
+      - run: mise run docs:format-spellcheck-dictionary-check
       - run: yarn --immutable
       - run: yarn typecheck
       - run: yarn spellcheck

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,0 @@
-SPELLCHECK_DICTIONARY=./dictionary.txt
-format-spellcheck-dictionary:
-	@cat $(SPELLCHECK_DICTIONARY) | sort --ignore-case | uniq > $(SPELLCHECK_DICTIONARY).tmp
-	@mv $(SPELLCHECK_DICTIONARY).tmp $(SPELLCHECK_DICTIONARY)
-
-format-spellcheck-dictionary-check:
-	@cat $(SPELLCHECK_DICTIONARY) | sort --ignore-case | uniq > $(SPELLCHECK_DICTIONARY).tmp
-	@diff $(SPELLCHECK_DICTIONARY) $(SPELLCHECK_DICTIONARY).tmp
-	@rm $(SPELLCHECK_DICTIONARY).tmp

--- a/mise.toml
+++ b/mise.toml
@@ -170,6 +170,25 @@ run = '''
 cargo llvm-cov -p forest-filecoin --codecov --output-path lcov.info
 '''
 
+[tasks."docs:format-spellcheck-dictionary"]
+description = "Format and deduplicate the spellcheck dictionary."
+dir = "docs"
+run = '''
+TMPFILE=$(mktemp)
+cat dictionary.txt | sort --ignore-case | uniq > "$TMPFILE"
+mv "$TMPFILE" dictionary.txt
+'''
+
+[tasks."docs:format-spellcheck-dictionary-check"]
+description = "Check if spellcheck dictionary is properly formatted."
+dir = "docs"
+run = '''
+TMPFILE=$(mktemp)
+trap "rm -f $TMPFILE" EXIT
+cat dictionary.txt | sort --ignore-case | uniq > "$TMPFILE"
+diff dictionary.txt "$TMPFILE"
+'''
+
 [tools]
 cargo-binstall = "1.16.6"
 go = "1.25.5"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- get rid of Makefile in `docs/` in favour of the powerful `mise` 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated build workflow configuration to streamline CI/CD pipeline execution
  * Unified spellcheck dictionary formatting and validation processes through a centralized task system
  * Optimized documentation checking procedures for improved efficiency in the build process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->