### PR TITLE
fix: fix invalid conversion when syncing from genesis on calibnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
 
 - [#6400](https://github.com/ChainSafe/forest/issues/6400) Fixed `eth_subscribe` `newHeads` to return Ethereum block format instead of Filecoin block headers array.
 
+- [#6430](https://github.com/ChainSafe/forest/issues/6430) Fixed a panic when syncing from genesis on the calibration network.
+
 ## Forest v0.30.5 "Dulce de Leche"
 
 Non-mandatory release supporting new API methods and addressing a critical panic issue.

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -206,10 +206,16 @@ where
     /// Get actor state from an address. Will be resolved to ID address.
     pub fn get_actor(&self, addr: &Address) -> anyhow::Result<Option<ActorState>> {
         match self {
-            StateTree::FvmV2(st) => Ok(st
-                .get_actor(&addr.into())
-                .map_err(|e| anyhow!("{e}"))?
-                .map(Into::into)),
+            StateTree::FvmV2(st) => {
+                anyhow::ensure!(
+                    addr.protocol() != crate::shim::address::Protocol::Delegated,
+                    "Delegated addresses are not supported in FVMv2 state trees"
+                );
+                Ok(st
+                    .get_actor(&addr.into())
+                    .map_err(|e| anyhow!("{e}"))?
+                    .map(Into::into))
+            }
             StateTree::FvmV3(st) => {
                 let id = st.lookup_id(&addr.into())?;
                 if let Some(id) = id {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- it's a workaround but it should be fine for now. Long term solution would be to remove the panics from `Address` shim, but this would incur cost for all shim-to-type conversions; given this fails only for FVM2 which is seldom used, this doesn't make economical sense.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/6430

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a panic occurring when syncing from genesis on the calibration network.
  * Added validation to reject unsupported delegated addresses with appropriate error messaging in FVMv2 environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->