### PR TITLE
test: cover state compuation with fvm2 and fvm3

### DIFF
--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -275,6 +275,7 @@ pub mod state_compute {
         #[tokio::test(flavor = "multi_thread")]
         async fn state_compute_calibnet_3111900() {
             let chain = NetworkChain::Calibnet;
+            // FVM@4
             let snapshot = get_state_compute_snapshot(&chain, 3111900).await.unwrap();
             let (sm, ts) = prepare_state_compute(&chain, &snapshot, false)
                 .await
@@ -285,6 +286,7 @@ pub mod state_compute {
         #[tokio::test(flavor = "multi_thread")]
         async fn state_compute_calibnet_480000() {
             let chain = NetworkChain::Calibnet;
+            // FVM@3
             let snapshot = get_state_compute_snapshot(&chain, 480000).await.unwrap();
             let (sm, ts) = prepare_state_compute(&chain, &snapshot, false)
                 .await
@@ -295,6 +297,7 @@ pub mod state_compute {
         #[tokio::test(flavor = "multi_thread")]
         async fn state_compute_calibnet_300000() {
             let chain = NetworkChain::Calibnet;
+            // FVM@2
             let snapshot = get_state_compute_snapshot(&chain, 300000).await.unwrap();
             let (sm, ts) = prepare_state_compute(&chain, &snapshot, false)
                 .await


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added and reorganized tests to cover additional epochs on Calibnet and Mainnet.
  * Renamed and expanded test suite entries for clearer coverage.
  * Tests now run full state computation and validation (not just preparation) across multiple epochs.
  * Included inline annotations indicating FVM version contexts for relevant test cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->