### PR TITLE
chore: derive more constructors

### DIFF
--- a/src/blocks/ticket.rs
+++ b/src/blocks/ticket.rs
@@ -8,6 +8,7 @@ use get_size2::GetSize;
 /// A Ticket is a marker of a tick of the blockchain's clock.  It is the source
 /// of randomness for proofs of storage and leader election.  It is generated
 /// by the miner of a block using a `VRF` and a `VDF`.
+#[cfg_attr(test, derive(derive_more::Constructor))]
 #[derive(
     Clone,
     Debug,
@@ -25,14 +26,6 @@ pub struct Ticket {
     /// A proof output by running a `VRF` on the `VDFResult` of the parent
     /// ticket
     pub vrfproof: VRFProof,
-}
-
-impl Ticket {
-    #[cfg(test)]
-    /// Ticket constructor
-    pub fn new(vrfproof: VRFProof) -> Self {
-        Self { vrfproof }
-    }
 }
 
 #[cfg(test)]

--- a/src/blocks/vrf_proof.rs
+++ b/src/blocks/vrf_proof.rs
@@ -6,17 +6,14 @@ use get_size2::GetSize;
 use serde::{Deserialize, Serialize};
 
 /// The output from running a VRF proof.
-#[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
+#[cfg_attr(
+    test,
+    derive(derive_quickcheck_arbitrary::Arbitrary, derive_more::Constructor)
+)]
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Default, Serialize, Deserialize, Hash)]
 pub struct VRFProof(#[serde(with = "serde_byte_array")] pub Vec<u8>);
 
 impl VRFProof {
-    /// Creates a `VRFProof` from a raw vector.
-    #[cfg(test)]
-    pub fn new(output: Vec<u8>) -> Self {
-        Self(output)
-    }
-
     /// Returns reference to underlying proof bytes.
     pub fn as_bytes(&self) -> &[u8] {
         &self.0

--- a/src/chain/snapshot_format.rs
+++ b/src/chain/snapshot_format.rs
@@ -43,7 +43,7 @@ impl<'de> Deserialize<'de> for FilecoinSnapshotVersion {
 }
 
 /// Defined in <https://github.com/filecoin-project/FIPs/blob/98e33b9fa306959aa0131519eb4cc155522b2081/FRCs/frc-0108.md#snapshotmetadata>
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, derive_more::Constructor)]
 #[serde(rename_all = "PascalCase")]
 pub struct FilecoinSnapshotMetadata {
     /// Snapshot version
@@ -55,18 +55,6 @@ pub struct FilecoinSnapshotMetadata {
 }
 
 impl FilecoinSnapshotMetadata {
-    pub fn new(
-        version: FilecoinSnapshotVersion,
-        head_tipset_key: NonEmpty<Cid>,
-        f3_data: Option<Cid>,
-    ) -> Self {
-        Self {
-            version,
-            head_tipset_key,
-            f3_data,
-        }
-    }
-
     pub fn new_v2(head_tipset_key: NonEmpty<Cid>, f3_data: Option<Cid>) -> Self {
         Self::new(FilecoinSnapshotVersion::V2, head_tipset_key, f3_data)
     }

--- a/src/chain_sync/metrics.rs
+++ b/src/chain_sync/metrics.rs
@@ -45,14 +45,8 @@ pub static INVALID_TIPSET_TOTAL: LazyLock<Counter> = LazyLock::new(|| {
     metric
 });
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, derive_more::Constructor)]
 pub struct Libp2pMessageKindLabel(&'static str);
-
-impl Libp2pMessageKindLabel {
-    pub const fn new(kind: &'static str) -> Self {
-        Self(kind)
-    }
-}
 
 impl EncodeLabelSet for Libp2pMessageKindLabel {
     fn encode(&self, mut encoder: LabelSetEncoder) -> Result<(), std::fmt::Error> {

--- a/src/chain_sync/network_context.rs
+++ b/src/chain_sync/network_context.rs
@@ -47,6 +47,7 @@ const MAX_CONCURRENT_CHAIN_EXCHANGE_REQUESTS: usize = 2;
 /// Context used in chain sync to handle network requests.
 /// This contains the peer manager, P2P service interface, and [`Blockstore`]
 /// required to make network requests.
+#[derive(derive_more::Constructor)]
 pub struct SyncNetworkContext<DB> {
     /// Channel to send network messages through P2P service
     network_send: flume::Sender<NetworkMessage>,
@@ -118,18 +119,6 @@ impl<DB> SyncNetworkContext<DB>
 where
     DB: Blockstore,
 {
-    pub fn new(
-        network_send: flume::Sender<NetworkMessage>,
-        peer_manager: Arc<PeerManager>,
-        db: Arc<DB>,
-    ) -> Self {
-        Self {
-            network_send,
-            peer_manager,
-            db,
-        }
-    }
-
     /// Returns a reference to the peer manager of the network context.
     pub fn peer_manager(&self) -> &PeerManager {
         self.peer_manager.as_ref()

--- a/src/db/blockstore_with_read_cache.rs
+++ b/src/db/blockstore_with_read_cache.rs
@@ -72,6 +72,7 @@ impl BlockstoreReadCacheStats for DefaultBlockstoreReadCacheStats {
     }
 }
 
+#[derive(derive_more::Constructor)]
 pub struct BlockstoreWithReadCache<
     DB: Blockstore,
     CACHE: BlockstoreReadCache,
@@ -85,14 +86,6 @@ pub struct BlockstoreWithReadCache<
 impl<DB: Blockstore, CACHE: BlockstoreReadCache, STATS: BlockstoreReadCacheStats>
     BlockstoreWithReadCache<DB, CACHE, STATS>
 {
-    pub fn new(db: DB, cache: CACHE, stats: Option<STATS>) -> Self {
-        Self {
-            inner: db,
-            cache,
-            stats,
-        }
-    }
-
     pub fn stats(&self) -> Option<&STATS> {
         self.stats.as_ref()
     }

--- a/src/fil_cns/mod.rs
+++ b/src/fil_cns/mod.rs
@@ -57,6 +57,7 @@ pub enum FilecoinConsensusError {
     ForestEncoding(#[from] ForestEncodingError),
 }
 
+#[derive(derive_more::Constructor)]
 pub struct FilecoinConsensus {
     /// `Drand` randomness beacon
     ///
@@ -67,10 +68,6 @@ pub struct FilecoinConsensus {
 }
 
 impl FilecoinConsensus {
-    pub fn new(beacon: Arc<BeaconSchedule>) -> Self {
-        Self { beacon }
-    }
-
     pub async fn validate_block<DB: Blockstore + Sync + Send + 'static>(
         &self,
         state_manager: Arc<StateManager<DB>>,

--- a/src/key_management/keystore.rs
+++ b/src/key_management/keystore.rs
@@ -41,7 +41,7 @@ type SaltByteArray = [u8; RECOMMENDED_SALT_LEN];
 /// `KeyInfo` structure, this contains the type of key (stored as a string) and
 /// the private key. Note how the private key is stored as a byte vector
 #[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
-#[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize, derive_more::Constructor)]
 pub struct KeyInfo {
     key_type: SignatureType,
     // Vec<u8> is used because The private keys for BLS and SECP256K1 are not of the same type
@@ -55,14 +55,6 @@ pub struct PersistentKeyInfo {
 }
 
 impl KeyInfo {
-    /// Return a new `KeyInfo` given the key type and private key
-    pub fn new(key_type: SignatureType, private_key: Vec<u8>) -> Self {
-        KeyInfo {
-            key_type,
-            private_key,
-        }
-    }
-
     /// Return a reference to the key's signature type
     pub fn key_type(&self) -> &SignatureType {
         &self.key_type

--- a/src/message_pool/msgpool/provider.rs
+++ b/src/message_pool/msgpool/provider.rs
@@ -62,18 +62,10 @@ pub trait Provider {
 
 /// This is the default Provider implementation that will be used for the
 /// `mpool` RPC.
+#[derive(derive_more::Constructor)]
 pub struct MpoolRpcProvider<DB> {
     subscriber: Publisher<HeadChange>,
     sm: Arc<StateManager<DB>>,
-}
-
-impl<DB> MpoolRpcProvider<DB>
-where
-    DB: Blockstore,
-{
-    pub fn new(subscriber: Publisher<HeadChange>, sm: Arc<StateManager<DB>>) -> Self {
-        MpoolRpcProvider { subscriber, sm }
-    }
 }
 
 #[async_trait]

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -169,15 +169,9 @@ pub struct RpcMethodLabel {
     pub method: String,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet, derive_more::Constructor)]
 pub struct KindLabel {
     kind: &'static str,
-}
-
-impl KindLabel {
-    pub const fn new(kind: &'static str) -> Self {
-        Self { kind }
-    }
 }
 
 pub mod values {

--- a/src/networks/metrics.rs
+++ b/src/networks/metrics.rs
@@ -13,7 +13,7 @@ use prometheus_client::{
 use super::calculate_expected_epoch;
 use crate::{networks::ChainConfig, shim::clock::ChainEpoch};
 
-#[derive(Educe)]
+#[derive(Educe, derive_more::Constructor)]
 #[educe(Debug)]
 pub struct NetworkHeightCollector<F>
 where
@@ -23,23 +23,6 @@ where
     genesis_timestamp: u64,
     #[educe(Debug(ignore))]
     get_chain_head_height: Arc<F>,
-}
-
-impl<F> NetworkHeightCollector<F>
-where
-    F: Fn() -> ChainEpoch,
-{
-    pub fn new(
-        block_delay_secs: u32,
-        genesis_timestamp: u64,
-        get_chain_head_height: Arc<F>,
-    ) -> Self {
-        Self {
-            block_delay_secs,
-            genesis_timestamp,
-            get_chain_head_height,
-        }
-    }
 }
 
 impl<F> Collector for NetworkHeightCollector<F>
@@ -82,7 +65,7 @@ where
     }
 }
 
-#[derive(Educe)]
+#[derive(Educe, derive_more::Constructor)]
 #[educe(Debug)]
 pub struct NetworkVersionCollector<F1, F2>
 where
@@ -94,24 +77,6 @@ where
     get_chain_head_height: Arc<F1>,
     #[educe(Debug(ignore))]
     get_chain_head_actor_version: Arc<F2>,
-}
-
-impl<F1, F2> NetworkVersionCollector<F1, F2>
-where
-    F1: Fn() -> ChainEpoch,
-    F2: Fn() -> u64,
-{
-    pub fn new(
-        chain_config: Arc<ChainConfig>,
-        get_chain_head_height: Arc<F1>,
-        get_chain_head_actor_version: Arc<F2>,
-    ) -> Self {
-        Self {
-            chain_config,
-            get_chain_head_height,
-            get_chain_head_actor_version,
-        }
-    }
 }
 
 impl<F1, F2> Collector for NetworkVersionCollector<F1, F2>

--- a/src/rpc/methods/eth/pubsub.rs
+++ b/src/rpc/methods/eth/pubsub.rs
@@ -69,14 +69,9 @@ use jsonrpsee::core::{SubscriptionError, SubscriptionResult};
 use std::sync::Arc;
 use tokio::sync::broadcast::{Receiver as Subscriber, error::RecvError};
 
+#[derive(derive_more::Constructor)]
 pub struct EthPubSub<DB> {
     ctx: Arc<RPCState<DB>>,
-}
-
-impl<DB> EthPubSub<DB> {
-    pub fn new(ctx: Arc<RPCState<DB>>) -> Self {
-        Self { ctx }
-    }
 }
 
 #[async_trait::async_trait]

--- a/src/rpc/types/mod.rs
+++ b/src/rpc/types/mod.rs
@@ -377,7 +377,9 @@ pub struct CirculatingSupply {
 
 lotus_json_with_self!(CirculatingSupply);
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema, derive_more::Constructor,
+)]
 #[serde(rename_all = "PascalCase")]
 pub struct MinerSectors {
     live: u64,
@@ -385,16 +387,6 @@ pub struct MinerSectors {
     faulty: u64,
 }
 lotus_json_with_self!(MinerSectors);
-
-impl MinerSectors {
-    pub fn new(live: u64, active: u64, faulty: u64) -> Self {
-        Self {
-            live,
-            active,
-            faulty,
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "PascalCase")]

--- a/src/shim/crypto.rs
+++ b/src/shim/crypto.rs
@@ -23,7 +23,7 @@ use schemars::JsonSchema;
 use std::borrow::Cow;
 
 /// A cryptographic signature, represented in bytes, of any key protocol.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, GetSize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, GetSize, derive_more::Constructor)]
 #[cfg_attr(test, derive(derive_quickcheck_arbitrary::Arbitrary))]
 pub struct Signature {
     pub sig_type: SignatureType,
@@ -70,10 +70,6 @@ impl<'de> de::Deserialize<'de> for Signature {
 }
 
 impl Signature {
-    pub fn new(sig_type: SignatureType, bytes: Vec<u8>) -> Self {
-        Signature { sig_type, bytes }
-    }
-
     /// Creates a BLS Signature given the raw bytes.
     pub fn new_bls(bytes: Vec<u8>) -> Self {
         Self {

--- a/src/state_manager/chain_rand.rs
+++ b/src/state_manager/chain_rand.rs
@@ -16,6 +16,7 @@ use byteorder::{BigEndian, WriteBytesExt};
 use fvm_ipld_blockstore::Blockstore;
 
 /// Allows for deriving the randomness from a particular tipset.
+#[derive(derive_more::Constructor)]
 pub struct ChainRand<DB> {
     chain_config: Arc<ChainConfig>,
     tipset: Tipset,
@@ -38,20 +39,6 @@ impl<DB> ChainRand<DB>
 where
     DB: Blockstore,
 {
-    pub fn new(
-        chain_config: Arc<ChainConfig>,
-        tipset: Tipset,
-        chain_index: Arc<ChainIndex<Arc<DB>>>,
-        beacon: Arc<BeaconSchedule>,
-    ) -> Self {
-        Self {
-            chain_config,
-            tipset,
-            chain_index,
-            beacon,
-        }
-    }
-
     /// Gets 32 bytes of randomness for `ChainRand` parameterized by the
     /// `DomainSeparationTag`, `ChainEpoch`, Entropy from the ticket chain.
     pub fn get_chain_randomness(

--- a/src/utils/version/mod.rs
+++ b/src/utils/version/mod.rs
@@ -21,15 +21,9 @@ pub static FOREST_VERSION_STRING: LazyLock<String> =
 pub static FOREST_VERSION: LazyLock<semver::Version> =
     LazyLock::new(|| semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Invalid version"));
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet, derive_more::Constructor)]
 pub struct VersionLabel {
     version: &'static str,
-}
-
-impl VersionLabel {
-    pub const fn new(version: &'static str) -> Self {
-        Self { version }
-    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- use `derive_more::Constructor` to remove trivial c-tor boilerplate

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Unified constructor implementations across 16 struct types by transitioning from explicit manual constructors to derive-based auto-generation. This improves code consistency and maintainability while maintaining complete backward compatibility with all existing public APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->