### PR TITLE
fix!: increase default JWT expiration time via `AuthNew`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Breaking
 
+- [#6475](https://github.com/ChainSafe/forest/pull/6475): Increased default JWT (generated via `Filecoin.AuthNew`) expiration time from 24 hours to 100 years to match Lotus behavior and ensure compatibility with clients like Curio.
+
 ### Added
 
 - [#6466](https://github.com/ChainSafe/forest/pull/6466) Enabled `Filecoin.EthGetBlockTransactionCountByHash` for API v2.

--- a/src/rpc/methods/auth.rs
+++ b/src/rpc/methods/auth.rs
@@ -29,12 +29,13 @@ impl RpcMethod<2> for AuthNew {
     ) -> Result<Self::Ok, ServerError> {
         let ks = ctx.keystore.read();
         let ki = ks.get(JWT_IDENTIFIER)?;
-        let token = create_token(
-            permissions,
-            ki.private_key(),
-            // default to 24h
-            chrono::Duration::seconds(expiration_secs.unwrap_or(60 * 60 * 24)),
-        )?;
+        // Lotus admin tokens do not expire but Forest requires all JWT tokens to
+        // have an expiration date. So we set the expiration date to 100 years in
+        // the future to match user-visible behavior of Lotus.
+        let token_exp = expiration_secs
+            .map(chrono::Duration::seconds)
+            .unwrap_or_else(|| chrono::Duration::days(365 * 100));
+        let token = create_token(permissions, ki.private_key(), token_exp)?;
         Ok(token.as_bytes().to_vec())
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- this better matches Lotus behavior (which doesn't implement token expiration at all). See [here](https://github.com/filecoin-project/lotus/blob/c3b13a6baf1ebfe84757a168d9090609909bac25/node/impl/common/common.go#L50-L56).
- The issue is that clients, such as Curio, expect tokens generated via this command to be eternal, and so they put it into DB and don't allow to override them. This causes issues when node is run for longer than 24h.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Default JWT/admin token expiration increased from 24 hours to 100 years; may affect systems relying on short-lived tokens.

* **Bug Fixes**
  * Token creation now honors configured expiration when provided and otherwise uses the new long-lived default, improving compatibility with admin-token requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->