### PR TITLE
fix: generate test snapshot with blocks in deterministic order

### DIFF
--- a/src/db/memory.rs
+++ b/src/db/memory.rs
@@ -38,6 +38,8 @@ impl MemoryDB {
             blockchain_db
                 .iter()
                 .chain(blockchain_persistent_db.iter())
+                // Sort to make the result CAR deterministic
+                .sorted_by_key(|&(&cid, _)| cid)
                 .map(|(&cid, data)| {
                     anyhow::Ok(CarBlock {
                         cid,

--- a/src/state_manager/utils.rs
+++ b/src/state_manager/utils.rs
@@ -241,7 +241,7 @@ pub mod state_compute {
         });
 
         let url = Url::parse(&format!("{DO_SPACE_ROOT}{file}"))?;
-        Ok(crate::utils::retry(
+        let path = crate::utils::retry(
             crate::utils::RetryArgs {
                 timeout: Some(Duration::from_secs(30)),
                 max_retries: Some(5),
@@ -256,7 +256,17 @@ pub mod state_compute {
             },
         )
         .await?
-        .path)
+        .path;
+        #[cfg(test)]
+        {
+            // To determine whether a test failure is caused by data corruption
+            use digest::Digest as _;
+            println!(
+                "snapshot: {file}, sha256sum: {}",
+                hex::encode(sha2::Sha256::digest(std::fs::read(&path)?))
+            );
+        }
+        Ok(path)
     }
 
     pub async fn prepare_state_compute(


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

We occasionally see errors below in [CI](https://github.com/ChainSafe/forest/actions/runs/21739579334/job/62712079740?pr=6546#step:10:2885). This PR makes generated test snapshots deterministic, and update tests to print sha256sum of snapshots to help determine whether a test failure is caused by data corruption.
```
thread 'state_manager::utils::state_compute::tests::cargo_test_state_compute_calibnet_1013135' (97832) panicked at src/state_manager/utils.rs:426:52:
called `Result::unwrap()` on an `Err` value: failed joining on tokio task: task 28 panicked with message "failed executing job for address: f03751, Reason: state migration failed for bafk2bzacebkjnjp5okqjhjxzft5qkuv36u4tz7inawseiwi2kw4j43xpxvhpm actor, addr f03751:Cid (bafy2bzacedxsid7zoc3nu2ttmmohedoedlzuznykhmghhfnq7laxbrimecdge) did not match any in database"
```

I regenerated `calibnet_1013135.forest.car.zst` for a few times and the CARs are all identical. Replaced the one on DO space to see if the transient test failure occurs again.

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved deterministic ordering of data exports for consistent output across operations.
  * Enhanced retry mechanism with added delay for improved reliability during transient failures.

* **Tests**
  * Added diagnostic logging for state snapshot integrity verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->