### PR TITLE
fix(ci): disable F3 on lotus until a new lotus image with calibnet F3 initial power table is published

### DIFF
--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -183,6 +183,7 @@ services:
       - LOTUS_CHAINSTORE_ENABLESPLITSTORE=false
       - LOTUS_SYNC_BOOTSTRAP_PEERS=1
       - FULLNODE_API_INFO=/dns/lotus/tcp/${LOTUS_RPC_PORT}/http
+      - LOTUS_DISABLE_F3_SUBSYSTEM=1
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |

--- a/scripts/tests/api_compare/filter-list
+++ b/scripts/tests/api_compare/filter-list
@@ -1,2 +1,4 @@
 # This list contains potentially broken methods (or tests) that are ignored.
 # They should be considered bugged, and not used until the root cause is resolved.
+# Disable until a new lotus image with calibnet F3 initial power table is published
+!Filecoin.F3

--- a/scripts/tests/bootstrapper/docker-compose-lotus.yml
+++ b/scripts/tests/bootstrapper/docker-compose-lotus.yml
@@ -69,6 +69,7 @@ services:
       - FULLNODE_API_INFO=/dns/lotus/tcp/${LOTUS_RPC_PORT}/http
       - LOTUS_P2P_BOOTSTRAPPERS=${FOREST_BOOTSTRAPPER_ADDRESS}
       - LOTUS_P2P_DHT_NO_ROUTING_TABLE_FILTER=1
+      - LOTUS_DISABLE_F3_SUBSYSTEM=1
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Lotus cannot bootstrap F3 until initial power table is set. Disable F3 on lotus for now to unblock CI.

https://github.com/ChainSafe/forest/actions/runs/21977918338/job/63495549964?pr=6597#step:6:1501
```
ERROR: initializing node: starting node: failed to open certstore: getting initial power table: failed to load the F3 bootstrap power table and none is specified in the manifest; could not close datastore: leveldb: closed
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/6595

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configurations to disable the F3 subsystem across multiple test services.
  * Updated test filter list to exclude F3-related tests from the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->