### PR TITLE
chore: limit `Vec` preallocation to follow serde convention

### DIFF
--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -537,12 +537,11 @@ where
 {
     let amt = Amt::<Cid, _>::load(root, db)?;
 
-    let mut cids = Vec::new();
-    for i in 0..amt.count() {
-        if let Some(c) = amt.get(i)? {
-            cids.push(*c);
-        }
-    }
+    let mut cids = Vec::with_capacity(amt.count() as usize);
+    amt.for_each_cacheless(|_, c| {
+        cids.push(*c);
+        Ok(())
+    })?;
 
     Ok(cids)
 }

--- a/src/utils/encoding/cid_de_cbor.rs
+++ b/src/utils/encoding/cid_de_cbor.rs
@@ -63,7 +63,8 @@ impl<'de> DeserializeSeed<'de> for FilterCids<'_> {
             where
                 V: de::MapAccess<'de>,
             {
-                self.0.reserve(visitor.size_hint().unwrap_or(0));
+                let capacity = super::size_hint_cautious_cid(visitor.size_hint().unwrap_or(0));
+                self.0.reserve(capacity);
                 // This is where recursion happens, we unravel each [`Ipld`] till we reach all
                 // the nodes.
                 while visitor
@@ -83,7 +84,8 @@ impl<'de> DeserializeSeed<'de> for FilterCids<'_> {
             where
                 A: SeqAccess<'de>,
             {
-                self.0.reserve(seq.size_hint().unwrap_or(0));
+                let capacity = super::size_hint_cautious_cid(seq.size_hint().unwrap_or(0));
+                self.0.reserve(capacity);
                 // This is where recursion happens, we unravel each [`Ipld`] till we reach all
                 // the nodes.
                 while seq.next_element_seed(FilterCids(self.0))?.is_some() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- limit `Vec` preallocation to follow serde convention
- optimized one CID sweep, it could potentially reduce re-allocations
- see https://docs.serde.rs/src/serde/private/size_hint.rs.html

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced excessive memory preallocation during deserialization by applying a more cautious sizing strategy, improving memory stability.

* **Tests**
  * Added unit tests validating the cautious sizing behavior across representative sizes.

* **Performance**
  * Improved vector pre-allocation during bulk reads to reduce reallocations and improve efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->