### PR TITLE
fix: use panic unwind on tests with quick profile

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -76,7 +76,7 @@ jobs:
           ls -ahl $FIL_PROOFS_PARAMETER_CACHE
       - uses: jdx/mise-action@v3
       - run: |
-          mise test quick
+          mise test
         env:
           FOREST_TEST_SKIP_PROOF_PARAM_CHECK: 1
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,6 +296,10 @@ lto = "off"
 incremental = true
 codegen-units = 256
 
+[profile.quick-test]
+inherits = "quick"
+panic = "unwind"
+
 [profile.profiling]
 inherits = "dev"
 opt-level = 0

--- a/mise.toml
+++ b/mise.toml
@@ -152,8 +152,8 @@ rm -rf node_modules
 # We need to run them separately.
 description = "Run doctests."
 usage = '''
-arg "<profile>" help="Build profile (quick, release, etc.)" default="quick" {
-   choices "quick" "release" "dev"
+arg "<profile>" help="Build profile (quick-test, dev, etc.)" default="quick-test" {
+   choices "quick" "quick-test" "release" "dev"
 }
 '''
 run = '''
@@ -163,8 +163,8 @@ cargo test --doc --profile ${usage_profile?} --no-default-features --features "t
 [tasks."test:nextest"]
 description = "Run Rust unit and integration tests except `cargo-test` group with nextest."
 usage = '''
-arg "<profile>" help="Build profile (quick, release, etc.)" default="quick" {
-   choices "quick" "release" "dev"
+arg "<profile>" help="Build profile (quick-test, dev, etc.)" default="quick-test" {
+   choices "quick" "quick-test" "release" "dev"
 }
 '''
 run = '''
@@ -175,8 +175,8 @@ cargo nextest run --cargo-profile ${usage_profile?} --workspace --no-default-fea
 [tasks."test:cargo"]
 description = "Run Rust unit, integration and doc tests of `cargo-test` group with cargo test."
 usage = '''
-arg "<profile>" help="Build profile (quick, release, etc.)" default="quick" {
-   choices "quick" "release" "dev"
+arg "<profile>" help="Build profile (quick-test, dev, etc.)" default="quick-test" {
+   choices "quick" "quick-test" "release" "dev"
 }
 '''
 run = '''
@@ -187,8 +187,8 @@ cargo test --lib --profile ${usage_profile?} --workspace --no-default-features -
 [tasks.test]
 description = "Run all tests."
 usage = '''
-arg "<profile>" help="Build profile (quick, release, etc.)" default="quick" {
-   choices "quick" "release" "dev"
+arg "<profile>" help="Build profile (quick-test, dev, etc.)" default="quick-test" {
+   choices "quick" "quick-test" "release" "dev"
 }
 '''
 run = '''


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->



- using the `quick` profile which inherits `panic=abort` results in extremely cryptic errors when, e.g., trying to override packages in `fil-actor-states`. See https://github.com/ChainSafe/fil-actor-states/actions/runs/21994597700/job/63550945119?pr=413
- the above results in weird duplicates in the dependency tree that cause further errors
- `panic=abort` is also undesirable in tests for various reasons (`should_panic` test would be incorrectly handled I guess, also worse error messages). 

Changes introduced in this pull request:
- introduced a `quick-test` profile that doesn't abort on paics.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new "quick-test" build profile tuned for faster test runs.
  * Updated test task configurations and defaults to include and prefer "quick-test" as an option.
  * Adjusted the unit test workflow to invoke tests using the updated/default profile settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->