### PR TITLE
chore: don't pollute workspace with test artefacts

### DIFF
--- a/src/cli_shared/mod.rs
+++ b/src/cli_shared/mod.rs
@@ -71,13 +71,14 @@ mod tests {
     #[test]
     fn read_config_with_path() {
         let default_config = Config::default();
-        let path: PathBuf = "config.toml".into();
+        let temp_dir = tempfile::tempdir().expect("couldn't create temp dir");
+        let config_file = temp_dir.path().join("config.toml");
         let serialized_config = toml::to_string(&default_config).unwrap();
-        std::fs::write(path.clone(), serialized_config).unwrap();
+        std::fs::write(&config_file, serialized_config).unwrap();
 
-        let (config_path, config) = read_config(Some(&path), None).unwrap();
+        let (config_path, config) = read_config(Some(&config_file), None).unwrap();
 
-        assert_eq!(config_path.unwrap(), ConfigPath::Cli(path));
+        assert_eq!(config_path.unwrap(), ConfigPath::Cli(config_file));
         assert_eq!(config.chain(), &NetworkChain::Mainnet);
         assert_eq!(config, default_config);
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- after running tests I always end up with lingering `config.toml` file polluting my workspace; this creates that test file in a temp directory.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by updating configuration file handling to use temporary files instead of hardcoded paths, ensuring more robust and isolated test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->