### PR TITLE
fix(test): drop client to avoid potential locks

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -893,6 +893,9 @@ mod tests {
             .unwrap();
         assert_eq!(response, jwt_read_permissions);
 
+        // Explicitly drop the WebSocket client to close the connection
+        drop(client);
+
         // Gracefully shutdown the RPC server
         shutdown_send.send(()).await.unwrap();
         shutdown_recv.recv().await;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

We had a timeout here https://github.com/ChainSafe/forest/actions/runs/22307864251/job/64531656250

Not sure 100% if it fixes the root cause but it can _potentially_ help.

Changes introduced in this pull request:

- drop websocket client before RPC shutdown in tests

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved WebSocket RPC client test cleanup to ensure proper resource shutdown sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->