### PR TITLE
feat(ci): autoformat commits

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,47 @@
+# This workflow runs on every push and automatically applies formatting using mise format
+name: Auto-format code
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  format:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+    # Only run on the main repo, skip forks
+    # Skip if commit is already from this auto-format workflow to avoid infinite loops
+    if: github.repository == 'ChainSafe/forest' && !contains(github.event.head_commit.message, '[LeshyBot] Apply automatic formatting')
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.LESHY_APP_ID }}
+          private-key: ${{ secrets.LESHY_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          ref: ${{ github.head_ref }}
+          # Value already defaults to true, but `persist-credentials` is required to push new commits to the repository.
+          persist-credentials: true
+
+      - uses: jdx/mise-action@v3
+      - run: mise install-lint-tools
+      - run: mise format
+
+      - name: Commit and push formatting changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "[LeshyBot] Apply automatic formatting"
+          commit_user_name: "leshyatwork[bot]"
+          commit_user_email: "217592034+leshyatwork[bot]@users.noreply.github.com"
+          commit_author: "leshyatwork[bot] <217592034+leshyatwork[bot]@users.noreply.github.com>"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Dependabot (or we) sometime push unformatted code; it's probably easier to just commit a fix from a bot than to wait for the CI to fail, notice it and run the format command yourself.


Changes introduced in this pull request:

- introduced a workflow that _should_ push formatting changes if needed. Might not work though, difficult to test locally. We'll iterate. :)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated formatting workflow that runs on every push, applies formatting, and commits changes only when differences are detected.
  * Includes concurrency control and safeguards to avoid re-triggering from its own commits, and uses secure authentication to perform conditional commits and pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->