### PR TITLE
chore: fix wording in snapshot download

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -739,7 +739,7 @@ async fn maybe_set_snapshot_path(
                 "Forest requires a snapshot to sync with the network, but automatic fetching is disabled."
             );
             let message = format!(
-                "Fetch a {} snapshot to the current directory? (denying will exit the program). ",
+                "Fetch a {} snapshot? (denying will exit the program). ",
                 indicatif::HumanBytes(num_bytes)
             );
             let have_permission = asyncify(|| {

--- a/src/tool/offline_server/server.rs
+++ b/src/tool/offline_server/server.rs
@@ -282,7 +282,7 @@ async fn handle_snapshots(
     if !auto_download_snapshot {
         warn!("Automatic snapshot download is disabled.");
         let message = format!(
-            "Fetch a {} snapshot to the current directory? (denying will exit the program). ",
+            "Fetch a {} snapshot? (denying will exit the program). ",
             indicatif::HumanBytes(num_bytes)
         );
         let have_permission =


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

snapshots are not downloaded to the CWD - they are downloaded to to forest data dir (normally). Let's just omit this info.

Changes introduced in this pull request:

- fixed snapshot download wording

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified snapshot fetch prompt messages by removing redundant directory path information, improving clarity and user experience while maintaining all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->