### PR TITLE
fix(test): print some logs in test_rpc_server for troubleshooting timeout issue

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -833,16 +833,19 @@ mod tests {
 
     #[test]
     fn test_rpc_server() {
+        const TIMEOUT: Duration = Duration::from_secs(5);
+        let (done_tx, done_rx) = flume::bounded(1);
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap();
-        rt.block_on(async { test_rpc_server_inner().await });
+        rt.block_on(async move { test_rpc_server_inner(done_tx).await });
+        done_rx.recv().unwrap();
         // To mitigate the transient timeout issue
-        rt.shutdown_timeout(Duration::from_secs(5));
+        rt.shutdown_timeout(TIMEOUT);
     }
 
-    async fn test_rpc_server_inner() {
+    async fn test_rpc_server_inner(done_tx: flume::Sender<()>) {
         let chain = NetworkChain::Calibnet;
         let db = Arc::new(MemoryDB::default());
         let mut services = JoinSet::new();
@@ -892,6 +895,8 @@ mod tests {
             .unwrap();
         assert_eq!(response, jwt_read_permissions);
 
+        drop(client);
+
         println!("sending a few websocket requests");
 
         let client = Client::from_url(
@@ -905,6 +910,8 @@ mod tests {
             .unwrap();
         assert_eq!(response, jwt_read_permissions);
 
+        drop(client);
+
         // Gracefully shutdown the RPC server
         println!("sending shutdown signal");
         shutdown_send.send(()).await.unwrap();
@@ -915,5 +922,6 @@ mod tests {
         println!("waiting on graceful shutdown");
         handle.await.unwrap().unwrap();
         println!("done");
+        done_tx.send(()).unwrap();
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tests restructured to run inside an outer runtime wrapper delegating to an inner async test for controlled execution and timeout handling.
  * Improved test logging with explicit progress and shutdown messages for HTTP and WebSocket flows.
  * WebSocket teardown now relies on the shutdown sequence instead of an explicit client drop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->