### PR TITLE
chore: use `CachePadded` in a cached blockstore hot loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,6 +3264,7 @@ dependencies = [
  "colored 3.1.1",
  "console-subscriber",
  "criterion",
+ "crossbeam-utils",
  "crypto_secretbox",
  "cs_serde_bytes",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 colored = "3"
 criterion = { version = "0.8", default-features = false, features = ["async_tokio"], optional = true }
+crossbeam-utils = "0.8"
 crypto_secretbox = "0.1"
 data-encoding = "2"
 data-encoding-macro = "0.1"

--- a/src/db/blockstore_with_read_cache.rs
+++ b/src/db/blockstore_with_read_cache.rs
@@ -50,8 +50,8 @@ pub trait BlockstoreReadCacheStats {
 
 #[derive(Debug, Default)]
 pub struct DefaultBlockstoreReadCacheStats {
-    hit: AtomicUsize,
-    miss: AtomicUsize,
+    hit: crossbeam_utils::CachePadded<AtomicUsize>,
+    miss: crossbeam_utils::CachePadded<AtomicUsize>,
 }
 
 impl BlockstoreReadCacheStats for DefaultBlockstoreReadCacheStats {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

See https://docs.rs/crossbeam/latest/crossbeam/utils/struct.CachePadded.html

I wouldn't assume huge performance gain, but we already have `crossbeam-utils` in the transitive dependencies.

Changes introduced in this pull request:

- wrap the `AtomicUsize` in `CachePadded` to avoid invalidating cache lines on every metric update.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal cache statistics counters to improve performance in concurrent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->