### PR TITLE
fix: inefficient Vec<u8> to BytesMut conversion 

### DIFF
--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -155,7 +155,7 @@ impl<ReaderT: super::RandomAccessFileReader> ForestCar<ReaderT> {
         })?;
 
         let cursor = Cursor::new_pos(&reader, 0);
-        let mut header_zstd_frame = decode_zstd_single_frame(cursor)?;
+        let mut header_zstd_frame = decode_zstd_single_frame(cursor)?.into();
         let block_frame = uvi_bytes()
             .decode(&mut header_zstd_frame)?
             .ok_or_else(|| invalid_data("malformed uvibytes"))?;
@@ -261,7 +261,7 @@ where
                     // Decode entire frame into memory, "position" arg is the frame start offset.
                     let entire_file = indexed.reader().get_ref(); // escape the positioned_io::Slice
                     let cursor = Cursor::new_pos(entire_file, position);
-                    let mut zstd_frame = decode_zstd_single_frame(cursor)?;
+                    let mut zstd_frame = decode_zstd_single_frame(cursor)?.into();
                     // Parse all key-value pairs and insert them into a map
                     let mut block_map = hashbrown::HashMap::new();
                     while let Some(block_frame) = uvi_bytes().decode_eof(&mut zstd_frame)? {
@@ -287,12 +287,12 @@ where
     }
 }
 
-fn decode_zstd_single_frame<ReaderT: Read>(reader: ReaderT) -> io::Result<BytesMut> {
+fn decode_zstd_single_frame<ReaderT: Read>(reader: ReaderT) -> io::Result<Bytes> {
     let mut zstd_frame = vec![];
     zstd::Decoder::new(reader)?
         .single_frame()
         .read_to_end(&mut zstd_frame)?;
-    Ok(zstd_frame.into_iter().collect())
+    Ok(zstd_frame.into())
 }
 
 pub struct Encoder {}

--- a/src/eth/transaction.rs
+++ b/src/eth/transaction.rs
@@ -6,7 +6,7 @@ use crate::eth::{LEGACY_V_VALUE_27, LEGACY_V_VALUE_28};
 use crate::shim::crypto::Signature;
 use crate::shim::fvm_shared_latest;
 use anyhow::{Context, bail, ensure};
-use bytes::BytesMut;
+use bytes::Bytes;
 use cbor4ii::core::{Value, dec::Decode as _, utils::SliceReader};
 use fvm_shared4::METHOD_CONSTRUCTOR;
 use num::{BigInt, Signed as _, bigint::Sign};
@@ -273,37 +273,37 @@ pub fn get_eth_params_and_recipient(
     Ok((params, to))
 }
 
-pub fn format_u64(value: u64) -> BytesMut {
+pub fn format_u64(value: u64) -> Bytes {
     if value != 0 {
         let i = (value.leading_zeros() / 8) as usize;
         let bytes = value.to_be_bytes();
         // `leading_zeros` for a positive `u64` returns a number in the range [1-63]
         // `i` is in the range [1-7], and `bytes` is an array of size 8
         // therefore, getting the slice from `i` to end should never fail
-        bytes.get(i..).expect("failed to get slice").into()
+        bytes.get(i..).expect("failed to get slice").to_vec().into()
     } else {
         // If all bytes are zero, return an empty slice
-        BytesMut::new()
+        Bytes::new()
     }
 }
 
-pub fn format_bigint(value: &BigInt) -> anyhow::Result<BytesMut> {
+pub fn format_bigint(value: &BigInt) -> anyhow::Result<Bytes> {
     Ok(if value.is_positive() {
-        BytesMut::from_iter(value.to_bytes_be().1.iter())
+        value.to_bytes_be().1.into()
     } else {
         if value.is_negative() {
             bail!("can't format a negative number");
         }
         // If all bytes are zero, return an empty slice
-        BytesMut::new()
+        Bytes::new()
     })
 }
 
-pub fn format_address(value: &Option<EthAddress>) -> BytesMut {
+pub fn format_address(value: &Option<EthAddress>) -> Bytes {
     if let Some(addr) = value {
-        addr.0.as_bytes().into()
+        addr.0.as_bytes().to_vec().into()
     } else {
-        BytesMut::new()
+        Bytes::new()
     }
 }
 
@@ -878,12 +878,11 @@ pub(crate) mod tests {
             assert!(bm.is_empty());
         } else {
             // check that buffer doesn't start with zero
-            let freezed = bm.freeze();
-            assert!(!freezed.starts_with(&[0]));
+            assert!(!bm.starts_with(&[0]));
 
             // roundtrip
             let mut padded = [0u8; 8];
-            let bytes: &[u8] = &freezed.slice(..);
+            let bytes: &[u8] = &bm.slice(..);
             padded[8 - bytes.len()..].copy_from_slice(bytes);
             assert_eq!(i, u64::from_be_bytes(padded));
         }
@@ -897,11 +896,10 @@ pub(crate) mod tests {
                     assert!(bm.is_empty());
                 } else {
                     // check that buffer doesn't start with zero
-                    let freezed = bm.freeze();
-                    assert!(!freezed.starts_with(&[0]));
+                    assert!(!bm.starts_with(&[0]));
 
                     // roundtrip
-                    let unsigned = num_bigint::BigUint::from_be_bytes(&freezed.slice(..));
+                    let unsigned = num_bigint::BigUint::from_be_bytes(&bm.slice(..));
                     assert_eq!(bi, unsigned.into());
                 }
             }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

`Vec<u8>` cannot be directly converted to `BytesMut`, `vec.into_iter().collect()` should be less efficient than `BytesMut::from(Bytes::from(vec))`

https://docs.rs/bytes/latest/src/bytes/bytes_mut.rs.html#918

```rust
    // private

    // For now, use a `Vec` to manage the memory for us, but we may want to
    // change that in the future to some alternate allocator strategy.
    //
    // Thus, we don't expose an easy way to construct from a `Vec` since an
    // internal change could make a simple pattern (`BytesMut::from(vec)`)
    // suddenly a lot more expensive.
    #[inline]
    pub(crate) fn from_vec(vec: Vec<u8>) -> BytesMut {
        let mut vec = ManuallyDrop::new(vec);
        let ptr = vptr(vec.as_mut_ptr());
        let len = vec.len();
        let cap = vec.capacity();

        let original_capacity_repr = original_capacity_to_repr(cap);
        let data = (original_capacity_repr << ORIGINAL_CAPACITY_OFFSET) | KIND_VEC;

        BytesMut {
            ptr,
            len,
            cap,
            data: invalid_ptr(data),
        }
    }
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory representation in transaction data formatting processes to improve efficiency and resource usage.
  * Enhanced frame decoding operations with refined buffer management for better performance.
  * Improved type consistency across modules to strengthen code stability and maintainability across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->