### PR TITLE
chore: fix duplicate word in comment

### DIFF
--- a/src/utils/encoding/mod.rs
+++ b/src/utils/encoding/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserializer, Serializer, de, ser};
 
 mod fallback_de_ipld_dagcbor;
 
-/// Limit the the number of bytes that are used for pre-allocating `Vec<Cid>`s. This follows what `serde` is
+/// Limit the number of bytes that are used for pre-allocating `Vec<Cid>`s. This follows what `serde` is
 /// doing internally with `serde::private::size_hint::cautious()`.
 /// The limit is set to 1 MiB, which is a reasonable upper bound for most use cases.
 fn size_hint_cautious_cid(size_hint: usize) -> usize {


### PR DESCRIPTION
## Summary of changes

fix duplicate word in comment


Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [x] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a duplicated word in documentation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->