### PR TITLE
chore: uncomment GoldenWeek and Xxx in ForkUpgradeParams

### DIFF
--- a/docs/openrpc-specs/v0.json
+++ b/docs/openrpc-specs/v0.json
@@ -9709,6 +9709,10 @@
             "type": "integer",
             "format": "int64"
           },
+          "UpgradeGoldenWeekHeight": {
+            "type": "integer",
+            "format": "int64"
+          },
           "UpgradeHyggeHeight": {
             "type": "integer",
             "format": "int64"
@@ -9804,6 +9808,10 @@
           "UpgradeWatermelonHeight": {
             "type": "integer",
             "format": "int64"
+          },
+          "UpgradeXxxHeight": {
+            "type": "integer",
+            "format": "int64"
           }
         },
         "required": [
@@ -9837,7 +9845,9 @@
           "UpgradeWaffleHeight",
           "UpgradeTuktukHeight",
           "UpgradeTeepHeight",
-          "UpgradeTockHeight"
+          "UpgradeTockHeight",
+          "UpgradeGoldenWeekHeight",
+          "UpgradeXxxHeight"
         ]
       },
       "GasTrace": {

--- a/docs/openrpc-specs/v1.json
+++ b/docs/openrpc-specs/v1.json
@@ -10090,6 +10090,10 @@
             "type": "integer",
             "format": "int64"
           },
+          "UpgradeGoldenWeekHeight": {
+            "type": "integer",
+            "format": "int64"
+          },
           "UpgradeHyggeHeight": {
             "type": "integer",
             "format": "int64"
@@ -10185,6 +10189,10 @@
           "UpgradeWatermelonHeight": {
             "type": "integer",
             "format": "int64"
+          },
+          "UpgradeXxxHeight": {
+            "type": "integer",
+            "format": "int64"
           }
         },
         "required": [
@@ -10218,7 +10226,9 @@
           "UpgradeWaffleHeight",
           "UpgradeTuktukHeight",
           "UpgradeTeepHeight",
-          "UpgradeTockHeight"
+          "UpgradeTockHeight",
+          "UpgradeGoldenWeekHeight",
+          "UpgradeXxxHeight"
         ]
       },
       "GasTrace": {

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -3142,8 +3142,8 @@ pub struct ForkUpgradeParams {
     upgrade_tuktuk_height: ChainEpoch,
     upgrade_teep_height: ChainEpoch,
     upgrade_tock_height: ChainEpoch,
-    //upgrade_golden_week_height: ChainEpoch,
-    //upgrade_xxx_height: ChainEpoch,
+    upgrade_golden_week_height: ChainEpoch,
+    upgrade_xxx_height: ChainEpoch,
 }
 
 impl TryFrom<&ChainConfig> for ForkUpgradeParams {
@@ -3191,8 +3191,8 @@ impl TryFrom<&ChainConfig> for ForkUpgradeParams {
             upgrade_tuktuk_height: get_height(TukTuk)?,
             upgrade_teep_height: get_height(Teep)?,
             upgrade_tock_height: get_height(Tock)?,
-            //upgrade_golden_week_height: get_height(GoldenWeek)?,
-            //upgrade_xxx_height: get_height(Xxx)?,
+            upgrade_golden_week_height: get_height(GoldenWeek)?,
+            upgrade_xxx_height: get_height(Xxx)?,
         })
     }
 }

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
@@ -6133,6 +6133,9 @@ components:
         UpgradeDragonHeight:
           type: integer
           format: int64
+        UpgradeGoldenWeekHeight:
+          type: integer
+          format: int64
         UpgradeHyggeHeight:
           type: integer
           format: int64
@@ -6205,6 +6208,9 @@ components:
         UpgradeWatermelonHeight:
           type: integer
           format: int64
+        UpgradeXxxHeight:
+          type: integer
+          format: int64
       required:
         - UpgradeSmokeHeight
         - UpgradeBreezeHeight
@@ -6237,6 +6243,8 @@ components:
         - UpgradeTuktukHeight
         - UpgradeTeepHeight
         - UpgradeTockHeight
+        - UpgradeGoldenWeekHeight
+        - UpgradeXxxHeight
     GasTrace:
       type: object
       properties:

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
@@ -6371,6 +6371,9 @@ components:
         UpgradeDragonHeight:
           type: integer
           format: int64
+        UpgradeGoldenWeekHeight:
+          type: integer
+          format: int64
         UpgradeHyggeHeight:
           type: integer
           format: int64
@@ -6443,6 +6446,9 @@ components:
         UpgradeWatermelonHeight:
           type: integer
           format: int64
+        UpgradeXxxHeight:
+          type: integer
+          format: int64
       required:
         - UpgradeSmokeHeight
         - UpgradeBreezeHeight
@@ -6475,6 +6481,8 @@ components:
         - UpgradeTuktukHeight
         - UpgradeTeepHeight
         - UpgradeTockHeight
+        - UpgradeGoldenWeekHeight
+        - UpgradeXxxHeight
     GasTrace:
       type: object
       properties:


### PR DESCRIPTION
## Summary of changes

Uncomment `upgrade_golden_week_height` and `upgrade_xxx_height` in `ForkUpgradeParams` and in the `TryFrom<&ChainConfig>` implementation (nv28 follow-up from the skeleton in #6706). OpenRPC specs and RPC snapshots are updated so the API and tests reflect the new fields.

Changes introduced in this pull request:

- Uncommented `upgrade_golden_week_height: ChainEpoch` and `upgrade_xxx_height: ChainEpoch` in the `ForkUpgradeParams` struct in `src/rpc/methods/state.rs`.
- Uncommented `upgrade_golden_week_height: get_height(GoldenWeek)?` and `upgrade_xxx_height: get_height(Xxx)?` in the `TryFrom<&ChainConfig>` implementation for `ForkUpgradeParams`.
- Added `UpgradeGoldenWeekHeight` and `UpgradeXxxHeight` to the `ForkUpgradeParams` schema in `docs/openrpc-specs/v0.json` and `docs/openrpc-specs/v1.json` (properties and required array).
- Updated RPC snapshots `src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap` and `src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap` so the `ForkUpgradeParams` schema includes the new fields and they pass the openrpc snapshot tests.

## Reference issue to close (if applicable)

Closes #6707

## Other information and links

- PR #6706 added the nv28 skeleton and left these fields commented until upgrade heights were finalised.
- `Height::GoldenWeek` and `Height::Xxx` are already defined in `src/networks/mod.rs` and used in chain configs (mainnet, calibnet, butterflynet, devnet).

## Change checklist

- [x] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's documentation standards,
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the CHANGELOG is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [x] I have read and agree to the CONTRIBUTING document.
- [x] I have read and agree to the AI Policy document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new fork upgrade configuration parameters: Golden Week Height and Xxx Height, now marked as required fields
  * Both parameters are available in the API schema specifications
  * Height values are automatically derived and populated from the blockchain configuration system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->