### PR TITLE
fix(mpool): resolve_to_key error handling

### DIFF
--- a/src/message_pool/msgpool/mod.rs
+++ b/src/message_pool/msgpool/mod.rs
@@ -343,12 +343,10 @@ impl<T: Provider> MpoolCtx<'_, T> {
             .get_mut(from)
             .and_then(|temp| temp.remove(&sequence))
             .is_none()
-        {
-            if let Ok(resolved) = resolve_to_key(self.api, self.key_cache, from, self.ts)
+            && let Ok(resolved) = resolve_to_key(self.api, self.key_cache, from, self.ts)
                 .inspect_err(|e| tracing::debug!(%from, "remove: failed to resolve address: {e:#}"))
-            {
-                remove(&resolved, self.pending, sequence, true)?;
-            }
+        {
+            remove(&resolved, self.pending, sequence, true)?;
         }
         Ok(())
     }

--- a/src/message_pool/msgpool/mod.rs
+++ b/src/message_pool/msgpool/mod.rs
@@ -65,7 +65,11 @@ where
     // Only republish messages from local addresses, ie. transactions which were
     // sent to this node directly.
     for actor in local_addrs.read().iter() {
-        let resolved = resolve_to_key(api, key_cache, actor, &ts)?;
+        let Ok(resolved) = resolve_to_key(api, key_cache, actor, &ts).inspect_err(|e| {
+            tracing::debug!(%actor, "republish: failed to resolve address: {e:#}");
+        }) else {
+            continue;
+        };
         if let Some(mset) = pending.read().get(&resolved) {
             if mset.msgs.is_empty() {
                 continue;
@@ -340,8 +344,11 @@ impl<T: Provider> MpoolCtx<'_, T> {
             .and_then(|temp| temp.remove(&sequence))
             .is_none()
         {
-            let resolved = resolve_to_key(self.api, self.key_cache, from, self.ts)?;
-            remove(&resolved, self.pending, sequence, true)?;
+            if let Ok(resolved) = resolve_to_key(self.api, self.key_cache, from, self.ts)
+                .inspect_err(|e| tracing::debug!(%from, "remove: failed to resolve address: {e:#}"))
+            {
+                remove(&resolved, self.pending, sequence, true)?;
+            }
         }
         Ok(())
     }

--- a/src/message_pool/msgpool/msg_pool.rs
+++ b/src/message_pool/msgpool/msg_pool.rs
@@ -608,7 +608,10 @@ where
     /// messages found, return None result type.
     pub fn pending_for(&self, a: &Address) -> Option<Vec<SignedMessage>> {
         let cur_ts = self.current_tipset();
-        let resolved = self.resolve_to_key(a, &cur_ts).ok()?;
+        let resolved = self
+            .resolve_to_key(a, &cur_ts)
+            .inspect_err(|e| tracing::debug!(%a, "pending_for: failed to resolve address: {e:#}"))
+            .ok()?;
         let pending = self.pending.read();
         let mset = pending.get(&resolved)?;
         if mset.msgs.is_empty() {

--- a/src/message_pool/msgpool/provider.rs
+++ b/src/message_pool/msgpool/provider.rs
@@ -101,11 +101,7 @@ impl<DB: Blockstore> Provider for ChainStore<DB> {
             .map_err(|err| err.into())
     }
 
-    // NOTE: Lotus resolves to deterministic address at finality to guarantee
-    // the ID→key mapping is reorg-stable. We currently resolve against the
-    // tipset's parent state, which is safe but does not provide the same
-    // reorg-safety guarantee.
-    // See https://github.com/filecoin-project/lotus/blob/006da4c7e1c1c29ac02b32112c0d205e4085ba35/chain/stmgr/stmgr.go#L347
+    // TODO(forest): https://github.com/ChainSafe/forest/issues/6891
     fn resolve_to_key(&self, addr: &Address, ts: &Tipset) -> Result<Address, Error> {
         let state = StateTree::new_from_root(self.blockstore().clone(), ts.parent_state())
             .map_err(|e| Error::Other(e.to_string()))?;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- log and continue if `resolve_to_key` fails.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address-resolution failures in message pool operations now emit debug logs with error details and skip affected items instead of aborting processing.

* **Refactor**
  * Improved logging and error-handling around message address resolution for better observability and more graceful failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->