### PR TITLE
chore: use `Byte` instead of `Vec<u8>` in some channels

### DIFF
--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -317,7 +317,7 @@ impl<T: Blockstore + SettingsStore> super::super::HeaviestTipsetKeyProvider for 
 }
 
 impl<WriterT: BlockstoreWriteOpsSubscribable> BlockstoreWriteOpsSubscribable for ManyCar<WriterT> {
-    fn subscribe_write_ops(&self) -> tokio::sync::broadcast::Receiver<Vec<(Cid, Vec<u8>)>> {
+    fn subscribe_write_ops(&self) -> tokio::sync::broadcast::Receiver<Vec<(Cid, bytes::Bytes)>> {
         self.writer().subscribe_write_ops()
     }
 

--- a/src/db/gc/snapshot.rs
+++ b/src/db/gc/snapshot.rs
@@ -71,7 +71,7 @@ pub struct SnapshotGarbageCollector<DB> {
     blessed_lite_snapshot: RwLock<Option<PathBuf>>,
     chain_follower: Arc<ChainFollower<DB>>,
     // On mainnet, it takes ~50MiB-200MiB RAM, depending on the time cost of snapshot export
-    memory_db: RwLock<Option<HashMap<Cid, Vec<u8>>>>,
+    memory_db: RwLock<Option<HashMap<Cid, bytes::Bytes>>>,
     memory_db_head_key: RwLock<Option<TipsetKey>>,
     exported_head_key: RwLock<Option<TipsetKey>>,
     trigger_tx: flume::Sender<()>,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -196,7 +196,7 @@ pub trait HeaviestTipsetKeyProvider {
 
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockstoreWriteOpsSubscribable {
-    fn subscribe_write_ops(&self) -> tokio::sync::broadcast::Receiver<Vec<(Cid, Vec<u8>)>>;
+    fn subscribe_write_ops(&self) -> tokio::sync::broadcast::Receiver<Vec<(Cid, bytes::Bytes)>>;
 
     fn unsubscribe_write_ops(&self);
 }

--- a/src/db/parity_db.rs
+++ b/src/db/parity_db.rs
@@ -83,7 +83,7 @@ impl DbColumn {
     }
 }
 
-type WriteOpsBroadcastTxSender = tokio::sync::broadcast::Sender<Vec<(Cid, Vec<u8>)>>;
+type WriteOpsBroadcastTxSender = tokio::sync::broadcast::Sender<Vec<(Cid, bytes::Bytes)>>;
 
 pub struct ParityDb {
     pub db: parity_db::Db,
@@ -242,7 +242,7 @@ impl Blockstore for ParityDb {
         self.write_to_column(k.to_bytes(), block, column)?;
         match &*self.write_ops_broadcast_tx.read() {
             Some(tx) if has_subscribers(tx) => {
-                let _ = tx.send(vec![(*k, block.to_vec())]);
+                let _ = tx.send(vec![(*k, bytes::Bytes::copy_from_slice(block))]);
             }
             _ => {}
         }
@@ -263,7 +263,7 @@ impl Blockstore for ParityDb {
             let column = Self::choose_column(&k);
             let v = v.as_ref().to_vec();
             if has_subscribers {
-                values_for_subscriber.push((k, v.clone()));
+                values_for_subscriber.push((k, bytes::Bytes::copy_from_slice(&v)));
             }
             (column, k.to_bytes(), v)
         });
@@ -372,7 +372,7 @@ impl ParityDb {
 }
 
 impl super::BlockstoreWriteOpsSubscribable for ParityDb {
-    fn subscribe_write_ops(&self) -> tokio::sync::broadcast::Receiver<Vec<(Cid, Vec<u8>)>> {
+    fn subscribe_write_ops(&self) -> tokio::sync::broadcast::Receiver<Vec<(Cid, bytes::Bytes)>> {
         let tx_lock = self.write_ops_broadcast_tx.read();
         if let Some(tx) = &*tx_lock {
             return tx.subscribe();
@@ -557,14 +557,9 @@ mod test {
         for (idx, cid) in cids.iter().enumerate() {
             let data_entry = &data[idx];
             db.put_keyed(cid, data_entry).unwrap();
-            assert_eq!(
-                rx1.blocking_recv().unwrap(),
-                vec![(*cid, data_entry.clone())]
-            );
-            assert_eq!(
-                rx2.blocking_recv().unwrap(),
-                vec![(*cid, data_entry.clone())]
-            );
+            let expected = vec![(*cid, bytes::Bytes::copy_from_slice(data_entry))];
+            assert_eq!(rx1.blocking_recv().unwrap(), expected);
+            assert_eq!(rx2.blocking_recv().unwrap(), expected);
         }
 
         drop(rx1);

--- a/src/db/parity_db/gc.rs
+++ b/src/db/parity_db/gc.rs
@@ -184,7 +184,7 @@ impl DBStatistics for GarbageCollectableParityDb {
 }
 
 impl BlockstoreWriteOpsSubscribable for GarbageCollectableParityDb {
-    fn subscribe_write_ops(&self) -> tokio::sync::broadcast::Receiver<Vec<(Cid, Vec<u8>)>> {
+    fn subscribe_write_ops(&self) -> tokio::sync::broadcast::Receiver<Vec<(Cid, bytes::Bytes)>> {
         BlockstoreWriteOpsSubscribable::subscribe_write_ops(&*self.db.read())
     }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This saves some allocation cloning
> When a value is sent, all [Receiver](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Receiver.html) handles are notified and will receive the value. The value is stored once inside the channel and cloned on demand for each receiver. Once all receivers have received a clone of the value, the value is released from the channel.

See https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html

`Bytes`'s `clone` is a shallow clone so it would just increment a counter

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data type representations in write operations handling across storage components for improved efficiency and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->