### PR TITLE
chore: deprecate `libsecp256k1` and fix RUSTSEC-2025-0161

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,15 +833,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1876,16 +1867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array 0.14.7",
- "subtle",
-]
-
-[[package]]
 name = "crypto_secretbox"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,15 +2262,6 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array 0.14.7",
-]
 
 [[package]]
 name = "digest"
@@ -3405,13 +3377,13 @@ dependencies = [
  "itertools 0.14.0",
  "jsonrpsee",
  "jsonwebtoken",
+ "k256",
  "keccak-hash",
  "kubert-prometheus-process",
  "lazy-regex",
  "libm",
  "libp2p",
  "libp2p-swarm-test",
- "libsecp256k1",
  "md-5",
  "memmap2 0.9.10",
  "multiaddr",
@@ -4529,17 +4501,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -4549,17 +4511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.7",
- "hmac 0.8.1",
 ]
 
 [[package]]
@@ -6013,54 +5964,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
-dependencies = [
- "arrayref",
- "base64 0.22.1",
- "digest 0.9.0",
- "hmac-drbg",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
-dependencies = [
- "libsecp256k1-core",
 ]
 
 [[package]]
@@ -8139,7 +8042,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -8926,19 +8829,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ is-terminal = "0.4"
 itertools = "0.14"
 jsonrpsee = { version = "0.26", features = ["server", "ws-client", "http-client", "macros"] }
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+k256 = "0.13"
 keccak-hash = "0.12"
 kubert-prometheus-process = "0.2"
 lazy-regex = "3"
@@ -152,7 +153,6 @@ libp2p = { workspace = true, features = [
   'ed25519',
   'secp256k1',
 ] }
-libsecp256k1 = "0.7"
 md5 = { package = "md-5", version = "0.11" }
 memmap2 = "0.9"
 multiaddr = "0.18"

--- a/src/eth/transaction.rs
+++ b/src/eth/transaction.rs
@@ -211,7 +211,7 @@ impl EthTx {
             .expect("Incorrect signature length");
         let pubkey =
             fvm_shared_latest::crypto::signature::ops::recover_secp_public_key(&hash.0, &sig_data)?;
-        let eth_addr = EthAddress::eth_address_from_pub_key(&pubkey)?;
+        let eth_addr = EthAddress::eth_address_from_uncompressed_public_key(&pubkey)?;
         eth_addr.to_filecoin_address()
     }
 }

--- a/src/key_management/errors.rs
+++ b/src/key_management/errors.rs
@@ -18,9 +18,19 @@ pub enum Error {
     #[error("Key not found")]
     NoKey,
     #[error(transparent)]
+    Bls(#[from] bls_signatures::Error),
+    #[error(transparent)]
+    K256(#[from] k256::ecdsa::Error),
+    #[error(transparent)]
     IO(#[from] io::Error),
     #[error("{0}")]
     Other(String),
     #[error("Could not convert from KeyInfo to Key")]
     KeyInfoConversion,
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(value: anyhow::Error) -> Self {
+        Error::Other(value.to_string())
+    }
 }

--- a/src/key_management/wallet.rs
+++ b/src/key_management/wallet.rs
@@ -26,7 +26,10 @@ impl TryFrom<KeyInfo> for Key {
     type Error = crate::key_management::errors::Error;
 
     fn try_from(key_info: KeyInfo) -> Result<Self, Self::Error> {
-        let public_key = wallet_helpers::to_public(*key_info.key_type(), key_info.private_key())?;
+        let public_key = wallet_helpers::to_uncompressed_public_key(
+            *key_info.key_type(),
+            key_info.private_key(),
+        )?;
         let address = wallet_helpers::new_address(*key_info.key_type(), &public_key)?;
         Ok(Key {
             key_info,
@@ -241,7 +244,6 @@ pub fn generate_key(typ: SignatureType) -> Result<Key, Error> {
 mod tests {
     use crate::utils::encoding::{blake2b_256, keccak_256};
     use bls_signatures::{PrivateKey as BlsPrivate, Serialize};
-    use libsecp256k1::{Message as SecpMessage, SecretKey as SecpPrivate};
 
     use super::*;
     use crate::key_management::{KeyStoreConfig, generate};
@@ -293,7 +295,8 @@ mod tests {
 
         let new_priv_key = generate(SignatureType::Bls).unwrap();
         let pub_key =
-            wallet_helpers::to_public(SignatureType::Bls, new_priv_key.as_slice()).unwrap();
+            wallet_helpers::to_uncompressed_public_key(SignatureType::Bls, new_priv_key.as_slice())
+                .unwrap();
         let address = Address::new_bls(pub_key.as_slice()).unwrap();
 
         // test to see if the new key has been created and added to the wallet
@@ -321,12 +324,11 @@ mod tests {
         let msg_sig = wallet.sign(&addr, &msg).unwrap();
 
         let msg_complete = blake2b_256(&msg);
-        let message = SecpMessage::parse(&msg_complete);
-        let priv_key = SecpPrivate::parse_slice(&priv_key_bytes).unwrap();
-        let (sig, recovery_id) = libsecp256k1::sign(&message, &priv_key);
+        let priv_key = k256::ecdsa::SigningKey::from_slice(&priv_key_bytes).unwrap();
+        let (sig, recovery_id) = priv_key.sign_prehash_recoverable(&msg_complete).unwrap();
         let mut new_bytes = [0; 65];
-        new_bytes[..64].copy_from_slice(&sig.serialize());
-        new_bytes[64] = recovery_id.serialize();
+        new_bytes[..64].copy_from_slice(&sig.to_bytes());
+        new_bytes[64] = recovery_id.to_byte();
         let actual = Signature::new_secp256k1(new_bytes.to_vec());
         assert_eq!(msg_sig, actual)
     }
@@ -361,12 +363,11 @@ mod tests {
         let msg_sig = wallet.sign(&addr, &msg).unwrap();
 
         let msg_complete = keccak_256(&msg);
-        let message = SecpMessage::parse(&msg_complete);
-        let priv_key = SecpPrivate::parse_slice(&priv_key_bytes).unwrap();
-        let (sig, recovery_id) = libsecp256k1::sign(&message, &priv_key);
+        let priv_key = k256::ecdsa::SigningKey::from_slice(&priv_key_bytes).unwrap();
+        let (sig, recovery_id) = priv_key.sign_prehash_recoverable(&msg_complete).unwrap();
         let mut new_bytes = [0; 65];
-        new_bytes[..64].copy_from_slice(&sig.serialize());
-        new_bytes[64] = recovery_id.serialize();
+        new_bytes[..64].copy_from_slice(&sig.to_bytes());
+        new_bytes[64] = recovery_id.to_byte();
         let actual = Signature::new_delegated(new_bytes.to_vec());
         assert_eq!(msg_sig, actual)
     }
@@ -383,8 +384,11 @@ mod tests {
         assert_eq!(key_info, key.key_info);
 
         let new_priv_key = generate(SignatureType::Secp256k1).unwrap();
-        let pub_key =
-            wallet_helpers::to_public(SignatureType::Secp256k1, new_priv_key.as_slice()).unwrap();
+        let pub_key = wallet_helpers::to_uncompressed_public_key(
+            SignatureType::Secp256k1,
+            new_priv_key.as_slice(),
+        )
+        .unwrap();
         let test_addr = Address::new_secp256k1(pub_key.as_slice()).unwrap();
         let key_info_err = wallet.export(&test_addr).unwrap_err();
         // test to make sure that an error is raised when an incorrect address is added
@@ -459,8 +463,11 @@ mod tests {
         assert!(matches!(wallet.get_default().unwrap_err(), Error::KeyInfo));
 
         let new_priv_key = generate(SignatureType::Secp256k1).unwrap();
-        let pub_key =
-            wallet_helpers::to_public(SignatureType::Secp256k1, new_priv_key.as_slice()).unwrap();
+        let pub_key = wallet_helpers::to_uncompressed_public_key(
+            SignatureType::Secp256k1,
+            new_priv_key.as_slice(),
+        )
+        .unwrap();
         let test_addr = Address::new_secp256k1(pub_key.as_slice()).unwrap();
 
         let key_info = KeyInfo::new(SignatureType::Secp256k1, new_priv_key);

--- a/src/key_management/wallet_helpers.rs
+++ b/src/key_management/wallet_helpers.rs
@@ -13,26 +13,18 @@ use crate::shim::{
 };
 use crate::utils::encoding::{blake2b_256, keccak_256};
 use bls_signatures::{PrivateKey as BlsPrivate, Serialize};
-use libsecp256k1::{Message as SecpMessage, PublicKey as SecpPublic, SecretKey as SecpPrivate};
 
-/// Return the public key for a given private key and [`SignatureType`]
-pub fn to_public(sig_type: SignatureType, private_key: &[u8]) -> Result<Vec<u8>, Error> {
+/// Return the uncompressed public key for a given private key and [`SignatureType`]
+pub fn to_uncompressed_public_key(
+    sig_type: SignatureType,
+    private_key: &[u8],
+) -> Result<Vec<u8>, Error> {
     match sig_type {
-        SignatureType::Bls => Ok(BlsPrivate::from_bytes(private_key)
-            .map_err(|err| Error::Other(err.to_string()))?
-            .public_key()
-            .as_bytes()),
-        SignatureType::Secp256k1 => {
-            let private_key = SecpPrivate::parse_slice(private_key)
-                .map_err(|err| Error::Other(err.to_string()))?;
-            let public_key = SecpPublic::from_secret_key(&private_key);
-            Ok(public_key.serialize().to_vec())
-        }
-        SignatureType::Delegated => {
-            let private_key = SecpPrivate::parse_slice(private_key)
-                .map_err(|err| Error::Other(err.to_string()))?;
-            let public_key = SecpPublic::from_secret_key(&private_key);
-            Ok(public_key.serialize().to_vec())
+        SignatureType::Bls => Ok(BlsPrivate::from_bytes(private_key)?.public_key().as_bytes()),
+        SignatureType::Secp256k1 | SignatureType::Delegated => {
+            let private_key = k256::ecdsa::SigningKey::from_slice(private_key)?;
+            let public_key = private_key.verifying_key();
+            Ok(public_key.to_encoded_point(false).as_bytes().to_vec())
         }
     }
 }
@@ -51,11 +43,8 @@ pub fn new_address(sig_type: SignatureType, public_key: &[u8]) -> Result<Address
             Ok(addr)
         }
         SignatureType::Delegated => {
-            let eth_addr = EthAddress::eth_address_from_pub_key(public_key)
-                .map_err(|err| Error::Other(err.to_string()))?;
-            let addr = eth_addr
-                .to_filecoin_address()
-                .map_err(|err| Error::Other(err.to_string()))?;
+            let eth_addr = EthAddress::eth_address_from_uncompressed_public_key(public_key)?;
+            let addr = eth_addr.to_filecoin_address()?;
             Ok(addr)
         }
     }
@@ -64,41 +53,29 @@ pub fn new_address(sig_type: SignatureType, public_key: &[u8]) -> Result<Address
 /// Sign takes in [`SignatureType`], private key and message. Returns a Signature
 /// for that message
 pub fn sign(sig_type: SignatureType, private_key: &[u8], msg: &[u8]) -> Result<Signature, Error> {
+    let sign_k256 = |msg_hash, sig_type| -> Result<Signature, Error> {
+        let priv_key = k256::ecdsa::SigningKey::from_slice(private_key)?;
+        let (sig, recovery_id) = priv_key.sign_prehash_recoverable(msg_hash)?;
+        let mut new_bytes = [0; 65];
+        new_bytes[..64].copy_from_slice(&sig.to_bytes());
+        new_bytes[64] = recovery_id.to_byte();
+        Ok(Signature {
+            sig_type,
+            bytes: new_bytes.to_vec(),
+        })
+    };
+
     match sig_type {
         SignatureType::Bls => {
-            let priv_key =
-                BlsPrivate::from_bytes(private_key).map_err(|err| Error::Other(err.to_string()))?;
+            let priv_key = BlsPrivate::from_bytes(private_key)?;
             // this returns a signature from bls-signatures, so we need to convert this to a
             // crypto signature
             let sig = priv_key.sign(msg);
             let crypto_sig = Signature::new_bls(sig.as_bytes());
             Ok(crypto_sig)
         }
-        SignatureType::Secp256k1 => {
-            let priv_key = SecpPrivate::parse_slice(private_key)
-                .map_err(|err| Error::Other(err.to_string()))?;
-            let msg_hash = blake2b_256(msg);
-            let message = SecpMessage::parse(&msg_hash);
-            let (sig, recovery_id) = libsecp256k1::sign(&message, &priv_key);
-            let mut new_bytes = [0; 65];
-            new_bytes[..64].copy_from_slice(&sig.serialize());
-            new_bytes[64] = recovery_id.serialize();
-            let crypto_sig = Signature::new_secp256k1(new_bytes.to_vec());
-            Ok(crypto_sig)
-        }
-        SignatureType::Delegated => {
-            let priv_key = SecpPrivate::parse_slice(private_key)
-                .map_err(|err| Error::Other(err.to_string()))?;
-
-            let msg_hash = keccak_256(msg);
-            let message = SecpMessage::parse(&msg_hash);
-            let (sig, recovery_id) = libsecp256k1::sign(&message, &priv_key);
-            let mut new_bytes = [0; 65];
-            new_bytes[..64].copy_from_slice(&sig.serialize());
-            new_bytes[64] = recovery_id.serialize();
-            let crypto_sig = Signature::new_delegated(new_bytes.to_vec());
-            Ok(crypto_sig)
-        }
+        SignatureType::Secp256k1 => sign_k256(&blake2b_256(msg), sig_type),
+        SignatureType::Delegated => sign_k256(&keccak_256(msg), sig_type),
     }
 }
 
@@ -110,13 +87,9 @@ pub fn generate(sig_type: SignatureType) -> Result<Vec<u8>, Error> {
             let key = BlsPrivate::generate(rng);
             Ok(key.as_bytes())
         }
-        SignatureType::Secp256k1 => {
-            let key = SecpPrivate::random(rng);
-            Ok(key.serialize().to_vec())
-        }
-        SignatureType::Delegated => {
-            let key = SecpPrivate::random(rng);
-            Ok(key.serialize().to_vec())
+        SignatureType::Secp256k1 | SignatureType::Delegated => {
+            let key = k256::ecdsa::SigningKey::random(rng);
+            Ok(key.to_bytes().to_vec())
         }
     }
 }

--- a/src/rpc/methods/eth/types.rs
+++ b/src/rpc/methods/eth/types.rs
@@ -8,13 +8,14 @@ use get_size2::GetSize;
 use ipld_core::serde::SerdeError;
 use jsonrpsee::core::traits::IdProvider;
 use jsonrpsee::types::SubscriptionId;
-use libsecp256k1::util::FULL_PUBLIC_KEY_SIZE;
 use rand::Rng;
 use serde::de::{IntoDeserializer, value::StringDeserializer};
 use std::{hash::Hash, ops::Deref};
 
 pub const METHOD_GET_BYTE_CODE: u64 = 3;
 pub const METHOD_GET_STORAGE_AT: u64 = 5;
+
+const UNCOMPRESSED_PUBLIC_KEY_SIZE: usize = 65;
 
 #[derive(
     Eq,
@@ -194,12 +195,12 @@ impl EthAddress {
     }
 
     /// Returns the Ethereum address corresponding to an uncompressed secp256k1 public key.
-    pub fn eth_address_from_pub_key(pubkey: &[u8]) -> anyhow::Result<Self> {
+    pub fn eth_address_from_uncompressed_public_key(pubkey: &[u8]) -> anyhow::Result<Self> {
         // Check if the public key has the correct length (65 bytes)
         ensure!(
-            pubkey.len() == FULL_PUBLIC_KEY_SIZE,
+            pubkey.len() == UNCOMPRESSED_PUBLIC_KEY_SIZE,
             "uncompressed public key should have {} bytes, but got {}",
-            FULL_PUBLIC_KEY_SIZE,
+            UNCOMPRESSED_PUBLIC_KEY_SIZE,
             pubkey.len()
         );
 
@@ -212,6 +213,38 @@ impl EthAddress {
         let hash = keccak_hash::keccak(pubkey.get(1..).context("failed to get pubkey data")?);
         let addr: &[u8] = &hash[12..32];
         EthAddress::try_from(addr)
+    }
+}
+
+impl TryFrom<&k256::ecdsa::VerifyingKey> for EthAddress {
+    type Error = anyhow::Error;
+
+    fn try_from(k: &k256::ecdsa::VerifyingKey) -> Result<Self, Self::Error> {
+        Self::eth_address_from_uncompressed_public_key(k.to_encoded_point(false).as_bytes())
+    }
+}
+
+impl TryFrom<k256::ecdsa::VerifyingKey> for EthAddress {
+    type Error = anyhow::Error;
+
+    fn try_from(k: k256::ecdsa::VerifyingKey) -> Result<Self, Self::Error> {
+        (&k).try_into()
+    }
+}
+
+impl TryFrom<&k256::ecdsa::SigningKey> for EthAddress {
+    type Error = anyhow::Error;
+
+    fn try_from(k: &k256::ecdsa::SigningKey) -> Result<Self, Self::Error> {
+        k.verifying_key().try_into()
+    }
+}
+
+impl TryFrom<k256::ecdsa::SigningKey> for EthAddress {
+    type Error = anyhow::Error;
+
+    fn try_from(k: k256::ecdsa::SigningKey) -> Result<Self, Self::Error> {
+        (&k).try_into()
     }
 }
 
@@ -624,9 +657,9 @@ mod tests {
     }
 
     #[test]
-    fn test_eth_address_from_pub_key() {
+    fn test_eth_address_from_uncompressed_public_key() {
         // Uncompressed pub key secp256k1)
-        let pubkey: [u8; FULL_PUBLIC_KEY_SIZE] = [
+        let pubkey: [u8; UNCOMPRESSED_PUBLIC_KEY_SIZE] = [
             4, 75, 249, 118, 22, 83, 215, 249, 252, 54, 149, 27, 253, 35, 238, 15, 229, 8, 50, 228,
             19, 137, 115, 123, 183, 243, 237, 144, 113, 41, 115, 70, 234, 174, 61, 199, 1, 81, 95,
             143, 102, 246, 176, 220, 176, 93, 241, 139, 94, 105, 141, 153, 20, 74, 35, 52, 139,
@@ -636,7 +669,7 @@ mod tests {
         let expected_eth_address =
             EthAddress::from_str("0xeb1d0c87b7e33d0ab44a397b675f0897295491c2").unwrap();
 
-        let result = EthAddress::eth_address_from_pub_key(&pubkey).unwrap();
+        let result = EthAddress::eth_address_from_uncompressed_public_key(&pubkey).unwrap();
         assert_eq!(result, expected_eth_address);
     }
 }

--- a/src/shim/crypto.rs
+++ b/src/shim/crypto.rs
@@ -274,7 +274,7 @@ pub fn verify_delegated_sig(
     let hash = keccak_256(data);
     let pub_key = recover_secp_public_key(&hash, &sig)?;
 
-    let eth_addr = EthAddress::eth_address_from_pub_key(&pub_key)?;
+    let eth_addr = EthAddress::eth_address_from_uncompressed_public_key(&pub_key)?;
 
     let rec_addr = eth_addr.to_filecoin_address()?;
 

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -50,7 +50,6 @@ use ipld_core::ipld::Ipld;
 use itertools::Itertools as _;
 use jsonrpsee::types::ErrorCode;
 use libp2p::PeerId;
-use libsecp256k1::{PublicKey, SecretKey};
 use num_traits::Signed;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -127,10 +126,7 @@ static KNOWN_CALIBNET_F4_ADDRESS: LazyLock<Address> = LazyLock::new(|| {
 });
 
 fn generate_eth_random_address() -> anyhow::Result<EthAddress> {
-    let rng = &mut crate::utils::rand::forest_os_rng();
-    let secret_key = SecretKey::random(rng);
-    let public_key = PublicKey::from_secret_key(&secret_key);
-    EthAddress::eth_address_from_pub_key(&public_key.serialize())
+    k256::ecdsa::SigningKey::random(&mut crate::utils::rand::forest_os_rng()).try_into()
 }
 
 const TICKET_QUALITY_GREEDY: f64 = 0.9;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

https://rustsec.org/advisories/RUSTSEC-2025-0161.html

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/6904

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated secp256k1 cryptographic operations to the `k256` library for improved compatibility.
  * Enhanced key derivation and Ethereum address generation logic.

* **Chores**
  * Updated dependencies and improved error handling for cryptographic operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->