### PR TITLE
feat: nv28 base migration

### DIFF
--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -28,6 +28,7 @@ mod nv24;
 mod nv25;
 mod nv26fix;
 mod nv27;
+mod nv28;
 mod type_migrations;
 
 type RunMigration<DB> = fn(&ChainConfig, &Arc<DB>, &Cid, ChainEpoch) -> anyhow::Result<Cid>;

--- a/src/state_migration/nv28/migration.rs
+++ b/src/state_migration/nv28/migration.rs
@@ -1,0 +1,88 @@
+// Copyright 2019-2026 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+//
+//! This module contains the migration logic for the `NV28` upgrade.
+
+use std::sync::Arc;
+
+use crate::networks::{ChainConfig, Height};
+use crate::shim::{
+    address::Address,
+    clock::ChainEpoch,
+    machine::BuiltinActorManifest,
+    state_tree::{StateTree, StateTreeVersion},
+};
+use crate::utils::db::CborStoreExt as _;
+use anyhow::Context as _;
+use cid::Cid;
+
+use fvm_ipld_blockstore::Blockstore;
+
+use super::{SystemStateOld, system, verifier::Verifier};
+use crate::state_migration::common::{StateMigration, migrators::nil_migrator};
+
+impl<BS: Blockstore> StateMigration<BS> {
+    pub fn add_nv28_migrations(
+        &mut self,
+        store: &Arc<BS>,
+        state: &Cid,
+        new_manifest: &BuiltinActorManifest,
+    ) -> anyhow::Result<()> {
+        let state_tree = StateTree::new_from_root(store.clone(), state)?;
+        let system_actor = state_tree.get_required_actor(&Address::SYSTEM_ACTOR)?;
+        let system_actor_state = store.get_cbor_required::<SystemStateOld>(&system_actor.state)?;
+
+        let current_manifest_data = system_actor_state.builtin_actors;
+
+        let current_manifest =
+            BuiltinActorManifest::load_v1_actor_list(store, &current_manifest_data)?;
+
+        for (name, code) in current_manifest.builtin_actors() {
+            let new_code = new_manifest.get(name)?;
+            self.add_migrator(code, nil_migrator(new_code))
+        }
+
+        self.add_migrator(
+            current_manifest.get_system(),
+            system::system_migrator(new_manifest),
+        );
+
+        Ok(())
+    }
+}
+
+/// Runs the migration for `NV28`. Returns the new state root.
+pub fn run_migration<DB>(
+    chain_config: &ChainConfig,
+    blockstore: &Arc<DB>,
+    state: &Cid,
+    epoch: ChainEpoch,
+) -> anyhow::Result<Cid>
+where
+    DB: Blockstore + Send + Sync,
+{
+    let new_manifest_cid = chain_config
+        .height_infos
+        .get(&Height::Xxx)
+        .context("no height info for network version NV28")?
+        .bundle
+        .as_ref()
+        .context("no bundle for network version NV28")?;
+
+    blockstore.get(new_manifest_cid)?.context(format!(
+        "manifest for network version NV28 not found in blockstore: {new_manifest_cid}"
+    ))?;
+
+    // Add migration specification verification
+    let verifier = Arc::new(Verifier::default());
+
+    let new_manifest = BuiltinActorManifest::load_manifest(blockstore, new_manifest_cid)?;
+    let mut migration = StateMigration::<DB>::new(Some(verifier));
+    migration.add_nv28_migrations(blockstore, state, &new_manifest)?;
+
+    let actors_in = StateTree::new_from_root(blockstore.clone(), state)?;
+    let actors_out = StateTree::new(blockstore.clone(), StateTreeVersion::V5)?;
+    let new_state = migration.migrate_state_tree(blockstore, epoch, actors_in, actors_out)?;
+
+    Ok(new_state)
+}

--- a/src/state_migration/nv28/mod.rs
+++ b/src/state_migration/nv28/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2019-2026 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! This module contains the migration logic for the `NV28` upgrade.
+mod migration;
+
+/// Run migration for `NV28`. This should be the only exported method in this
+/// module.
+#[allow(unused)]
+pub use migration::run_migration;
+
+use crate::{define_system_states, impl_system, impl_verifier};
+
+define_system_states!(
+    fil_actor_system_state::v17::State,
+    fil_actor_system_state::v18::State
+);
+
+impl_system!();
+impl_verifier!();


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- added base migration for nv28

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added infrastructure and migration logic for the NV28 network upgrade. This prepares the system for handling state transitions but is not yet active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->