### PR TITLE
fix: progress tracker must not count fiascos

### DIFF
--- a/src/utils/net/download_file.rs
+++ b/src/utils/net/download_file.rs
@@ -38,6 +38,7 @@ use futures::stream::{self, StreamExt as _, TryStreamExt as _};
 use human_repr::HumanCount as _;
 use humantime::format_duration;
 use md5::{Digest as _, Md5};
+use std::sync::atomic::Ordering;
 use std::{
     ffi::OsStr,
     fs::File,
@@ -299,9 +300,11 @@ async fn download_http_parallel(
     // Progress tracking - log every 5 seconds like the forest::progress system
     let bytes_downloaded = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let last_logged_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
-    let last_logged_time = Arc::new(parking_lot::Mutex::new(Instant::now()));
+    // Store elapsed millis since start_time to avoid needing a Mutex<Instant>.
+    let last_logged_millis = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let start_time = Instant::now();
     const UPDATE_FREQUENCY: Duration = Duration::from_secs(5);
+    const UPDATE_FREQUENCY_MS: u64 = UPDATE_FREQUENCY.as_millis() as u64;
 
     // Download chunks in parallel
     let download_tasks = (0..effective_connections).map(|i| {
@@ -310,7 +313,7 @@ async fn download_http_parallel(
         let tmp_path = tmp_dst_path.clone();
         let bytes_downloaded = Arc::clone(&bytes_downloaded);
         let last_logged_bytes = Arc::clone(&last_logged_bytes);
-        let last_logged_time = Arc::clone(&last_logged_time);
+        let last_logged_millis = Arc::clone(&last_logged_millis);
         let callback = callback.clone();
 
         let start = i * chunk_size;
@@ -347,65 +350,92 @@ async fn download_http_parallel(
 
                 // Stream bytes and update progress incrementally
                 let mut stream = response.bytes_stream();
-                let mut chunk_bytes_written = 0usize;
+                let mut chunk_bytes_written = 0u64;
 
-                while let Some(chunk_result) = stream.try_next().await? {
-                    // Write this chunk of data
-                    file.write_all(&chunk_result).await?;
-                    chunk_bytes_written += chunk_result.len();
+                let result: anyhow::Result<()> = async {
+                    while let Some(chunk_result) = stream.try_next().await? {
+                        file.write_all(&chunk_result).await?;
+                        chunk_bytes_written += chunk_result.len() as u64;
 
-                    // Update global progress counter
-                    let downloaded = bytes_downloaded.fetch_add(
-                        chunk_result.len() as u64,
-                        std::sync::atomic::Ordering::Relaxed,
-                    ) + chunk_result.len() as u64;
+                        let downloaded = bytes_downloaded.fetch_add(
+                            chunk_result.len() as u64,
+                            Ordering::Relaxed,
+                        ) + chunk_result.len() as u64;
 
-                    // Log progress every 5 seconds (forest::progress format)
-                    let now = Instant::now();
-                    let mut last_logged = last_logged_time.lock();
-                    if (now - *last_logged) > UPDATE_FREQUENCY {
-                        let last_bytes =
-                            last_logged_bytes.load(std::sync::atomic::Ordering::Relaxed);
-                        let elapsed_secs = (now - start_time).as_secs_f64();
-                        let seconds_since_last = (now - *last_logged).as_secs_f64().max(0.1);
-                        let speed = (downloaded - last_bytes) as f64 / seconds_since_last;
-                        let percent = if total_size > 0 {
-                            downloaded * 100 / total_size
-                        } else {
-                            0
-                        };
+                        // Log progress every 5 seconds (lockless fast path)
+                        let elapsed_ms =
+                            start_time.elapsed().as_millis() as u64;
+                        let prev_ms =
+                            last_logged_millis.load(Ordering::Relaxed);
+                        if elapsed_ms.saturating_sub(prev_ms)
+                            >= UPDATE_FREQUENCY_MS
+                            && last_logged_millis
+                                // Spurious failure is fine — another task logs instead.
+                                .compare_exchange_weak(
+                                    prev_ms,
+                                    elapsed_ms,
+                                    Ordering::Relaxed,
+                                    Ordering::Relaxed,
+                                )
+                                .is_ok()
+                        {
+                            let last_bytes =
+                                last_logged_bytes.load(Ordering::Relaxed);
+                            let elapsed_secs =
+                                elapsed_ms as f64 / 1000.0;
+                            let seconds_since_last =
+                                (elapsed_ms - prev_ms) as f64 / 1000.0;
+                            let speed = downloaded.saturating_sub(last_bytes)
+                                as f64
+                                / seconds_since_last.max(0.1);
+                            let percent = if total_size > 0 {
+                                downloaded * 100 / total_size
+                            } else {
+                                0
+                            };
 
-                        tracing::info!(
-                            target: "forest::progress",
-                            "Loading {} / {}, {}%, {}/s, elapsed time: {}",
-                            downloaded.human_count_bytes() ,
-                            total_size.human_count_bytes() ,
-                            percent,
-                            speed.human_count_bytes(),
-                            format_duration(Duration::from_secs(elapsed_secs as u64))
+                            tracing::info!(
+                                target: "forest::progress",
+                                "Loading {} / {}, {}%, {}/s, elapsed time: {}",
+                                downloaded.human_count_bytes(),
+                                total_size.human_count_bytes(),
+                                percent,
+                                speed.human_count_bytes(),
+                                format_duration(Duration::from_secs(
+                                    elapsed_secs as u64
+                                ))
+                            );
+
+                            last_logged_bytes
+                                .store(downloaded, Ordering::Relaxed);
+                        }
+
+                        call_progress_callback(
+                            callback.as_deref(),
+                            downloaded,
+                            total_size,
                         );
-
-                        *last_logged = now;
-                        last_logged_bytes.store(downloaded, std::sync::atomic::Ordering::Relaxed);
                     }
 
-                    // Also call user callback if provided (for RPC state tracking)
-                    call_progress_callback(callback.as_deref(), downloaded, total_size);
-                }
-
-                file.flush().await?;
-
-                // Verify we got the expected amount of data
-                if chunk_bytes_written != expected_size {
-                    anyhow::bail!(
-                        "Chunk {} size mismatch: expected {} bytes, got {}",
-                        i,
-                        expected_size,
-                        chunk_bytes_written
+                    file.flush().await?;
+                    ensure!(
+                        chunk_bytes_written == expected_size as u64,
+                        "Chunk {i} size mismatch: expected {expected_size} \
+                         bytes, got {chunk_bytes_written}"
                     );
+                    Ok(())
                 }
+                .await;
 
-                Ok::<_, anyhow::Error>(())
+                // On failure, undo progress so retries don't push past 100%.
+                result.inspect_err(|e| {
+                    tracing::warn!(
+                        "Chunk {i} download failed after {}: {e:#}",
+                        chunk_bytes_written.human_count_bytes(),
+                    );
+                    bytes_downloaded
+                        .fetch_sub(chunk_bytes_written, Ordering::Relaxed);
+                })
             };
 
             download_chunk

--- a/src/utils/net/download_file.rs
+++ b/src/utils/net/download_file.rs
@@ -357,18 +357,14 @@ async fn download_http_parallel(
                         file.write_all(&chunk_result).await?;
                         chunk_bytes_written += chunk_result.len() as u64;
 
-                        let downloaded = bytes_downloaded.fetch_add(
-                            chunk_result.len() as u64,
-                            Ordering::Relaxed,
-                        ) + chunk_result.len() as u64;
+                        let downloaded = bytes_downloaded
+                            .fetch_add(chunk_result.len() as u64, Ordering::Relaxed)
+                            + chunk_result.len() as u64;
 
                         // Log progress every 5 seconds (lockless fast path)
-                        let elapsed_ms =
-                            start_time.elapsed().as_millis() as u64;
-                        let prev_ms =
-                            last_logged_millis.load(Ordering::Relaxed);
-                        if elapsed_ms.saturating_sub(prev_ms)
-                            >= UPDATE_FREQUENCY_MS
+                        let elapsed_ms = start_time.elapsed().as_millis() as u64;
+                        let prev_ms = last_logged_millis.load(Ordering::Relaxed);
+                        if elapsed_ms.saturating_sub(prev_ms) >= UPDATE_FREQUENCY_MS
                             && last_logged_millis
                                 // Spurious failure is fine — another task logs instead.
                                 .compare_exchange_weak(
@@ -379,14 +375,10 @@ async fn download_http_parallel(
                                 )
                                 .is_ok()
                         {
-                            let last_bytes =
-                                last_logged_bytes.load(Ordering::Relaxed);
-                            let elapsed_secs =
-                                elapsed_ms as f64 / 1000.0;
-                            let seconds_since_last =
-                                (elapsed_ms - prev_ms) as f64 / 1000.0;
-                            let speed = downloaded.saturating_sub(last_bytes)
-                                as f64
+                            let last_bytes = last_logged_bytes.load(Ordering::Relaxed);
+                            let elapsed_secs = elapsed_ms as f64 / 1000.0;
+                            let seconds_since_last = (elapsed_ms - prev_ms) as f64 / 1000.0;
+                            let speed = downloaded.saturating_sub(last_bytes) as f64
                                 / seconds_since_last.max(0.1);
                             let percent = if total_size > 0 {
                                 downloaded * 100 / total_size
@@ -406,15 +398,10 @@ async fn download_http_parallel(
                                 ))
                             );
 
-                            last_logged_bytes
-                                .store(downloaded, Ordering::Relaxed);
+                            last_logged_bytes.store(downloaded, Ordering::Relaxed);
                         }
 
-                        call_progress_callback(
-                            callback.as_deref(),
-                            downloaded,
-                            total_size,
-                        );
+                        call_progress_callback(callback.as_deref(), downloaded, total_size);
                     }
 
                     file.flush().await?;
@@ -433,8 +420,7 @@ async fn download_http_parallel(
                         "Chunk {i} download failed after {}: {e:#}",
                         chunk_bytes_written.human_count_bytes(),
                     );
-                    bytes_downloaded
-                        .fetch_sub(chunk_bytes_written, Ordering::Relaxed);
+                    bytes_downloaded.fetch_sub(chunk_bytes_written, Ordering::Relaxed);
                 })
             };
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Tailed attempts seemed to have happily increased the counter, thus resulting in weird outputs


Changes introduced in this pull request:
- subtract failed chunks from the reported value,
- minor fixes, mostly getting rid of needless `Mutex`.

<img width="1106" height="816" alt="image" src="https://github.com/user-attachments/assets/c4578345-2c19-4d70-bd47-405a7a732fe5" />


## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

Now it's better
```
2026-04-16T14:21:14.969810Z  INFO retry: forest::progress: Loading 69.54 GiB / 74.81 GiB, 92%, 109 MiB/s, elapsed time: 10m 55s
2026-04-16T14:21:19.971844Z  INFO retry: forest::progress: Loading 70.08 GiB / 74.81 GiB, 93%, 108.7 MiB/s, elapsed time: 11m
2026-04-16T14:21:24.971827Z  INFO retry: forest::progress: Loading 70.61 GiB / 74.81 GiB, 94%, 109.7 MiB/s, elapsed time: 11m 5s
2026-04-16T14:21:29.971828Z  INFO retry: forest::progress: Loading 71.15 GiB / 74.81 GiB, 95%, 110.4 MiB/s, elapsed time: 11m 10s
2026-04-16T14:21:34.971968Z  INFO retry: forest::progress: Loading 71.51 GiB / 74.81 GiB, 95%, 73.3 MiB/s, elapsed time: 11m 15s
2026-04-16T14:21:39.971927Z  INFO retry: forest::progress: Loading 71.8 GiB / 74.81 GiB, 95%, 59.8 MiB/s, elapsed time: 11m 20s
2026-04-16T14:22:51.752285Z  WARN retry: forest::utils::net::download_file: Chunk 1 download failed after 12.09 GiB: error decoding response body: error reading a body from connection: end of file before message length reached
2026-04-16T14:22:53.674776Z  INFO retry: forest::progress: Loading 59.85 GiB / 74.81 GiB, 80%, 0 B/s, elapsed time: 12m 33s
2026-04-16T14:22:58.676983Z  INFO retry: forest::progress: Loading 60.16 GiB / 74.81 GiB, 80%, 64 MiB/s, elapsed time: 12m 38s
2026-04-16T14:23:03.677030Z  INFO retry: forest::progress: Loading 60.46 GiB / 74.81 GiB, 80%, 62.6 MiB/s, elapsed time: 12m 43s
2026-04-16T14:23:08.677332Z  INFO retry: forest::progress: Loading 60.78 GiB / 74.81 GiB, 81%, 64.4 MiB/s, elapsed time: 12m 48s
```

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed download progress accuracy to prevent progress from exceeding 100% after chunk retries.
  * Added validation for chunk completion with improved error handling and warning logs when partial writes occur.

* **Refactor**
  * Improved parallel download progress logging and tracking to reduce contention and ensure a single updater at a time.
  * Streamlined speed and percent calculations for consistent progress reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->