### PR TITLE
chore: bump rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]

--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -741,10 +741,9 @@ mod lotus_json {
     }
 
     #[cfg(test)]
-    quickcheck::quickcheck! {
-        fn quickcheck(val: Tipset) -> () {
-            assert_unchanged_via_json(val)
-        }
+    #[quickcheck_macros::quickcheck]
+    fn quickcheck(val: Tipset) {
+        assert_unchanged_via_json(val)
     }
 }
 

--- a/src/cid_collections/hash_map.rs
+++ b/src/cid_collections/hash_map.rs
@@ -352,8 +352,6 @@ impl<V> Iterator for Keys<'_, V> {
 mod tests {
     use super::*;
 
-    use quickcheck::quickcheck;
-
     #[derive(derive_quickcheck_arbitrary::Arbitrary, Clone, Debug)]
     enum Operation {
         ContainsKey(MaybeCompactedCid),
@@ -362,56 +360,47 @@ mod tests {
         Entry { key: MaybeCompactedCid, value: u8 },
     }
 
-    quickcheck! {
-        fn operations(operations: Vec<Operation>) -> () {
-            use Operation as Op;
+    #[quickcheck_macros::quickcheck]
+    fn operations(operations: Vec<Operation>) {
+        use Operation as Op;
 
-            let mut subject = CidHashMap::default();
-            let mut reference = ahash::HashMap::default();
-            for operation in operations {
-                match operation {
-                    Op::ContainsKey(key) => {
-                        let key = key.into();
-                        assert_eq!(
-                            subject.contains_key(&key),
-                            reference.contains_key(&key)
-                        )
-                    },
-                    Op::Get(key) => {
-                        let key = key.into();
-                        assert_eq!(
-                            subject.get(&key),
-                            reference.get(&key)
-                        )
-                    },
-                    Op::Insert(key, val) => {
-                        let key = key.into();
-                        assert_eq!(
-                            subject.insert(key, val),
-                            reference.insert(key, val)
-                        )
-                    },
-                    Op::Entry {
-                        key, value
-                    } => {
-                        let key = key.into();
-                        match (subject.entry(key), reference.entry(key)) {
-                            (Entry::Occupied(subj), StdEntry::Occupied(refr)) => assert_eq!(subj.get(), refr.get()),
-                            (Entry::Vacant(subj), StdEntry::Vacant(refr)) => assert_eq!(subj.insert(value), refr.insert(value)),
-                            (subj, refr) => panic!("{subj:?}, {refr:?}")
+        let mut subject = CidHashMap::default();
+        let mut reference = ahash::HashMap::default();
+        for operation in operations {
+            match operation {
+                Op::ContainsKey(key) => {
+                    let key = key.into();
+                    assert_eq!(subject.contains_key(&key), reference.contains_key(&key))
+                }
+                Op::Get(key) => {
+                    let key = key.into();
+                    assert_eq!(subject.get(&key), reference.get(&key))
+                }
+                Op::Insert(key, val) => {
+                    let key = key.into();
+                    assert_eq!(subject.insert(key, val), reference.insert(key, val))
+                }
+                Op::Entry { key, value } => {
+                    let key = key.into();
+                    match (subject.entry(key), reference.entry(key)) {
+                        (Entry::Occupied(subj), StdEntry::Occupied(refr)) => {
+                            assert_eq!(subj.get(), refr.get())
                         }
+                        (Entry::Vacant(subj), StdEntry::Vacant(refr)) => {
+                            assert_eq!(subj.insert(value), refr.insert(value))
+                        }
+                        (subj, refr) => panic!("{subj:?}, {refr:?}"),
                     }
                 }
-            };
-            assert_eq!(reference, ahash::HashMap::from_iter(subject));
+            }
         }
+        assert_eq!(reference, ahash::HashMap::from_iter(subject));
+    }
 
-        fn collect(pairs: Vec<(Cid, u8)>) -> () {
-            let refr = ahash::HashMap::from_iter(pairs.clone());
-            let via_subject = ahash::HashMap::from_iter(
-                CidHashMap::from_iter(pairs)
-            );
-            assert_eq!(refr, via_subject);
-        }
+    #[quickcheck_macros::quickcheck]
+    fn collect(pairs: Vec<(Cid, u8)>) {
+        let refr = ahash::HashMap::from_iter(pairs.clone());
+        let via_subject = ahash::HashMap::from_iter(CidHashMap::from_iter(pairs));
+        assert_eq!(refr, via_subject);
     }
 }

--- a/src/cid_collections/mod.rs
+++ b/src/cid_collections/mod.rs
@@ -169,7 +169,7 @@ mod imp {
 mod tests {
     use super::*;
     use cid::Cid;
-    use quickcheck::{Arbitrary, quickcheck};
+    use quickcheck::Arbitrary;
 
     impl Arbitrary for MaybeCompactedCid {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
@@ -180,11 +180,10 @@ mod tests {
         }
     }
 
-    quickcheck! {
-        fn cid_via_maybe_compacted_cid(before: Cid) -> () {
-            let via = MaybeCompactedCid::from(before);
-            let after = Cid::from(via);
-            assert_eq!(before, after);
-        }
+    #[quickcheck_macros::quickcheck]
+    fn cid_via_maybe_compacted_cid(before: Cid) {
+        let via = MaybeCompactedCid::from(before);
+        let after = Cid::from(via);
+        assert_eq!(before, after);
     }
 }

--- a/src/cli/humantoken.rs
+++ b/src/cli/humantoken.rs
@@ -642,27 +642,23 @@ mod print {
 
 #[cfg(test)]
 mod fuzz {
-    use quickcheck::quickcheck;
-
     use super::*;
 
-    quickcheck! {
-        fn roundtrip(expected: crate::shim::econ::TokenAmount) -> () {
-            // Default formatting
-            let actual = parse(&format!("{}", expected.pretty())).unwrap();
-            assert_eq!(expected, actual);
+    #[quickcheck_macros::quickcheck]
+    fn roundtrip(expected: crate::shim::econ::TokenAmount) {
+        // Default formatting
+        let actual = parse(&format!("{}", expected.pretty())).unwrap();
+        assert_eq!(expected, actual);
 
-            // Absolute formatting
-            let actual = parse(&format!("{:#}", expected.pretty())).unwrap();
-            assert_eq!(expected, actual);
+        // Absolute formatting
+        let actual = parse(&format!("{:#}", expected.pretty())).unwrap();
+        assert_eq!(expected, actual);
 
-            // Don't test rounded formatting...
-        }
+        // Don't test rounded formatting...
     }
 
-    quickcheck! {
-        fn parser_no_panic(s: String) -> () {
-            let _ = parse(&s);
-        }
+    #[quickcheck_macros::quickcheck]
+    fn parser_no_panic(s: String) {
+        let _ = parse(&s);
     }
 }

--- a/src/cli/subcommands/net_cmd.rs
+++ b/src/cli/subcommands/net_cmd.rs
@@ -72,12 +72,7 @@ impl NetCommands {
                     .into_iter()
                     .map(|res| res.unwrap_or_else(|_| "<agent unknown>".to_owned()));
 
-                    HashMap::from_iter(
-                        addrs
-                            .iter()
-                            .map(|info| info.id.to_owned())
-                            .zip(agents.into_iter()),
-                    )
+                    HashMap::from_iter(addrs.iter().map(|info| info.id.to_owned()).zip(agents))
                 } else {
                     HashMap::default()
                 };

--- a/src/db/car/forest/index/hash.rs
+++ b/src/db/car/forest/index/hash.rs
@@ -65,13 +65,14 @@ mod tests {
     use super::*;
     use crate::utils::{cid::CidCborExt as _, multihash::prelude::*};
 
-    quickcheck::quickcheck! {
-        fn always_in_range(hash: NonMaximalU64, num_buckets: NonZeroUsize) -> bool {
-            ideal_slot_ix(hash, num_buckets) < num_buckets.get()
-        }
-        fn backwards(ideal: usize, num_buckets: NonZeroUsize) -> () {
-            do_backwards(ideal, num_buckets)
-        }
+    #[quickcheck_macros::quickcheck]
+    fn always_in_range(hash: NonMaximalU64, num_buckets: NonZeroUsize) -> bool {
+        ideal_slot_ix(hash, num_buckets) < num_buckets.get()
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn backwards(ideal: usize, num_buckets: NonZeroUsize) {
+        do_backwards(ideal, num_buckets)
     }
 
     fn do_backwards(ideal: usize, num_buckets: NonZeroUsize) {

--- a/src/db/car/forest/index/mod.rs
+++ b/src/db/car/forest/index/mod.rs
@@ -889,38 +889,59 @@ mod tests {
         }
     }
 
-    quickcheck::quickcheck! {
-        fn hashmap_of_cids(reference: HashMap<Cid, HashSet<u64>>) -> () {
-            do_hashmap_of_cids(reference)
-        }
-        fn hashmap_of_hashes(reference: HashMap<NonMaximalU64, HashSet<u64>>) -> () {
-            do_hashmap_of_hashes(reference)
-        }
-        fn everything_maps_to_first_slot(values: Vec<HashSet<u64>>) -> () {
-            let Some(initial_width) = initial_width(values.iter().map(HashSet::len).sum(), DEFAULT_LOAD_FACTOR) else {
-                return;
-            };
-            let reference = HashMap::from_iter(iter::zip(hash::from_ideal_slot_ix(0, initial_width).unique(), values));
-            do_hashmap_of_hashes(reference)
-        }
-        fn everything_maps_to_first_10_slots(values: Vec<HashSet<u64>>) -> () {
-            let Some(initial_width) = initial_width(values.iter().map(HashSet::len).sum(), DEFAULT_LOAD_FACTOR) else {
-                return;
-            };
-            let mut generators = Vec::from_iter((0..cmp::min(initial_width.get(), 10)).map(|it|hash::from_ideal_slot_ix(it, initial_width).unique()));
-            let hashes_in_first_10 = generators.iter_mut().flatten();
-            let reference = HashMap::from_iter(iter::zip(hashes_in_first_10, values));
-            do_hashmap_of_hashes(reference)
-        }
-        fn header(it: V1Header) -> () {
-            round_trip(&it);
-        }
-        fn slot(it: Slot) -> () {
-            round_trip(&it);
-        }
-        fn raw_slot(it: RawSlot) -> () {
-            round_trip(&it);
-        }
+    #[quickcheck_macros::quickcheck]
+    fn hashmap_of_cids(reference: HashMap<Cid, HashSet<u64>>) {
+        do_hashmap_of_cids(reference)
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn hashmap_of_hashes(reference: HashMap<NonMaximalU64, HashSet<u64>>) {
+        do_hashmap_of_hashes(reference)
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn everything_maps_to_first_slot(values: Vec<HashSet<u64>>) {
+        let Some(initial_width) =
+            initial_width(values.iter().map(HashSet::len).sum(), DEFAULT_LOAD_FACTOR)
+        else {
+            return;
+        };
+        let reference = HashMap::from_iter(iter::zip(
+            hash::from_ideal_slot_ix(0, initial_width).unique(),
+            values,
+        ));
+        do_hashmap_of_hashes(reference)
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn everything_maps_to_first_10_slots(values: Vec<HashSet<u64>>) {
+        let Some(initial_width) =
+            initial_width(values.iter().map(HashSet::len).sum(), DEFAULT_LOAD_FACTOR)
+        else {
+            return;
+        };
+        let mut generators = Vec::from_iter(
+            (0..cmp::min(initial_width.get(), 10))
+                .map(|it| hash::from_ideal_slot_ix(it, initial_width).unique()),
+        );
+        let hashes_in_first_10 = generators.iter_mut().flatten();
+        let reference = HashMap::from_iter(iter::zip(hashes_in_first_10, values));
+        do_hashmap_of_hashes(reference)
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn header(it: V1Header) {
+        round_trip(&it);
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn slot(it: Slot) {
+        round_trip(&it);
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn raw_slot(it: RawSlot) {
+        round_trip(&it);
     }
 
     #[track_caller]

--- a/src/db/gc/snapshot.rs
+++ b/src/db/gc/snapshot.rs
@@ -278,11 +278,9 @@ where
         // Unsubscribe before taking the snapshot of in-memory db to avoid deadlock
         db.unsubscribe_write_ops();
         match joinset.join_next().await {
-            Some(Ok(map)) => {
-                if !map.is_empty() {
-                    *self.memory_db.write() = Some(map);
-                    *self.memory_db_head_key.write() = current_chain_head;
-                }
+            Some(Ok(map)) if !map.is_empty() => {
+                *self.memory_db.write() = Some(map);
+                *self.memory_db_head_key.write() = current_chain_head;
             }
             Some(Err(e)) => tracing::warn!("{e}"),
             _ => {}

--- a/src/db/memory.rs
+++ b/src/db/memory.rs
@@ -117,8 +117,8 @@ impl EthMappingsStore for MemoryDB {
         let cids = self
             .eth_mappings_db
             .read()
-            .iter()
-            .filter_map(|(_, value)| fvm_ipld_encoding::from_slice::<(Cid, u64)>(value).ok())
+            .values()
+            .filter_map(|value| fvm_ipld_encoding::from_slice::<(Cid, u64)>(value).ok())
             .collect();
 
         Ok(cids)

--- a/src/eth/transaction.rs
+++ b/src/eth/transaction.rs
@@ -636,7 +636,7 @@ pub(crate) mod tests {
         // from which the chain ID is derived.
         let v = (2 * eth_chain_id + 35).to_biguint().unwrap().to_bytes_be();
         let eip_155_sig_len = calc_valid_eip155_sig_len(eth_chain_id).0 as usize;
-        let mut eip_155_sig = vec![0u8; eip_155_sig_len as usize - v.len()];
+        let mut eip_155_sig = vec![0u8; eip_155_sig_len - v.len()];
         eip_155_sig[0] = EIP_155_SIG_PREFIX;
         eip_155_sig.extend(v);
 

--- a/src/libp2p/discovery.rs
+++ b/src/libp2p/discovery.rs
@@ -365,22 +365,18 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 
     fn on_swarm_event(&mut self, event: FromSwarm) {
         match &event {
-            FromSwarm::ConnectionEstablished(e) => {
-                if e.other_established == 0 {
-                    self.n_node_connected += 1;
-                    self.peers.insert(e.peer_id);
-                    self.pending_events
-                        .push_back(DiscoveryEvent::PeerConnected(e.peer_id));
-                }
+            FromSwarm::ConnectionEstablished(e) if e.other_established == 0 => {
+                self.n_node_connected += 1;
+                self.peers.insert(e.peer_id);
+                self.pending_events
+                    .push_back(DiscoveryEvent::PeerConnected(e.peer_id));
             }
-            FromSwarm::ConnectionClosed(e) => {
-                if e.remaining_established == 0 {
-                    self.n_node_connected -= 1;
-                    self.peers.remove(&e.peer_id);
-                    self.peer_info.remove(&e.peer_id);
-                    self.pending_events
-                        .push_back(DiscoveryEvent::PeerDisconnected(e.peer_id));
-                }
+            FromSwarm::ConnectionClosed(e) if e.remaining_established == 0 => {
+                self.n_node_connected -= 1;
+                self.peers.remove(&e.peer_id);
+                self.peer_info.remove(&e.peer_id);
+                self.pending_events
+                    .push_back(DiscoveryEvent::PeerDisconnected(e.peer_id));
             }
             _ => {}
         };

--- a/src/lotus_json/ipld.rs
+++ b/src/lotus_json/ipld.rs
@@ -275,34 +275,31 @@ fn snapshots() {
 }
 
 #[cfg(test)]
-quickcheck::quickcheck! {
-    fn quickcheck(val: Ipld) -> () {
-        let mut val = val;
-        /// `NaN != NaN`, which breaks our round-trip tests.
-        /// Correct this by changing any `NaN`s to zero.
-        fn fixup_floats(ipld: &mut Ipld) {
-            match ipld {
-                Ipld::Float(v) => {
-                    if v.is_nan() {
-                        *ipld = Ipld::Float(0.0);
-                    }
-                }
-                Ipld::List(list) => {
-                    for item in list {
-                        fixup_floats(item);
-                    }
-                }
-                Ipld::Map(map) => {
-                    for item in map.values_mut() {
-                        fixup_floats(item);
-                    }
-                }
-                _ => {}
+#[quickcheck_macros::quickcheck]
+fn quickcheck(val: Ipld) {
+    let mut val = val;
+    /// `NaN != NaN`, which breaks our round-trip tests.
+    /// Correct this by changing any `NaN`s to zero.
+    fn fixup_floats(ipld: &mut Ipld) {
+        match ipld {
+            Ipld::Float(v) if v.is_nan() => {
+                *ipld = Ipld::Float(0.0);
             }
+            Ipld::List(list) => {
+                for item in list {
+                    fixup_floats(item);
+                }
+            }
+            Ipld::Map(map) => {
+                for item in map.values_mut() {
+                    fixup_floats(item);
+                }
+            }
+            _ => {}
         }
-        fixup_floats(&mut val);
-        assert_unchanged_via_json(val)
     }
+    fixup_floats(&mut val);
+    assert_unchanged_via_json(val)
 }
 
 /// [`quickcheck`] [found a round-trip bug in CI][failing job], tracked by [#3383][issue]

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -124,14 +124,14 @@
 use crate::shim::actors::miner::DeadlineInfo;
 use derive_more::From;
 use fvm_shared4::piece::PaddedPieceSize;
+#[cfg(test)]
+use pretty_assertions::assert_eq;
 use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::DeserializeOwned};
 #[cfg(test)]
 use serde_json::json;
 use std::{fmt::Display, str::FromStr};
 use uuid::Uuid;
-#[cfg(test)]
-use {pretty_assertions::assert_eq, quickcheck::quickcheck};
 
 pub trait HasLotusJson: Sized {
     /// The struct representing JSON. You should `#[derive(Deserialize, Serialize)]` on it.

--- a/src/lotus_json/opt.rs
+++ b/src/lotus_json/opt.rs
@@ -33,8 +33,7 @@ fn shapshots() {
 }
 
 #[cfg(test)]
-quickcheck! {
-    fn quickcheck(val: Option<::cid::Cid>) -> () {
-        assert_unchanged_via_json(val)
-    }
+#[quickcheck_macros::quickcheck]
+fn quickcheck(val: Option<::cid::Cid>) {
+    assert_unchanged_via_json(val)
 }

--- a/src/lotus_json/raw_bytes.rs
+++ b/src/lotus_json/raw_bytes.rs
@@ -10,10 +10,9 @@ fn snapshots() {
 }
 
 #[cfg(test)]
-quickcheck! {
-    fn quickcheck(val: Vec<u8>) -> () {
-        assert_unchanged_via_json(RawBytes::new(val))
-    }
+#[quickcheck_macros::quickcheck]
+fn quickcheck(val: Vec<u8>) {
+    assert_unchanged_via_json(RawBytes::new(val))
 }
 
 impl HasLotusJson for RawBytes {

--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -66,8 +66,7 @@ fn snapshots() {
 }
 
 #[cfg(test)]
-quickcheck! {
-    fn quickcheck(val: Vec<::cid::Cid>) -> () {
-        assert_unchanged_via_json(val)
-    }
+#[quickcheck_macros::quickcheck]
+fn quickcheck(val: Vec<::cid::Cid>) {
+    assert_unchanged_via_json(val)
 }

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -1699,10 +1699,9 @@ fn snapshots() {
 }
 
 #[cfg(test)]
-quickcheck::quickcheck! {
-    fn quickcheck(val: PathChange) -> () {
-        assert_unchanged_via_json(val)
-    }
+#[quickcheck_macros::quickcheck]
+fn quickcheck(val: PathChange) {
+    assert_unchanged_via_json(val)
 }
 
 #[cfg(test)]

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -527,7 +527,7 @@ where
             receipts.len()
         );
         let mut executed_messages = Vec::with_capacity(messages.len());
-        for (message, receipt) in messages.iter().cloned().zip(receipts.into_iter()) {
+        for (message, receipt) in messages.iter().cloned().zip(receipts) {
             let events = if let Some(events_root) = receipt.events_root() {
                 Some(
                     match StampedEvent::get_events(self.cs.blockstore(), &events_root) {

--- a/src/tool/subcommands/net_cmd.rs
+++ b/src/tool/subcommands/net_cmd.rs
@@ -45,8 +45,7 @@ impl NetCommands {
                     }
                     tokio::time::sleep(Duration::from_secs(interval)).await;
                 }
-                if n_success > 0 {
-                    let avg_ms = total_duration.as_millis() / n_success;
+                if let Some(avg_ms) = total_duration.as_millis().checked_div(n_success) {
                     println!("Average latency: {avg_ms}ms");
                 }
             }

--- a/src/utils/net/download_file.rs
+++ b/src/utils/net/download_file.rs
@@ -380,11 +380,7 @@ async fn download_http_parallel(
                             let seconds_since_last = (elapsed_ms - prev_ms) as f64 / 1000.0;
                             let speed = downloaded.saturating_sub(last_bytes) as f64
                                 / seconds_since_last.max(0.1);
-                            let percent = if total_size > 0 {
-                                downloaded * 100 / total_size
-                            } else {
-                                0
-                            };
+                            let percent = (downloaded * 100).checked_div(total_size).unwrap_or(0);
 
                             tracing::info!(
                                 target: "forest::progress",

--- a/src/utils/net/download_file.rs
+++ b/src/utils/net/download_file.rs
@@ -380,8 +380,10 @@ async fn download_http_parallel(
                             let seconds_since_last = (elapsed_ms - prev_ms) as f64 / 1000.0;
                             let speed = downloaded.saturating_sub(last_bytes) as f64
                                 / seconds_since_last.max(0.1);
-                            let percent = (downloaded * 100).checked_div(total_size).unwrap_or(0);
-
+                            let percent = downloaded
+                                .checked_mul(100)
+                                .and_then(|v| v.checked_div(total_size))
+                                .unwrap_or(0);
                             tracing::info!(
                                 target: "forest::progress",
                                 "Loading {} / {}, {}%, {}/s, elapsed time: {}",


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- bump rust toolchain: https://releases.rs/docs/1.95.0/
- fix clippy warnings

```
warning: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> src/cli/subcommands/net_cmd.rs:79:34
    |
 79 | ...                   .zip(agents.into_iter()),
    |                            ^^^^^^^^^^^^^^^^^^
    |
note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`


warning: iterating on a map's values
   --> src/db/memory.rs:117:20
    |
117 |           let cids = self
    |  ____________________^
118 | |             .eth_mappings_db
119 | |             .read()
120 | |             .iter()
121 | |             .filter_map(|(_, value)| fvm_ipld_encoding::from_slice::<(Cid, u64)>(value).ok())
    | |_____________________________________________________________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#iter_kv_map
    = note: `#[warn(clippy::iter_kv_map)]` on by default
	
	
warning: this `if` can be collapsed into the outer `match`
   --> src/db/gc/snapshot.rs:282:17
    |
282 | /                 if !map.is_empty() {
283 | |                     *self.memory_db.write() = Some(map);
284 | |                     *self.memory_db_head_key.write() = current_chain_head;
285 | |                 }
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_match
    = note: `#[warn(clippy::collapsible_match)]` on by default
	
	
warning: this `if` can be collapsed into the outer `match`
   --> src/libp2p/discovery.rs:369:17
    |
369 | /                 if e.other_established == 0 {
370 | |                     self.n_node_connected += 1;
371 | |                     self.peers.insert(e.peer_id);
372 | |                     self.pending_events
373 | |                         .push_back(DiscoveryEvent::PeerConnected(e.peer_id));
374 | |                 }
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_match
	
warning: casting to the same type is unnecessary (`usize` -> `usize`)
   --> src/eth/transaction.rs:639:41
    |
639 |         let mut eip_155_sig = vec![0u8; eip_155_sig_len as usize - v.len()];
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eip_155_sig_len`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default
	
	
warning: manual checked division
  --> src/tool/subcommands/net_cmd.rs:48:20
   |
48 |                 if n_success > 0 {
   |                    ^^^^^^^^^^^^^ check performed here
49 |                     let avg_ms = total_duration.as_millis() / n_success;
   |                                  -------------------------------------- division performed here
   |
   = help: consider using `checked_div`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#manual_checked_ops
   = note: `#[warn(clippy::manual_checked_ops)]` on by default
   
   
warning: unneeded unit return type
   --> src/lotus_json/ipld.rs:279:25
    |
279 | fn quickcheck(val: Ipld) -> () {
    |                         ^^^^^^ help: remove the `-> ()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#unused_unit
    = note: `#[warn(clippy::unused_unit)]` on by default
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain to 1.95.0.
  * Migrated test harness usage to the newer attribute-based test macros.

* **Refactor**
  * Simplified iterator and consumption patterns and tightened control-flow with guard patterns.
  * Minor control-flow adjustments in async/result handling.

* **Bug Fixes**
  * Added overflow-safe arithmetic to prevent division/overflow edge cases in progress and latency reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->