### PR TITLE
feat(wallet)!: apply FRC-0102 envelope to sign/verify by default

### DIFF
--- a/.config/forest.dic
+++ b/.config/forest.dic
@@ -1,4 +1,4 @@
-271
+273
 Algorand/M
 API's
 API/SM
@@ -99,6 +99,7 @@ Filecoin/M
 Filfox
 Filops
 FilOz
+Filsnap
 FIP/S
 FVM
 GC
@@ -121,6 +122,7 @@ implementer/S
 implementor/SM
 infeasible
 interop/S
+interoperating
 ip
 IPFS
 IPLD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Breaking
 
 - [#7073](https://github.com/ChainSafe/forest/pull/7073): Replaced the underlying cache engine across the node. The eviction policy is no longer strict LRU — it is now CLOCK-PRO via [`quick_cache`](https://crates.io/crates/quick_cache), which is scan-resistant and typically gives higher hit rates on chain workloads. The Prometheus metric names `lru_cache_hit_total` and `lru_cache_miss_total` are renamed to `cache_hit_total` and `cache_miss_total`. **Operators must update dashboards, alert rules, and recording rules** that reference the old names. Label set (`kind="..."`) is unchanged.
+- [#6442](https://github.com/ChainSafe/forest/issues/6442): `forest-wallet sign` and `forest-wallet verify` now apply the FRC-0102 signing envelope to the message by default. Pass `--raw` on both sides to reproduce the previous raw-bytes behaviour.
 
 ### Added
 

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -37,7 +37,6 @@ use crate::{
     rpc::{self, prelude::*},
 };
 use anyhow::{Context as _, bail};
-use base64::{Engine, prelude::BASE64_STANDARD};
 use clap::Subcommand;
 use dialoguer::{Password, console::Term, theme::ColorfulTheme};
 use directories::ProjectDirs;
@@ -169,17 +168,17 @@ impl WalletBackend {
         }
     }
 
-    async fn wallet_sign(&self, address: Address, message: String) -> anyhow::Result<Signature> {
+    async fn wallet_sign(&self, address: Address, message: Vec<u8>) -> anyhow::Result<Signature> {
         if let Some(keystore) = &self.local {
             let key = crate::key_management::try_find_key(&address, keystore)?;
 
             Ok(crate::key_management::sign(
                 *key.key_info.key_type(),
                 key.key_info.private_key(),
-                &BASE64_STANDARD.decode(message)?,
+                &message,
             )?)
         } else {
-            Ok(WalletSign::call(&self.remote, (address, message.into_bytes())).await?)
+            Ok(WalletSign::call(&self.remote, (address, message)).await?)
         }
     }
 
@@ -262,6 +261,11 @@ pub enum WalletCommands {
         /// The address to be used to sign the message
         #[arg(short)]
         address: StrictAddress,
+        /// Sign the raw message bytes without the FRC-0102 envelope. Use this
+        /// for interoperating with pre-FRC-0102 tooling, or when the bytes are
+        /// already an on-chain Filecoin message (which must not be wrapped).
+        #[arg(long)]
+        raw: bool,
     },
     /// Validates whether a given string can be decoded as a well-formed address
     ValidateAddress {
@@ -280,6 +284,12 @@ pub enum WalletCommands {
         /// The signature of the message to verify
         #[arg(short)]
         signature: String,
+        /// Verify against the raw message bytes without applying the
+        /// FRC-0102 envelope. Use this for signatures produced by
+        /// pre-FRC-0102 tooling or for on-chain Filecoin messages (which are
+        /// signed raw, without the envelope).
+        #[arg(long)]
+        raw: bool,
     },
     /// Deletes the wallet associated with the given address.
     Delete {
@@ -446,9 +456,13 @@ impl WalletCommands {
                 Ok(())
             }
             Self::SetDefault { key } => backend.wallet_set_default(key.into()).await,
-            Self::Sign { address, message } => {
+            Self::Sign {
+                address,
+                message,
+                raw,
+            } => {
                 let message = hex::decode(message).context("Message has to be a hex string")?;
-                let message = BASE64_STANDARD.encode(message);
+                let message = if raw { message } else { wrap_frc0102(&message) };
 
                 let signature = backend.wallet_sign(address.into(), message).await?;
                 println!("{}", hex::encode(signature.to_bytes()));
@@ -463,10 +477,12 @@ impl WalletCommands {
                 message,
                 address,
                 signature,
+                raw,
             } => {
                 let sig_bytes =
                     hex::decode(signature).context("Signature has to be a hex string")?;
                 let msg = hex::decode(message).context("Message has to be a hex string")?;
+                let msg = if raw { msg } else { wrap_frc0102(&msg) };
 
                 let signature = Signature::from_bytes(sig_bytes)?;
                 let is_valid = backend
@@ -615,6 +631,15 @@ fn resolve_target_address(target_address: &str) -> anyhow::Result<(Address, bool
     }
 }
 
+const FRC_0102_FILECOIN_PREFIX: &[u8] = b"\x19Filecoin Signed Message:\n";
+
+/// Wraps `msg` with the FRC-0102 envelope: `0x19 || "Filecoin Signed Message:\n" || ascii(len(msg)) || msg`
+// See <https://github.com/filecoin-project/FIPs/blob/bdd5283279fd115c87c9bbf71d2e40c9d075f5aa/FRCs/frc-0102.md>.
+fn wrap_frc0102(msg: &[u8]) -> Vec<u8> {
+    let len = msg.len().to_string();
+    [FRC_0102_FILECOIN_PREFIX, len.as_bytes(), msg].concat()
+}
+
 fn resolve_method_num(from: &Address, to: &Address, is_0x_recipient: bool) -> u64 {
     if !is_eth_address(from) && !is_0x_recipient {
         return METHOD_SEND;
@@ -635,7 +660,7 @@ mod tests {
     use crate::shim::address::{Address, CurrentNetwork, Network};
     use crate::shim::message::METHOD_SEND;
 
-    use super::{resolve_method_num, resolve_target_address};
+    use super::{SignatureType, resolve_method_num, resolve_target_address, wrap_frc0102};
 
     #[test]
     fn test_resolve_target_address_id() {
@@ -752,5 +777,83 @@ mod tests {
             .unwrap();
         let method = resolve_method_num(&from, &to, true);
         assert_eq!(method, EVMMethod::InvokeContract as u64);
+    }
+
+    #[test]
+    fn test_wrap_frc0102_empty() {
+        let wrapped = wrap_frc0102(&[]);
+        assert_eq!(wrapped, b"\x19Filecoin Signed Message:\n0");
+    }
+
+    #[test]
+    fn test_wrap_frc0102_short() {
+        let wrapped = wrap_frc0102(b"hello");
+        assert_eq!(wrapped, b"\x19Filecoin Signed Message:\n5hello");
+    }
+
+    #[test]
+    fn test_wrap_frc0102_longer() {
+        let msg = b"this is a longer test message";
+        let wrapped = wrap_frc0102(msg);
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"\x19Filecoin Signed Message:\n");
+        expected.extend_from_slice(msg.len().to_string().as_bytes());
+        expected.extend_from_slice(msg);
+        assert_eq!(wrapped, expected);
+    }
+
+    #[test]
+    fn test_wrap_frc0102_binary_msg() {
+        // Non-UTF-8 bytes must pass through unchanged.
+        let msg: &[u8] = &[0x00, 0xFF, 0x10, 0x80];
+        let wrapped = wrap_frc0102(msg);
+        assert_eq!(&wrapped[..26], b"\x19Filecoin Signed Message:\n");
+        assert_eq!(&wrapped[26..27], b"4");
+        assert_eq!(&wrapped[27..], msg);
+    }
+
+    #[test]
+    fn test_wrap_frc0102_length_boundaries() {
+        // Length is encoded as decimal ASCII; check 1-, 2-, 3- and 4-digit boundaries.
+        for len in [0, 9, 10, 99, 100, 999, 1000] {
+            let msg = vec![0xABu8; len];
+            let wrapped = wrap_frc0102(&msg);
+            let digits = len.to_string();
+            assert_eq!(&wrapped[..26], b"\x19Filecoin Signed Message:\n");
+            assert_eq!(&wrapped[26..26 + digits.len()], digits.as_bytes());
+            assert_eq!(&wrapped[26 + digits.len()..], msg.as_slice());
+        }
+    }
+
+    #[test]
+    fn test_wrap_frc0102_contains_newline() {
+        // The spec does not require any escaping; embedded newlines pass through.
+        let msg = b"line1\nline2";
+        let wrapped = wrap_frc0102(msg);
+        assert_eq!(wrapped, b"\x19Filecoin Signed Message:\n11line1\nline2");
+    }
+
+    #[test]
+    fn test_frc0102_roundtrip_sign_verify_secp256k1() {
+        use crate::key_management::generate_key;
+        let key = generate_key(SignatureType::Secp256k1).unwrap();
+        let raw_msg = b"hello world";
+        let wrapped = wrap_frc0102(raw_msg);
+
+        // Sign the wrapped bytes (what `forest-wallet sign` does by default).
+        let signature = crate::key_management::sign(
+            *key.key_info.key_type(),
+            key.key_info.private_key(),
+            &wrapped,
+        )
+        .unwrap();
+
+        // `verify` on the wrapped bytes must succeed.
+        signature.verify(&wrapped, &key.address).unwrap();
+
+        assert!(
+            signature.verify(raw_msg, &key.address).is_err(),
+            "raw-bytes verify should fail when the signature was produced over the FRC-0102 envelope"
+        );
     }
 }


### PR DESCRIPTION
## Summary of changes

Changes introduced in this pull request:

- Wrap the decoded message with the FRC-0102 Filecoin signing envelope (`\x19Filecoin Signed Message:\n<len>`) in `forest-wallet sign` and `forest-wallet verify` before handing it to the signer/verifier. Aligns Forest with Ledger Filecoin, Filsnap, iso-filecoin and Lotus (filecoin-project/lotus#13388).
- Add a `--raw` flag to both `sign` and `verify` that restores the previous raw-bytes behaviour. `--raw` is also the correct choice when signing on-chain Filecoin messages, which must not be wrapped.
- Add a `wrap_frc0102(&[u8]) -> Vec<u8>` helper with a `const FRC_0102_FILECOIN_PREFIX: &[u8]` in `wallet_cmd.rs`.
- Expand the unit test suite with 7 cases: empty/short/long/binary/length-boundary/embedded-newline format checks, plus a `secp256k1` round-trip that asserts `verify(wrapped)` succeeds and `verify(raw)` fails.
- `CHANGELOG.md`: `Breaking` entry that also calls out (a) pre-FRC-0102 nodes cannot verify the new default without `--raw`, and (b) on-chain messages must still use `--raw`.

The envelope is applied **client-side only**. Forest's and Lotus's `WalletSign` / `WalletVerify` RPCs treat their input as opaque bytes and do not wrap, so a single wrap here is correct against today's daemons. If that ever changes server-side, users will want `--raw` to avoid a double envelope.

## Reference issue to close (if applicable)

Closes #6442

## Other information and links

- Reference Go implementation: filecoin-project/lotus#13388 (wallet `sign`/`verify` wrap by default + `--raw` opt-out).
- Spec: <https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0102.md>.
- Scope matches Lotus PR — Filecoin native prefix only, not the EIP-191 variant for f410/EVM addresses. Leaving EVM-envelope support as a follow-up.

## Change checklist

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [x] I have read and agree to the [CONTRIBUTING][2] document.
- [x] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

## AI Usage Disclosure

This PR was prepared with assistance from **Claude Code** (Anthropic). Extent:

- Issue triage, reading of the Lotus reference implementation (filecoin-project/lotus#13388), implementation, self-review (two passes with an independent reviewer agent), test design, and PR drafting were AI-assisted.
- All changes were compiled and tested locally by me before pushing — `cargo fmt --all -- --check`, `cargo clippy --profile quick --all-targets --no-deps -- -D warnings` (with `FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT=1`), and `cargo test --lib -- wrap_frc0102 frc0102_roundtrip` (7/7 pass) are all green.
- End-to-end CLI verification against a running daemon has not been performed locally; that path goes through an unchanged `wallet_sign` / `wallet_verify` that receives the already-wrapped bytes.
- I have reviewed every diff line and take full responsibility for correctness.

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Signed messages now use the FRC-0102 Filecoin signing envelope by default; signatures from pre-FRC-0102 releases may not verify unless `--raw` is used.

* **New Features**
  * Added a `--raw` option to control envelope wrapping for both sign and verify commands.

* **Documentation**
  * Added a “Breaking” note to the changelog documenting the behavior change.

* **Chores**
  * Updated wordlist with two new entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChainSafe/forest/pull/6967)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->