### PR TITLE
chore: prepare nv28 calibnet upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Added
 
+- [#6916](https://github.com/ChainSafe/forest/issues/6916): Added NV28 _FireHorse_ network upgrade support for calibnet. The upgrade epoch is set to `3694534` which corresponds to `2026-05-07T14:00:00Z`.
+
 ### Changed
 
 ### Removed

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1244,6 +1244,98 @@
   },
   {
     "network": {
+      "type": "calibnet"
+    },
+    "version": "v18.0.0",
+    "bundle_cid": "bafy2bzacebkfatnbe6w4rj7lf6gkjh7mywlrpdh2dj6hu2dl4rmtwksszm2hs",
+    "manifest": {
+      "actors": [
+        [
+          "system",
+          1,
+          "bafk2bzacecq366vuipuunlityjeaj7q7iexemcpkv7b5netouxcow4qr4cr6c"
+        ],
+        [
+          "init",
+          2,
+          "bafk2bzaceckaapwi22d56nqlnieqapwaqmicv7oqtbuowa4vfrckqr465eank"
+        ],
+        [
+          "cron",
+          3,
+          "bafk2bzacea6qt5zk7n6z3xg3mn6rbd54ijnzqkz7mdt4vinjclylgp44unau6"
+        ],
+        [
+          "account",
+          4,
+          "bafk2bzaceaaekrmq3cqnzokwmuksgr7vqgslpm67blh3fhj4cwgnk5vgoksam"
+        ],
+        [
+          "storagepower",
+          5,
+          "bafk2bzacec44gnb4mttxdquf4v565figj5l4oquggy5eoftwgdvvsmeeqhtnu"
+        ],
+        [
+          "storageminer",
+          6,
+          "bafk2bzacedmjs2a62u5isgkewjaik6zxq3obrowalnb2vvkmipomro2rvesh2"
+        ],
+        [
+          "storagemarket",
+          7,
+          "bafk2bzaceabzd7bytvpvamtunoqsbjlhhtu52vrshvel4hc4i7p52qkzuuubk"
+        ],
+        [
+          "paymentchannel",
+          8,
+          "bafk2bzacecycr25bi4fqwpkrkyiarch3qlhakt6l5linxrs4vpjzv5a3a55rg"
+        ],
+        [
+          "multisig",
+          9,
+          "bafk2bzacechrsbw65ojbktr63swju5g7275fl3lxminrz7damr4me6wq6fjxm"
+        ],
+        [
+          "reward",
+          10,
+          "bafk2bzacebr7cct7gottmvpd4ye5av5rbeoqhhlniyizu3tdoia2v3jzgzib2"
+        ],
+        [
+          "verifiedregistry",
+          11,
+          "bafk2bzaceb6slpid3f7miqz6kylytd2azlngbce2jsa7p2cos3ejnixxat5cu"
+        ],
+        [
+          "datacap",
+          12,
+          "bafk2bzaced6f3eomhaanxsrgwxp7oienjh7baramvz42kw5swszcpo44gay5m"
+        ],
+        [
+          "placeholder",
+          13,
+          "bafk2bzacedfvut2myeleyq67fljcrw4kkmn5pb5dpyozovj7jpoez5irnc3ro"
+        ],
+        [
+          "evm",
+          14,
+          "bafk2bzaceb63lj5qyx6hrtagl4mlqla6rb2ligpeglurhfvn2avubim62oyxc"
+        ],
+        [
+          "eam",
+          15,
+          "bafk2bzacedwo54emfh7xdayrnojvbighqdwvqcmaatovcnvfm3b3oouwpdzi6"
+        ],
+        [
+          "ethaccount",
+          16,
+          "bafk2bzaceduuafkwihklhnrwrcjvembs2t24mayoy54dy4pw65tnozzqikdbs"
+        ]
+      ],
+      "actor_list_cid": "bafy2bzaceb22zyxdtqlmveumv7qibp6ncrwmfuskzldj2qiudmvn7bfeeaur6"
+    }
+  },
+  {
+    "network": {
       "type": "butterflynet"
     },
     "version": "v17.0.0",

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -85,6 +85,7 @@ pub static ACTOR_BUNDLES: LazyLock<Box<[ActorBundleInfo]>> = LazyLock::new(|| {
         "bafy2bzacebc7zpsrihpyd2jdcvmegbbk6yhzkifre3hxtoul5wdxxklbwitry" @ "v16.0.0-rc3" for "calibrationnet",
         "bafy2bzacecqtwq6hjhj2zy5gwjp76a4tpcg2lt7dps5ycenvynk2ijqqyo65e" @ "v16.0.1" for "calibrationnet",
         "bafy2bzacecn64rlb52rjsvgopnidz6w42z3zobmjxqek5s4xqjh3ly47rcurg" @ "v17.0.0" for "calibrationnet",
+        "bafy2bzacebkfatnbe6w4rj7lf6gkjh7mywlrpdh2dj6hu2dl4rmtwksszm2hs" @ "v18.0.0" for "calibrationnet",
         "bafy2bzacedzjwguwuihh4tptzfkkwaj3naamrnklbaixn2wfzqh67twwp56pi" @ "v17.0.0" for "butterflynet",
         "bafy2bzacec3ikcjko4zok3qoe7nxnqilx2mj65tp25kkkbf7bwkejflfrdpwo" @ "v18.0.0-rc1" for "butterflynet",
         "bafy2bzacedozk3jh2j4nobqotkbofodq4chbrabioxbfrygpldgoxs3zwgggk" @ "v9.0.3" for "devnet",

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -95,7 +95,8 @@ pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|
         make_height!(TockFix, 2_558_014, get_bundle_cid("v16.0.1")),
         // Wed 10 Sep 23:00:00 UTC 2025
         make_height!(GoldenWeek, 3_007_294, get_bundle_cid("v17.0.0")),
-        make_height!(FireHorse, i64::MAX),
+        // 2026-05-07T14:00:00Z
+        make_height!(FireHorse, 3_694_534, get_bundle_cid("v18.0.0")),
     ])
 });
 

--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -66,6 +66,7 @@ where
                 (Height::Teep, nv25::run_migration::<DB>),
                 (Height::TockFix, nv26fix::run_migration::<DB>),
                 (Height::GoldenWeek, nv27::run_migration::<DB>),
+                (Height::FireHorse, nv28::run_migration::<DB>),
             ]
         }
         NetworkChain::Butterflynet => {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- prepared NV28 upgrade for calibnet

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the NV28 "FireHorse" network upgrade on Calibnet, Butterflynet, and Devnet, with activation scheduled for epoch 3,694,534 (May 7, 2026 at 14:00:00 UTC).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->