### PR TITLE
fix: flaky Kademlia test

### DIFF
--- a/scripts/tests/calibnet_kademlia_check.sh
+++ b/scripts/tests/calibnet_kademlia_check.sh
@@ -18,7 +18,7 @@ echo "Stateless node peer id: $STATELESS_NODE_PEER_ID"
 CONFIG_PATH="./forest_config.toml"
 cat <<- EOF > $CONFIG_PATH
 	[network]
-	listening_multiaddrs = ["/ip4/127.0.0.1/tcp/0"]
+	listening_multiaddrs = ["/ip4/127.0.0.1/tcp/0", "/ip4/127.0.0.1/udp/0/quic-v1"]
 	bootstrap_peers = ["$STATELESS_NODE_ADDRESS"]
 	mdns = false
 	kademlia = true

--- a/scripts/tests/calibnet_stateless_mode_check.sh
+++ b/scripts/tests/calibnet_stateless_mode_check.sh
@@ -11,14 +11,14 @@ forest_init_stateless
 STATELESS_NODE_ADDRESS=$($FOREST_CLI_PATH net listen | tail -n 1)
 echo "Stateless node address: $STATELESS_NODE_ADDRESS"
 # Example format: 12D3KooWAB9z7vZ1x1v9t4BViVkX1Hy1ScoRnWV2GgGy5ec6pfUZ
-STATELESS_NODE_PEER_ID=$(echo "$STATELESS_NODE_ADDRESS" | cut --delimiter="/" --fields=7 --zero-terminated)
+STATELESS_NODE_PEER_ID=$(echo "$STATELESS_NODE_ADDRESS" | rev | cut --delimiter="/" --fields=1 --zero-terminated | rev)
 echo "Stateless node peer id: $STATELESS_NODE_PEER_ID"
 
 # Run a normal forest node that only connects to the stateless node
 CONFIG_PATH="./forest_config.toml"
 cat <<- EOF > $CONFIG_PATH
 	[network]
-	listening_multiaddrs = ["/ip4/127.0.0.1/tcp/0"]
+	listening_multiaddrs = ["/ip4/127.0.0.1/tcp/0", "/ip4/127.0.0.1/udp/0/quic-v1"]
 	bootstrap_peers = ["$STATELESS_NODE_ADDRESS"]
 	mdns = false
 	kademlia = false

--- a/scripts/tests/harness.sh
+++ b/scripts/tests/harness.sh
@@ -83,7 +83,7 @@ function forest_run_node_stateless_detached {
 		data_dir = "/tmp/stateless_forest_data"
 
 		[network]
-		listening_multiaddrs = ["/ip4/127.0.0.1/tcp/0"]
+		listening_multiaddrs = ["/ip4/127.0.0.1/tcp/0", "/ip4/127.0.0.1/udp/0/quic-v1"]
 	EOF
 
   $FOREST_PATH --chain calibnet --encrypt-keystore false --config "$CONFIG_PATH" --log-dir "$LOG_DIRECTORY" --save-token ./stateless_admin_token --stateless &

--- a/src/libp2p/peer_manager.rs
+++ b/src/libp2p/peer_manager.rs
@@ -162,6 +162,7 @@ impl PeerManager {
         let peer_stats = peers.full_peers.entry(*peer).or_default();
         peer_stats.successes += 1;
         log_time(peer_stats, dur);
+        metrics::FULL_PEERS.set(peers.full_peers.len() as i64);
     }
 
     /// Logs a failure for the given peer, and updates the average request
@@ -177,6 +178,7 @@ impl PeerManager {
         let peer_stats = peers.full_peers.entry(*peer).or_default();
         peer_stats.failures += 1;
         log_time(peer_stats, dur);
+        metrics::FULL_PEERS.set(peers.full_peers.len() as i64);
     }
 
     /// Removes a peer from the set and returns true if the value was present
@@ -316,7 +318,7 @@ impl PeerManager {
 
 fn remove_peer(peers: &mut PeerSets, peer_id: &PeerId) {
     if peers.full_peers.remove(peer_id).is_some() {
-        metrics::FULL_PEERS.set(peers.full_peers.len() as _);
+        metrics::FULL_PEERS.set(peers.full_peers.len() as i64);
     }
     trace!(
         "removing peer {peer_id}, remaining chain exchange peers: {}",


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fix a bug that `full_peers` metric was only updated when a remote peer gets disconnected.
- update test node setup to also listen on quic-v1 protocol

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test suite to support both TCP and UDP/QUIC network protocols for comprehensive protocol coverage.
  * Enhanced stateless node test configurations with expanded network endpoint support.

* **Chores**
  * Refined peer metrics collection for improved monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->