### PR TITLE
fix: increase connection backlog based on max connections

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -44,7 +44,6 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::{
-    net::TcpListener,
     signal::{
         ctrl_c,
         unix::{SignalKind, signal},
@@ -226,10 +225,8 @@ async fn maybe_start_metrics_service(
     ctx: &AppContext,
 ) -> anyhow::Result<()> {
     if config.client.enable_metrics_endpoint {
-        // Start Prometheus server port
-        let prometheus_listener = TcpListener::bind(config.client.metrics_address)
-            .await
-            .with_context(|| format!("could not bind to {}", config.client.metrics_address))?;
+        let prometheus_listener =
+            crate::utils::net::bind_tcp_listener(config.client.metrics_address, 0).await?;
         info!(
             "Prometheus server started at {}",
             config.client.metrics_address
@@ -382,7 +379,7 @@ async fn maybe_start_health_check_service(
         };
         let healthcheck_address = forest_state.config.client.healthcheck_address;
         info!("Healthcheck endpoint will listen at {healthcheck_address}");
-        let listener = tokio::net::TcpListener::bind(healthcheck_address).await?;
+        let listener = crate::utils::net::bind_tcp_listener(healthcheck_address, 0).await?;
         services.spawn(async move {
             crate::health::init_healthcheck_server(forest_state, listener)
                 .await
@@ -472,12 +469,11 @@ fn maybe_start_rpc_service(
             let mpool_locker = MpoolLocker::new();
             let temp_dir = Arc::new(ctx.temp_dir.clone());
             async move {
-                let rpc_listener = tokio::net::TcpListener::bind(rpc_address)
-                    .await
-                    .map_err(|e| {
-                        anyhow::anyhow!("Unable to listen on RPC endpoint {rpc_address}: {e}")
-                    })
-                    .unwrap();
+                let rpc_listener = crate::utils::net::bind_tcp_listener(
+                    rpc_address,
+                    crate::rpc::default_max_connections(),
+                )
+                .await?;
                 start_rpc(
                     RPCState {
                         state_manager,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -458,14 +458,20 @@ static DEFAULT_REQUEST_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
         .unwrap_or(Duration::from_secs(60))
 });
 
-/// Default maximum connections for the RPC server. This needs to be high enough to
-/// accommodate the regular usage for RPC providers.
-static DEFAULT_MAX_CONNECTIONS: LazyLock<u32> = LazyLock::new(|| {
-    env::var("FOREST_RPC_MAX_CONNECTIONS")
-        .ok()
-        .and_then(|it| it.parse().ok())
-        .unwrap_or(1000)
-});
+/// Maximum concurrent connections accepted by the RPC server.
+///
+/// Configurable via `FOREST_RPC_MAX_CONNECTIONS`. The value also bounds the
+/// TCP listen backlog so that bursts of connection attempts do not get
+/// silently dropped by the kernel.
+pub fn default_max_connections() -> u32 {
+    static VALUE: LazyLock<u32> = LazyLock::new(|| {
+        env::var("FOREST_RPC_MAX_CONNECTIONS")
+            .ok()
+            .and_then(|it| it.parse().ok())
+            .unwrap_or(1000)
+    });
+    *VALUE
+}
 
 const MAX_REQUEST_BODY_SIZE: u32 = 64 * 1024 * 1024;
 const MAX_RESPONSE_BODY_SIZE: u32 = MAX_REQUEST_BODY_SIZE;
@@ -568,7 +574,7 @@ where
                     // Default size (10 MiB) is not enough for methods like `Filecoin.StateMinerActiveSectors`
                     .max_request_body_size(MAX_REQUEST_BODY_SIZE)
                     .max_response_body_size(MAX_RESPONSE_BODY_SIZE)
-                    .max_connections(*DEFAULT_MAX_CONNECTIONS)
+                    .max_connections(default_max_connections())
                     .set_id_provider(RandomHexStringIdProvider::new())
                     .build(),
             )

--- a/src/tool/offline_server/server.rs
+++ b/src/tool/offline_server/server.rs
@@ -232,7 +232,9 @@ where
 {
     info!("Starting offline RPC Server");
     let rpc_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), rpc_port);
-    let rpc_listener = tokio::net::TcpListener::bind(rpc_address).await?;
+    let rpc_listener =
+        crate::utils::net::bind_tcp_listener(rpc_address, crate::rpc::default_max_connections())
+            .await?;
     let mut terminate = signal(SignalKind::terminate())?;
     let (stop_handle, server_handle) = stop_channel();
     let result = tokio::select! {

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -6,19 +6,52 @@ pub use download_file::*;
 
 use crate::utils::io::WithProgress;
 use crate::utils::reqwest_resume;
+use anyhow::Context as _;
 use cid::Cid;
 use futures::{AsyncWriteExt, TryStreamExt};
 use reqwest::Response;
+use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
 use tap::Pipe;
 use tokio::io::AsyncBufRead;
+use tokio::net::TcpListener;
 use tokio_util::{
     compat::TokioAsyncReadCompatExt,
     either::Either::{Left, Right},
 };
 use tracing::info;
 use url::Url;
+
+/// Minimum listen backlog applied by [`bind_tcp_listener`].
+///
+/// `tokio::net::TcpListener::bind` (via `mio` and the Rust standard library)
+/// uses a fixed backlog of 128, which is too small to absorb bursts of
+/// simultaneous connection attempts: when the accept queue overflows, the
+/// kernel silently drops the completed handshakes and clients only retry
+/// after `TCP_RTO_MIN` (~1s on Linux). The kernel further clamps the
+/// requested backlog to `/proc/sys/net/core/somaxconn`, so it is safe to
+/// ask for a large value.
+const MIN_LISTEN_BACKLOG: u32 = 1024;
+
+/// Bind a TCP listener with an explicit listen backlog, floored at
+/// [`MIN_LISTEN_BACKLOG`]. Use this for any externally-facing listener that
+/// might face a burst of simultaneous connection attempts.
+pub async fn bind_tcp_listener(addr: SocketAddr, backlog: u32) -> anyhow::Result<TcpListener> {
+    let socket = if addr.is_ipv6() {
+        tokio::net::TcpSocket::new_v6()
+    } else {
+        tokio::net::TcpSocket::new_v4()
+    }
+    .with_context(|| format!("could not create TCP socket for {addr}"))?;
+    let _ = socket.set_reuseaddr(true);
+    socket
+        .bind(addr)
+        .with_context(|| format!("could not bind to {addr}"))?;
+    socket
+        .listen(backlog.max(MIN_LISTEN_BACKLOG))
+        .with_context(|| format!("could not listen on {addr}"))
+}
 
 pub fn global_http_client() -> reqwest::Client {
     static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- increases the connection backlog based on what we set via `FOREST_RPC_MAX_CONNECTIONS`.


```
# main
❯ OHA_CONCURRENCY=1000 bash rpc_bench.sh
method:    eth_chainId
params:    []
payload:   {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}
lotus:     http://127.0.0.1:1234/rpc/v1
forest:    http://127.0.0.1:2345/rpc/v1

=== sanity probe ===
forest   -> {"jsonrpc":"2.0","id":1,"result":"0x4cb2f"}

=== oha ===
--- forest (http://127.0.0.1:2345/rpc/v1) ---
warmup (200 requests)...
Summary:
  Success rate:	100.00%
  Total:	1.0690 sec
  Slowest:	1.0450 sec
  Fastest:	0.0001 sec
  Average:	0.1439 sec
  Requests/sec:	1870.8967

  Total data:	83.98 KiB
  Size/request:	43 B
  Size/sec:	78.56 KiB
```

```
# PR
❯ OHA_CONCURRENCY=1000 bash rpc_bench.sh
method:    eth_chainId
params:    []
payload:   {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}
lotus:     http://127.0.0.1:1234/rpc/v1
forest:    http://127.0.0.1:2345/rpc/v1

=== sanity probe ===
forest   -> {"jsonrpc":"2.0","id":1,"result":"0x4cb2f"}

=== oha ===
--- forest (http://127.0.0.1:2345/rpc/v1) ---
warmup (200 requests)...
Summary:
  Success rate:	100.00%
  Total:	44.1626 ms
  Slowest:	42.3777 ms
  Fastest:	0.0739 ms
  Average:	8.1844 ms
  Requests/sec:	45287.1774

  Total data:	83.98 KiB
  Size/request:	43 B
  Size/sec:	1.86 MiB
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling and reporting for network listener initialization across metrics, healthcheck, and RPC endpoints
  * Increased robustness against connection spikes with optimized listen backlog configuration
  * RPC server maximum connections now configurable via environment variable with default fallback to 1000

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChainSafe/forest/pull/7034)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->