### PR TITLE
feat: nv28 upgrade mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 - [#7025](https://github.com/ChainSafe/forest/pull/7025): `FOREST_RPC_MAX_RESPONSE_BODY_SIZE` environment variable. Sets the JSON-RPC server's maximum response body size in bytes (default 64 MiB). Operators serving log-heavy `eth_getTransactionReceipt`/`eth_getBlockReceipts` calls can raise this above 64 MiB.
 
+- [#6917](https://github.com/ChainSafe/forest/issues/6917): Set the mainnet NV28 _FireHorse_ network upgrade epoch to `6052800` which corresponds to `Wed May 27 02:00:00 PM UTC 2026`.
+
 ### Changed
 
 ### Removed

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -3235,5 +3235,97 @@
       ],
       "actor_list_cid": "bafy2bzaceasz5pov3d4tyxxdcxj2qvvdnkdxihzycj5oos5t2xj5pznwvxvem"
     }
+  },
+  {
+    "network": {
+      "type": "mainnet"
+    },
+    "version": "v18.0.0",
+    "bundle_cid": "bafy2bzacedxsqapxwj5znwy4leem5gsuenhhfyqcntews3yis5iek67thy6lc",
+    "manifest": {
+      "actors": [
+        [
+          "system",
+          1,
+          "bafk2bzaceb6wbrd6oqnplfdawnu6n27gwwajtfj4xjq3k54uq77ynniniyzce"
+        ],
+        [
+          "init",
+          2,
+          "bafk2bzacedrpq4kw6x7cq72w4g4fw56wj6ml4b3doeay6jyivm4dhkxijbe62"
+        ],
+        [
+          "cron",
+          3,
+          "bafk2bzaceakrzoywbqj4wrjyo33azrpozkn2rwb7qidfmsda42zpyqmiohn7o"
+        ],
+        [
+          "account",
+          4,
+          "bafk2bzacebt5o43hdveql4tqrnr7bg62by3d336ddsfl3l72xedhlsrbe6nia"
+        ],
+        [
+          "storagepower",
+          5,
+          "bafk2bzaced6wh6odb572jjegr6vxoukzfblp7vogipaub5rsljbpo5mo35a5i"
+        ],
+        [
+          "storageminer",
+          6,
+          "bafk2bzacead23tnh3ywx2cwudftngssfjgptsvr3nao7xv6mcfot7gvju4bak"
+        ],
+        [
+          "storagemarket",
+          7,
+          "bafk2bzacedddzlqirkt63auacz4eogkswfjhbayc4mlrsvsxix4kbnj22mjmy"
+        ],
+        [
+          "paymentchannel",
+          8,
+          "bafk2bzacebuw6l22xfht4gv4q5ltk66sy6ibp6ou63wvy6zaiyzievu3cl4v2"
+        ],
+        [
+          "multisig",
+          9,
+          "bafk2bzacecgyiuanstjcdo43xkax274hmyyfiw7ju44uvcyreayonp7r3fmls"
+        ],
+        [
+          "reward",
+          10,
+          "bafk2bzacec53jz3itt55424ebyn2ea3rc62zvyyrnscx3gkv4ulw2hholxiii"
+        ],
+        [
+          "verifiedregistry",
+          11,
+          "bafk2bzacebnep6ruikyegl6jo6jdd7dmrk2vrk4xmywoq2g6ps5tmvutu3zbe"
+        ],
+        [
+          "datacap",
+          12,
+          "bafk2bzacedc2r4rf2cnofn5zhnxawhkn445hqgiptfsd4746ejnkmga4uz2ze"
+        ],
+        [
+          "placeholder",
+          13,
+          "bafk2bzacedfvut2myeleyq67fljcrw4kkmn5pb5dpyozovj7jpoez5irnc3ro"
+        ],
+        [
+          "evm",
+          14,
+          "bafk2bzacea57ib7fosqleehx5z6uvockk3xk5wqycmge5m4rfq4ptr7xrkfsi"
+        ],
+        [
+          "eam",
+          15,
+          "bafk2bzacec4bwptvkfvc22s2pqm4zdv77aorypuykq33dwlbmguc5tlpsuexw"
+        ],
+        [
+          "ethaccount",
+          16,
+          "bafk2bzacecb3ebhbvmyaf5lhvdolndxfckuoxugs6hswoapxwacye7hax75ou"
+        ]
+      ],
+      "actor_list_cid": "bafy2bzacea275suujjuaddglc2kbbgracldjbbs5cjys6zsivcswubv5x7es4"
+    }
   }
 ]

--- a/src/networks/actors_bundle.rs
+++ b/src/networks/actors_bundle.rs
@@ -107,6 +107,7 @@ pub static ACTOR_BUNDLES: LazyLock<Box<[ActorBundleInfo]>> = LazyLock::new(|| {
         "bafy2bzaceakwje2hyinucrhgtsfo44p54iw4g6otbv5ghov65vajhxgntr53u" @ "v15.0.0" for "mainnet",
         "bafy2bzacecnepvsh4lw6pwljobvwm6zwu6mbwveatp7llhpuguvjhjiqz7o46" @ "v16.0.1" for "mainnet",
         "bafy2bzaceai74ppsvuxs3nvpzzeuptdr3wl7vmdpbphvtz4qt5hfq2qdfvz3e" @ "v17.0.0" for "mainnet",
+        "bafy2bzacedxsqapxwj5znwy4leem5gsuenhhfyqcntews3yis5iek67thy6lc" @ "v18.0.0" for "mainnet",
     ])
 });
 

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -92,7 +92,8 @@ pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|
         make_height!(Tock, 4_878_840 + EPOCHS_IN_DAY * 90),
         // Wed 24 Sep 23:00:00 UTC 2025
         make_height!(GoldenWeek, 5_348_280, get_bundle_cid("v17.0.0")),
-        make_height!(FireHorse, i64::MAX),
+        // Wed May 27 02:00:00 PM UTC 2026
+        make_height!(FireHorse, 6_052_800, get_bundle_cid("v18.0.0")),
     ])
 });
 

--- a/src/state_migration/mod.rs
+++ b/src/state_migration/mod.rs
@@ -49,6 +49,7 @@ where
                 (Height::TukTuk, nv24::run_migration::<DB>),
                 (Height::Teep, nv25::run_migration::<DB>),
                 (Height::GoldenWeek, nv27::run_migration::<DB>),
+                (Height::FireHorse, nv28::run_migration::<DB>),
             ]
         }
         NetworkChain::Calibnet => {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Set the mainnet NV28 _FireHorse_ network upgrade epoch to `6052800` which corresponds to `Wed May 27 02:00:00 PM UTC 2026`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md

https://filecoinproject.slack.com/archives/C05P37R9KQD/p1778518210802829?thread_ts=1778508150.666689&cid=C05P37R9KQD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for the FireHorse (NV28) network upgrade scheduled for mainnet at epoch 6052800 (May 27, 2026).
  * Updated actor bundle metadata and state migration configurations for the upcoming upgrade.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChainSafe/forest/pull/7037)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->