### PR TITLE
feat: add DESCRIPTION to all missing RPC methods

### DIFF
--- a/src/rpc/methods/auth.rs
+++ b/src/rpc/methods/auth.rs
@@ -30,6 +30,8 @@ impl AuthNew {
 
 impl RpcMethod<2> for AuthNew {
     const NAME: &'static str = "Filecoin.AuthNew";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Creates a new JWT token with the specified permissions.");
     const N_REQUIRED_PARAMS: usize = 1;
     // Note: Lotus does not support the optional `expiration_secs` parameter
     const PARAM_NAMES: [&'static str; 2] = ["permissions", "expiration_secs"];
@@ -57,6 +59,8 @@ impl RpcMethod<2> for AuthNew {
 pub enum AuthVerify {}
 impl RpcMethod<1> for AuthVerify {
     const NAME: &'static str = "Filecoin.AuthVerify";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Verifies a JWT token and returns its permissions.");
     const PARAM_NAMES: [&'static str; 1] = ["header_raw"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/beacon.rs
+++ b/src/rpc/methods/beacon.rs
@@ -13,6 +13,9 @@ use enumflags2::{BitFlags, make_bitflags};
 pub enum BeaconGetEntry {}
 impl RpcMethod<1> for BeaconGetEntry {
     const NAME: &'static str = "Filecoin.BeaconGetEntry";
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Returns the beacon entry for the given Filecoin epoch, blocking until the entry is available.",
+    );
     const PARAM_NAMES: [&'static str; 1] = ["first"];
     const API_PATHS: BitFlags<ApiPaths> = make_bitflags!(ApiPaths::V0); // Not supported in V1
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -302,6 +302,8 @@ impl RpcMethod<1> for ChainGetParentReceipts {
 pub enum ChainGetMessagesInTipset {}
 impl RpcMethod<1> for ChainGetMessagesInTipset {
     const NAME: &'static str = "Filecoin.ChainGetMessagesInTipset";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns all messages included in the specified tipset.");
     const PARAM_NAMES: [&'static str; 1] = ["tipsetKey"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -324,6 +326,8 @@ impl RpcMethod<1> for ChainGetMessagesInTipset {
 pub enum ChainPruneSnapshot {}
 impl RpcMethod<1> for ChainPruneSnapshot {
     const NAME: &'static str = "Forest.SnapshotGC";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Triggers garbage collection of old snapshot data.");
     const PARAM_NAMES: [&'static str; 1] = ["blocking"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Admin;
@@ -349,6 +353,8 @@ impl RpcMethod<1> for ChainPruneSnapshot {
 pub enum ForestChainExport {}
 impl RpcMethod<1> for ForestChainExport {
     const NAME: &'static str = "Forest.ChainExport";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Exports the chain state to a file using Forest-specific parameters.");
     const PARAM_NAMES: [&'static str; 1] = ["params"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -488,6 +494,8 @@ impl RpcMethod<1> for ForestChainExport {
 pub enum ForestChainExportStatus {}
 impl RpcMethod<0> for ForestChainExportStatus {
     const NAME: &'static str = "Forest.ChainExportStatus";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the status of the current chain export operation.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -529,6 +537,8 @@ impl RpcMethod<0> for ForestChainExportStatus {
 pub enum ForestChainExportCancel {}
 impl RpcMethod<0> for ForestChainExportCancel {
     const NAME: &'static str = "Forest.ChainExportCancel";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Cancels an in-progress chain export.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -553,6 +563,8 @@ impl RpcMethod<0> for ForestChainExportCancel {
 pub enum ForestChainExportDiff {}
 impl RpcMethod<1> for ForestChainExportDiff {
     const NAME: &'static str = "Forest.ChainExportDiff";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Exports a diff between two chain states to a file.");
     const PARAM_NAMES: [&'static str; 1] = ["params"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -612,6 +624,8 @@ impl RpcMethod<1> for ForestChainExportDiff {
 pub enum ChainExport {}
 impl RpcMethod<1> for ChainExport {
     const NAME: &'static str = "Filecoin.ChainExport";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Exports the chain state to a CAR file.");
     const PARAM_NAMES: [&'static str; 1] = ["params"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -703,6 +717,9 @@ impl RpcMethod<1> for ChainHasObj {
 pub enum ChainStatObj {}
 impl RpcMethod<2> for ChainStatObj {
     const NAME: &'static str = "Filecoin.ChainStatObj";
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Returns statistics about the DAG rooted at the given CID, optionally diffed against a base CID.",
+    );
     const PARAM_NAMES: [&'static str; 2] = ["obj_cid", "base_cid"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -932,6 +949,8 @@ impl RpcMethod<2> for ChainGetTipSetAfterHeight {
 pub enum ChainGetGenesis {}
 impl RpcMethod<0> for ChainGetGenesis {
     const NAME: &'static str = "Filecoin.ChainGetGenesis";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the genesis tipset of the chain.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -1264,6 +1283,8 @@ impl RpcMethod<0> for ChainGetTipSetFinalityStatus {
 pub enum ChainSetHead {}
 impl RpcMethod<1> for ChainSetHead {
     const NAME: &'static str = "Filecoin.ChainSetHead";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Forcefully sets the current chain head to the specified tipset.");
     const PARAM_NAMES: [&'static str; 1] = ["tsk"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Admin;
@@ -1297,6 +1318,8 @@ impl RpcMethod<1> for ChainSetHead {
 pub enum ChainGetMinBaseFee {}
 impl RpcMethod<1> for ChainGetMinBaseFee {
     const NAME: &'static str = "Forest.ChainGetMinBaseFee";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the minimum base fee over the given number of recent epochs.");
     const PARAM_NAMES: [&'static str; 1] = ["lookback"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -1351,6 +1374,8 @@ impl RpcMethod<1> for ChainTipSetWeight {
 pub enum ChainGetTipsetByParentState {}
 impl RpcMethod<1> for ChainGetTipsetByParentState {
     const NAME: &'static str = "Forest.ChainGetTipsetByParentState";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the tipset whose parent state root matches the given CID.");
     const PARAM_NAMES: [&'static str; 1] = ["parentState"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -537,8 +537,7 @@ impl RpcMethod<0> for ForestChainExportStatus {
 pub enum ForestChainExportCancel {}
 impl RpcMethod<0> for ForestChainExportCancel {
     const NAME: &'static str = "Forest.ChainExportCancel";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Cancels an in-progress chain export.");
+    const DESCRIPTION: Option<&'static str> = Some("Cancels an in-progress chain export.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -624,8 +623,7 @@ impl RpcMethod<1> for ForestChainExportDiff {
 pub enum ChainExport {}
 impl RpcMethod<1> for ChainExport {
     const NAME: &'static str = "Filecoin.ChainExport";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Exports the chain state to a CAR file.");
+    const DESCRIPTION: Option<&'static str> = Some("Exports the chain state to a CAR file.");
     const PARAM_NAMES: [&'static str; 1] = ["params"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -949,8 +947,7 @@ impl RpcMethod<2> for ChainGetTipSetAfterHeight {
 pub enum ChainGetGenesis {}
 impl RpcMethod<0> for ChainGetGenesis {
     const NAME: &'static str = "Filecoin.ChainGetGenesis";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the genesis tipset of the chain.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the genesis tipset of the chain.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/common.rs
+++ b/src/rpc/methods/common.rs
@@ -33,8 +33,7 @@ impl RpcMethod<0> for Session {
 pub enum Version {}
 impl RpcMethod<0> for Version {
     const NAME: &'static str = "Filecoin.Version";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the version of the node and its API.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the version of the node and its API.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -61,8 +60,7 @@ impl RpcMethod<0> for Version {
 pub enum Shutdown {}
 impl RpcMethod<0> for Shutdown {
     const NAME: &'static str = "Filecoin.Shutdown";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Triggers a graceful shutdown of the node.");
+    const DESCRIPTION: Option<&'static str> = Some("Triggers a graceful shutdown of the node.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Admin;

--- a/src/rpc/methods/common.rs
+++ b/src/rpc/methods/common.rs
@@ -16,6 +16,8 @@ static SESSION_UUID: LazyLock<Uuid> = LazyLock::new(crate::utils::rand::new_uuid
 pub enum Session {}
 impl RpcMethod<0> for Session {
     const NAME: &'static str = "Filecoin.Session";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns a UUID that uniquely identifies the API node session.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -31,6 +33,8 @@ impl RpcMethod<0> for Session {
 pub enum Version {}
 impl RpcMethod<0> for Version {
     const NAME: &'static str = "Filecoin.Version";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the version of the node and its API.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -57,6 +61,8 @@ impl RpcMethod<0> for Version {
 pub enum Shutdown {}
 impl RpcMethod<0> for Shutdown {
     const NAME: &'static str = "Filecoin.Shutdown";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Triggers a graceful shutdown of the node.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Admin;
@@ -77,6 +83,8 @@ impl RpcMethod<0> for Shutdown {
 pub enum StartTime {}
 impl RpcMethod<0> for StartTime {
     const NAME: &'static str = "Filecoin.StartTime";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the time at which the node was started.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -758,6 +758,8 @@ pub enum Web3ClientVersion {}
 impl RpcMethod<0> for Web3ClientVersion {
     const NAME: &'static str = "Filecoin.Web3ClientVersion";
     const NAME_ALIAS: Option<&'static str> = Some("web3_clientVersion");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the current client version string.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -787,6 +789,8 @@ pub enum EthAccounts {}
 impl RpcMethod<0> for EthAccounts {
     const NAME: &'static str = "Filecoin.EthAccounts";
     const NAME_ALIAS: Option<&'static str> = Some("eth_accounts");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns a list of addresses owned by the client.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -842,6 +846,8 @@ pub enum EthBlockNumber {}
 impl RpcMethod<0> for EthBlockNumber {
     const NAME: &'static str = "Filecoin.EthBlockNumber";
     const NAME_ALIAS: Option<&'static str> = Some("eth_blockNumber");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the number of the most recent block.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -878,6 +884,8 @@ pub enum EthChainId {}
 impl RpcMethod<0> for EthChainId {
     const NAME: &'static str = "Filecoin.EthChainId";
     const NAME_ALIAS: Option<&'static str> = Some("eth_chainId");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the chain ID used for signing EIP-155 transactions.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -1391,6 +1399,8 @@ pub enum EthGetBlockByHash {}
 impl RpcMethod<2> for EthGetBlockByHash {
     const NAME: &'static str = "Filecoin.EthGetBlockByHash";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getBlockByHash");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the block with the given hash.");
     const PARAM_NAMES: [&'static str; 2] = ["blockHash", "fullTxInfo"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -1553,6 +1563,8 @@ pub enum EthGetBlockTransactionCountByHash {}
 impl RpcMethod<1> for EthGetBlockTransactionCountByHash {
     const NAME: &'static str = "Filecoin.EthGetBlockTransactionCountByHash";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getBlockTransactionCountByHash");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the number of transactions in the block with the given hash.");
     const PARAM_NAMES: [&'static str; 1] = ["blockHash"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -1608,6 +1620,9 @@ pub enum EthGetMessageCidByTransactionHash {}
 impl RpcMethod<1> for EthGetMessageCidByTransactionHash {
     const NAME: &'static str = "Filecoin.EthGetMessageCidByTransactionHash";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getMessageCidByTransactionHash");
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Returns the Filecoin message CID corresponding to the given Ethereum transaction hash.",
+    );
     const PARAM_NAMES: [&'static str; 1] = ["txHash"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -1669,6 +1684,8 @@ pub enum EthSyncing {}
 impl RpcMethod<0> for EthSyncing {
     const NAME: &'static str = "Filecoin.EthSyncing";
     const NAME_ALIAS: Option<&'static str> = Some("eth_syncing");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the sync status of the node, or false if it is fully synced.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -1715,6 +1732,8 @@ pub enum EthEstimateGas {}
 impl RpcMethod<2> for EthEstimateGas {
     const NAME: &'static str = "Filecoin.EthEstimateGas";
     const NAME_ALIAS: Option<&'static str> = Some("eth_estimateGas");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Estimates the gas needed to execute the given transaction.");
     const N_REQUIRED_PARAMS: usize = 1;
     const PARAM_NAMES: [&'static str; 2] = ["tx", "blockParam"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
@@ -1903,6 +1922,8 @@ pub enum EthFeeHistory {}
 impl RpcMethod<3> for EthFeeHistory {
     const NAME: &'static str = "Filecoin.EthFeeHistory";
     const NAME_ALIAS: Option<&'static str> = Some("eth_feeHistory");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns historical gas fee data for the given block range.");
     const N_REQUIRED_PARAMS: usize = 2;
     const PARAM_NAMES: [&'static str; 3] = ["blockCount", "newestBlockNumber", "rewardPercentiles"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
@@ -2234,6 +2255,8 @@ pub enum EthGetTransactionCount {}
 impl RpcMethod<2> for EthGetTransactionCount {
     const NAME: &'static str = "Filecoin.EthGetTransactionCount";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getTransactionCount");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the number of transactions sent from the given address.");
     const PARAM_NAMES: [&'static str; 2] = ["sender", "blockParam"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2290,6 +2313,8 @@ pub enum EthMaxPriorityFeePerGas {}
 impl RpcMethod<0> for EthMaxPriorityFeePerGas {
     const NAME: &'static str = "Filecoin.EthMaxPriorityFeePerGas";
     const NAME_ALIAS: Option<&'static str> = Some("eth_maxPriorityFeePerGas");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the current maximum priority fee per gas in attoFIL.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2313,6 +2338,8 @@ pub enum EthProtocolVersion {}
 impl RpcMethod<0> for EthProtocolVersion {
     const NAME: &'static str = "Filecoin.EthProtocolVersion";
     const NAME_ALIAS: Option<&'static str> = Some("eth_protocolVersion");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the current Ethereum protocol version.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2385,6 +2412,8 @@ pub enum EthGetTransactionByBlockHashAndIndex {}
 impl RpcMethod<2> for EthGetTransactionByBlockHashAndIndex {
     const NAME: &'static str = "Filecoin.EthGetTransactionByBlockHashAndIndex";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getTransactionByBlockHashAndIndex");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns a transaction by block hash and transaction index.");
     const PARAM_NAMES: [&'static str; 2] = ["blockHash", "txIndex"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2429,6 +2458,8 @@ pub enum EthGetTransactionByHash {}
 impl RpcMethod<1> for EthGetTransactionByHash {
     const NAME: &'static str = "Filecoin.EthGetTransactionByHash";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getTransactionByHash");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns a transaction by its hash.");
     const PARAM_NAMES: [&'static str; 1] = ["txHash"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2449,6 +2480,9 @@ pub enum EthGetTransactionByHashLimited {}
 impl RpcMethod<2> for EthGetTransactionByHashLimited {
     const NAME: &'static str = "Filecoin.EthGetTransactionByHashLimited";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getTransactionByHashLimited");
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Returns a transaction by its hash, limited to a specified number of lookback epochs.",
+    );
     const PARAM_NAMES: [&'static str; 2] = ["txHash", "limit"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2523,6 +2557,9 @@ pub enum EthGetTransactionHashByCid {}
 impl RpcMethod<1> for EthGetTransactionHashByCid {
     const NAME: &'static str = "Filecoin.EthGetTransactionHashByCid";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getTransactionHashByCid");
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Returns the Ethereum transaction hash corresponding to the given Filecoin message CID.",
+    );
     const PARAM_NAMES: [&'static str; 1] = ["cid"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2565,6 +2602,8 @@ pub enum EthCall {}
 impl RpcMethod<2> for EthCall {
     const NAME: &'static str = "Filecoin.EthCall";
     const NAME_ALIAS: Option<&'static str> = Some("eth_call");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Executes a message call immediately without creating a transaction.");
     const N_REQUIRED_PARAMS: usize = 2;
     const PARAM_NAMES: [&'static str; 2] = ["tx", "blockParam"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
@@ -2606,6 +2645,8 @@ pub enum EthNewFilter {}
 impl RpcMethod<1> for EthNewFilter {
     const NAME: &'static str = "Filecoin.EthNewFilter";
     const NAME_ALIAS: Option<&'static str> = Some("eth_newFilter");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Creates a filter object based on filter options.");
     const PARAM_NAMES: [&'static str; 1] = ["filterSpec"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2628,6 +2669,8 @@ pub enum EthNewPendingTransactionFilter {}
 impl RpcMethod<0> for EthNewPendingTransactionFilter {
     const NAME: &'static str = "Filecoin.EthNewPendingTransactionFilter";
     const NAME_ALIAS: Option<&'static str> = Some("eth_newPendingTransactionFilter");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Creates a filter that notifies when new pending transactions arrive.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2649,6 +2692,8 @@ pub enum EthNewBlockFilter {}
 impl RpcMethod<0> for EthNewBlockFilter {
     const NAME: &'static str = "Filecoin.EthNewBlockFilter";
     const NAME_ALIAS: Option<&'static str> = Some("eth_newBlockFilter");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Creates a filter that notifies when a new block is added.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2671,6 +2716,8 @@ pub enum EthUninstallFilter {}
 impl RpcMethod<1> for EthUninstallFilter {
     const NAME: &'static str = "Filecoin.EthUninstallFilter";
     const NAME_ALIAS: Option<&'static str> = Some("eth_uninstallFilter");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Removes the filter with the given ID.");
     const PARAM_NAMES: [&'static str; 1] = ["filterId"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2693,6 +2740,8 @@ pub enum EthUnsubscribe {}
 impl RpcMethod<0> for EthUnsubscribe {
     const NAME: &'static str = "Filecoin.EthUnsubscribe";
     const NAME_ALIAS: Option<&'static str> = Some("eth_unsubscribe");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Cancels the subscription with the given ID.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2719,6 +2768,8 @@ pub enum EthSubscribe {}
 impl RpcMethod<0> for EthSubscribe {
     const NAME: &'static str = "Filecoin.EthSubscribe";
     const NAME_ALIAS: Option<&'static str> = Some("eth_subscribe");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Creates a subscription to specified events.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2860,6 +2911,8 @@ pub enum EthGetTransactionReceipt {}
 impl RpcMethod<1> for EthGetTransactionReceipt {
     const NAME: &'static str = "Filecoin.EthGetTransactionReceipt";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getTransactionReceipt");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the receipt of a transaction by its hash.");
     const N_REQUIRED_PARAMS: usize = 1;
     const PARAM_NAMES: [&'static str; 1] = ["txHash"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
@@ -2879,6 +2932,9 @@ pub enum EthGetTransactionReceiptLimited {}
 impl RpcMethod<2> for EthGetTransactionReceiptLimited {
     const NAME: &'static str = "Filecoin.EthGetTransactionReceiptLimited";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getTransactionReceiptLimited");
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Returns the receipt of a transaction by its hash, limited to a specified number of lookback epochs.",
+    );
     const N_REQUIRED_PARAMS: usize = 1;
     const PARAM_NAMES: [&'static str; 2] = ["txHash", "limit"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
@@ -2898,6 +2954,8 @@ pub enum EthSendRawTransaction {}
 impl RpcMethod<1> for EthSendRawTransaction {
     const NAME: &'static str = "Filecoin.EthSendRawTransaction";
     const NAME_ALIAS: Option<&'static str> = Some("eth_sendRawTransaction");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Submits a signed transaction to the network.");
     const PARAM_NAMES: [&'static str; 1] = ["rawTx"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2921,6 +2979,8 @@ pub enum EthSendRawTransactionUntrusted {}
 impl RpcMethod<1> for EthSendRawTransactionUntrusted {
     const NAME: &'static str = "Filecoin.EthSendRawTransactionUntrusted";
     const NAME_ALIAS: Option<&'static str> = Some("eth_sendRawTransactionUntrusted");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Submits a signed transaction to the network without trusted sender verification.");
     const PARAM_NAMES: [&'static str; 1] = ["rawTx"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -3183,6 +3243,8 @@ pub enum EthGetLogs {}
 impl RpcMethod<1> for EthGetLogs {
     const NAME: &'static str = "Filecoin.EthGetLogs";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getLogs");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns logs matching the given filter criteria.");
     const N_REQUIRED_PARAMS: usize = 1;
     const PARAM_NAMES: [&'static str; 1] = ["ethFilter"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
@@ -3218,6 +3280,8 @@ pub enum EthGetFilterLogs {}
 impl RpcMethod<1> for EthGetFilterLogs {
     const NAME: &'static str = "Filecoin.EthGetFilterLogs";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getFilterLogs");
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns logs matching the given filter.");
     const N_REQUIRED_PARAMS: usize = 1;
     const PARAM_NAMES: [&'static str; 1] = ["filterId"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -758,8 +758,7 @@ pub enum Web3ClientVersion {}
 impl RpcMethod<0> for Web3ClientVersion {
     const NAME: &'static str = "Filecoin.Web3ClientVersion";
     const NAME_ALIAS: Option<&'static str> = Some("web3_clientVersion");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the current client version string.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the current client version string.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -846,8 +845,7 @@ pub enum EthBlockNumber {}
 impl RpcMethod<0> for EthBlockNumber {
     const NAME: &'static str = "Filecoin.EthBlockNumber";
     const NAME_ALIAS: Option<&'static str> = Some("eth_blockNumber");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the number of the most recent block.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the number of the most recent block.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -1399,8 +1397,7 @@ pub enum EthGetBlockByHash {}
 impl RpcMethod<2> for EthGetBlockByHash {
     const NAME: &'static str = "Filecoin.EthGetBlockByHash";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getBlockByHash");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the block with the given hash.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the block with the given hash.");
     const PARAM_NAMES: [&'static str; 2] = ["blockHash", "fullTxInfo"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2458,8 +2455,7 @@ pub enum EthGetTransactionByHash {}
 impl RpcMethod<1> for EthGetTransactionByHash {
     const NAME: &'static str = "Filecoin.EthGetTransactionByHash";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getTransactionByHash");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns a transaction by its hash.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns a transaction by its hash.");
     const PARAM_NAMES: [&'static str; 1] = ["txHash"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2716,8 +2712,7 @@ pub enum EthUninstallFilter {}
 impl RpcMethod<1> for EthUninstallFilter {
     const NAME: &'static str = "Filecoin.EthUninstallFilter";
     const NAME_ALIAS: Option<&'static str> = Some("eth_uninstallFilter");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Removes the filter with the given ID.");
+    const DESCRIPTION: Option<&'static str> = Some("Removes the filter with the given ID.");
     const PARAM_NAMES: [&'static str; 1] = ["filterId"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2740,8 +2735,7 @@ pub enum EthUnsubscribe {}
 impl RpcMethod<0> for EthUnsubscribe {
     const NAME: &'static str = "Filecoin.EthUnsubscribe";
     const NAME_ALIAS: Option<&'static str> = Some("eth_unsubscribe");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Cancels the subscription with the given ID.");
+    const DESCRIPTION: Option<&'static str> = Some("Cancels an active subscription.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2768,8 +2762,7 @@ pub enum EthSubscribe {}
 impl RpcMethod<0> for EthSubscribe {
     const NAME: &'static str = "Filecoin.EthSubscribe";
     const NAME_ALIAS: Option<&'static str> = Some("eth_subscribe");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Creates a subscription to specified events.");
+    const DESCRIPTION: Option<&'static str> = Some("Creates an event subscription.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -2954,8 +2947,7 @@ pub enum EthSendRawTransaction {}
 impl RpcMethod<1> for EthSendRawTransaction {
     const NAME: &'static str = "Filecoin.EthSendRawTransaction";
     const NAME_ALIAS: Option<&'static str> = Some("eth_sendRawTransaction");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Submits a signed transaction to the network.");
+    const DESCRIPTION: Option<&'static str> = Some("Submits a signed transaction to the network.");
     const PARAM_NAMES: [&'static str; 1] = ["rawTx"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -3280,8 +3272,7 @@ pub enum EthGetFilterLogs {}
 impl RpcMethod<1> for EthGetFilterLogs {
     const NAME: &'static str = "Filecoin.EthGetFilterLogs";
     const NAME_ALIAS: Option<&'static str> = Some("eth_getFilterLogs");
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns logs matching the given filter.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns logs matching the given filter.");
     const N_REQUIRED_PARAMS: usize = 1;
     const PARAM_NAMES: [&'static str; 1] = ["filterId"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();

--- a/src/rpc/methods/f3.rs
+++ b/src/rpc/methods/f3.rs
@@ -57,6 +57,8 @@ pub enum GetRawNetworkName {}
 
 impl RpcMethod<0> for GetRawNetworkName {
     const NAME: &'static str = "F3.GetRawNetworkName";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the raw network name used by the F3 sidecar.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -82,6 +84,8 @@ impl RpcMethod<0> for GetRawNetworkName {
 pub enum GetTipsetByEpoch {}
 impl RpcMethod<1> for GetTipsetByEpoch {
     const NAME: &'static str = "F3.GetTipsetByEpoch";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the tipset at or before the given epoch.");
     const PARAM_NAMES: [&'static str; 1] = ["epoch"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -106,6 +110,8 @@ impl RpcMethod<1> for GetTipsetByEpoch {
 pub enum GetTipset {}
 impl RpcMethod<1> for GetTipset {
     const NAME: &'static str = "F3.GetTipset";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the tipset for the given F3 tipset key.");
     const PARAM_NAMES: [&'static str; 1] = ["tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -127,6 +133,8 @@ impl RpcMethod<1> for GetTipset {
 pub enum GetHead {}
 impl RpcMethod<0> for GetHead {
     const NAME: &'static str = "F3.GetHead";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the current chain head as an F3 tipset.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -146,6 +154,8 @@ impl RpcMethod<0> for GetHead {
 pub enum GetParent {}
 impl RpcMethod<1> for GetParent {
     const NAME: &'static str = "F3.GetParent";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the parent tipset of the given F3 tipset.");
     const PARAM_NAMES: [&'static str; 1] = ["tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -435,6 +445,8 @@ impl GetPowerTable {
 
 impl RpcMethod<1> for GetPowerTable {
     const NAME: &'static str = "F3.GetPowerTable";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the power table for the given F3 tipset.");
     const PARAM_NAMES: [&'static str; 1] = ["tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -459,6 +471,8 @@ impl RpcMethod<1> for GetPowerTable {
 pub enum ProtectPeer {}
 impl RpcMethod<1> for ProtectPeer {
     const NAME: &'static str = "F3.ProtectPeer";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Marks the specified peer as protected from connection pruning.");
     const PARAM_NAMES: [&'static str; 1] = ["peer_id"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -487,6 +501,8 @@ pub enum GetParticipatingMinerIDs {}
 
 impl RpcMethod<0> for GetParticipatingMinerIDs {
     const NAME: &'static str = "F3.GetParticipatingMinerIDs";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the IDs of miners currently participating in F3.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -511,6 +527,8 @@ impl RpcMethod<0> for GetParticipatingMinerIDs {
 pub enum Finalize {}
 impl RpcMethod<1> for Finalize {
     const NAME: &'static str = "F3.Finalize";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Signals finalization of an F3 instance at the given tipset.");
     const PARAM_NAMES: [&'static str; 1] = ["tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Write;
@@ -591,6 +609,8 @@ impl RpcMethod<1> for Finalize {
 pub enum SignMessage {}
 impl RpcMethod<2> for SignMessage {
     const NAME: &'static str = "F3.SignMessage";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Signs a message using the key of the miner identified by the given public key.");
     const PARAM_NAMES: [&'static str; 2] = ["pubkey", "message"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Sign;
@@ -647,6 +667,8 @@ impl RpcMethod<1> for F3ExportLatestSnapshot {
 pub enum F3GetCertificate {}
 impl RpcMethod<1> for F3GetCertificate {
     const NAME: &'static str = "Filecoin.F3GetCertificate";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the F3 finality certificate at the given instance number.");
     const PARAM_NAMES: [&'static str; 1] = ["instance"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -683,6 +705,8 @@ impl F3GetLatestCertificate {
 
 impl RpcMethod<0> for F3GetLatestCertificate {
     const NAME: &'static str = "Filecoin.F3GetLatestCertificate";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the latest F3 finality certificate.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -702,6 +726,8 @@ impl RpcMethod<0> for F3GetLatestCertificate {
 pub enum F3GetECPowerTable {}
 impl RpcMethod<1> for F3GetECPowerTable {
     const NAME: &'static str = "Filecoin.F3GetECPowerTable";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the EC power table for the given tipset.");
     const PARAM_NAMES: [&'static str; 1] = ["tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -722,6 +748,8 @@ impl RpcMethod<1> for F3GetECPowerTable {
 pub enum F3GetF3PowerTable {}
 impl RpcMethod<1> for F3GetF3PowerTable {
     const NAME: &'static str = "Filecoin.F3GetF3PowerTable";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the F3 power table for the given tipset.");
     const PARAM_NAMES: [&'static str; 1] = ["tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -782,6 +810,8 @@ impl F3IsRunning {
 
 impl RpcMethod<0> for F3IsRunning {
     const NAME: &'static str = "Filecoin.F3IsRunning";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Indicates whether the F3 subsystem is currently running.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -812,6 +842,8 @@ impl F3GetProgress {
 
 impl RpcMethod<0> for F3GetProgress {
     const NAME: &'static str = "Filecoin.F3GetProgress";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the current progress of the F3 instance.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -842,6 +874,8 @@ impl F3GetManifest {
 
 impl RpcMethod<0> for F3GetManifest {
     const NAME: &'static str = "Filecoin.F3GetManifest";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the current F3 manifest.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -862,6 +896,8 @@ impl RpcMethod<0> for F3GetManifest {
 pub enum F3ListParticipants {}
 impl RpcMethod<0> for F3ListParticipants {
     const NAME: &'static str = "Filecoin.F3ListParticipants";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the list of currently active F3 participants.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -896,6 +932,8 @@ impl F3ListParticipants {
 pub enum F3GetOrRenewParticipationTicket {}
 impl RpcMethod<3> for F3GetOrRenewParticipationTicket {
     const NAME: &'static str = "Filecoin.F3GetOrRenewParticipationTicket";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Gets or renews a participation ticket for the F3 protocol.");
     const PARAM_NAMES: [&'static str; 3] = ["miner_address", "previous_lease_ticket", "instances"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Sign;
@@ -932,6 +970,8 @@ impl RpcMethod<3> for F3GetOrRenewParticipationTicket {
 pub enum F3Participate {}
 impl RpcMethod<1> for F3Participate {
     const NAME: &'static str = "Filecoin.F3Participate";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Enrolls the caller as a participant in the F3 protocol using the given lease ticket.");
     const PARAM_NAMES: [&'static str; 1] = ["lease_ticket"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Sign;

--- a/src/rpc/methods/f3.rs
+++ b/src/rpc/methods/f3.rs
@@ -705,8 +705,7 @@ impl F3GetLatestCertificate {
 
 impl RpcMethod<0> for F3GetLatestCertificate {
     const NAME: &'static str = "Filecoin.F3GetLatestCertificate";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the latest F3 finality certificate.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the latest F3 finality certificate.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -874,8 +873,7 @@ impl F3GetManifest {
 
 impl RpcMethod<0> for F3GetManifest {
     const NAME: &'static str = "Filecoin.F3GetManifest";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the current F3 manifest.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the current F3 manifest.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -970,8 +968,9 @@ impl RpcMethod<3> for F3GetOrRenewParticipationTicket {
 pub enum F3Participate {}
 impl RpcMethod<1> for F3Participate {
     const NAME: &'static str = "Filecoin.F3Participate";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Enrolls the caller as a participant in the F3 protocol using the given lease ticket.");
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Enrolls the caller as a participant in the F3 protocol using the given lease ticket.",
+    );
     const PARAM_NAMES: [&'static str; 1] = ["lease_ticket"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Sign;

--- a/src/rpc/methods/market.rs
+++ b/src/rpc/methods/market.rs
@@ -15,6 +15,8 @@ const METHOD_ADD_BALANCE: MethodNum = 2;
 pub enum MarketAddBalance {}
 impl RpcMethod<3> for MarketAddBalance {
     const NAME: &'static str = "Filecoin.MarketAddBalance";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Adds funds to the market actor escrow for the given address.");
     const PARAM_NAMES: [&'static str; 3] = ["wallet", "address", "amount"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Sign;

--- a/src/rpc/methods/msig.rs
+++ b/src/rpc/methods/msig.rs
@@ -83,9 +83,8 @@ impl RpcMethod<2> for MsigGetPending {
 pub enum MsigGetVested {}
 impl RpcMethod<3> for MsigGetVested {
     const NAME: &'static str = "Filecoin.MsigGetVested";
-    const DESCRIPTION: Option<&'static str> = Some(
-        "Returns the amount of FIL that has vested in a multisig actor between two tipsets.",
-    );
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the amount of FIL that has vested in a multisig actor between two tipsets.");
     const PARAM_NAMES: [&'static str; 3] = ["address", "start_tsk", "end_tsk"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/msig.rs
+++ b/src/rpc/methods/msig.rs
@@ -15,6 +15,8 @@ pub enum MsigGetAvailableBalance {}
 
 impl RpcMethod<2> for MsigGetAvailableBalance {
     const NAME: &'static str = "Filecoin.MsigGetAvailableBalance";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the portion of a multisig balance that can be immediately spent.");
     const PARAM_NAMES: [&'static str; 2] = ["address", "tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -44,6 +46,8 @@ pub enum MsigGetPending {}
 
 impl RpcMethod<2> for MsigGetPending {
     const NAME: &'static str = "Filecoin.MsigGetPending";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns all pending transactions for a multisig actor.");
     const PARAM_NAMES: [&'static str; 2] = ["address", "tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -79,6 +83,9 @@ impl RpcMethod<2> for MsigGetPending {
 pub enum MsigGetVested {}
 impl RpcMethod<3> for MsigGetVested {
     const NAME: &'static str = "Filecoin.MsigGetVested";
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Returns the amount of FIL that has vested in a multisig actor between two tipsets.",
+    );
     const PARAM_NAMES: [&'static str; 3] = ["address", "start_tsk", "end_tsk"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -119,6 +126,8 @@ impl RpcMethod<3> for MsigGetVested {
 pub enum MsigGetVestingSchedule {}
 impl RpcMethod<2> for MsigGetVestingSchedule {
     const NAME: &'static str = "Filecoin.MsigGetVestingSchedule";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the vesting schedule of a multisig actor.");
     const PARAM_NAMES: [&'static str; 2] = ["address", "tsk"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/net.rs
+++ b/src/rpc/methods/net.rs
@@ -256,8 +256,7 @@ impl RpcMethod<1> for NetAgentVersion {
 pub enum NetAutoNatStatus {}
 impl RpcMethod<0> for NetAutoNatStatus {
     const NAME: &'static str = "Filecoin.NetAutoNatStatus";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the AutoNAT status of the node.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the AutoNAT status of the node.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/net.rs
+++ b/src/rpc/methods/net.rs
@@ -83,6 +83,8 @@ impl RpcMethod<0> for NetPeers {
 pub enum NetFindPeer {}
 impl RpcMethod<1> for NetFindPeer {
     const NAME: &'static str = "Filecoin.NetFindPeer";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Finds a peer by ID and returns its multiaddresses.");
     const PARAM_NAMES: [&'static str; 1] = ["peer_id"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -113,6 +115,8 @@ impl RpcMethod<1> for NetFindPeer {
 pub enum NetListening {}
 impl RpcMethod<0> for NetListening {
     const NAME: &'static str = "Filecoin.NetListening";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Indicates whether the node is currently listening for connections.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;
@@ -133,6 +137,8 @@ impl RpcMethod<0> for NetListening {
 pub enum NetInfo {}
 impl RpcMethod<0> for NetInfo {
     const NAME: &'static str = "Forest.NetInfo";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns general information about the libp2p network stack.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -250,6 +256,8 @@ impl RpcMethod<1> for NetAgentVersion {
 pub enum NetAutoNatStatus {}
 impl RpcMethod<0> for NetAutoNatStatus {
     const NAME: &'static str = "Filecoin.NetAutoNatStatus";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the AutoNAT status of the node.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -275,6 +283,8 @@ impl RpcMethod<0> for NetAutoNatStatus {
 pub enum NetVersion {}
 impl RpcMethod<0> for NetVersion {
     const NAME: &'static str = "Filecoin.NetVersion";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the current network version (chain ID) as a string.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all_with_v2();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/node.rs
+++ b/src/rpc/methods/node.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 pub enum NodeStatus {}
 impl RpcMethod<0> for NodeStatus {
     const NAME: &'static str = "Filecoin.NodeStatus";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns sync and chain health status of the node.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -142,6 +142,8 @@ impl RpcMethod<2> for StateReplay {
 pub enum StateNetworkName {}
 impl RpcMethod<0> for StateNetworkName {
     const NAME: &'static str = "Filecoin.StateNetworkName";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the human-readable name of the Filecoin network.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -1179,6 +1181,8 @@ pub enum StateGetReceipt {}
 
 impl RpcMethod<2> for StateGetReceipt {
     const NAME: &'static str = "Filecoin.StateGetReceipt";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the message receipt for the given message CID.");
     const PARAM_NAMES: [&'static str; 2] = ["cid", "tipset_key"];
     const API_PATHS: BitFlags<ApiPaths> = make_bitflags!(ApiPaths::V0); // deprecated in V1
     const PERMISSION: Permission = Permission::Read;
@@ -1204,6 +1208,8 @@ pub enum StateWaitMsgV0 {}
 
 impl RpcMethod<2> for StateWaitMsgV0 {
     const NAME: &'static str = "Filecoin.StateWaitMsg";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Searches for a message on chain, blocking until it appears, then returns its receipt.");
     const PARAM_NAMES: [&'static str; 2] = ["messageCid", "confidence"];
     const API_PATHS: BitFlags<ApiPaths> = make_bitflags!(ApiPaths::V0); // Changed in V1
     const PERMISSION: Permission = Permission::Read;
@@ -1380,6 +1386,8 @@ pub enum StateFetchRoot {}
 
 impl RpcMethod<2> for StateFetchRoot {
     const NAME: &'static str = "Forest.StateFetchRoot";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Fetches and ensures the given state root is available in the blockstore.");
     const PARAM_NAMES: [&'static str; 2] = ["root_cid", "save_to_file"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -2184,6 +2192,8 @@ pub enum StateSectorPreCommitInfoV0 {}
 
 impl RpcMethod<3> for StateSectorPreCommitInfoV0 {
     const NAME: &'static str = "Filecoin.StateSectorPreCommitInfo";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns pre-committed sector information for the given miner and sector number.");
     const PARAM_NAMES: [&'static str; 3] = ["minerAddress", "sectorNumber", "tipsetKey"];
     const API_PATHS: BitFlags<ApiPaths> = make_bitflags!(ApiPaths::V0); // Changed in V1
     const PERMISSION: Permission = Permission::Read;
@@ -3289,6 +3299,8 @@ impl TryFrom<&ChainConfig> for ForkUpgradeParams {
 pub enum StateMinerInitialPledgeForSector {}
 impl RpcMethod<4> for StateMinerInitialPledgeForSector {
     const NAME: &'static str = "Filecoin.StateMinerInitialPledgeForSector";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the initial pledge collateral required for a sector.");
     const PARAM_NAMES: [&'static str; 4] = [
         "sector_duration",
         "sector_size",

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1208,8 +1208,9 @@ pub enum StateWaitMsgV0 {}
 
 impl RpcMethod<2> for StateWaitMsgV0 {
     const NAME: &'static str = "Filecoin.StateWaitMsg";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Searches for a message on chain, blocking until it appears, then returns its receipt.");
+    const DESCRIPTION: Option<&'static str> = Some(
+        "Searches for a message on chain, blocking until it appears, then returns its receipt.",
+    );
     const PARAM_NAMES: [&'static str; 2] = ["messageCid", "confidence"];
     const API_PATHS: BitFlags<ApiPaths> = make_bitflags!(ApiPaths::V0); // Changed in V1
     const PERMISSION: Permission = Permission::Read;

--- a/src/rpc/methods/sync.rs
+++ b/src/rpc/methods/sync.rs
@@ -17,6 +17,8 @@ pub use types::*;
 pub enum SyncCheckBad {}
 impl RpcMethod<1> for SyncCheckBad {
     const NAME: &'static str = "Filecoin.SyncCheckBad";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Checks whether a block CID is in the bad block cache.");
     const PARAM_NAMES: [&'static str; 1] = ["cid"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -42,6 +44,8 @@ impl RpcMethod<1> for SyncCheckBad {
 pub enum SyncMarkBad {}
 impl RpcMethod<1> for SyncMarkBad {
     const NAME: &'static str = "Filecoin.SyncMarkBad";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Marks a block CID as bad, causing the node to ignore it.");
     const PARAM_NAMES: [&'static str; 1] = ["cid"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Admin;

--- a/src/rpc/methods/wallet.rs
+++ b/src/rpc/methods/wallet.rs
@@ -42,6 +42,8 @@ impl RpcMethod<1> for WalletBalance {
 pub enum WalletDefaultAddress {}
 impl RpcMethod<0> for WalletDefaultAddress {
     const NAME: &'static str = "Filecoin.WalletDefaultAddress";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Returns the default wallet address.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -62,6 +64,8 @@ impl RpcMethod<0> for WalletDefaultAddress {
 pub enum WalletExport {}
 impl RpcMethod<1> for WalletExport {
     const NAME: &'static str = "Filecoin.WalletExport";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Exports the key info for the given address.");
     const PARAM_NAMES: [&'static str; 1] = ["address"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Admin;
@@ -105,6 +109,8 @@ impl RpcMethod<1> for WalletHas {
 pub enum WalletImport {}
 impl RpcMethod<1> for WalletImport {
     const NAME: &'static str = "Filecoin.WalletImport";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Imports a key into the wallet and returns the associated address.");
     const PARAM_NAMES: [&'static str; 1] = ["key"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Admin;
@@ -149,6 +155,8 @@ impl RpcMethod<0> for WalletList {
 pub enum WalletNew {}
 impl RpcMethod<1> for WalletNew {
     const NAME: &'static str = "Filecoin.WalletNew";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Creates a new wallet address with the given signature type.");
     const PARAM_NAMES: [&'static str; 1] = ["signature_type"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Write;
@@ -177,6 +185,8 @@ impl RpcMethod<1> for WalletNew {
 pub enum WalletSetDefault {}
 impl RpcMethod<1> for WalletSetDefault {
     const NAME: &'static str = "Filecoin.WalletSetDefault";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Sets the default wallet address.");
     const PARAM_NAMES: [&'static str; 1] = ["address"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Write;
@@ -265,6 +275,8 @@ impl RpcMethod<2> for WalletSignMessage {
 pub enum WalletValidateAddress {}
 impl RpcMethod<1> for WalletValidateAddress {
     const NAME: &'static str = "Filecoin.WalletValidateAddress";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Validates and parses the given address string.");
     const PARAM_NAMES: [&'static str; 1] = ["address"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -284,6 +296,8 @@ impl RpcMethod<1> for WalletValidateAddress {
 pub enum WalletVerify {}
 impl RpcMethod<3> for WalletVerify {
     const NAME: &'static str = "Filecoin.WalletVerify";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Verifies a signature against the given address and data.");
     const PARAM_NAMES: [&'static str; 3] = ["address", "message", "signature"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -303,6 +317,8 @@ impl RpcMethod<3> for WalletVerify {
 pub enum WalletDelete {}
 impl RpcMethod<1> for WalletDelete {
     const NAME: &'static str = "Filecoin.WalletDelete";
+    const DESCRIPTION: Option<&'static str> =
+        Some("Deletes the key for the given address from the wallet.");
     const PARAM_NAMES: [&'static str; 1] = ["address"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Write;

--- a/src/rpc/methods/wallet.rs
+++ b/src/rpc/methods/wallet.rs
@@ -42,8 +42,7 @@ impl RpcMethod<1> for WalletBalance {
 pub enum WalletDefaultAddress {}
 impl RpcMethod<0> for WalletDefaultAddress {
     const NAME: &'static str = "Filecoin.WalletDefaultAddress";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Returns the default wallet address.");
+    const DESCRIPTION: Option<&'static str> = Some("Returns the default wallet address.");
     const PARAM_NAMES: [&'static str; 0] = [];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
@@ -64,8 +63,7 @@ impl RpcMethod<0> for WalletDefaultAddress {
 pub enum WalletExport {}
 impl RpcMethod<1> for WalletExport {
     const NAME: &'static str = "Filecoin.WalletExport";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Exports the key info for the given address.");
+    const DESCRIPTION: Option<&'static str> = Some("Exports the key info for the given address.");
     const PARAM_NAMES: [&'static str; 1] = ["address"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Admin;
@@ -185,8 +183,7 @@ impl RpcMethod<1> for WalletNew {
 pub enum WalletSetDefault {}
 impl RpcMethod<1> for WalletSetDefault {
     const NAME: &'static str = "Filecoin.WalletSetDefault";
-    const DESCRIPTION: Option<&'static str> =
-        Some("Sets the default wallet address.");
+    const DESCRIPTION: Option<&'static str> = Some("Sets the default wallet address.");
     const PARAM_NAMES: [&'static str; 1] = ["address"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Write;

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
@@ -8,6 +8,7 @@ info:
   version: 0.33.4
 methods:
   - name: Filecoin.AuthNew
+    description: Creates a new JWT token with the specified permissions.
     params:
       - name: permissions
         required: true
@@ -31,6 +32,7 @@ methods:
         $ref: "#/components/schemas/Base64String"
     paramStructure: by-position
   - name: Filecoin.AuthVerify
+    description: Verifies a JWT token and returns its permissions.
     params:
       - name: header_raw
         required: true
@@ -60,6 +62,7 @@ methods:
         $ref: "#/components/schemas/BeaconEntry"
     paramStructure: by-position
   - name: Forest.SnapshotGC
+    description: Triggers garbage collection of old snapshot data.
     params:
       - name: blocking
         required: true
@@ -72,6 +75,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.ChainExport
+    description: Exports the chain state to a CAR file.
     params:
       - name: params
         required: true
@@ -127,6 +131,7 @@ methods:
           $ref: "#/components/schemas/Event"
     paramStructure: by-position
   - name: Filecoin.ChainGetGenesis
+    description: Returns the genesis tipset of the chain.
     params: []
     result:
       name: Filecoin.ChainGetGenesis.Result
@@ -150,6 +155,7 @@ methods:
         $ref: "#/components/schemas/Message"
     paramStructure: by-position
   - name: Filecoin.ChainGetMessagesInTipset
+    description: Returns all messages included in the specified tipset.
     params:
       - name: tipsetKey
         required: true
@@ -170,6 +176,7 @@ methods:
           $ref: "#/components/schemas/ApiMessage"
     paramStructure: by-position
   - name: Forest.ChainGetMinBaseFee
+    description: Returns the minimum base fee over the given number of recent epochs.
     params:
       - name: lookback
         required: true
@@ -335,6 +342,7 @@ methods:
         $ref: "#/components/schemas/Base64String"
     paramStructure: by-position
   - name: Filecoin.ChainSetHead
+    description: Forcefully sets the current chain head to the specified tipset.
     params:
       - name: tsk
         required: true
@@ -382,6 +390,7 @@ methods:
         $ref: "#/components/schemas/BigInt"
     paramStructure: by-position
   - name: Forest.ChainExport
+    description: Exports the chain state to a file using Forest-specific parameters.
     params:
       - name: params
         required: true
@@ -394,6 +403,7 @@ methods:
         $ref: "#/components/schemas/ApiExportResult"
     paramStructure: by-position
   - name: Forest.ChainExportDiff
+    description: Exports a diff between two chain states to a file.
     params:
       - name: params
         required: true
@@ -406,6 +416,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Forest.ChainExportStatus
+    description: Returns the status of the current chain export operation.
     params: []
     result:
       name: Forest.ChainExportStatus.Result
@@ -414,6 +425,7 @@ methods:
         $ref: "#/components/schemas/ApiExportStatus"
     paramStructure: by-position
   - name: Forest.ChainExportCancel
+    description: Cancels an in-progress chain export.
     params: []
     result:
       name: Forest.ChainExportCancel.Result
@@ -422,6 +434,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Forest.ChainGetTipsetByParentState
+    description: Returns the tipset whose parent state root matches the given CID.
     params:
       - name: parentState
         required: true
@@ -436,6 +449,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.Session
+    description: Returns a UUID that uniquely identifies the API node session.
     params: []
     result:
       name: Filecoin.Session.Result
@@ -445,6 +459,7 @@ methods:
         format: uuid
     paramStructure: by-position
   - name: Filecoin.Shutdown
+    description: Triggers a graceful shutdown of the node.
     params: []
     result:
       name: Filecoin.Shutdown.Result
@@ -453,6 +468,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.StartTime
+    description: Returns the time at which the node was started.
     params: []
     result:
       name: Filecoin.StartTime.Result
@@ -462,6 +478,7 @@ methods:
         format: date-time
     paramStructure: by-position
   - name: Filecoin.Version
+    description: Returns the version of the node and its API.
     params: []
     result:
       name: Filecoin.Version.Result
@@ -470,6 +487,7 @@ methods:
         $ref: "#/components/schemas/PublicVersion"
     paramStructure: by-position
   - name: Filecoin.EthAccounts
+    description: Returns a list of addresses owned by the client.
     params: []
     result:
       name: Filecoin.EthAccounts.Result
@@ -482,6 +500,7 @@ methods:
           type: string
     paramStructure: by-position
   - name: eth_accounts
+    description: Returns a list of addresses owned by the client.
     params: []
     result:
       name: eth_accounts.Result
@@ -544,6 +563,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthBlockNumber
+    description: Returns the number of the most recent block.
     params: []
     result:
       name: Filecoin.EthBlockNumber.Result
@@ -552,6 +572,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_blockNumber
+    description: Returns the number of the most recent block.
     params: []
     result:
       name: eth_blockNumber.Result
@@ -560,6 +581,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthCall
+    description: Executes a message call immediately without creating a transaction.
     params:
       - name: tx
         required: true
@@ -576,6 +598,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: eth_call
+    description: Executes a message call immediately without creating a transaction.
     params:
       - name: tx
         required: true
@@ -592,6 +615,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthChainId
+    description: Returns the chain ID used for signing EIP-155 transactions.
     params: []
     result:
       name: Filecoin.EthChainId.Result
@@ -600,6 +624,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: eth_chainId
+    description: Returns the chain ID used for signing EIP-155 transactions.
     params: []
     result:
       name: eth_chainId.Result
@@ -608,6 +633,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.EthEstimateGas
+    description: Estimates the gas needed to execute the given transaction.
     params:
       - name: tx
         required: true
@@ -626,6 +652,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_estimateGas
+    description: Estimates the gas needed to execute the given transaction.
     params:
       - name: tx
         required: true
@@ -644,6 +671,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthFeeHistory
+    description: Returns historical gas fee data for the given block range.
     params:
       - name: blockCount
         required: true
@@ -669,6 +697,7 @@ methods:
         $ref: "#/components/schemas/EthFeeHistoryResult"
     paramStructure: by-position
   - name: eth_feeHistory
+    description: Returns historical gas fee data for the given block range.
     params:
       - name: blockCount
         required: true
@@ -746,6 +775,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthGetBlockByHash
+    description: Returns the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -762,6 +792,7 @@ methods:
         $ref: "#/components/schemas/Block"
     paramStructure: by-position
   - name: eth_getBlockByHash
+    description: Returns the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -890,6 +921,7 @@ methods:
           $ref: "#/components/schemas/EthTxReceipt"
     paramStructure: by-position
   - name: Filecoin.EthGetBlockTransactionCountByHash
+    description: Returns the number of transactions in the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -902,6 +934,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_getBlockTransactionCountByHash
+    description: Returns the number of transactions in the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -974,6 +1007,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthGetLogs
+    description: Returns logs matching the given filter criteria.
     params:
       - name: ethFilter
         required: true
@@ -986,6 +1020,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: eth_getLogs
+    description: Returns logs matching the given filter criteria.
     params:
       - name: ethFilter
         required: true
@@ -998,6 +1033,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: Filecoin.EthGetFilterLogs
+    description: Returns logs matching the given filter.
     params:
       - name: filterId
         required: true
@@ -1010,6 +1046,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: eth_getFilterLogs
+    description: Returns logs matching the given filter.
     params:
       - name: filterId
         required: true
@@ -1118,6 +1155,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionByHash
+    description: Returns a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1132,6 +1170,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionByHash
+    description: Returns a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1184,6 +1223,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionCount
+    description: Returns the number of transactions sent from the given address.
     params:
       - name: sender
         required: true
@@ -1200,6 +1240,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_getTransactionCount
+    description: Returns the number of transactions sent from the given address.
     params:
       - name: sender
         required: true
@@ -1282,6 +1323,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionByBlockHashAndIndex
+    description: Returns a transaction by block hash and transaction index.
     params:
       - name: blockHash
         required: true
@@ -1300,6 +1342,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionByBlockHashAndIndex
+    description: Returns a transaction by block hash and transaction index.
     params:
       - name: blockHash
         required: true
@@ -1318,6 +1361,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthMaxPriorityFeePerGas
+    description: Returns the current maximum priority fee per gas in attoFIL.
     params: []
     result:
       name: Filecoin.EthMaxPriorityFeePerGas.Result
@@ -1326,6 +1370,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: eth_maxPriorityFeePerGas
+    description: Returns the current maximum priority fee per gas in attoFIL.
     params: []
     result:
       name: eth_maxPriorityFeePerGas.Result
@@ -1334,6 +1379,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthProtocolVersion
+    description: Returns the current Ethereum protocol version.
     params: []
     result:
       name: Filecoin.EthProtocolVersion.Result
@@ -1342,6 +1388,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_protocolVersion
+    description: Returns the current Ethereum protocol version.
     params: []
     result:
       name: eth_protocolVersion.Result
@@ -1350,6 +1397,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionReceipt
+    description: Returns the receipt of a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1364,6 +1412,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionReceipt
+    description: Returns the receipt of a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1416,6 +1465,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthNewFilter
+    description: Creates a filter object based on filter options.
     params:
       - name: filterSpec
         required: true
@@ -1428,6 +1478,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newFilter
+    description: Creates a filter object based on filter options.
     params:
       - name: filterSpec
         required: true
@@ -1440,6 +1491,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthNewPendingTransactionFilter
+    description: Creates a filter that notifies when new pending transactions arrive.
     params: []
     result:
       name: Filecoin.EthNewPendingTransactionFilter.Result
@@ -1448,6 +1500,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newPendingTransactionFilter
+    description: Creates a filter that notifies when new pending transactions arrive.
     params: []
     result:
       name: eth_newPendingTransactionFilter.Result
@@ -1456,6 +1509,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthNewBlockFilter
+    description: Creates a filter that notifies when a new block is added.
     params: []
     result:
       name: Filecoin.EthNewBlockFilter.Result
@@ -1464,6 +1518,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newBlockFilter
+    description: Creates a filter that notifies when a new block is added.
     params: []
     result:
       name: eth_newBlockFilter.Result
@@ -1472,6 +1527,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthUninstallFilter
+    description: Removes the filter with the given ID.
     params:
       - name: filterId
         required: true
@@ -1484,6 +1540,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: eth_uninstallFilter
+    description: Removes the filter with the given ID.
     params:
       - name: filterId
         required: true
@@ -1496,6 +1553,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.EthUnsubscribe
+    description: Cancels an active subscription.
     params: []
     result:
       name: Filecoin.EthUnsubscribe.Result
@@ -1504,6 +1562,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: eth_unsubscribe
+    description: Cancels an active subscription.
     params: []
     result:
       name: eth_unsubscribe.Result
@@ -1512,6 +1571,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.EthSubscribe
+    description: Creates an event subscription.
     params: []
     result:
       name: Filecoin.EthSubscribe.Result
@@ -1520,6 +1580,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: eth_subscribe
+    description: Creates an event subscription.
     params: []
     result:
       name: eth_subscribe.Result
@@ -1528,6 +1589,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.EthSyncing
+    description: Returns the sync status of the node, or false if it is fully synced.
     params: []
     result:
       name: Filecoin.EthSyncing.Result
@@ -1536,6 +1598,7 @@ methods:
         $ref: "#/components/schemas/EthSyncingResultLotusJson"
     paramStructure: by-position
   - name: eth_syncing
+    description: Returns the sync status of the node, or false if it is fully synced.
     params: []
     result:
       name: eth_syncing.Result
@@ -1696,6 +1759,7 @@ methods:
           $ref: "#/components/schemas/EthReplayBlockTransactionTrace"
     paramStructure: by-position
   - name: Filecoin.Web3ClientVersion
+    description: Returns the current client version string.
     params: []
     result:
       name: Filecoin.Web3ClientVersion.Result
@@ -1704,6 +1768,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: web3_clientVersion
+    description: Returns the current client version string.
     params: []
     result:
       name: web3_clientVersion.Result
@@ -1712,6 +1777,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.EthSendRawTransaction
+    description: Submits a signed transaction to the network.
     params:
       - name: rawTx
         required: true
@@ -1724,6 +1790,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: eth_sendRawTransaction
+    description: Submits a signed transaction to the network.
     params:
       - name: rawTx
         required: true
@@ -1736,6 +1803,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: Filecoin.EthSendRawTransactionUntrusted
+    description: Submits a signed transaction to the network without trusted sender verification.
     params:
       - name: rawTx
         required: true
@@ -1748,6 +1816,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: eth_sendRawTransactionUntrusted
+    description: Submits a signed transaction to the network without trusted sender verification.
     params:
       - name: rawTx
         required: true
@@ -1867,6 +1936,7 @@ methods:
         $ref: "#/components/schemas/Message"
     paramStructure: by-position
   - name: Filecoin.MarketAddBalance
+    description: Adds funds to the market actor escrow for the given address.
     params:
       - name: wallet
         required: true
@@ -2075,6 +2145,7 @@ methods:
           $ref: "#/components/schemas/SignedMessage"
     paramStructure: by-position
   - name: Filecoin.MsigGetAvailableBalance
+    description: Returns the portion of a multisig balance that can be immediately spent.
     params:
       - name: address
         required: true
@@ -2095,6 +2166,7 @@ methods:
         $ref: "#/components/schemas/TokenAmount"
     paramStructure: by-position
   - name: Filecoin.MsigGetPending
+    description: Returns all pending transactions for a multisig actor.
     params:
       - name: address
         required: true
@@ -2119,6 +2191,7 @@ methods:
           $ref: "#/components/schemas/Transaction"
     paramStructure: by-position
   - name: Filecoin.MsigGetVested
+    description: Returns the amount of FIL that has vested in a multisig actor between two tipsets.
     params:
       - name: address
         required: true
@@ -2147,6 +2220,7 @@ methods:
         $ref: "#/components/schemas/BigInt"
     paramStructure: by-position
   - name: Filecoin.MsigGetVestingSchedule
+    description: Returns the vesting schedule of a multisig actor.
     params:
       - name: address
         required: true
@@ -2189,6 +2263,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.NetAutoNatStatus
+    description: Returns the AutoNAT status of the node.
     params: []
     result:
       name: Filecoin.NetAutoNatStatus.Result
@@ -2223,6 +2298,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.NetFindPeer
+    description: Finds a peer by ID and returns its multiaddresses.
     params:
       - name: peer_id
         required: true
@@ -2235,6 +2311,7 @@ methods:
         $ref: "#/components/schemas/AddrInfo"
     paramStructure: by-position
   - name: Forest.NetInfo
+    description: Returns general information about the libp2p network stack.
     params: []
     result:
       name: Forest.NetInfo.Result
@@ -2243,6 +2320,7 @@ methods:
         $ref: "#/components/schemas/NetInfoResult"
     paramStructure: by-position
   - name: Filecoin.NetListening
+    description: Indicates whether the node is currently listening for connections.
     params: []
     result:
       name: Filecoin.NetListening.Result
@@ -2251,6 +2329,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: net_listening
+    description: Indicates whether the node is currently listening for connections.
     params: []
     result:
       name: net_listening.Result
@@ -2319,6 +2398,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.NetVersion
+    description: Returns the current network version (chain ID) as a string.
     params: []
     result:
       name: Filecoin.NetVersion.Result
@@ -2327,6 +2407,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: net_version
+    description: Returns the current network version (chain ID) as a string.
     params: []
     result:
       name: net_version.Result
@@ -2364,6 +2445,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.NodeStatus
+    description: Returns sync and chain health status of the node.
     params: []
     result:
       name: Filecoin.NodeStatus.Result
@@ -2520,6 +2602,7 @@ methods:
         $ref: "#/components/schemas/DealCollateralBounds"
     paramStructure: by-position
   - name: Forest.StateFetchRoot
+    description: Fetches and ensures the given state root is available in the blockstore.
     params:
       - name: root_cid
         required: true
@@ -2890,6 +2973,7 @@ methods:
         $ref: "#/components/schemas/Base64String"
     paramStructure: by-position
   - name: Filecoin.StateGetReceipt
+    description: Returns the message receipt for the given message CID.
     params:
       - name: cid
         required: true
@@ -3463,6 +3547,7 @@ methods:
           $ref: "#/components/schemas/SectorOnChainInfo"
     paramStructure: by-position
   - name: Filecoin.StateNetworkName
+    description: Returns the human-readable name of the Filecoin network.
     params: []
     result:
       name: Filecoin.StateNetworkName.Result
@@ -3704,6 +3789,7 @@ methods:
         $ref: "#/components/schemas/SectorLocation"
     paramStructure: by-position
   - name: Filecoin.StateSectorPreCommitInfo
+    description: Returns pre-committed sector information for the given miner and sector number.
     params:
       - name: minerAddress
         required: true
@@ -3827,6 +3913,7 @@ methods:
         $ref: "#/components/schemas/MessageLookup"
     paramStructure: by-position
   - name: Filecoin.StateMinerInitialPledgeForSector
+    description: Returns the initial pledge collateral required for a sector.
     params:
       - name: sector_duration
         required: true
@@ -3858,6 +3945,7 @@ methods:
         $ref: "#/components/schemas/TokenAmount"
     paramStructure: by-position
   - name: Filecoin.SyncCheckBad
+    description: Checks whether a block CID is in the bad block cache.
     params:
       - name: cid
         required: true
@@ -3870,6 +3958,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.SyncMarkBad
+    description: Marks a block CID as bad, causing the node to ignore it.
     params:
       - name: cid
         required: true
@@ -3926,6 +4015,7 @@ methods:
         $ref: "#/components/schemas/TokenAmount"
     paramStructure: by-position
   - name: Filecoin.WalletDefaultAddress
+    description: Returns the default wallet address.
     params: []
     result:
       name: Filecoin.WalletDefaultAddress.Result
@@ -3936,6 +4026,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.WalletDelete
+    description: Deletes the key for the given address from the wallet.
     params:
       - name: address
         required: true
@@ -3948,6 +4039,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.WalletExport
+    description: Exports the key info for the given address.
     params:
       - name: address
         required: true
@@ -3973,6 +4065,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.WalletImport
+    description: Imports a key into the wallet and returns the associated address.
     params:
       - name: key
         required: true
@@ -3998,6 +4091,7 @@ methods:
           $ref: "#/components/schemas/Address"
     paramStructure: by-position
   - name: Filecoin.WalletNew
+    description: Creates a new wallet address with the given signature type.
     params:
       - name: signature_type
         required: true
@@ -4010,6 +4104,7 @@ methods:
         $ref: "#/components/schemas/Address"
     paramStructure: by-position
   - name: Filecoin.WalletSetDefault
+    description: Sets the default wallet address.
     params:
       - name: address
         required: true
@@ -4056,6 +4151,7 @@ methods:
         $ref: "#/components/schemas/SignedMessage"
     paramStructure: by-position
   - name: Filecoin.WalletValidateAddress
+    description: Validates and parses the given address string.
     params:
       - name: address
         required: true
@@ -4068,6 +4164,7 @@ methods:
         $ref: "#/components/schemas/Address"
     paramStructure: by-position
   - name: Filecoin.WalletVerify
+    description: Verifies a signature against the given address and data.
     params:
       - name: address
         required: true
@@ -4088,6 +4185,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: F3.GetRawNetworkName
+    description: Returns the raw network name used by the F3 sidecar.
     params: []
     result:
       name: F3.GetRawNetworkName.Result
@@ -4096,6 +4194,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.F3GetCertificate
+    description: Returns the F3 finality certificate at the given instance number.
     params:
       - name: instance
         required: true
@@ -4110,6 +4209,7 @@ methods:
         $ref: "#/components/schemas/FinalityCertificate"
     paramStructure: by-position
   - name: Filecoin.F3GetECPowerTable
+    description: Returns the EC power table for the given tipset.
     params:
       - name: tipset_key
         required: true
@@ -4130,6 +4230,7 @@ methods:
           $ref: "#/components/schemas/F3PowerEntryLotusJson"
     paramStructure: by-position
   - name: Filecoin.F3GetF3PowerTable
+    description: Returns the F3 power table for the given tipset.
     params:
       - name: tipset_key
         required: true
@@ -4169,6 +4270,7 @@ methods:
           $ref: "#/components/schemas/F3PowerEntryLotusJson"
     paramStructure: by-position
   - name: Filecoin.F3IsRunning
+    description: Indicates whether the F3 subsystem is currently running.
     params: []
     result:
       name: Filecoin.F3IsRunning.Result
@@ -4177,6 +4279,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.F3GetProgress
+    description: Returns the current progress of the F3 instance.
     params: []
     result:
       name: Filecoin.F3GetProgress.Result
@@ -4185,6 +4288,7 @@ methods:
         $ref: "#/components/schemas/F3InstanceProgress"
     paramStructure: by-position
   - name: Filecoin.F3GetManifest
+    description: Returns the current F3 manifest.
     params: []
     result:
       name: Filecoin.F3GetManifest.Result
@@ -4193,6 +4297,7 @@ methods:
         $ref: "#/components/schemas/F3Manifest"
     paramStructure: by-position
   - name: Filecoin.F3ListParticipants
+    description: Returns the list of currently active F3 participants.
     params: []
     result:
       name: Filecoin.F3ListParticipants.Result
@@ -4205,6 +4310,7 @@ methods:
           $ref: "#/components/schemas/F3Participant"
     paramStructure: by-position
   - name: Filecoin.F3GetLatestCertificate
+    description: Returns the latest F3 finality certificate.
     params: []
     result:
       name: Filecoin.F3GetLatestCertificate.Result
@@ -4213,6 +4319,7 @@ methods:
         $ref: "#/components/schemas/FinalityCertificate"
     paramStructure: by-position
   - name: Filecoin.F3GetOrRenewParticipationTicket
+    description: Gets or renews a participation ticket for the F3 protocol.
     params:
       - name: miner_address
         required: true
@@ -4260,6 +4367,7 @@ methods:
         $ref: "#/components/schemas/Cid"
     paramStructure: by-position
   - name: F3.GetHead
+    description: Returns the current chain head as an F3 tipset.
     params: []
     result:
       name: F3.GetHead.Result
@@ -4268,6 +4376,7 @@ methods:
         $ref: "#/components/schemas/F3TipSet"
     paramStructure: by-position
   - name: F3.GetParent
+    description: Returns the parent tipset of the given F3 tipset.
     params:
       - name: tipset_key
         required: true
@@ -4280,6 +4389,7 @@ methods:
         $ref: "#/components/schemas/F3TipSet"
     paramStructure: by-position
   - name: F3.GetParticipatingMinerIDs
+    description: Returns the IDs of miners currently participating in F3.
     params: []
     result:
       name: F3.GetParticipatingMinerIDs.Result
@@ -4294,6 +4404,7 @@ methods:
           minimum: 0
     paramStructure: by-position
   - name: F3.GetPowerTable
+    description: Returns the power table for the given F3 tipset.
     params:
       - name: tipset_key
         required: true
@@ -4310,6 +4421,7 @@ methods:
           $ref: "#/components/schemas/F3PowerEntryLotusJson"
     paramStructure: by-position
   - name: F3.GetTipset
+    description: Returns the tipset for the given F3 tipset key.
     params:
       - name: tipset_key
         required: true
@@ -4322,6 +4434,7 @@ methods:
         $ref: "#/components/schemas/F3TipSet"
     paramStructure: by-position
   - name: F3.GetTipsetByEpoch
+    description: Returns the tipset at or before the given epoch.
     params:
       - name: epoch
         required: true
@@ -4335,6 +4448,7 @@ methods:
         $ref: "#/components/schemas/F3TipSet"
     paramStructure: by-position
   - name: F3.Finalize
+    description: Signals finalization of an F3 instance at the given tipset.
     params:
       - name: tipset_key
         required: true
@@ -4347,6 +4461,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: F3.ProtectPeer
+    description: Marks the specified peer as protected from connection pruning.
     params:
       - name: peer_id
         required: true
@@ -4359,6 +4474,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: F3.SignMessage
+    description: Signs a message using the key of the miner identified by the given public key.
     params:
       - name: pubkey
         required: true

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
@@ -8,6 +8,7 @@ info:
   version: 0.33.4
 methods:
   - name: Filecoin.AuthNew
+    description: Creates a new JWT token with the specified permissions.
     params:
       - name: permissions
         required: true
@@ -31,6 +32,7 @@ methods:
         $ref: "#/components/schemas/Base64String"
     paramStructure: by-position
   - name: Filecoin.AuthVerify
+    description: Verifies a JWT token and returns its permissions.
     params:
       - name: header_raw
         required: true
@@ -47,6 +49,7 @@ methods:
           type: string
     paramStructure: by-position
   - name: Forest.SnapshotGC
+    description: Triggers garbage collection of old snapshot data.
     params:
       - name: blocking
         required: true
@@ -59,6 +62,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.ChainExport
+    description: Exports the chain state to a CAR file.
     params:
       - name: params
         required: true
@@ -114,6 +118,7 @@ methods:
           $ref: "#/components/schemas/Event"
     paramStructure: by-position
   - name: Filecoin.ChainGetGenesis
+    description: Returns the genesis tipset of the chain.
     params: []
     result:
       name: Filecoin.ChainGetGenesis.Result
@@ -146,6 +151,7 @@ methods:
         $ref: "#/components/schemas/Message"
     paramStructure: by-position
   - name: Filecoin.ChainGetMessagesInTipset
+    description: Returns all messages included in the specified tipset.
     params:
       - name: tipsetKey
         required: true
@@ -166,6 +172,7 @@ methods:
           $ref: "#/components/schemas/ApiMessage"
     paramStructure: by-position
   - name: Forest.ChainGetMinBaseFee
+    description: Returns the minimum base fee over the given number of recent epochs.
     params:
       - name: lookback
         required: true
@@ -331,6 +338,7 @@ methods:
         $ref: "#/components/schemas/Base64String"
     paramStructure: by-position
   - name: Filecoin.ChainSetHead
+    description: Forcefully sets the current chain head to the specified tipset.
     params:
       - name: tsk
         required: true
@@ -378,6 +386,7 @@ methods:
         $ref: "#/components/schemas/BigInt"
     paramStructure: by-position
   - name: Forest.ChainExport
+    description: Exports the chain state to a file using Forest-specific parameters.
     params:
       - name: params
         required: true
@@ -390,6 +399,7 @@ methods:
         $ref: "#/components/schemas/ApiExportResult"
     paramStructure: by-position
   - name: Forest.ChainExportDiff
+    description: Exports a diff between two chain states to a file.
     params:
       - name: params
         required: true
@@ -402,6 +412,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Forest.ChainExportStatus
+    description: Returns the status of the current chain export operation.
     params: []
     result:
       name: Forest.ChainExportStatus.Result
@@ -410,6 +421,7 @@ methods:
         $ref: "#/components/schemas/ApiExportStatus"
     paramStructure: by-position
   - name: Forest.ChainExportCancel
+    description: Cancels an in-progress chain export.
     params: []
     result:
       name: Forest.ChainExportCancel.Result
@@ -418,6 +430,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Forest.ChainGetTipsetByParentState
+    description: Returns the tipset whose parent state root matches the given CID.
     params:
       - name: parentState
         required: true
@@ -432,6 +445,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.Session
+    description: Returns a UUID that uniquely identifies the API node session.
     params: []
     result:
       name: Filecoin.Session.Result
@@ -441,6 +455,7 @@ methods:
         format: uuid
     paramStructure: by-position
   - name: Filecoin.Shutdown
+    description: Triggers a graceful shutdown of the node.
     params: []
     result:
       name: Filecoin.Shutdown.Result
@@ -449,6 +464,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.StartTime
+    description: Returns the time at which the node was started.
     params: []
     result:
       name: Filecoin.StartTime.Result
@@ -458,6 +474,7 @@ methods:
         format: date-time
     paramStructure: by-position
   - name: Filecoin.Version
+    description: Returns the version of the node and its API.
     params: []
     result:
       name: Filecoin.Version.Result
@@ -466,6 +483,7 @@ methods:
         $ref: "#/components/schemas/PublicVersion"
     paramStructure: by-position
   - name: Filecoin.EthAccounts
+    description: Returns a list of addresses owned by the client.
     params: []
     result:
       name: Filecoin.EthAccounts.Result
@@ -478,6 +496,7 @@ methods:
           type: string
     paramStructure: by-position
   - name: eth_accounts
+    description: Returns a list of addresses owned by the client.
     params: []
     result:
       name: eth_accounts.Result
@@ -540,6 +559,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthBlockNumber
+    description: Returns the number of the most recent block.
     params: []
     result:
       name: Filecoin.EthBlockNumber.Result
@@ -548,6 +568,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_blockNumber
+    description: Returns the number of the most recent block.
     params: []
     result:
       name: eth_blockNumber.Result
@@ -556,6 +577,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthCall
+    description: Executes a message call immediately without creating a transaction.
     params:
       - name: tx
         required: true
@@ -572,6 +594,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: eth_call
+    description: Executes a message call immediately without creating a transaction.
     params:
       - name: tx
         required: true
@@ -588,6 +611,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthChainId
+    description: Returns the chain ID used for signing EIP-155 transactions.
     params: []
     result:
       name: Filecoin.EthChainId.Result
@@ -596,6 +620,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: eth_chainId
+    description: Returns the chain ID used for signing EIP-155 transactions.
     params: []
     result:
       name: eth_chainId.Result
@@ -604,6 +629,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.EthEstimateGas
+    description: Estimates the gas needed to execute the given transaction.
     params:
       - name: tx
         required: true
@@ -622,6 +648,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_estimateGas
+    description: Estimates the gas needed to execute the given transaction.
     params:
       - name: tx
         required: true
@@ -640,6 +667,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthFeeHistory
+    description: Returns historical gas fee data for the given block range.
     params:
       - name: blockCount
         required: true
@@ -665,6 +693,7 @@ methods:
         $ref: "#/components/schemas/EthFeeHistoryResult"
     paramStructure: by-position
   - name: eth_feeHistory
+    description: Returns historical gas fee data for the given block range.
     params:
       - name: blockCount
         required: true
@@ -742,6 +771,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthGetBlockByHash
+    description: Returns the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -758,6 +788,7 @@ methods:
         $ref: "#/components/schemas/Block"
     paramStructure: by-position
   - name: eth_getBlockByHash
+    description: Returns the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -886,6 +917,7 @@ methods:
           $ref: "#/components/schemas/EthTxReceipt"
     paramStructure: by-position
   - name: Filecoin.EthGetBlockTransactionCountByHash
+    description: Returns the number of transactions in the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -898,6 +930,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_getBlockTransactionCountByHash
+    description: Returns the number of transactions in the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -970,6 +1003,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthGetLogs
+    description: Returns logs matching the given filter criteria.
     params:
       - name: ethFilter
         required: true
@@ -982,6 +1016,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: eth_getLogs
+    description: Returns logs matching the given filter criteria.
     params:
       - name: ethFilter
         required: true
@@ -994,6 +1029,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: Filecoin.EthGetFilterLogs
+    description: Returns logs matching the given filter.
     params:
       - name: filterId
         required: true
@@ -1006,6 +1042,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: eth_getFilterLogs
+    description: Returns logs matching the given filter.
     params:
       - name: filterId
         required: true
@@ -1114,6 +1151,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionByHash
+    description: Returns a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1128,6 +1166,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionByHash
+    description: Returns a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1180,6 +1219,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionCount
+    description: Returns the number of transactions sent from the given address.
     params:
       - name: sender
         required: true
@@ -1196,6 +1236,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_getTransactionCount
+    description: Returns the number of transactions sent from the given address.
     params:
       - name: sender
         required: true
@@ -1278,6 +1319,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionByBlockHashAndIndex
+    description: Returns a transaction by block hash and transaction index.
     params:
       - name: blockHash
         required: true
@@ -1296,6 +1338,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionByBlockHashAndIndex
+    description: Returns a transaction by block hash and transaction index.
     params:
       - name: blockHash
         required: true
@@ -1314,6 +1357,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthMaxPriorityFeePerGas
+    description: Returns the current maximum priority fee per gas in attoFIL.
     params: []
     result:
       name: Filecoin.EthMaxPriorityFeePerGas.Result
@@ -1322,6 +1366,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: eth_maxPriorityFeePerGas
+    description: Returns the current maximum priority fee per gas in attoFIL.
     params: []
     result:
       name: eth_maxPriorityFeePerGas.Result
@@ -1330,6 +1375,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthProtocolVersion
+    description: Returns the current Ethereum protocol version.
     params: []
     result:
       name: Filecoin.EthProtocolVersion.Result
@@ -1338,6 +1384,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_protocolVersion
+    description: Returns the current Ethereum protocol version.
     params: []
     result:
       name: eth_protocolVersion.Result
@@ -1346,6 +1393,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionReceipt
+    description: Returns the receipt of a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1360,6 +1408,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionReceipt
+    description: Returns the receipt of a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1412,6 +1461,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthNewFilter
+    description: Creates a filter object based on filter options.
     params:
       - name: filterSpec
         required: true
@@ -1424,6 +1474,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newFilter
+    description: Creates a filter object based on filter options.
     params:
       - name: filterSpec
         required: true
@@ -1436,6 +1487,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthNewPendingTransactionFilter
+    description: Creates a filter that notifies when new pending transactions arrive.
     params: []
     result:
       name: Filecoin.EthNewPendingTransactionFilter.Result
@@ -1444,6 +1496,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newPendingTransactionFilter
+    description: Creates a filter that notifies when new pending transactions arrive.
     params: []
     result:
       name: eth_newPendingTransactionFilter.Result
@@ -1452,6 +1505,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthNewBlockFilter
+    description: Creates a filter that notifies when a new block is added.
     params: []
     result:
       name: Filecoin.EthNewBlockFilter.Result
@@ -1460,6 +1514,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newBlockFilter
+    description: Creates a filter that notifies when a new block is added.
     params: []
     result:
       name: eth_newBlockFilter.Result
@@ -1468,6 +1523,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthUninstallFilter
+    description: Removes the filter with the given ID.
     params:
       - name: filterId
         required: true
@@ -1480,6 +1536,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: eth_uninstallFilter
+    description: Removes the filter with the given ID.
     params:
       - name: filterId
         required: true
@@ -1492,6 +1549,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.EthUnsubscribe
+    description: Cancels an active subscription.
     params: []
     result:
       name: Filecoin.EthUnsubscribe.Result
@@ -1500,6 +1558,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: eth_unsubscribe
+    description: Cancels an active subscription.
     params: []
     result:
       name: eth_unsubscribe.Result
@@ -1508,6 +1567,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.EthSubscribe
+    description: Creates an event subscription.
     params: []
     result:
       name: Filecoin.EthSubscribe.Result
@@ -1516,6 +1576,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: eth_subscribe
+    description: Creates an event subscription.
     params: []
     result:
       name: eth_subscribe.Result
@@ -1524,6 +1585,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.EthSyncing
+    description: Returns the sync status of the node, or false if it is fully synced.
     params: []
     result:
       name: Filecoin.EthSyncing.Result
@@ -1532,6 +1594,7 @@ methods:
         $ref: "#/components/schemas/EthSyncingResultLotusJson"
     paramStructure: by-position
   - name: eth_syncing
+    description: Returns the sync status of the node, or false if it is fully synced.
     params: []
     result:
       name: eth_syncing.Result
@@ -1776,6 +1839,7 @@ methods:
           $ref: "#/components/schemas/EthReplayBlockTransactionTrace"
     paramStructure: by-position
   - name: Filecoin.Web3ClientVersion
+    description: Returns the current client version string.
     params: []
     result:
       name: Filecoin.Web3ClientVersion.Result
@@ -1784,6 +1848,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: web3_clientVersion
+    description: Returns the current client version string.
     params: []
     result:
       name: web3_clientVersion.Result
@@ -1792,6 +1857,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.EthSendRawTransaction
+    description: Submits a signed transaction to the network.
     params:
       - name: rawTx
         required: true
@@ -1804,6 +1870,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: eth_sendRawTransaction
+    description: Submits a signed transaction to the network.
     params:
       - name: rawTx
         required: true
@@ -1816,6 +1883,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: Filecoin.EthSendRawTransactionUntrusted
+    description: Submits a signed transaction to the network without trusted sender verification.
     params:
       - name: rawTx
         required: true
@@ -1828,6 +1896,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: eth_sendRawTransactionUntrusted
+    description: Submits a signed transaction to the network without trusted sender verification.
     params:
       - name: rawTx
         required: true
@@ -1947,6 +2016,7 @@ methods:
         $ref: "#/components/schemas/Message"
     paramStructure: by-position
   - name: Filecoin.MarketAddBalance
+    description: Adds funds to the market actor escrow for the given address.
     params:
       - name: wallet
         required: true
@@ -2155,6 +2225,7 @@ methods:
           $ref: "#/components/schemas/SignedMessage"
     paramStructure: by-position
   - name: Filecoin.MsigGetAvailableBalance
+    description: Returns the portion of a multisig balance that can be immediately spent.
     params:
       - name: address
         required: true
@@ -2175,6 +2246,7 @@ methods:
         $ref: "#/components/schemas/TokenAmount"
     paramStructure: by-position
   - name: Filecoin.MsigGetPending
+    description: Returns all pending transactions for a multisig actor.
     params:
       - name: address
         required: true
@@ -2199,6 +2271,7 @@ methods:
           $ref: "#/components/schemas/Transaction"
     paramStructure: by-position
   - name: Filecoin.MsigGetVested
+    description: Returns the amount of FIL that has vested in a multisig actor between two tipsets.
     params:
       - name: address
         required: true
@@ -2227,6 +2300,7 @@ methods:
         $ref: "#/components/schemas/BigInt"
     paramStructure: by-position
   - name: Filecoin.MsigGetVestingSchedule
+    description: Returns the vesting schedule of a multisig actor.
     params:
       - name: address
         required: true
@@ -2269,6 +2343,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.NetAutoNatStatus
+    description: Returns the AutoNAT status of the node.
     params: []
     result:
       name: Filecoin.NetAutoNatStatus.Result
@@ -2303,6 +2378,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.NetFindPeer
+    description: Finds a peer by ID and returns its multiaddresses.
     params:
       - name: peer_id
         required: true
@@ -2315,6 +2391,7 @@ methods:
         $ref: "#/components/schemas/AddrInfo"
     paramStructure: by-position
   - name: Forest.NetInfo
+    description: Returns general information about the libp2p network stack.
     params: []
     result:
       name: Forest.NetInfo.Result
@@ -2323,6 +2400,7 @@ methods:
         $ref: "#/components/schemas/NetInfoResult"
     paramStructure: by-position
   - name: Filecoin.NetListening
+    description: Indicates whether the node is currently listening for connections.
     params: []
     result:
       name: Filecoin.NetListening.Result
@@ -2331,6 +2409,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: net_listening
+    description: Indicates whether the node is currently listening for connections.
     params: []
     result:
       name: net_listening.Result
@@ -2399,6 +2478,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.NetVersion
+    description: Returns the current network version (chain ID) as a string.
     params: []
     result:
       name: Filecoin.NetVersion.Result
@@ -2407,6 +2487,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: net_version
+    description: Returns the current network version (chain ID) as a string.
     params: []
     result:
       name: net_version.Result
@@ -2444,6 +2525,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.NodeStatus
+    description: Returns sync and chain health status of the node.
     params: []
     result:
       name: Filecoin.NodeStatus.Result
@@ -2600,6 +2682,7 @@ methods:
         $ref: "#/components/schemas/DealCollateralBounds"
     paramStructure: by-position
   - name: Forest.StateFetchRoot
+    description: Fetches and ensures the given state root is available in the blockstore.
     params:
       - name: root_cid
         required: true
@@ -3523,6 +3606,7 @@ methods:
           $ref: "#/components/schemas/SectorOnChainInfo"
     paramStructure: by-position
   - name: Filecoin.StateNetworkName
+    description: Returns the human-readable name of the Filecoin network.
     params: []
     result:
       name: Filecoin.StateNetworkName.Result
@@ -3880,6 +3964,7 @@ methods:
         $ref: "#/components/schemas/MessageLookup"
     paramStructure: by-position
   - name: Filecoin.StateMinerInitialPledgeForSector
+    description: Returns the initial pledge collateral required for a sector.
     params:
       - name: sector_duration
         required: true
@@ -3911,6 +3996,7 @@ methods:
         $ref: "#/components/schemas/TokenAmount"
     paramStructure: by-position
   - name: Filecoin.SyncCheckBad
+    description: Checks whether a block CID is in the bad block cache.
     params:
       - name: cid
         required: true
@@ -3923,6 +4009,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.SyncMarkBad
+    description: Marks a block CID as bad, causing the node to ignore it.
     params:
       - name: cid
         required: true
@@ -3979,6 +4066,7 @@ methods:
         $ref: "#/components/schemas/TokenAmount"
     paramStructure: by-position
   - name: Filecoin.WalletDefaultAddress
+    description: Returns the default wallet address.
     params: []
     result:
       name: Filecoin.WalletDefaultAddress.Result
@@ -3989,6 +4077,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.WalletDelete
+    description: Deletes the key for the given address from the wallet.
     params:
       - name: address
         required: true
@@ -4001,6 +4090,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.WalletExport
+    description: Exports the key info for the given address.
     params:
       - name: address
         required: true
@@ -4026,6 +4116,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.WalletImport
+    description: Imports a key into the wallet and returns the associated address.
     params:
       - name: key
         required: true
@@ -4051,6 +4142,7 @@ methods:
           $ref: "#/components/schemas/Address"
     paramStructure: by-position
   - name: Filecoin.WalletNew
+    description: Creates a new wallet address with the given signature type.
     params:
       - name: signature_type
         required: true
@@ -4063,6 +4155,7 @@ methods:
         $ref: "#/components/schemas/Address"
     paramStructure: by-position
   - name: Filecoin.WalletSetDefault
+    description: Sets the default wallet address.
     params:
       - name: address
         required: true
@@ -4109,6 +4202,7 @@ methods:
         $ref: "#/components/schemas/SignedMessage"
     paramStructure: by-position
   - name: Filecoin.WalletValidateAddress
+    description: Validates and parses the given address string.
     params:
       - name: address
         required: true
@@ -4121,6 +4215,7 @@ methods:
         $ref: "#/components/schemas/Address"
     paramStructure: by-position
   - name: Filecoin.WalletVerify
+    description: Verifies a signature against the given address and data.
     params:
       - name: address
         required: true
@@ -4141,6 +4236,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: F3.GetRawNetworkName
+    description: Returns the raw network name used by the F3 sidecar.
     params: []
     result:
       name: F3.GetRawNetworkName.Result
@@ -4149,6 +4245,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.F3GetCertificate
+    description: Returns the F3 finality certificate at the given instance number.
     params:
       - name: instance
         required: true
@@ -4163,6 +4260,7 @@ methods:
         $ref: "#/components/schemas/FinalityCertificate"
     paramStructure: by-position
   - name: Filecoin.F3GetECPowerTable
+    description: Returns the EC power table for the given tipset.
     params:
       - name: tipset_key
         required: true
@@ -4183,6 +4281,7 @@ methods:
           $ref: "#/components/schemas/F3PowerEntryLotusJson"
     paramStructure: by-position
   - name: Filecoin.F3GetF3PowerTable
+    description: Returns the F3 power table for the given tipset.
     params:
       - name: tipset_key
         required: true
@@ -4222,6 +4321,7 @@ methods:
           $ref: "#/components/schemas/F3PowerEntryLotusJson"
     paramStructure: by-position
   - name: Filecoin.F3IsRunning
+    description: Indicates whether the F3 subsystem is currently running.
     params: []
     result:
       name: Filecoin.F3IsRunning.Result
@@ -4230,6 +4330,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.F3GetProgress
+    description: Returns the current progress of the F3 instance.
     params: []
     result:
       name: Filecoin.F3GetProgress.Result
@@ -4238,6 +4339,7 @@ methods:
         $ref: "#/components/schemas/F3InstanceProgress"
     paramStructure: by-position
   - name: Filecoin.F3GetManifest
+    description: Returns the current F3 manifest.
     params: []
     result:
       name: Filecoin.F3GetManifest.Result
@@ -4246,6 +4348,7 @@ methods:
         $ref: "#/components/schemas/F3Manifest"
     paramStructure: by-position
   - name: Filecoin.F3ListParticipants
+    description: Returns the list of currently active F3 participants.
     params: []
     result:
       name: Filecoin.F3ListParticipants.Result
@@ -4258,6 +4361,7 @@ methods:
           $ref: "#/components/schemas/F3Participant"
     paramStructure: by-position
   - name: Filecoin.F3GetLatestCertificate
+    description: Returns the latest F3 finality certificate.
     params: []
     result:
       name: Filecoin.F3GetLatestCertificate.Result
@@ -4266,6 +4370,7 @@ methods:
         $ref: "#/components/schemas/FinalityCertificate"
     paramStructure: by-position
   - name: Filecoin.F3GetOrRenewParticipationTicket
+    description: Gets or renews a participation ticket for the F3 protocol.
     params:
       - name: miner_address
         required: true
@@ -4313,6 +4418,7 @@ methods:
         $ref: "#/components/schemas/Cid"
     paramStructure: by-position
   - name: F3.GetHead
+    description: Returns the current chain head as an F3 tipset.
     params: []
     result:
       name: F3.GetHead.Result
@@ -4321,6 +4427,7 @@ methods:
         $ref: "#/components/schemas/F3TipSet"
     paramStructure: by-position
   - name: F3.GetParent
+    description: Returns the parent tipset of the given F3 tipset.
     params:
       - name: tipset_key
         required: true
@@ -4333,6 +4440,7 @@ methods:
         $ref: "#/components/schemas/F3TipSet"
     paramStructure: by-position
   - name: F3.GetParticipatingMinerIDs
+    description: Returns the IDs of miners currently participating in F3.
     params: []
     result:
       name: F3.GetParticipatingMinerIDs.Result
@@ -4347,6 +4455,7 @@ methods:
           minimum: 0
     paramStructure: by-position
   - name: F3.GetPowerTable
+    description: Returns the power table for the given F3 tipset.
     params:
       - name: tipset_key
         required: true
@@ -4363,6 +4472,7 @@ methods:
           $ref: "#/components/schemas/F3PowerEntryLotusJson"
     paramStructure: by-position
   - name: F3.GetTipset
+    description: Returns the tipset for the given F3 tipset key.
     params:
       - name: tipset_key
         required: true
@@ -4375,6 +4485,7 @@ methods:
         $ref: "#/components/schemas/F3TipSet"
     paramStructure: by-position
   - name: F3.GetTipsetByEpoch
+    description: Returns the tipset at or before the given epoch.
     params:
       - name: epoch
         required: true
@@ -4388,6 +4499,7 @@ methods:
         $ref: "#/components/schemas/F3TipSet"
     paramStructure: by-position
   - name: F3.Finalize
+    description: Signals finalization of an F3 instance at the given tipset.
     params:
       - name: tipset_key
         required: true
@@ -4400,6 +4512,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: F3.ProtectPeer
+    description: Marks the specified peer as protected from connection pruning.
     params:
       - name: peer_id
         required: true
@@ -4412,6 +4525,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: F3.SignMessage
+    description: Signs a message using the key of the miner identified by the given public key.
     params:
       - name: pubkey
         required: true

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v2.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v2.snap
@@ -30,6 +30,7 @@ methods:
         $ref: "#/components/schemas/ChainFinalityStatus"
     paramStructure: by-position
   - name: Forest.ChainExport
+    description: Exports the chain state to a file using Forest-specific parameters.
     params:
       - name: params
         required: true
@@ -42,6 +43,7 @@ methods:
         $ref: "#/components/schemas/ApiExportResult"
     paramStructure: by-position
   - name: Forest.ChainExportDiff
+    description: Exports a diff between two chain states to a file.
     params:
       - name: params
         required: true
@@ -54,6 +56,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Forest.ChainExportStatus
+    description: Returns the status of the current chain export operation.
     params: []
     result:
       name: Forest.ChainExportStatus.Result
@@ -62,6 +65,7 @@ methods:
         $ref: "#/components/schemas/ApiExportStatus"
     paramStructure: by-position
   - name: Forest.ChainExportCancel
+    description: Cancels an in-progress chain export.
     params: []
     result:
       name: Forest.ChainExportCancel.Result
@@ -70,6 +74,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.EthAccounts
+    description: Returns a list of addresses owned by the client.
     params: []
     result:
       name: Filecoin.EthAccounts.Result
@@ -82,6 +87,7 @@ methods:
           type: string
     paramStructure: by-position
   - name: eth_accounts
+    description: Returns a list of addresses owned by the client.
     params: []
     result:
       name: eth_accounts.Result
@@ -144,6 +150,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthBlockNumber
+    description: Returns the number of the most recent block.
     params: []
     result:
       name: Filecoin.EthBlockNumber.Result
@@ -152,6 +159,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_blockNumber
+    description: Returns the number of the most recent block.
     params: []
     result:
       name: eth_blockNumber.Result
@@ -160,6 +168,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthCall
+    description: Executes a message call immediately without creating a transaction.
     params:
       - name: tx
         required: true
@@ -176,6 +185,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: eth_call
+    description: Executes a message call immediately without creating a transaction.
     params:
       - name: tx
         required: true
@@ -192,6 +202,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthChainId
+    description: Returns the chain ID used for signing EIP-155 transactions.
     params: []
     result:
       name: Filecoin.EthChainId.Result
@@ -200,6 +211,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: eth_chainId
+    description: Returns the chain ID used for signing EIP-155 transactions.
     params: []
     result:
       name: eth_chainId.Result
@@ -208,6 +220,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.EthEstimateGas
+    description: Estimates the gas needed to execute the given transaction.
     params:
       - name: tx
         required: true
@@ -226,6 +239,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_estimateGas
+    description: Estimates the gas needed to execute the given transaction.
     params:
       - name: tx
         required: true
@@ -244,6 +258,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthFeeHistory
+    description: Returns historical gas fee data for the given block range.
     params:
       - name: blockCount
         required: true
@@ -269,6 +284,7 @@ methods:
         $ref: "#/components/schemas/EthFeeHistoryResult"
     paramStructure: by-position
   - name: eth_feeHistory
+    description: Returns historical gas fee data for the given block range.
     params:
       - name: blockCount
         required: true
@@ -346,6 +362,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthGetBlockByHash
+    description: Returns the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -362,6 +379,7 @@ methods:
         $ref: "#/components/schemas/Block"
     paramStructure: by-position
   - name: eth_getBlockByHash
+    description: Returns the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -490,6 +508,7 @@ methods:
           $ref: "#/components/schemas/EthTxReceipt"
     paramStructure: by-position
   - name: Filecoin.EthGetBlockTransactionCountByHash
+    description: Returns the number of transactions in the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -502,6 +521,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_getBlockTransactionCountByHash
+    description: Returns the number of transactions in the block with the given hash.
     params:
       - name: blockHash
         required: true
@@ -574,6 +594,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthGetLogs
+    description: Returns logs matching the given filter criteria.
     params:
       - name: ethFilter
         required: true
@@ -586,6 +607,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: eth_getLogs
+    description: Returns logs matching the given filter criteria.
     params:
       - name: ethFilter
         required: true
@@ -598,6 +620,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: Filecoin.EthGetFilterLogs
+    description: Returns logs matching the given filter.
     params:
       - name: filterId
         required: true
@@ -610,6 +633,7 @@ methods:
         $ref: "#/components/schemas/EthFilterResult"
     paramStructure: by-position
   - name: eth_getFilterLogs
+    description: Returns logs matching the given filter.
     params:
       - name: filterId
         required: true
@@ -718,6 +742,7 @@ methods:
         $ref: "#/components/schemas/EthBytes"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionByHash
+    description: Returns a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -732,6 +757,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionByHash
+    description: Returns a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -784,6 +810,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionCount
+    description: Returns the number of transactions sent from the given address.
     params:
       - name: sender
         required: true
@@ -800,6 +827,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_getTransactionCount
+    description: Returns the number of transactions sent from the given address.
     params:
       - name: sender
         required: true
@@ -882,6 +910,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionByBlockHashAndIndex
+    description: Returns a transaction by block hash and transaction index.
     params:
       - name: blockHash
         required: true
@@ -900,6 +929,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionByBlockHashAndIndex
+    description: Returns a transaction by block hash and transaction index.
     params:
       - name: blockHash
         required: true
@@ -918,6 +948,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthMaxPriorityFeePerGas
+    description: Returns the current maximum priority fee per gas in attoFIL.
     params: []
     result:
       name: Filecoin.EthMaxPriorityFeePerGas.Result
@@ -926,6 +957,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: eth_maxPriorityFeePerGas
+    description: Returns the current maximum priority fee per gas in attoFIL.
     params: []
     result:
       name: eth_maxPriorityFeePerGas.Result
@@ -934,6 +966,7 @@ methods:
         $ref: "#/components/schemas/EthBigInt"
     paramStructure: by-position
   - name: Filecoin.EthProtocolVersion
+    description: Returns the current Ethereum protocol version.
     params: []
     result:
       name: Filecoin.EthProtocolVersion.Result
@@ -942,6 +975,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: eth_protocolVersion
+    description: Returns the current Ethereum protocol version.
     params: []
     result:
       name: eth_protocolVersion.Result
@@ -950,6 +984,7 @@ methods:
         $ref: "#/components/schemas/EthUint64"
     paramStructure: by-position
   - name: Filecoin.EthGetTransactionReceipt
+    description: Returns the receipt of a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -964,6 +999,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: eth_getTransactionReceipt
+    description: Returns the receipt of a transaction by its hash.
     params:
       - name: txHash
         required: true
@@ -1016,6 +1052,7 @@ methods:
           - type: "null"
     paramStructure: by-position
   - name: Filecoin.EthNewFilter
+    description: Creates a filter object based on filter options.
     params:
       - name: filterSpec
         required: true
@@ -1028,6 +1065,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newFilter
+    description: Creates a filter object based on filter options.
     params:
       - name: filterSpec
         required: true
@@ -1040,6 +1078,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthNewPendingTransactionFilter
+    description: Creates a filter that notifies when new pending transactions arrive.
     params: []
     result:
       name: Filecoin.EthNewPendingTransactionFilter.Result
@@ -1048,6 +1087,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newPendingTransactionFilter
+    description: Creates a filter that notifies when new pending transactions arrive.
     params: []
     result:
       name: eth_newPendingTransactionFilter.Result
@@ -1056,6 +1096,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthNewBlockFilter
+    description: Creates a filter that notifies when a new block is added.
     params: []
     result:
       name: Filecoin.EthNewBlockFilter.Result
@@ -1064,6 +1105,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: eth_newBlockFilter
+    description: Creates a filter that notifies when a new block is added.
     params: []
     result:
       name: eth_newBlockFilter.Result
@@ -1072,6 +1114,7 @@ methods:
         $ref: "#/components/schemas/FilterID"
     paramStructure: by-position
   - name: Filecoin.EthUninstallFilter
+    description: Removes the filter with the given ID.
     params:
       - name: filterId
         required: true
@@ -1084,6 +1127,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: eth_uninstallFilter
+    description: Removes the filter with the given ID.
     params:
       - name: filterId
         required: true
@@ -1096,6 +1140,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.EthUnsubscribe
+    description: Cancels an active subscription.
     params: []
     result:
       name: Filecoin.EthUnsubscribe.Result
@@ -1104,6 +1149,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: eth_unsubscribe
+    description: Cancels an active subscription.
     params: []
     result:
       name: eth_unsubscribe.Result
@@ -1112,6 +1158,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.EthSubscribe
+    description: Creates an event subscription.
     params: []
     result:
       name: Filecoin.EthSubscribe.Result
@@ -1120,6 +1167,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: eth_subscribe
+    description: Creates an event subscription.
     params: []
     result:
       name: eth_subscribe.Result
@@ -1128,6 +1176,7 @@ methods:
         type: "null"
     paramStructure: by-position
   - name: Filecoin.EthSyncing
+    description: Returns the sync status of the node, or false if it is fully synced.
     params: []
     result:
       name: Filecoin.EthSyncing.Result
@@ -1136,6 +1185,7 @@ methods:
         $ref: "#/components/schemas/EthSyncingResultLotusJson"
     paramStructure: by-position
   - name: eth_syncing
+    description: Returns the sync status of the node, or false if it is fully synced.
     params: []
     result:
       name: eth_syncing.Result
@@ -1380,6 +1430,7 @@ methods:
           $ref: "#/components/schemas/EthReplayBlockTransactionTrace"
     paramStructure: by-position
   - name: Filecoin.Web3ClientVersion
+    description: Returns the current client version string.
     params: []
     result:
       name: Filecoin.Web3ClientVersion.Result
@@ -1388,6 +1439,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: web3_clientVersion
+    description: Returns the current client version string.
     params: []
     result:
       name: web3_clientVersion.Result
@@ -1396,6 +1448,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: Filecoin.EthSendRawTransaction
+    description: Submits a signed transaction to the network.
     params:
       - name: rawTx
         required: true
@@ -1408,6 +1461,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: eth_sendRawTransaction
+    description: Submits a signed transaction to the network.
     params:
       - name: rawTx
         required: true
@@ -1420,6 +1474,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: Filecoin.EthSendRawTransactionUntrusted
+    description: Submits a signed transaction to the network without trusted sender verification.
     params:
       - name: rawTx
         required: true
@@ -1432,6 +1487,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: eth_sendRawTransactionUntrusted
+    description: Submits a signed transaction to the network without trusted sender verification.
     params:
       - name: rawTx
         required: true
@@ -1444,6 +1500,7 @@ methods:
         $ref: "#/components/schemas/EthHash"
     paramStructure: by-position
   - name: Filecoin.NetListening
+    description: Indicates whether the node is currently listening for connections.
     params: []
     result:
       name: Filecoin.NetListening.Result
@@ -1452,6 +1509,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: net_listening
+    description: Indicates whether the node is currently listening for connections.
     params: []
     result:
       name: net_listening.Result
@@ -1460,6 +1518,7 @@ methods:
         type: boolean
     paramStructure: by-position
   - name: Filecoin.NetVersion
+    description: Returns the current network version (chain ID) as a string.
     params: []
     result:
       name: Filecoin.NetVersion.Result
@@ -1468,6 +1527,7 @@ methods:
         type: string
     paramStructure: by-position
   - name: net_version
+    description: Returns the current network version (chain ID) as a string.
     params: []
     result:
       name: net_version.Result


### PR DESCRIPTION
## Summary

- Adds `const DESCRIPTION` to all 96 `RpcMethod` implementations that were missing it
- Brings coverage from 133/229 (58%) to 229/229 (100%)
- Descriptions follow the existing style: present-tense, action-oriented, single sentence
- Descriptions flow directly into the OpenRPC spec via `Self::DESCRIPTION` in `reflect/mod.rs`

Closes #6460

## Test plan

- [x] `cargo check` passes (pre-existing local env issue with spaces in path is unrelated)
- [x] OpenRPC spec: `Self::DESCRIPTION` maps to the `description` field in the OpenRPC method descriptor (`src/rpc/reflect/mod.rs:242`) — same wiring used by the 133 already-described methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved RPC API descriptions across authentication, beacon, chain, network, state, sync, wallet, multisig, market, F3, and Ethereum-compatible methods—adding human-readable method summaries to improve discoverability and usability of the API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChainSafe/forest/pull/7070?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->