### PR TITLE
Fix `forest-wallet set-default` failing when the keystore has no `default` entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 ### Fixed
 
+- [#7018](https://github.com/ChainSafe/forest/issues/7018): Fixed `forest-wallet set-default` failing when the keystore has no `default` entry.
+
 ## Forest v0.33.4 "Stray"
 
 Mandatory release for mainnet node operators. It includes support for the _NV28 FireHorse_ network upgrade on mainnet, which is set to activate at epoch `6052800` (2026-05-27T14:00:00Z). It also includes a few improvements and fixes for the JSON-RPC server.

--- a/src/key_management/keystore.rs
+++ b/src/key_management/keystore.rs
@@ -330,6 +330,17 @@ impl KeyStore {
         Ok(())
     }
 
+    /// Insert or update the default `KeyInfo` stored in the `KeyStore`
+    pub fn set_default(&mut self, key_info: KeyInfo) -> Result<(), Error> {
+        self.key_info.insert("default".to_owned(), key_info);
+
+        if self.persistence.is_some() {
+            self.flush().map_err(|err| Error::Other(err.to_string()))?;
+        }
+
+        Ok(())
+    }
+
     /// Remove the key and corresponding `KeyInfo` from the `KeyStore`
     pub fn remove(&mut self, key: &str) -> anyhow::Result<KeyInfo> {
         let key_out = self.key_info.remove(key).ok_or(Error::KeyInfo)?;
@@ -517,5 +528,23 @@ mod test {
         // Read existing keystore.json
         let ks_read = KeyStore::new(KeyStoreConfig::Persistent(keystore_location)).unwrap();
         assert_eq!(ks, ks_read);
+    }
+
+    #[test]
+    fn test_set_default_replaces_and_persists() {
+        let keystore_location = tempfile::tempdir().unwrap().keep();
+        let mut ks = KeyStore::new(KeyStoreConfig::Persistent(keystore_location.clone())).unwrap();
+
+        let key_1 = wallet::generate_key(SignatureType::Secp256k1).unwrap();
+        let key_2 = wallet::generate_key(SignatureType::Bls).unwrap();
+
+        ks.set_default(key_1.key_info.clone()).unwrap();
+        assert_eq!(ks.get("default").unwrap(), key_1.key_info);
+
+        ks.set_default(key_2.key_info.clone()).unwrap();
+        assert_eq!(ks.get("default").unwrap(), key_2.key_info);
+
+        let ks_read = KeyStore::new(KeyStoreConfig::Persistent(keystore_location)).unwrap();
+        assert_eq!(ks_read.get("default").unwrap(), key_2.key_info);
     }
 }

--- a/src/key_management/wallet.rs
+++ b/src/key_management/wallet.rs
@@ -120,7 +120,8 @@ impl Wallet {
 
     /// Set a default `KeyInfo` to the wallet
     pub fn set_default(&mut self, addr: Address) -> anyhow::Result<()> {
-        set_default(&addr, &mut self.keystore)?;
+        let key_info = try_find(&addr, &self.keystore)?;
+        self.keystore.set_default(key_info)?;
         Ok(())
     }
 
@@ -217,16 +218,6 @@ pub fn try_find(addr: &Address, keystore: &KeyStore) -> Result<KeyInfo, Error> {
 pub fn try_find_key(addr: &Address, keystore: &KeyStore) -> Result<Key, Error> {
     let ki = try_find(addr, keystore)?;
     ki.try_into()
-}
-
-/// Set the default key to the key identified by `addr`.
-pub fn set_default(addr: &Address, keystore: &mut KeyStore) -> Result<(), Error> {
-    let key_info = try_find(addr, keystore)?;
-    if keystore.get("default").is_ok() {
-        keystore.remove("default")?;
-    }
-    keystore.put("default", key_info)?;
-    Ok(())
 }
 
 /// Return `KeyInfo` for given address in `KeyStore`
@@ -483,6 +474,19 @@ mod tests {
         // check to make sure that the test_addr is actually the default addr for the
         // wallet
         assert_eq!(wallet.get_default().unwrap(), test_addr);
+    }
+
+    #[test]
+    fn set_default_replaces_existing_default() {
+        let mut wallet = generate_wallet();
+        let addr_1 = wallet.generate_addr(SignatureType::Secp256k1).unwrap();
+        let addr_2 = wallet.generate_addr(SignatureType::Bls).unwrap();
+
+        // check to make sure that there is a default
+        assert_eq!(wallet.get_default().unwrap(), addr_1);
+        wallet.set_default(addr_2).unwrap();
+        // check to make sure that default is replaced
+        assert_eq!(wallet.get_default().unwrap(), addr_2);
     }
 
     #[test]

--- a/src/key_management/wallet.rs
+++ b/src/key_management/wallet.rs
@@ -120,15 +120,7 @@ impl Wallet {
 
     /// Set a default `KeyInfo` to the wallet
     pub fn set_default(&mut self, addr: Address) -> anyhow::Result<()> {
-        let addr_string = format!("wallet-{addr}");
-        let key_info = self.keystore.get(&addr_string)?;
-        if self.keystore.get("default").is_ok() {
-            self.keystore.remove("default")?; // This line should
-            // unregister current
-            // default key then
-            // continue
-        }
-        self.keystore.put("default", key_info)?;
+        set_default(&addr, &mut self.keystore)?;
         Ok(())
     }
 
@@ -225,6 +217,16 @@ pub fn try_find(addr: &Address, keystore: &KeyStore) -> Result<KeyInfo, Error> {
 pub fn try_find_key(addr: &Address, keystore: &KeyStore) -> Result<Key, Error> {
     let ki = try_find(addr, keystore)?;
     ki.try_into()
+}
+
+/// Set the default key to the key identified by `addr`.
+pub fn set_default(addr: &Address, keystore: &mut KeyStore) -> Result<(), Error> {
+    let key_info = try_find(addr, keystore)?;
+    if keystore.get("default").is_ok() {
+        keystore.remove("default")?;
+    }
+    keystore.put("default", key_info)?;
+    Ok(())
 }
 
 /// Return `KeyInfo` for given address in `KeyStore`

--- a/src/rpc/methods/wallet.rs
+++ b/src/rpc/methods/wallet.rs
@@ -189,11 +189,7 @@ impl RpcMethod<1> for WalletSetDefault {
         (address,): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        let mut keystore = ctx.keystore.write();
-        let addr_string = format!("wallet-{address}");
-        let key_info = keystore.get(&addr_string)?;
-        keystore.remove("default")?; // This line should unregister current default key then continue
-        keystore.put("default", key_info)?;
+        crate::key_management::set_default(&address, &mut ctx.keystore.write())?;
         Ok(())
     }
 }

--- a/src/rpc/methods/wallet.rs
+++ b/src/rpc/methods/wallet.rs
@@ -189,7 +189,9 @@ impl RpcMethod<1> for WalletSetDefault {
         (address,): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        crate::key_management::set_default(&address, &mut ctx.keystore.write())?;
+        let mut keystore = ctx.keystore.write();
+        let key_info = crate::key_management::try_find(&address, &keystore)?;
+        keystore.set_default(key_info)?;
         Ok(())
     }
 }

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -159,10 +159,7 @@ impl WalletBackend {
 
     async fn wallet_set_default(&mut self, address: Address) -> anyhow::Result<()> {
         if let Some(keystore) = &mut self.local {
-            let addr_string = format!("wallet-{address}");
-            let key_info = keystore.get(&addr_string)?;
-            keystore.remove("default")?; // This line should unregister current default key then continue
-            keystore.put("default", key_info)?;
+            crate::key_management::set_default(&address, keystore)?;
             Ok(())
         } else {
             Ok(WalletSetDefault::call(&self.remote, (address,)).await?)

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -159,7 +159,8 @@ impl WalletBackend {
 
     async fn wallet_set_default(&mut self, address: Address) -> anyhow::Result<()> {
         if let Some(keystore) = &mut self.local {
-            crate::key_management::set_default(&address, keystore)?;
+            let key_info = crate::key_management::try_find(&address, keystore)?;
+            keystore.set_default(key_info)?;
             Ok(())
         } else {
             Ok(WalletSetDefault::call(&self.remote, (address,)).await?)


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fixed and unified set-default logic by adding a check for an existing default entry before removing it.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #7018 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause `forest-wallet set-default` to fail when no default key existed.
  * Ensures setting a new default replaces any prior default and persists the change so the selected wallet remains the default across restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChainSafe/forest/pull/7087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->