### PR TITLE
fix: incorporate EC finality calculator into tipset lookup-by-height cache

### DIFF
--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -162,7 +162,6 @@ impl ChainStore {
     }
 
     /// Gets the EC calculator finalized epoch
-    #[allow(dead_code)]
     pub fn ec_calculator_finalized_epoch(&self) -> ChainEpoch {
         *self.ec_calculator_finalized_epoch.read()
     }

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -162,6 +162,7 @@ impl ChainStore {
     }
 
     /// Gets the EC calculator finalized epoch
+    #[allow(dead_code)]
     pub fn ec_calculator_finalized_epoch(&self) -> ChainEpoch {
         *self.ec_calculator_finalized_epoch.read()
     }

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -33,7 +33,10 @@ use fvm_ipld_encoding::CborStore;
 use nonzero_ext::nonzero;
 use parking_lot::{Mutex, RwLock};
 use serde::{Serialize, de::DeserializeOwned};
-use std::num::NonZeroUsize;
+use std::{
+    num::NonZeroUsize,
+    sync::atomic::{self, AtomicI64},
+};
 use tokio::sync::broadcast;
 use tracing::{debug, error, trace, warn};
 
@@ -64,7 +67,7 @@ pub struct ChainStore {
     f3_finalized_tipset: Arc<RwLock<Option<Tipset>>>,
 
     /// EC calculator finalized epoch cache
-    ec_calculator_finalized_epoch: Arc<RwLock<ChainEpoch>>,
+    ec_calculator_finalized_epoch: Arc<AtomicI64>,
 
     /// Used as a cache for tipset `lookbacks`.
     chain_index: ChainIndex,
@@ -121,7 +124,7 @@ impl ChainStore {
         let heaviest_tipset = Arc::new(RwLock::new(head.shallow_clone()));
         let f3_finalized_tipset: Arc<RwLock<Option<Tipset>>> = Default::default();
         let chain_index = ChainIndex::new(db.shallow_clone());
-        let ec_calculator_finalized_epoch = Arc::new(RwLock::new(
+        let ec_calculator_finalized_epoch = Arc::new(AtomicI64::new(
             ChainGetTipSetFinalityStatus::get_ec_finality_epoch(&chain_index, &chain_config, &head),
         ));
         let chain_index = chain_index.with_is_tipset_finalized(Arc::new({
@@ -133,7 +136,7 @@ impl ChainStore {
                     .as_ref()
                     .map(|ts| ts.epoch())
                     .unwrap_or_default()
-                    .max(*ec_calculator_finalized_epoch.read());
+                    .max(ec_calculator_finalized_epoch.load(atomic::Ordering::Relaxed));
                 ts.epoch() <= finalized
             }
         }));
@@ -163,7 +166,8 @@ impl ChainStore {
 
     /// Gets the EC calculator finalized epoch
     pub fn ec_calculator_finalized_epoch(&self) -> ChainEpoch {
-        *self.ec_calculator_finalized_epoch.read()
+        self.ec_calculator_finalized_epoch
+            .load(atomic::Ordering::Relaxed)
     }
 
     /// Cache for messages in tipsets, keyed by tipset key.
@@ -176,12 +180,14 @@ impl ChainStore {
         head.key().save(self.db())?;
         self.db().set_heaviest_tipset_key(head.key())?;
         let old_head = std::mem::replace(&mut *self.heaviest_tipset.write(), head.shallow_clone());
-        *self.ec_calculator_finalized_epoch.write() =
+        self.ec_calculator_finalized_epoch.store(
             ChainGetTipSetFinalityStatus::get_ec_finality_epoch(
                 self.chain_index(),
                 self.chain_config(),
                 &head,
-            );
+            ),
+            atomic::Ordering::Relaxed,
+        );
         if crate::utils::broadcast::has_subscribers(&self.head_changes_tx) {
             let changes = match crate::rpc::chain::chain_get_path(self, old_head.key(), head.key())
             {

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -136,7 +136,7 @@ impl ChainStore {
                     .as_ref()
                     .map(|ts| ts.epoch())
                     .unwrap_or_default()
-                    .max(ec_calculator_finalized_epoch.load(atomic::Ordering::Relaxed));
+                    .max(ec_calculator_finalized_epoch.load(atomic::Ordering::Acquire));
                 ts.epoch() <= finalized
             }
         }));
@@ -167,7 +167,7 @@ impl ChainStore {
     /// Gets the EC calculator finalized epoch
     pub fn ec_calculator_finalized_epoch(&self) -> ChainEpoch {
         self.ec_calculator_finalized_epoch
-            .load(atomic::Ordering::Relaxed)
+            .load(atomic::Ordering::Acquire)
     }
 
     /// Cache for messages in tipsets, keyed by tipset key.
@@ -186,7 +186,7 @@ impl ChainStore {
                 self.chain_config(),
                 &head,
             ),
-            atomic::Ordering::Relaxed,
+            atomic::Ordering::Release,
         );
         if crate::utils::broadcast::has_subscribers(&self.head_changes_tx) {
             let changes = match crate::rpc::chain::chain_get_path(self, old_head.key(), head.key())

--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -8,7 +8,10 @@ use super::{
 };
 use crate::networks::{ChainConfig, Height};
 use crate::prelude::*;
-use crate::rpc::eth::{eth_tx_from_signed_eth_message, types::EthHash};
+use crate::rpc::{
+    chain::ChainGetTipSetFinalityStatus,
+    eth::{eth_tx_from_signed_eth_message, types::EthHash},
+};
 use crate::shim::clock::ChainEpoch;
 use crate::shim::{executor::Receipt, message::Message, version::NetworkVersion};
 use crate::state_manager::ExecutedTipset;
@@ -60,6 +63,9 @@ pub struct ChainStore {
     /// F3 finalized tipset cache
     f3_finalized_tipset: Arc<RwLock<Option<Tipset>>>,
 
+    /// EC calculator finalized epoch cache
+    ec_calculator_finalized_epoch: Arc<RwLock<ChainEpoch>>,
+
     /// Used as a cache for tipset `lookbacks`.
     chain_index: ChainIndex,
 
@@ -84,6 +90,7 @@ impl ShallowClone for ChainStore {
             head_changes_tx: self.head_changes_tx.clone(),
             heaviest_tipset: self.heaviest_tipset.shallow_clone(),
             f3_finalized_tipset: self.f3_finalized_tipset.shallow_clone(),
+            ec_calculator_finalized_epoch: self.ec_calculator_finalized_epoch.shallow_clone(),
             chain_index: self.chain_index.shallow_clone(),
             tipset_tracker: self.tipset_tracker.shallow_clone(),
             genesis_block_header: self.genesis_block_header.shallow_clone(),
@@ -111,35 +118,37 @@ impl ChainStore {
         } else {
             Tipset::from(&genesis_block_header)
         };
-        let heaviest_tipset = Arc::new(RwLock::new(head));
+        let heaviest_tipset = Arc::new(RwLock::new(head.shallow_clone()));
         let f3_finalized_tipset: Arc<RwLock<Option<Tipset>>> = Default::default();
-        let chain_index = ChainIndex::new(db.shallow_clone()).with_is_tipset_finalized(Arc::new({
-            let chain_finality = chain_config.policy.chain_finality;
-            let heaviest_tipset = heaviest_tipset.clone();
-            let f3_finalized_tipset = f3_finalized_tipset.clone();
+        let chain_index = ChainIndex::new(db.shallow_clone());
+        let ec_calculator_finalized_epoch = Arc::new(RwLock::new(
+            ChainGetTipSetFinalityStatus::get_ec_finality_epoch(&chain_index, &chain_config, &head),
+        ));
+        let chain_index = chain_index.with_is_tipset_finalized(Arc::new({
+            let f3_finalized_tipset = f3_finalized_tipset.shallow_clone();
+            let ec_calculator_finalized_epoch = ec_calculator_finalized_epoch.shallow_clone();
             move |ts| {
                 let finalized = f3_finalized_tipset
                     .read()
                     .as_ref()
                     .map(|ts| ts.epoch())
                     .unwrap_or_default()
-                    .max(heaviest_tipset.read().epoch() - chain_finality);
+                    .max(*ec_calculator_finalized_epoch.read());
                 ts.epoch() <= finalized
             }
         }));
-        let cs = Self {
+        Ok(Self {
             head_changes_tx: publisher,
             chain_index,
             tipset_tracker: TipsetTracker::new(db, chain_config.clone()),
             heaviest_tipset,
             f3_finalized_tipset,
+            ec_calculator_finalized_epoch,
             genesis_block_header: genesis_block_header.into(),
             validated_blocks: Default::default(),
             chain_config,
             messages_in_tipset_cache: Default::default(),
-        };
-
-        Ok(cs)
+        })
     }
 
     /// Sets F3 finalized tipset
@@ -152,6 +161,11 @@ impl ChainStore {
         self.f3_finalized_tipset.read().clone()
     }
 
+    /// Gets the EC calculator finalized epoch
+    pub fn ec_calculator_finalized_epoch(&self) -> ChainEpoch {
+        *self.ec_calculator_finalized_epoch.read()
+    }
+
     /// Cache for messages in tipsets, keyed by tipset key.
     pub fn messages_in_tipset_cache(&self) -> &MessagesInTipsetCache {
         &self.messages_in_tipset_cache
@@ -161,8 +175,13 @@ impl ChainStore {
     pub fn set_heaviest_tipset(&self, head: Tipset) -> Result<(), Error> {
         head.key().save(self.db())?;
         self.db().set_heaviest_tipset_key(head.key())?;
-        let old_head = std::mem::replace(&mut *self.heaviest_tipset.write(), head.clone());
-
+        let old_head = std::mem::replace(&mut *self.heaviest_tipset.write(), head.shallow_clone());
+        *self.ec_calculator_finalized_epoch.write() =
+            ChainGetTipSetFinalityStatus::get_ec_finality_epoch(
+                self.chain_index(),
+                self.chain_config(),
+                &head,
+            );
         if crate::utils::broadcast::has_subscribers(&self.head_changes_tx) {
             let changes = match crate::rpc::chain::chain_get_path(self, old_head.key(), head.key())
             {

--- a/src/chain/store/index.rs
+++ b/src/chain/store/index.rs
@@ -166,6 +166,10 @@ impl ChainIndex {
             epoch.mod_floor(&CHECKPOINT_INTERVAL) == 0
         }
 
+        if to == 0 {
+            return Ok(Some(Tipset::from(from.genesis(&self.db)?)));
+        }
+
         let from_epoch = from.epoch();
 
         let mut checkpoint_from_epoch = to;
@@ -180,14 +184,13 @@ impl ChainIndex {
             checkpoint_from_epoch = next_checkpoint(checkpoint_from_epoch);
         }
 
-        if to == 0 {
-            return Ok(Some(Tipset::from(from.genesis(&self.db)?)));
-        }
         if to > from.epoch() {
             return Err(Error::Other(format!(
                 "looking for tipset with height greater than start point, req: {to}, head: {from}",
                 from = from.epoch()
             )));
+        } else if to == from.epoch() {
+            return Ok(Some(from));
         }
 
         let from_epoch = from.epoch();

--- a/src/chain/store/index.rs
+++ b/src/chain/store/index.rs
@@ -225,6 +225,18 @@ impl ChainIndex {
         Ok(None)
     }
 
+    pub async fn tipset_by_height_async(
+        &self,
+        to: ChainEpoch,
+        from: Tipset,
+        resolve: ResolveNullTipset,
+    ) -> Result<Option<Tipset>, Error> {
+        let this = self.shallow_clone();
+        tokio::task::spawn_blocking(move || this.tipset_by_height(to, from, resolve))
+            .await
+            .map_err(|e| Error::Other(e.to_string()))?
+    }
+
     /// Same as [`Self::tipset_by_height`], but errors if that would return `None`.
     pub fn load_required_tipset_by_height(
         &self,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -812,22 +812,31 @@ fn warmup_in_background(ctx: &AppContext) {
     let cs = ctx.chain_store().shallow_clone();
     tokio::task::spawn_blocking(move || {
         let start = Instant::now();
-        match cs.chain_index().tipset_by_height(
-            // 0 would short-circuit the cache
-            1,
-            cs.heaviest_tipset(),
-            ResolveNullTipset::TakeOlder,
-        ) {
-            Ok(_) => {
-                tracing::info!(
-                    "Successfully populated tipset_by_height cache, took {}",
-                    humantime::format_duration(start.elapsed())
-                );
-            }
-            Err(e) => {
-                tracing::warn!("Failed to populate tipset_by_height cache: {e}");
-            }
+        let mut from = cs.heaviest_tipset();
+        let ec_calculator_finalized_epoch = cs.ec_calculator_finalized_epoch();
+        let warmup_epochs = (19..ec_calculator_finalized_epoch).step_by(20).collect_vec();
+        for epoch in warmup_epochs.into_iter().rev() {
+            tracing::info!("warming up tipset_by_height@{epoch}");
+            from = match cs.chain_index().tipset_by_height(
+                epoch,
+                from.shallow_clone(),
+                ResolveNullTipset::TakeOlder,
+            ) {
+                Ok(Some(ts)) => ts,
+                Ok(None) => {
+                    tracing::error!("tipset@{epoch} not found");
+                    continue;
+                }
+                Err(e) => {
+                    tracing::error!("failed to load tipset@{epoch}: {e}");
+                    continue;
+                }
+            };
         }
+        tracing::info!(
+            "Populated tipset_by_height cache, took {}",
+            humantime::format_duration(start.elapsed())
+        );
     });
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -816,33 +816,22 @@ fn warmup_in_background(ctx: &AppContext) {
     let cs = ctx.chain_store().shallow_clone();
     tokio::task::spawn_blocking(move || {
         let start = Instant::now();
-        let mut from = cs.heaviest_tipset();
-        let ec_calculator_finalized_epoch = cs.ec_calculator_finalized_epoch();
-        let warmup_epochs = (19..ec_calculator_finalized_epoch)
-            .step_by(20)
-            .collect_vec();
-        for epoch in warmup_epochs.into_iter().rev() {
-            tracing::info!("warming up tipset_by_height@{epoch}");
-            from = match cs.chain_index().tipset_by_height(
-                epoch,
-                from.shallow_clone(),
-                ResolveNullTipset::TakeOlder,
-            ) {
-                Ok(Some(ts)) => ts,
-                Ok(None) => {
-                    tracing::error!("tipset@{epoch} not found");
-                    continue;
-                }
-                Err(e) => {
-                    tracing::error!("failed to load tipset@{epoch}: {e}");
-                    continue;
-                }
-            };
+        match cs.chain_index().tipset_by_height(
+            // 0 would short-circuit the cache
+            1,
+            cs.heaviest_tipset(),
+            ResolveNullTipset::TakeOlder,
+        ) {
+            Ok(_) => {
+                tracing::info!(
+                    "Successfully populated tipset_by_height cache, took {}",
+                    humantime::format_duration(start.elapsed())
+                );
+            }
+            Err(e) => {
+                tracing::warn!("Failed to populate tipset_by_height cache: {e}");
+            }
         }
-        tracing::info!(
-            "Populated tipset_by_height cache, took {}",
-            humantime::format_duration(start.elapsed())
-        );
     });
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -406,6 +406,31 @@ async fn prefill_rpc_caches_for_tipset(state_manager: StateManager, tsk: TipsetK
                 }
             }
             {
+                let finalized_epoch = state_manager
+                    .chain_store()
+                    .ec_calculator_finalized_epoch()
+                    .max(
+                        state_manager
+                            .chain_store()
+                            .f3_finalized_tipset()
+                            .map(|ts| ts.epoch())
+                            .unwrap_or(0),
+                    );
+                if let Err(e) = state_manager
+                    .chain_index()
+                    .tipset_by_height_async(
+                        finalized_epoch,
+                        ts.shallow_clone(),
+                        ResolveNullTipset::TakeOlder,
+                    )
+                    .await
+                {
+                    warn!(
+                        "failed to call `ChainIndex::tipset_by_height` at finalized epoch {finalized_epoch} for cache warmup: {e:#}"
+                    );
+                }
+            }
+            {
                 use crate::rpc::eth::filter::{Matcher, SkipEvent};
                 struct CollectEventsCachePrefillingMatcher;
                 impl Matcher for CollectEventsCachePrefillingMatcher {

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -7,7 +7,7 @@ use types::*;
 #[cfg(test)]
 use crate::blocks::RawBlockHeader;
 use crate::blocks::{Block, CachingBlockHeader, Tipset, TipsetKey};
-use crate::chain::index::ResolveNullTipset;
+use crate::chain::index::{ChainIndex, ResolveNullTipset};
 use crate::chain::{ChainStore, ExportOptions, FilecoinSnapshotVersion, HeadChange};
 use crate::chain_sync::{get_full_tipset, load_full_tipset};
 use crate::cid_collections::{CidHashSet, FileBackedCidHashSet};
@@ -17,6 +17,7 @@ use crate::lotus_json::{HasLotusJson, LotusJson, lotus_json_with_self};
 #[cfg(test)]
 use crate::lotus_json::{assert_all_snapshots, assert_unchanged_via_json};
 use crate::message::{ChainMessage, SignedMessage};
+use crate::networks::ChainConfig;
 use crate::prelude::*;
 use crate::rpc::eth::{
     Block as EthBlock, EthLog, TxInfo, eth_logs_with_filter, types::ApiHeaders,
@@ -1167,10 +1168,51 @@ impl ChainGetTipSetFinalityStatus {
         }
     }
 
-    fn get_ec_finality_threshold_depth_and_tipset(
-        ctx: &Ctx,
-        head: Tipset,
-    ) -> anyhow::Result<(i64, Option<Tipset>)> {
+    pub fn get_ec_finality_epoch(
+        chain_index: &ChainIndex,
+        chain_config: &ChainConfig,
+        head: &Tipset,
+    ) -> i64 {
+        let depth =
+            Self::get_ec_finality_threshold_depth_with_cache(chain_index, chain_config, head);
+        Self::get_ec_finality_epoch_by_depth(chain_config, head, depth)
+    }
+
+    fn get_ec_finality_epoch_by_depth(
+        chain_config: &ChainConfig,
+        head: &Tipset,
+        depth: i64,
+    ) -> i64 {
+        if depth >= 0 {
+            (head.epoch() - depth).max(0)
+        } else {
+            (head.epoch() - chain_config.policy.chain_finality).max(0)
+        }
+    }
+
+    fn get_ec_finality_threshold_depth_with_cache(
+        chain_index: &ChainIndex,
+        chain_config: &ChainConfig,
+        head: &Tipset,
+    ) -> i64 {
+        static CACHE: parking_lot::Mutex<Option<(Tipset, i64)>> = parking_lot::Mutex::new(None);
+        let mut cache = CACHE.lock();
+        if let Some((cached_head, cached_threshold)) = &*cache
+            && cached_head == head
+        {
+            *cached_threshold
+        } else {
+            let threshold = Self::get_ec_finality_threshold_depth(chain_index, chain_config, head);
+            *cache = Some((head.shallow_clone(), threshold));
+            threshold
+        }
+    }
+
+    fn get_ec_finality_threshold_depth(
+        chain_index: &ChainIndex,
+        chain_config: &ChainConfig,
+        head: &Tipset,
+    ) -> i64 {
         use crate::chain::ec_finality::calculator::{
             DEFAULT_BLOCKS_PER_EPOCH, DEFAULT_BYZANTINE_FRACTION, DEFAULT_GUARANTEE,
             find_threshold_depth,
@@ -1184,13 +1226,13 @@ impl ChainGetTipSetFinalityStatus {
         /// they consume array slots without advancing the meaningful epoch count.
         const FINALITY_CHAIN_EXTRA_EPOCHS: usize = 5;
 
-        let finality = ctx.chain_config().policy.chain_finality;
+        let finality = chain_config.policy.chain_finality;
         let chain_len = finality as usize + FINALITY_CHAIN_EXTRA_EPOCHS;
         let mut chain = Vec::with_capacity(chain_len);
         let mut ts = head.shallow_clone();
         while chain.len() < chain_len {
             chain.push(ts.len() as i64);
-            if let Ok(parent) = ctx.chain_index().load_required_tipset(ts.parents()) {
+            if let Ok(parent) = chain_index.load_required_tipset(ts.parents()) {
                 // insert 0 for null rounds
                 if let Ok(n_null_tipsets_to_pad) = usize::try_from(ts.epoch() - parent.epoch() - 1)
                     && n_null_tipsets_to_pad > 0
@@ -1206,7 +1248,7 @@ impl ChainGetTipSetFinalityStatus {
         }
         // Reverse to chronological order (oldest first).
         chain.reverse();
-        let depth = match find_threshold_depth(
+        match find_threshold_depth(
             &chain,
             finality,
             DEFAULT_BLOCKS_PER_EPOCH,
@@ -1220,23 +1262,25 @@ impl ChainGetTipSetFinalityStatus {
                 );
                 -1
             }
-        };
-        let finalized = if depth >= 0
-            && let Ok(Some(ts)) = ctx.chain_index().tipset_by_height(
-                (head.epoch() - depth).max(0),
-                head.shallow_clone(),
-                ResolveNullTipset::TakeOlder,
-            ) {
-            Some(ts)
-        } else {
-            let ec_finality_epoch =
-                (head.epoch() - ctx.chain_config().policy.chain_finality).max(0);
-            ctx.chain_index().tipset_by_height(
-                ec_finality_epoch,
-                head,
-                ResolveNullTipset::TakeOlder,
-            )?
-        };
+        }
+    }
+
+    fn get_ec_finality_threshold_depth_and_tipset(
+        ctx: &Ctx,
+        head: Tipset,
+    ) -> anyhow::Result<(i64, Option<Tipset>)> {
+        let depth = Self::get_ec_finality_threshold_depth_with_cache(
+            ctx.chain_index(),
+            ctx.chain_config(),
+            &head,
+        );
+        let ec_finality_epoch =
+            Self::get_ec_finality_epoch_by_depth(ctx.chain_config(), &head, depth);
+        let finalized = ctx.chain_index().tipset_by_height(
+            ec_finality_epoch,
+            head,
+            ResolveNullTipset::TakeOlder,
+        )?;
         Ok((depth, finalized))
     }
 }

--- a/src/rpc/methods/chain.rs
+++ b/src/rpc/methods/chain.rs
@@ -44,6 +44,7 @@ use num::BigInt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use std::convert::Infallible;
 use std::fs::File;
 use std::{collections::VecDeque, path::PathBuf, sync::LazyLock};
 use tokio::sync::{
@@ -1122,6 +1123,7 @@ impl RpcMethod<1> for ChainGetTipSetV2 {
 
 pub enum ChainGetTipSetFinalityStatus {}
 
+const EC_CALCULATOR_FINALITY_CACHE_SIZE: usize = 4;
 impl ChainGetTipSetFinalityStatus {
     pub fn get_finality_status(ctx: &Ctx) -> anyhow::Result<ChainFinalityStatus> {
         let head = ctx.chain_store().heaviest_tipset();
@@ -1153,19 +1155,11 @@ impl ChainGetTipSetFinalityStatus {
         ctx: &Ctx,
         head: Tipset,
     ) -> anyhow::Result<(i64, Option<Tipset>)> {
-        static CACHE: parking_lot::Mutex<Option<(Tipset, i64, Option<Tipset>)>> =
-            parking_lot::Mutex::new(None);
-        let mut cache = CACHE.lock();
-        if let Some((cached_head, cached_threshold, cached_tipset)) = &*cache
-            && cached_head == &head
-        {
-            Ok((*cached_threshold, cached_tipset.shallow_clone()))
-        } else {
-            let (threshold, tipset) =
-                Self::get_ec_finality_threshold_depth_and_tipset(ctx, head.shallow_clone())?;
-            *cache = Some((head, threshold, tipset.shallow_clone()));
-            Ok((threshold, tipset))
-        }
+        static CACHE: LazyLock<quick_cache::sync::Cache<TipsetKey, (i64, Option<Tipset>)>> =
+            LazyLock::new(|| quick_cache::sync::Cache::new(EC_CALCULATOR_FINALITY_CACHE_SIZE));
+        CACHE.get_or_insert_with(head.shallow_clone().key(), move || {
+            Self::get_ec_finality_threshold_depth_and_tipset(ctx, head)
+        })
     }
 
     pub fn get_ec_finality_epoch(
@@ -1195,17 +1189,17 @@ impl ChainGetTipSetFinalityStatus {
         chain_config: &ChainConfig,
         head: &Tipset,
     ) -> i64 {
-        static CACHE: parking_lot::Mutex<Option<(Tipset, i64)>> = parking_lot::Mutex::new(None);
-        let mut cache = CACHE.lock();
-        if let Some((cached_head, cached_threshold)) = &*cache
-            && cached_head == head
-        {
-            *cached_threshold
-        } else {
-            let threshold = Self::get_ec_finality_threshold_depth(chain_index, chain_config, head);
-            *cache = Some((head.shallow_clone(), threshold));
-            threshold
-        }
+        static CACHE: LazyLock<quick_cache::sync::Cache<TipsetKey, i64>> =
+            LazyLock::new(|| quick_cache::sync::Cache::new(EC_CALCULATOR_FINALITY_CACHE_SIZE));
+        CACHE
+            .get_or_insert_with(head.key(), move || -> Result<i64, Infallible> {
+                Ok(Self::get_ec_finality_threshold_depth(
+                    chain_index,
+                    chain_config,
+                    head,
+                ))
+            })
+            .expect("infallible")
     }
 
     fn get_ec_finality_threshold_depth(


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Previously, we don't cache the lookup for epoch (head-900, head] (Only when F3 is down), with EC finality calculator, the finaltiy is ~100 (actually 20 @6052192) instead of 900 on mainnet

Changes introduced in this pull request:

- 

Benchmark of querying tipset @ (head epoch - 500). 
```
# command
oha -n 1000 -c 1 -m POST http://localhost:2345/rpc/v1 -H 'Content-Type: application/json' -D eth_getBlockByNumber_call.json

# payload
{
        "method": "eth_getBlockByNumber",
        "params": ["0x5c571f", false],
        "id": 1,
        "jsonrpc": "2.0"
}

# main
  Success rate: 100.00%30s    40s    50s    60s    70s     ││0.0124  0.0166  0.0207  0.0248  0.0290  0.0331  0.0372    │
  Total:────────19659.0131 ms──────────────────────────────┘└──────────────────────────────────────────────────────────┘
  Slowest:      150.5417 ms
  Fastest:      12.4223 ms
  Average:      19.6465 ms
  Requests/sec: 50.8673

  Total data:   2.82 MiB
  Size/request: 2.88 KiB
  Size/sec:     146.74 KiB

Response time histogram:
   12.422 ms [1]   |
   26.234 ms [812] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   40.046 ms [184] |■■■■■■■
   53.858 ms [1]   |
   67.670 ms [0]   |
   81.482 ms [1]   |
   95.294 ms [0]   |
  109.106 ms [0]   |
  122.918 ms [0]   |
  136.730 ms [0]   |
  150.542 ms [1]   |

Response time distribution:
  10.00% in 16.0410 ms
  25.00% in 16.3323 ms
  50.00% in 16.6541 ms
  75.00% in 20.0071 ms
  90.00% in 28.3209 ms
  95.00% in 34.7470 ms
  99.00% in 36.3333 ms
  99.90% in 150.5417 ms
  99.99% in 150.5417 ms
  
# PR  
  Success rate: 100.00%
  Total:        658.4161 ms
  Slowest:      20.1629 ms
  Fastest:      0.2080 ms
  Average:      0.6541 ms
  Requests/sec: 1518.7965

  Total data:   2.82 MiB
  Size/request: 2.88 KiB
  Size/sec:     4.28 MiB

Response time histogram:
   0.208 ms [1]   |
   2.204 ms [966] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   4.199 ms [28]  |
   6.194 ms [4]   |
   8.190 ms [0]   |
  10.185 ms [0]   |
  12.181 ms [0]   |
  14.176 ms [0]   |
  16.172 ms [0]   |
  18.167 ms [0]   |
  20.163 ms [1]   |

Response time distribution:
  10.00% in 0.2769 ms
  25.00% in 0.3087 ms
  50.00% in 0.4054 ms
  75.00% in 0.6308 ms
  90.00% in 1.3820 ms
  95.00% in 1.9961 ms
  99.00% in 3.0389 ms
  99.90% in 20.1629 ms
  99.99% in 20.1629 ms
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Finality logic now derives a dynamic EC-based finalized epoch and uses a unified predicate that stays consistent as the chain head advances.
  * The EC-derived finalized epoch is exposed so other components can reference the computed finality point.

* **Performance**
  * Added async tipset lookups and an extra cache warmup step to prefetch finalized tipsets, improving RPC responsiveness and cache hit rates; lookup failures are logged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChainSafe/forest/pull/7112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->