### PR TITLE
fix: correct metrics for batches

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -650,9 +650,11 @@ pub async fn start_rpc(
                         keystore: keystore.clone(),
                     })
                     .layer(LogLayer::default())
-                    .layer(MetricsLayer::default())
-                    // `ParallelBatchLayer` has to be the last layer
-                    .layer(ParallelBatchLayer::new(max_response_body_size));
+                    // `ParallelBatchLayer` fans a batch out into per-entry `call`s, so it must be
+                    // outer to `MetricsLayer` for batched methods to be measured. Both must stay
+                    // inner to the batch-transforming layers above.
+                    .layer(ParallelBatchLayer::new(max_response_body_size))
+                    .layer(MetricsLayer::default());
                 let mut jsonrpsee_svc = svc_builder
                     .set_rpc_middleware(rpc_middleware)
                     .build(methods, stop_handle);
@@ -948,6 +950,29 @@ mod tests {
         assert_eq!(batch_response.len(), 2);
         assert_eq!(batch_response.num_successful_calls(), 2);
         assert_eq!(batch_response.num_failed_calls(), 0);
+
+        // `eth_chainId` is only ever requested inside the batch above, so its presence in the RPC
+        // timing metric proves batched methods flow through `MetricsLayer`. Guards against batch
+        // entries bypassing metrics (which happens if `MetricsLayer` is outer to `ParallelBatchLayer`).
+        let mut encoded = String::new();
+        prometheus_client::encoding::text::encode_registry(
+            &mut encoded,
+            &crate::metrics::default_registry(),
+        )
+        .unwrap();
+        let recorded = encoded.lines().any(|line| {
+            line.starts_with("rpc_processing_time_count{")
+                && line.contains(r#"method="eth_chainId""#)
+                && line
+                    .rsplit(' ')
+                    .next()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .is_some_and(|count| count == 1)
+        });
+        assert!(
+            recorded,
+            "batched method `eth_chainId` was not recorded in rpc_processing_time:\n{encoded}"
+        );
 
         // Gracefully shutdown the RPC server
         println!("sending shutdown signal");


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- correct metrics for batches - in case a call was in a batch, it was not recorded at all in the metric.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RPC metrics for batched requests so batched RPC calls (including chain ID queries) are now measured and counted correctly in Prometheus timing metrics, ensuring accurate performance reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChainSafe/forest/pull/7113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->