### PR TITLE
feat: size metrics for chain follower internal hash maps

### DIFF
--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -34,8 +34,8 @@ use crate::{
     shim::clock::ChainEpoch,
     state_manager::StateManager,
 };
-use ahash::{HashMap, HashSet};
 use chrono::Utc;
+use hashbrown::{HashMap, HashSet};
 use libp2p::PeerId;
 use parking_lot::{Mutex, RwLock};
 use std::time::Instant;
@@ -127,6 +127,12 @@ impl ChainFollower {
             bad_blocks.shallow_clone(),
             stateless_mode,
         )));
+
+        crate::metrics::register_collector(Box::new(SyncTasks(tasks.shallow_clone())));
+        crate::metrics::register_collector(Box::new(SyncStateMachineWrapper(
+            state_machine.shallow_clone(),
+        )));
+
         Self {
             tasks,
             state_machine,
@@ -612,7 +618,9 @@ impl std::fmt::Display for SyncEvent {
     }
 }
 
+#[derive(derive_more::Debug)]
 struct SyncStateMachine {
+    #[debug(skip)]
     cs: ChainStore,
     bad_block_cache: Option<BadBlockCache>,
     // Map from TipsetKey to FullTipset
@@ -975,6 +983,120 @@ impl SyncTask {
                     }
                 }
             }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SyncTasks(Arc<Mutex<HashSet<SyncTask>>>);
+
+#[derive(Debug)]
+struct SyncStateMachineWrapper(Arc<Mutex<SyncStateMachine>>);
+
+mod metrics_collection {
+    use super::*;
+    use prometheus_client::{
+        collector::Collector,
+        encoding::{DescriptorEncoder, EncodeMetric},
+        metrics::gauge::Gauge,
+        registry::Unit,
+    };
+
+    impl Collector for SyncTasks {
+        fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+            {
+                let size_in_bytes = {
+                    let g: Gauge = Default::default();
+                    g.set(self.0.lock().allocation_size() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "chain_follower_tasks_size",
+                    "Size of the chain follower tasks in bytes",
+                    Some(&Unit::Bytes),
+                    size_in_bytes.metric_type(),
+                )?;
+                size_in_bytes.encode(size_metric_encoder)?;
+            }
+            {
+                let len = {
+                    let g: Gauge = Default::default();
+                    g.set(self.0.lock().len() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "chain_follower_tasks_len",
+                    "Length of the chain follower tasks",
+                    None,
+                    len.metric_type(),
+                )?;
+                len.encode(size_metric_encoder)?;
+            }
+            {
+                let cap = {
+                    let g: Gauge = Default::default();
+                    g.set(self.0.lock().capacity() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "chain_follower_tasks_cap",
+                    "Capacity of the chain follower tasks",
+                    None,
+                    cap.metric_type(),
+                )?;
+                cap.encode(size_metric_encoder)?;
+            }
+
+            Ok(())
+        }
+    }
+
+    impl Collector for SyncStateMachineWrapper {
+        fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+            {
+                let size_in_bytes = {
+                    let g: Gauge = Default::default();
+                    g.set(self.0.lock().tipsets.allocation_size() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "chain_follower_tipsets_size",
+                    "Size of the chain follower tipsets in bytes",
+                    Some(&Unit::Bytes),
+                    size_in_bytes.metric_type(),
+                )?;
+                size_in_bytes.encode(size_metric_encoder)?;
+            }
+            {
+                let len = {
+                    let g: Gauge = Default::default();
+                    g.set(self.0.lock().tipsets.len() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "chain_follower_tipsets_len",
+                    "Length of the chain follower tipsets",
+                    None,
+                    len.metric_type(),
+                )?;
+                len.encode(size_metric_encoder)?;
+            }
+            {
+                let cap = {
+                    let g: Gauge = Default::default();
+                    g.set(self.0.lock().tipsets.capacity() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "chain_follower_tipsets_cap",
+                    "Capacity of the chain follower tipsets",
+                    None,
+                    cap.metric_type(),
+                )?;
+                cap.encode(size_metric_encoder)?;
+            }
+
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

```
# HELP chain_follower_tasks_size_bytes Size of the chain follower tasks in bytes
# TYPE chain_follower_tasks_size_bytes gauge
# UNIT chain_follower_tasks_size_bytes bytes
chain_follower_tasks_size_bytes 544
# HELP chain_follower_tasks_len Length of the chain follower tasks
# TYPE chain_follower_tasks_len gauge
chain_follower_tasks_len 1
# HELP chain_follower_tasks_cap Capacity of the chain follower tasks
# TYPE chain_follower_tasks_cap gauge
chain_follower_tasks_cap 14
# HELP chain_follower_tipsets_size_bytes Size of the chain follower tipsets in bytes
# TYPE chain_follower_tipsets_size_bytes gauge
# UNIT chain_follower_tipsets_size_bytes bytes
chain_follower_tipsets_size_bytes 83984
# HELP chain_follower_tipsets_len Length of the chain follower tipsets
# TYPE chain_follower_tipsets_len gauge
chain_follower_tipsets_len 67
# HELP chain_follower_tipsets_cap Capacity of the chain follower tipsets
# TYPE chain_follower_tipsets_cap gauge
chain_follower_tipsets_cap 1772
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Monitoring & Observability**
  * Introduced Prometheus metrics collectors for chain synchronization tasks and state-machine operations with detailed monitoring capabilities.
  * New gauges expose allocation size, data structure length, and capacity metrics for internal synchronization components.
  * Enhanced metrics coverage provides comprehensive visibility into synchronization task performance and internal resource utilization patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->