### PR TITLE
feat: metrics for message pool internal maps

### DIFF
--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -359,6 +359,8 @@ async fn chain_follower(
                         });
                     }
                 }
+
+                tasks_set.shrink_to_fit();
             }
         }
     });
@@ -772,6 +774,8 @@ impl SyncStateMachine {
             self.tipsets
                 .insert(merged_tipset.key().clone(), merged_tipset);
         }
+
+        self.tipsets.shrink_to_fit();
     }
 
     // Mark blocks in tipset as bad.

--- a/src/message_pool/msgpool/pending_store.rs
+++ b/src/message_pool/msgpool/pending_store.rs
@@ -3,7 +3,7 @@
 
 //! Pending message storage and event broadcast.
 
-use ahash::{HashMap, HashMapExt};
+use hashbrown::HashMap;
 use parking_lot::RwLock as SyncRwLock;
 use tokio::sync::broadcast;
 
@@ -43,13 +43,13 @@ impl PendingStore {
     /// Construct an empty store with the given per-actor limits.
     pub(in crate::message_pool) fn new(limits: MsgSetLimits) -> Self {
         let (events, _) = broadcast::channel(MPOOL_UPDATE_CHANNEL_CAPACITY);
-        Self {
-            inner: Arc::new(Inner {
-                pending: SyncRwLock::new(HashMap::new()),
-                events,
-                limits,
-            }),
-        }
+        let inner = Arc::new(Inner {
+            pending: SyncRwLock::new(HashMap::new()),
+            events,
+            limits,
+        });
+        crate::metrics::register_collector(Box::new(InnerMetricsCollector(inner.shallow_clone())));
+        Self { inner }
     }
 
     /// Insert a signed message under its already-resolved sender address.
@@ -109,6 +109,11 @@ impl PendingStore {
         removed
     }
 
+    /// Shrinks the capacity of the internal map as much as possible.
+    pub(in crate::message_pool) fn shrink_to_fit(&self) {
+        self.inner.pending.write().shrink_to_fit();
+    }
+
     /// Deep-clone of the pending map — one read-lock acquisition.
     pub(in crate::message_pool) fn snapshot(&self) -> HashMap<Address, MsgSet> {
         self.inner.pending.read().clone()
@@ -123,6 +128,68 @@ impl PendingStore {
     /// independent; dropping it does not affect other subscribers.
     pub fn subscribe(&self) -> broadcast::Receiver<MpoolUpdate> {
         self.inner.events.subscribe()
+    }
+}
+
+#[derive(derive_more::Debug, derive_more::Deref)]
+struct InnerMetricsCollector(#[debug(skip)] Arc<Inner>);
+
+mod metrics_collection {
+    use super::*;
+    use prometheus_client::{
+        collector::Collector,
+        encoding::{DescriptorEncoder, EncodeMetric},
+        metrics::gauge::Gauge,
+        registry::Unit,
+    };
+
+    impl Collector for InnerMetricsCollector {
+        fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+            {
+                let size_in_bytes = {
+                    let g: Gauge = Default::default();
+                    g.set(self.pending.read().allocation_size() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "mpool_pending_size",
+                    "Size of message pool pending messages in bytes",
+                    Some(&Unit::Bytes),
+                    size_in_bytes.metric_type(),
+                )?;
+                size_in_bytes.encode(size_metric_encoder)?;
+            }
+            {
+                let len = {
+                    let g: Gauge = Default::default();
+                    g.set(self.pending.read().len() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "mpool_pending_len",
+                    "Length of the message pool pending messages",
+                    None,
+                    len.metric_type(),
+                )?;
+                len.encode(size_metric_encoder)?;
+            }
+            {
+                let cap = {
+                    let g: Gauge = Default::default();
+                    g.set(self.pending.read().capacity() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "mpool_pending_cap",
+                    "Capacity of the message pool pending messages",
+                    None,
+                    cap.metric_type(),
+                )?;
+                cap.encode(size_metric_encoder)?;
+            }
+
+            Ok(())
+        }
     }
 }
 

--- a/src/message_pool/msgpool/pending_store.rs
+++ b/src/message_pool/msgpool/pending_store.rs
@@ -153,7 +153,7 @@ mod metrics_collection {
                 };
                 let size_metric_encoder = encoder.encode_descriptor(
                     "mpool_pending_size",
-                    "Size of message pool pending messages in bytes",
+                    "Allocation size of message pool pending messages in bytes",
                     Some(&Unit::Bytes),
                     size_in_bytes.metric_type(),
                 )?;

--- a/src/message_pool/msgpool/reorg.rs
+++ b/src/message_pool/msgpool/reorg.rs
@@ -105,6 +105,7 @@ where
                 }
             }
         }
+        self.pending.shrink_to_fit();
         Ok(())
     }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-
```
# HELP mpool_pending_size_bytes Allocation size of message pool pending messages in bytes
# TYPE mpool_pending_size_bytes gauge
# UNIT mpool_pending_size_bytes bytes
mpool_pending_size_bytes 2464
# HELP mpool_pending_len Length of the message pool pending messages
# TYPE mpool_pending_len gauge
mpool_pending_len 14
# HELP mpool_pending_cap Capacity of the message pool pending messages
# TYPE mpool_pending_cap gauge
mpool_pending_cap 14
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring metrics for the message-pool pending queue, exposing pending size, entry count, and capacity via Prometheus.

* **Improvements**
  * Reduced memory usage by trimming internal map capacities automatically after reorganizations and during routine processing to lower retained memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->