### PR TITLE
feat: add metrics for zstd frame cache

### DIFF
--- a/src/daemon/context.rs
+++ b/src/daemon/context.rs
@@ -51,6 +51,7 @@ impl AppContext {
         let chain_cfg = get_chain_config_and_set_network(cfg);
         let (net_keypair, p2p_peer_id) = get_or_create_p2p_keypair_and_peer_id(cfg)?;
         let (db, db_meta_data) = setup_db(opts, cfg).await?;
+        db.shallow_clone().register_metrics();
         let state_manager = create_state_manager(cfg, &db, &chain_cfg).await?;
         let (keystore, admin_jwt) = load_or_create_keystore_and_configure_jwt(opts, cfg).await?;
         let snapshot_progress_tracker = SnapshotProgressTracker::default();

--- a/src/db/car/many.rs
+++ b/src/db/car/many.rs
@@ -22,9 +22,6 @@ use crate::shim::clock::ChainEpoch;
 use crate::utils::io::EitherMmapOrRandomAccessFile;
 use crate::utils::multihash::prelude::*;
 use crate::{blocks::Tipset, libp2p_bitswap::BitswapStoreRead};
-use anyhow::Context as _;
-use cid::Cid;
-use fvm_ipld_blockstore::Blockstore;
 use parking_lot::RwLock;
 use std::{
     cmp::Ord,
@@ -84,6 +81,13 @@ impl<WriterT> ManyCar<WriterT> {
 
     pub fn writer(&self) -> &WriterT {
         &self.writer
+    }
+
+    pub fn register_metrics(self: Arc<Self>)
+    where
+        WriterT: Send + Sync + 'static,
+    {
+        crate::metrics::register_collector(Box::new(ManyCarMetricsCollector(self)));
     }
 }
 
@@ -339,6 +343,71 @@ impl<WriterT: BlockstoreWriteOpsSubscribable> BlockstoreWriteOpsSubscribable for
 impl<T: GarbageCollectableDb> GarbageCollectableDb for ManyCar<T> {
     fn reset_gc_columns(&self) -> anyhow::Result<()> {
         self.writer().reset_gc_columns()
+    }
+}
+
+#[derive(derive_more::Debug, derive_more::Deref)]
+struct ManyCarMetricsCollector<T>(#[debug(skip)] Arc<ManyCar<T>>);
+
+mod metrics_collection {
+    use super::*;
+    use prometheus_client::{
+        collector::Collector,
+        encoding::{DescriptorEncoder, EncodeMetric},
+        metrics::gauge::Gauge,
+        registry::Unit,
+    };
+
+    impl<T> Collector for ManyCarMetricsCollector<T>
+    where
+        T: Send + Sync + 'static,
+    {
+        fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+            {
+                let size_in_bytes = {
+                    let g: Gauge = Default::default();
+                    g.set(self.shared_cache.read().cache.weight() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "many_car_cache_size",
+                    "Size of the many car zstd frame cache in bytes",
+                    Some(&Unit::Bytes),
+                    size_in_bytes.metric_type(),
+                )?;
+                size_in_bytes.encode(size_metric_encoder)?;
+            }
+            {
+                let len = {
+                    let g: Gauge = Default::default();
+                    g.set(self.shared_cache.read().len() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "many_car_cache_len",
+                    "Length of the many car zstd frame cache",
+                    None,
+                    len.metric_type(),
+                )?;
+                len.encode(size_metric_encoder)?;
+            }
+            {
+                let cap = {
+                    let g: Gauge = Default::default();
+                    g.set(self.shared_cache.read().capacity() as i64);
+                    g
+                };
+                let size_metric_encoder = encoder.encode_descriptor(
+                    "many_car_cache_cap",
+                    "Capacity of the many car zstd frame cache in bytes",
+                    Some(&Unit::Bytes),
+                    cap.metric_type(),
+                )?;
+                cap.encode(size_metric_encoder)?;
+            }
+
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

```
# HELP many_car_cache_size_bytes Size of the many car zstd frame cache in bytes
# TYPE many_car_cache_size_bytes gauge
# UNIT many_car_cache_size_bytes bytes
many_car_cache_size_bytes 268421514
# HELP many_car_cache_len Length of the many car zstd frame cache
# TYPE many_car_cache_len gauge
many_car_cache_len 15599
# HELP many_car_cache_cap_bytes Capacity of the many car zstd frame cache in bytes
# TYPE many_car_cache_cap_bytes gauge
# UNIT many_car_cache_cap_bytes bytes
many_car_cache_cap_bytes 268435456
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics collection for database operations and CAR cache performance is now automatically registered, providing improved observability for cache weight, capacity, and item count tracking via Prometheus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->