### PR TITLE
fix: make validated block cache bounded

### DIFF
--- a/src/chain/store/chain_store.rs
+++ b/src/chain/store/chain_store.rs
@@ -27,11 +27,11 @@ use crate::{
     interpreter::{BlockMessages, VMTrace},
     rpc::chain::PathChanges,
 };
-use ahash::{HashMap, HashSet};
+use ahash::HashMap;
 use fil_actors_shared::fvm_ipld_amt::Amtv0 as Amt;
 use fvm_ipld_encoding::CborStore;
 use nonzero_ext::nonzero;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
     num::NonZeroUsize,
@@ -42,6 +42,9 @@ use tracing::{debug, error, trace, warn};
 
 // A cap on the size of the future_sink
 const SINK_CAP: usize = 200;
+
+// Assume a tipset has 5 blocks on average, we cache 1-day-worth of validated blocks. (5 * 2 * 60 * 24 = 14400)
+const VALIDATED_BLOCKS_CACHE_SIZE: NonZeroUsize = nonzero!(14400usize);
 
 /// Disambiguate the type to signify that we are expecting a delta and not an actual epoch/height
 /// while maintaining the same type.
@@ -78,7 +81,7 @@ pub struct ChainStore {
     genesis_block_header: Arc<CachingBlockHeader>,
 
     /// validated blocks
-    pub(crate) validated_blocks: Arc<Mutex<HashSet<Cid>>>,
+    pub(crate) validated_blocks: SizeTrackingCache<CidWrapper, ()>,
 
     /// Needed by the Ethereum mapping.
     chain_config: Arc<ChainConfig>,
@@ -148,7 +151,10 @@ impl ChainStore {
             f3_finalized_tipset,
             ec_calculator_finalized_epoch,
             genesis_block_header: genesis_block_header.into(),
-            validated_blocks: Default::default(),
+            validated_blocks: SizeTrackingCache::new_with_metrics(
+                "validated_blocks",
+                VALIDATED_BLOCKS_CACHE_SIZE,
+            ),
             chain_config,
             messages_in_tipset_cache: Default::default(),
         })
@@ -341,7 +347,7 @@ impl ChainStore {
 
     /// Checks metadata file if block has already been validated.
     pub fn is_block_validated(&self, cid: &Cid) -> bool {
-        let validated = self.validated_blocks.lock().contains(cid);
+        let validated = self.validated_blocks.get(cid).is_some();
         if validated {
             trace!("Block {cid} was previously validated");
         }
@@ -350,13 +356,11 @@ impl ChainStore {
 
     /// Marks block as validated in the metadata file.
     pub fn mark_block_as_validated(&self, cid: &Cid) {
-        let mut file = self.validated_blocks.lock();
-        file.insert(*cid);
+        self.validated_blocks.insert((*cid).into(), ());
     }
 
     pub fn unmark_block_as_validated(&self, cid: &Cid) {
-        let mut file = self.validated_blocks.lock();
-        let _did_work = file.remove(cid);
+        self.validated_blocks.remove(cid);
     }
 
     /// Retrieves ordered valid messages from a `Tipset`. This will only include

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -153,11 +153,7 @@ impl ChainFollower {
     pub fn reset(&self) {
         let start = Instant::now();
         self.tasks.lock().clear();
-        self.state_manager
-            .chain_store()
-            .validated_blocks
-            .lock()
-            .clear();
+        self.state_manager.chain_store().validated_blocks.clear();
         self.state_machine.lock().tipsets.clear();
         if let Some(bad_blocks) = &self.bad_blocks {
             bad_blocks.clear();


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

```
# HELP cache_validated_blocks_size_bytes Size of cache validated_blocks in bytes
# TYPE cache_validated_blocks_size_bytes gauge
# UNIT cache_validated_blocks_size_bytes bytes
cache_validated_blocks_size_bytes 6624
# HELP cache_validated_blocks_len Length of cache validated_blocks
# TYPE cache_validated_blocks_len gauge
cache_validated_blocks_len 69
# HELP cache_validated_blocks_cap Capacity of cache validated_blocks
# TYPE cache_validated_blocks_cap gauge
cache_validated_blocks_cap 14400
# HELP cache_validated_blocks_hits Cache hits of validated_blocks
# TYPE cache_validated_blocks_hits counter
cache_validated_blocks_hits_total 60
# HELP cache_validated_blocks_misses Cache misses of validated_blocks
# TYPE cache_validated_blocks_misses counter
cache_validated_blocks_misses_total 122
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal block validation tracking mechanism for improved performance.
  * Updated chain synchronization reset process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->