### PR TITLE
feat: add mise task jemalloc:heap for memory leak profiling

### DIFF
--- a/mise-tasks/jemalloc/heap.sh
+++ b/mise-tasks/jemalloc/heap.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#MISE description="Build and heap-profile a Forest binary with jemalloc. Usage: mise run jemalloc:heap <bin> [-- <bin-args...>](e.g. `mise run jemalloc:heap forest --encrypt-keystore=false --chain calibnet`). Dumps to /var/tmp/jeprof/jeprof.*.heap"
+#MISE env={MALLOC_CONF="prof:true,prof_leak:true,prof_final:true,prof_prefix:/var/tmp/jeprof/jeprof"}
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: mise run jemalloc:heap <bin> [-- <bin-args...>]" >&2
+    exit 2
+fi
+
+# create dump dir if not exist
+mkdir -p /var/tmp/jeprof
+
+cargo run \
+    --no-default-features --features jemalloc-profiling --profile=release-symbols \
+    --bin "$1" \
+    -- "${@:2}"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

```
mise run jemalloc:heap forest --encrypt-keystore=false --chain calibnet
...
[ctrl-c]
...
2026-06-09T01:48:25.440080Z  INFO forest::daemon::main: Shutting down tokio...
2026-06-09T01:48:25.441847Z  INFO forest::daemon::main: Forest finish shutdown
<jemalloc>: Leak approximation summary: ~110909013 bytes, ~2548 objects, >= 67 contexts
<jemalloc>: Run jeprof on dump output for leak detail
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced heap profiling tooling accessible via command-line for development and performance analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->