### PR TITLE
feat: `trace_block` caching

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -407,8 +407,10 @@ async fn prefill_rpc_caches_for_tipset(state_manager: StateManager, tsk: TipsetK
                 }
             }
             {
-                if let Err(e) = state_manager.execution_trace(&ts).await {
-                    warn!("failed to call `StateManager::execution_trace` for cache warmup: {e:#}");
+                // Warms both the FVM-replay cache and the parity-trace cache,
+                // since `eth_trace_block` calls `execution_trace` internally.
+                if let Err(e) = crate::rpc::eth::eth_trace_block(&state_manager, &ts).await {
+                    warn!("failed to call `eth_trace_block` for cache warmup: {e:#}");
                 }
             }
             {

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -3475,17 +3475,17 @@ impl RpcMethod<1> for EthTraceBlock {
         let ts = resolver
             .tipset_by_block_number_or_hash(block_param, ResolveNullTipset::TakeOlder)
             .await?;
-        eth_trace_block(&ctx, &ts).await
+        eth_trace_block(&ctx.state_manager, &ts).await
     }
 }
 
 /// Replays a tipset and resolves every non-system transaction into a [`trace::TipsetTraceEntry`].
 async fn execute_tipset_traces(
-    ctx: &Ctx,
+    state_manager: &StateManager,
     ts: &Tipset,
 ) -> Result<(StateTree<DbImpl>, Vec<trace::TipsetTraceEntry>), ServerError> {
-    let (state_root, raw_traces) = ctx.state_manager.execution_trace(ts).await?;
-    let state = ctx.state_manager.get_state_tree(&state_root)?;
+    let (state_root, raw_traces) = state_manager.execution_trace(ts).await?;
+    let state = state_manager.get_state_tree(&state_root)?;
 
     // Resolve every non-system message's tx hash in parallel. Each lookup is
     // an independent DB read; running them sequentially adds O(N) IO
@@ -3493,8 +3493,8 @@ async fn execute_tipset_traces(
     let raw = non_system_traces_with_positions(raw_traces).collect_vec();
     let mut entries: Vec<trace::TipsetTraceEntry> = Vec::with_capacity(raw.len());
     let mut join_set = tokio::task::JoinSet::new();
-    let db = ctx.db();
-    let eth_chain_id = ctx.chain_config().eth_chain_id;
+    let db = state_manager.db();
+    let eth_chain_id = state_manager.chain_config().eth_chain_id;
     for (msg_position, invoc_result) in raw {
         let db = db.shallow_clone();
         join_set.spawn_blocking(move || {
@@ -3533,23 +3533,43 @@ fn non_system_traces_with_positions(
         .map(|(idx, ir)| (idx as i64, ir))
 }
 
-async fn eth_trace_block(ctx: &Ctx, ts: &Tipset) -> Result<Vec<EthBlockTrace>, ServerError> {
-    let (state, entries) = execute_tipset_traces(ctx, ts).await?;
-    let block_hash: EthHash = ts.key().cid()?.into();
-    let mut all_traces = vec![];
+/// Builds the Parity-style block traces for `ts`, caching the result by tipset.
+/// Unlike [`StateManager::execution_trace`], this also caches the tx-hash
+/// lookups and parity-trace construction.
+pub(crate) async fn eth_trace_block(
+    state_manager: &StateManager,
+    ts: &Tipset,
+) -> Result<Vec<EthBlockTrace>, ServerError> {
+    // 64 most-recent blocks; bounded by count, not bytes (a few MiB on mainnet,
+    // see the `cache_eth_trace_block_size` metric).
+    const ETH_TRACE_BLOCK_CACHE_SIZE: NonZeroUsize = nonzero!(64usize);
+    static ETH_TRACE_BLOCK_CACHE: LazyLock<SizeTrackingCache<CidWrapper, Arc<Vec<EthBlockTrace>>>> =
+        LazyLock::new(|| {
+            SizeTrackingCache::new_with_metrics("eth_trace_block", ETH_TRACE_BLOCK_CACHE_SIZE)
+        });
 
-    for entry in entries {
-        for trace in entry.build_parity_traces(&state)? {
-            all_traces.push(EthBlockTrace {
-                trace,
-                block_hash,
-                block_number: ts.epoch(),
-                transaction_hash: entry.tx_hash,
-                transaction_position: entry.msg_position,
-            });
-        }
-    }
-    Ok(all_traces)
+    let block_cid = ts.key().cid()?;
+    let traces = ETH_TRACE_BLOCK_CACHE
+        .get_or_insert_async(&CidWrapper::from(block_cid), async move {
+            let (state, entries) = execute_tipset_traces(state_manager, ts).await?;
+            let block_hash: EthHash = block_cid.into();
+            let mut all_traces = vec![];
+
+            for entry in entries {
+                for trace in entry.build_parity_traces(&state)? {
+                    all_traces.push(EthBlockTrace {
+                        trace,
+                        block_hash,
+                        block_number: ts.epoch(),
+                        transaction_hash: entry.tx_hash,
+                        transaction_position: entry.msg_position,
+                    });
+                }
+            }
+            anyhow::Ok(Arc::new(all_traces))
+        })
+        .await?;
+    Ok(Arc::unwrap_or_clone(traces))
 }
 
 pub enum EthDebugTraceTransaction {}
@@ -3657,7 +3677,7 @@ async fn debug_trace_transaction(
         return Ok(GethTrace::PreState(frame));
     }
 
-    let (state, entries) = execute_tipset_traces(&ctx, &ts).await?;
+    let (state, entries) = execute_tipset_traces(&ctx.state_manager, &ts).await?;
     let entry = entries
         .into_iter()
         .find(|e| e.tx_hash == eth_hash)
@@ -3860,7 +3880,7 @@ impl RpcMethod<1> for EthTraceTransaction {
             .tipset_by_block_number_or_hash(eth_txn.block_number, ResolveNullTipset::TakeOlder)
             .await?;
 
-        let traces = eth_trace_block(&ctx, &ts)
+        let traces = eth_trace_block(&ctx.state_manager, &ts)
             .await?
             .into_iter()
             .filter(|trace| trace.transaction_hash == eth_hash)
@@ -3909,7 +3929,7 @@ async fn eth_trace_replay_block_transactions(
     ctx: &Ctx,
     ts: &Tipset,
 ) -> Result<Vec<EthReplayBlockTransactionTrace>, ServerError> {
-    let (state, entries) = execute_tipset_traces(ctx, ts).await?;
+    let (state, entries) = execute_tipset_traces(&ctx.state_manager, ts).await?;
 
     let mut all_traces = vec![];
     for entry in entries {

--- a/src/rpc/methods/eth/trace/types.rs
+++ b/src/rpc/methods/eth/trace/types.rs
@@ -13,12 +13,13 @@ use crate::rpc::eth::trace::GETH_TRACE_REVERT_ERROR;
 use crate::rpc::eth::trace::utils::extract_revert_reason;
 use crate::shim::error::ExitCode;
 use anyhow::{Context as _, Result, bail};
+use get_size2::GetSize;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 /// Typed error for Parity-style EVM trace entries.
-#[derive(Debug, Hash, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Hash, Clone, PartialEq, Eq, thiserror::Error, GetSize)]
 pub enum TraceError {
     #[error("Reverted")]
     Reverted,
@@ -102,7 +103,9 @@ fn parse_exit_code_display(s: &str) -> u32 {
         .unwrap_or(0)
 }
 
-#[derive(Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(
+    Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema, GetSize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct EthCallTraceAction {
     pub call_type: String,
@@ -113,7 +116,9 @@ pub struct EthCallTraceAction {
     pub input: EthBytes,
 }
 
-#[derive(Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(
+    Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema, GetSize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct EthCreateTraceAction {
     pub from: EthAddress,
@@ -122,7 +127,7 @@ pub struct EthCreateTraceAction {
     pub init: EthBytes,
 }
 
-#[derive(Eq, Hash, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Eq, Hash, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema, GetSize)]
 #[serde(untagged)]
 pub enum TraceAction {
     Call(EthCallTraceAction),
@@ -135,14 +140,18 @@ impl Default for TraceAction {
     }
 }
 
-#[derive(Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(
+    Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema, GetSize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct EthCallTraceResult {
     pub gas_used: EthUint64,
     pub output: EthBytes,
 }
 
-#[derive(Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(
+    Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema, GetSize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct EthCreateTraceResult {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -151,7 +160,7 @@ pub struct EthCreateTraceResult {
     pub code: EthBytes,
 }
 
-#[derive(Eq, Hash, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Eq, Hash, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema, GetSize)]
 #[serde(untagged)]
 pub enum TraceResult {
     Call(EthCallTraceResult),
@@ -496,7 +505,9 @@ impl EthTraceResults {
     }
 }
 
-#[derive(Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(
+    Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema, GetSize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct EthTrace {
     pub r#type: String,
@@ -595,7 +606,9 @@ impl EthTrace {
     }
 }
 
-#[derive(Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(
+    Eq, Hash, PartialEq, Default, Serialize, Deserialize, Debug, Clone, JsonSchema, GetSize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct EthBlockTrace {
     #[serde(flatten)]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- adds caching for block traces, which significantly improves latency (10x) on `pending` which is the most common parameter to the method.

```
# HELP cache_eth_trace_block_size_bytes Size of cache eth_trace_block in bytes
# TYPE cache_eth_trace_block_size_bytes gauge
# UNIT cache_eth_trace_block_size_bytes bytes
cache_eth_trace_block_size_bytes 2895433
# HELP cache_eth_trace_block_len Length of cache eth_trace_block
# TYPE cache_eth_trace_block_len gauge
cache_eth_trace_block_len 64
# HELP cache_eth_trace_block_cap Capacity of cache eth_trace_block
# TYPE cache_eth_trace_block_cap gauge
cache_eth_trace_block_cap 64
# HELP cache_eth_trace_block_hits Cache hits of eth_trace_block
# TYPE cache_eth_trace_block_hits counter
cache_eth_trace_block_hits_total 24608
# HELP cache_eth_trace_block_misses Cache misses of eth_trace_block
# TYPE cache_eth_trace_block_misses counter
cache_eth_trace_block_misses_total 322
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/7155

## Other information and links

`main`
```
Summary:
  Success rate:	100.00%
  Total:	2045.1002 ms
  Slowest:	5.2598 ms
  Fastest:	1.5648 ms
  Average:	2.0402 ms
  Requests/sec:	4889.7359

  Total data:	724.86 MiB
  Size/request:	74.23 KiB
  Size/sec:	354.44 MiB

Response time histogram:
  1.565 ms [1]    |
  1.934 ms [5074] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  2.304 ms [2767] |■■■■■■■■■■■■■■■■■
  2.673 ms [1731] |■■■■■■■■■■
  3.043 ms [301]  |■
  3.412 ms [51]   |
  3.782 ms [45]   |
  4.151 ms [15]   |
  4.521 ms [10]   |
  4.890 ms [4]    |
  5.260 ms [1]    |

Response time distribution:
  10.00% in 1.6986 ms
  25.00% in 1.7741 ms
  50.00% in 1.9259 ms
  75.00% in 2.2391 ms
  90.00% in 2.5130 ms
  95.00% in 2.6427 ms
  99.00% in 3.2456 ms
  99.90% in 4.3415 ms
  99.99% in 4.6867 ms


Details (average, fastest, slowest):
  DNS+dialup:	0.1008 ms, 0.0464 ms, 0.1486 ms
  DNS-lookup:	0.0157 ms, 0.0083 ms, 0.0211 ms

Status code distribution:
  [200] 10000 responses
```
this PR
```
Summary:
  Success rate:	100.00%
  Total:	2201.0784 ms
  Slowest:	1.2123 ms
  Fastest:	0.2006 ms
  Average:	0.2193 ms
  Requests/sec:	4543.2276

  Total data:	714.50 MiB
  Size/request:	73.17 KiB
  Size/sec:	324.61 MiB

Response time histogram:
  0.201 ms [1]    |
  0.302 ms [9636] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.403 ms [231]  |
  0.504 ms [97]   |
  0.605 ms [29]   |
  0.706 ms [0]    |
  0.808 ms [2]    |
  0.909 ms [3]    |
  1.010 ms [0]    |
  1.111 ms [0]    |
  1.212 ms [1]    |

Response time distribution:
  10.00% in 0.2035 ms
  25.00% in 0.2051 ms
  50.00% in 0.2087 ms
  75.00% in 0.2154 ms
  90.00% in 0.2303 ms
  95.00% in 0.2635 ms
  99.00% in 0.4210 ms
  99.90% in 0.5446 ms
  99.99% in 0.9009 ms


Details (average, fastest, slowest):
  DNS+dialup:	0.1109 ms, 0.1109 ms, 0.1109 ms
  DNS-lookup:	0.0166 ms, 0.0166 ms, 0.0166 ms

Status code distribution:
  [200] 10000 responses
```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized Ethereum trace block operations with improved caching mechanisms, reducing computational overhead for repeated trace requests.
  * Enhanced RPC cache warmup process to simultaneously prepare multiple trace caches, improving startup performance and response times for trace-related calls.
  * Refactored trace handling to streamline state management integration across trace RPC endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->