### PR TITLE
fix: RPC cache prefilling for eth pending tag

### DIFF
--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -847,10 +847,10 @@ impl SyncStateMachine {
                 tipset,
                 is_proposed_head,
             } => {
-                let tsk = tipset.key().clone();
                 if self.try_mark_tipset_as_validated(tipset, is_proposed_head)
                     && crate::utils::broadcast::has_subscribers(&self.validated_tipset_broadcast_tx)
-                    && let Err(e) = self.validated_tipset_broadcast_tx.send(tsk)
+                    // Sending the actual head key here as it could be expanded from the above tipset when `is_proposed_head` is `true`
+                    && let Err(e) = self.validated_tipset_broadcast_tx.send(self.cs.heaviest_tipset().key().clone())
                 {
                     warn!("Failed to broadcast validated tipset: {e}");
                 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

The validated tipset key might be expanded before updating chain head, we should warm up with the expanded key or eth pending tipset might not be warmed up

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the validated tipset broadcast during chain synchronization to ensure consistent use of the current heaviest tipset information, improving alignment in head-key expansion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->