### PR TITLE
feat: single authentication per connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ### Changed
 
+- [#7164](https://github.com/ChainSafe/forest/issues/7164): JSON-RPC authentication is now performed once per connection (e.g. at the WebSocket upgrade) instead of on every request, matching Lotus. Note that token expiry is no longer re-checked for the lifetime of an established connection.
+
 ### Removed
 
 ### Fixed

--- a/src/rpc/auth_layer.rs
+++ b/src/rpc/auth_layer.rs
@@ -61,24 +61,34 @@ impl<S> Layer<S> for AuthLayer {
     type Service = Auth<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        Auth {
-            headers: self.headers.clone(),
-            keystore: self.keystore.clone(),
-            service,
-        }
+        // Resolve the JWT claims once per connection (e.g. at the WebSocket
+        // upgrade) instead of re-verifying the token on every request. This
+        // matches Lotus, which authenticates once when the connection is
+        // established. Note that a long-lived connection therefore keeps the
+        // permissions it was granted at connection time; token expiry is not
+        // re-checked mid-session.
+        let claims =
+            resolve_claims(&self.keystore, self.headers.get(AUTHORIZATION)).map(Into::into);
+        Auth { claims, service }
     }
 }
 
 #[derive(Clone)]
 pub struct Auth<S> {
-    headers: HeaderMap,
-    keystore: Arc<RwLock<KeyStore>>,
+    /// Permission claims resolved once for this connection. `Err` means the
+    /// auth header was malformed or the token failed verification, in which
+    /// case every call on this connection is rejected with that error.
+    claims: Result<Arc<[String]>, ErrorCode>,
     service: S,
 }
 
 impl<S> Auth<S> {
     fn authorize<'a>(&self, method_name: &str) -> Result<(), ErrorObject<'a>> {
-        match check_permissions(&self.keystore, self.headers.get(AUTHORIZATION), method_name) {
+        let allowed = match &self.claims {
+            Ok(claims) => is_method_allowed(claims, method_name),
+            Err(code) => Err(*code),
+        };
+        match allowed {
             Ok(true) => Ok(()),
             Ok(false) => {
                 tracing::warn!("Unauthorized access attempt for method {method_name}");
@@ -156,11 +166,14 @@ fn auth_verify(token: &str, keystore: &RwLock<KeyStore>) -> anyhow::Result<Vec<S
     Ok(verify_token(token, key_info.private_key())?)
 }
 
-fn check_permissions(
+/// Verify the auth header's JWT and return the token's permission claims.
+///
+/// This performs the (relatively expensive) JWT verification and is intended to
+/// be called once per connection, not once per request.
+fn resolve_claims(
     keystore: &RwLock<KeyStore>,
     auth_header: Option<&HeaderValue>,
-    method: &str,
-) -> Result<bool, ErrorCode> {
+) -> Result<Vec<String>, ErrorCode> {
     let claims = match auth_header {
         Some(token) => {
             let token = token
@@ -176,11 +189,27 @@ fn check_permissions(
         None => vec!["read".to_owned()],
     };
     debug!("Decoded JWT Claims: {}", claims.join(","));
+    Ok(claims)
+}
 
+/// Check whether the already-resolved `claims` permit calling `method`.
+fn is_method_allowed(claims: &[String], method: &str) -> Result<bool, ErrorCode> {
     match METHOD_NAME2REQUIRED_PERMISSION.get(&method) {
-        Some(required_by_method) => Ok(is_allowed(*required_by_method, &claims)),
+        Some(required_by_method) => Ok(is_allowed(*required_by_method, claims)),
         None => Err(ErrorCode::MethodNotFound),
     }
+}
+
+/// Combined token resolution and permission check. Now that the connection path
+/// resolves claims once via [`resolve_claims`], this is only used by tests.
+#[cfg(test)]
+fn check_permissions(
+    keystore: &RwLock<KeyStore>,
+    auth_header: Option<&HeaderValue>,
+    method: &str,
+) -> Result<bool, ErrorCode> {
+    let claims = resolve_claims(keystore, auth_header)?;
+    is_method_allowed(&claims, method)
 }
 
 #[cfg(test)]
@@ -254,5 +283,79 @@ mod tests {
         let auth_header = HeaderValue::from_str(&token).unwrap();
         let res = check_permissions(&keystore, Some(&auth_header), wallet::WalletNew::NAME);
         assert_eq!(res, Ok(true));
+    }
+
+    /// `AuthLayer::layer` resolves the connection's token to claims exactly once
+    /// (at connection setup); the resulting [`Auth`] service then authorizes
+    /// calls against those cached claims without re-verifying the token.
+    #[test]
+    fn layer_resolves_claims_once_from_connection_header() {
+        use crate::auth::*;
+        let keystore = Arc::new(RwLock::new(
+            KeyStore::new(crate::KeyStoreConfig::Memory).unwrap(),
+        ));
+        let key_info = generate_priv_key();
+        keystore
+            .write()
+            .put(JWT_IDENTIFIER, key_info.clone())
+            .unwrap();
+        let token = create_token(
+            ADMIN.iter().map(ToString::to_string).collect(),
+            key_info.private_key(),
+            Duration::hours(1),
+        )
+        .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+
+        // Building the per-connection service resolves the claims once.
+        let auth = AuthLayer { headers, keystore }.layer(());
+        let claims = auth.claims.clone().expect("admin token should resolve");
+        assert!(claims.iter().any(|c| c == "admin"));
+
+        // The cached claims authorize an admin method without touching the token again.
+        assert!(auth.authorize(wallet::WalletNew::NAME).is_ok());
+    }
+
+    /// Cached claims are reused per request: a read-only connection is allowed
+    /// read methods, rejected for write methods, and gets `MethodNotFound` for
+    /// unknown methods.
+    #[test]
+    fn authorize_enforces_cached_permissions() {
+        let auth = Auth {
+            claims: Ok(vec!["read".to_owned()].into()),
+            service: (),
+        };
+
+        assert!(auth.authorize(ChainHead::NAME).is_ok());
+
+        let err = auth.authorize(wallet::WalletNew::NAME).unwrap_err();
+        assert_eq!(
+            err.code(),
+            i32::from(http::StatusCode::UNAUTHORIZED.as_u16())
+        );
+
+        let err = auth.authorize("Cthulhu.InvokeElderGods").unwrap_err();
+        assert_eq!(err.code(), ErrorCode::MethodNotFound.code());
+    }
+
+    /// A connection whose token failed verification caches the error and rejects
+    /// every subsequent call with it, regardless of the method.
+    #[test]
+    fn authorize_with_failed_token_rejects_every_call() {
+        let auth = Auth {
+            claims: Err(ErrorCode::InvalidRequest),
+            service: (),
+        };
+
+        let err = auth.authorize(ChainHead::NAME).unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidRequest.code());
+
+        let err = auth.authorize(wallet::WalletNew::NAME).unwrap_err();
+        assert_eq!(err.code(), ErrorCode::InvalidRequest.code());
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- check JWT once per connection

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/7164

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * JSON-RPC authentication is now performed once per connection rather than for each request, improving performance
  * Token expiry checking is no longer re-evaluated during an active connection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->