### PR TITLE
fix: remove extra clone from tipset serialization

### DIFF
--- a/src/blocks/tipset.rs
+++ b/src/blocks/tipset.rs
@@ -649,12 +649,8 @@ mod lotus_json {
     #[schemars(rename = "TipsetInner")]
     #[serde(rename_all = "PascalCase")]
     struct TipsetLotusJsonInner {
-        #[serde(with = "crate::lotus_json")]
-        #[schemars(with = "LotusJson<TipsetKey>")]
-        cids: TipsetKey,
-        #[serde(with = "crate::lotus_json")]
-        #[schemars(with = "LotusJson<NonEmpty<CachingBlockHeader>>")]
-        blocks: NonEmpty<CachingBlockHeader>,
+        cids: <TipsetKey as HasLotusJson>::LotusJson,
+        blocks: <NonEmpty<CachingBlockHeader> as HasLotusJson>::LotusJson,
         height: i64,
     }
 
@@ -669,7 +665,10 @@ mod lotus_json {
                 height: _ignored1,
             } = Deserialize::deserialize(deserializer)?;
 
-            Ok(Self(Tipset::new(blocks).map_err(D::Error::custom)?))
+            Ok(Self(
+                Tipset::new(NonEmpty::<CachingBlockHeader>::from_lotus_json(blocks))
+                    .map_err(D::Error::custom)?,
+            ))
         }
     }
 
@@ -680,9 +679,9 @@ mod lotus_json {
         {
             let Self(tipset) = self;
             TipsetLotusJsonInner {
-                cids: tipset.key().clone(),
+                cids: tipset.key().clone().into_lotus_json(),
+                blocks: tipset.block_headers().clone().into_lotus_json(),
                 height: tipset.epoch(),
-                blocks: tipset.block_headers().clone(),
             }
             .serialize(serializer)
         }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- While serializing the tipset we were cloning the enitre blockheader just to create a struct and then clone again for serialization.
- Changed the field to directly use the `HashLotusJson` field to avoid cloning.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal JSON serialization handling for Tipset data structures to use consistent type conversion patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->