### PR TITLE
chore: demote failed fetch tipset log

### DIFF
--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -975,7 +975,8 @@ impl SyncTask {
                 {
                     Ok(parents) => Some(SyncEvent::NewFullTipsets(parents)),
                     Err(e) => {
-                        tracing::warn!(%key, %epoch, "failed to fetch tipset: {e:#}");
+                        // It's not a massive error; could be a transient network issue or a fork.
+                        tracing::debug!(%key, %epoch, "failed to fetch tipset: {e:#}");
                         None
                     }
                 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- we get massive amount of non-actionable log entries around failing tipset fetches. This is an issue on its own https://github.com/ChainSafe/forest/issues/7177, but the logs aren't really useful for any user.
```
2026-06-15T09:15:13.096448Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 1 network failures, 99 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzacebmphegarmh3mhokkckeiv6df764xkbal4djei4uw4y667oowldww)] }, request_len: 16, options: 3 } key=[bafy2bzacebmphegarmh3mhokkckeiv6df764xkbal4djei4uw4y667oowldww] epoch=6100129
2026-06-15T09:15:13.117248Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 0 network failures, 100 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzacea2bt6cjtblsu5bn26snuyrdn3u2wd2fjnndvu5ttapaan65e7ylc)] }, request_len: 16, options: 3 } key=[bafy2bzacea2bt6cjtblsu5bn26snuyrdn3u2wd2fjnndvu5ttapaan65e7ylc] epoch=6099938
2026-06-15T09:15:13.128640Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 1 network failures, 99 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzacedx4wz5lf7gudcytctrargl4ylf5dzfscroqzn2tljgsydacph3xg)] }, request_len: 16, options: 3 } key=[bafy2bzacedx4wz5lf7gudcytctrargl4ylf5dzfscroqzn2tljgsydacph3xg] epoch=6103592
2026-06-15T09:15:13.157160Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 1 network failures, 99 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzacec4qiie3fa5mqega64duetu7ppbjx5vqqcf2sdtoijd5lpkhvnwiy)] }, request_len: 16, options: 3 } key=[bafy2bzacec4qiie3fa5mqega64duetu7ppbjx5vqqcf2sdtoijd5lpkhvnwiy] epoch=6103697
2026-06-15T09:15:13.175651Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 0 network failures, 100 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzacea2rwulzgdvoc6iszsbuvzrgwc5zsmbruffkt7worldv4lqvpx3ww)] }, request_len: 16, options: 3 } key=[bafy2bzacea2rwulzgdvoc6iszsbuvzrgwc5zsmbruffkt7worldv4lqvpx3ww] epoch=6102882
2026-06-15T09:15:13.209372Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 0 network failures, 100 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzacebjfc44s6vwobwvj6l4g2s6g4xel6euk7ac2adzweq3q5cokmukdo)] }, request_len: 16, options: 3 } key=[bafy2bzacebjfc44s6vwobwvj6l4g2s6g4xel6euk7ac2adzweq3q5cokmukdo] epoch=6100375
2026-06-15T09:15:13.273283Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 0 network failures, 100 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzaced26bemgzdvunrn7iy5h6u2ie5ro63paby524lu4ru5xjoql5la64)] }, request_len: 16, options: 3 } key=[bafy2bzaced26bemgzdvunrn7iy5h6u2ie5ro63paby524lu4ru5xjoql5la64] epoch=6102792
2026-06-15T09:15:13.277657Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 1 network failures, 99 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzacebu3zj35qh4xe7fkeccnppr62yg6uoczqqycydq3cuu3m5o6qb6nc)] }, request_len: 16, options: 3 } key=[bafy2bzacebu3zj35qh4xe7fkeccnppr62yg6uoczqqycydq3cuu3m5o6qb6nc] epoch=6103053
2026-06-15T09:15:13.291498Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 0 network failures, 100 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzaceaavxsk222xfih6zheve7iljd2yvfmvfyekcdjfbubhrphiapjzvs)] }, request_len: 16, options: 3 } key=[bafy2bzaceaavxsk222xfih6zheve7iljd2yvfmvfyekcdjfbubhrphiapjzvs] epoch=6103012
2026-06-15T09:15:13.296523Z  WARN forest::chain_sync::chain_follower: failed to fetch tipset: ChainExchange request failed for all top peers. 2 network failures, 98 lookup failures, request:
ChainExchangeRequest { start: NonEmpty { inner: [Cid(bafy2bzacebvhwenxk2kk55poi3kwt7a33j5fqmdu5n4kjj4wbabb7u5cvywza)] }, request_len: 16, options: 3 } key=[bafy2bzacebvhwenxk2kk55poi3kwt7a33j5fqmdu5n4kjj4wbabb7u5cvywza] epoch=6100248
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging levels for improved diagnostic output during network operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->