### PR TITLE
fix(mpool): removing the applied tipset from pending store should advance with correct nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 - [#7129](https://github.com/ChainSafe/forest/pull/7129): Fixed a few inaccurate cache size metrics.
 
+- [#6974](https://github.com/ChainSafe/forest/issues/6974): Fixed the message pool reporting a still-pending nonce as the next nonce after an applied message was removed.
+
 ## Forest v0.33.6 "Ebb"
 
 Non-mandatory release for all node operators. It fixes a critical memory leak in `v0.33.5`. (Earlier releases are not affected)

--- a/src/message_pool/msgpool/msg_set.rs
+++ b/src/message_pool/msgpool/msg_set.rs
@@ -154,8 +154,8 @@ impl MsgSet {
     /// Remove the message at `sequence` and adjust `next_sequence`.
     ///
     /// - **Applied** (included on-chain): advance `next_sequence` to
-    ///   `sequence + 1` if needed. For messages not in our pool, also run
-    ///   the gap-filling loop to advance past consecutive known messages.
+    ///   `sequence + 1`, then run the gap-filling loop to advance past any
+    ///   consecutive pending messages.
     /// - **Pruned** (evicted): rewind `next_sequence` to `sequence` if the
     ///   removal creates a gap.
     ///
@@ -175,10 +175,13 @@ impl MsgSet {
 
         // adjust next sequence
         if applied {
-            // we removed a (known) message because it was applied in a tipset
-            // we can't possibly have filled a gap in this case
+            // we removed a (known) message because it was applied in a tipset and we need to
+            // advance past it and any consecutive pending successors
             if sequence >= self.next_sequence {
                 self.next_sequence = sequence + 1;
+                while self.msgs.contains_key(&self.next_sequence) {
+                    self.next_sequence += 1;
+                }
             }
         } else if sequence < self.next_sequence {
             // we removed a message because it was pruned
@@ -503,6 +506,35 @@ mod tests {
         assert_eq!(
             mset.next_sequence, 6,
             "applied rm of unknown seq >= next_sequence advances to seq+1"
+        );
+    }
+
+    #[test]
+    fn rm_applied_known_advances_past_pending_successors() {
+        let limits = MsgSetLimits::new(1000, 1000);
+        // next_sequence starts at 5, so nonces 6 and 7 are added as gapped,
+        // leaving next_sequence behind at 5.
+        let mut mset = MsgSet::new(5);
+
+        for seq in [6, 7] {
+            mset.add(
+                make_smsg(Address::default(), seq, 100),
+                StrictnessPolicy::Relaxed,
+                TrustPolicy::Trusted,
+                limits,
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            mset.next_sequence, 5,
+            "gapped adds leave next_sequence at 5"
+        );
+
+        // Nonce 6 (known) is applied while 7 is still pending.
+        mset.rm(6, true);
+        assert_eq!(
+            mset.next_sequence, 8,
+            "must advance past the still-pending nonce 7, not stop at 7"
         );
     }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- If tipset message is applied then while removing the message from the pending store we should advance the next sequence past the buffered successors (pending message sequence).

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/6974

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the message pool incorrectly reported a pending nonce as the next sequence number after an applied message was removed. The system now properly advances past all consecutive pending messages when calculating the next available nonce.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->