### PR TITLE
chore: add in-flight RPC metric

### DIFF
--- a/.config/forest.dic
+++ b/.config/forest.dic
@@ -1,4 +1,4 @@
-273
+274
 Algorand/M
 API's
 API/SM
@@ -189,6 +189,7 @@ precommit
 preloaded
 pubsub
 R2
+RAII
 RBF
 README
 repo/S

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 - [#7168](https://github.com/ChainSafe/forest/pull/7168): Added the `FOREST_RPC_METRICS_DISABLED` environment variable to disable JSON-RPC per-method metrics while leaving other metrics intact.
 
+- [#7195](https://github.com/ChainSafe/forest/pull/7195): Added the `rpc_in_flight_requests` metric reporting the number of JSON-RPC requests currently being processed.
+
 ### Changed
 
 - [#7164](https://github.com/ChainSafe/forest/issues/7164): JSON-RPC authentication is now performed once per connection (e.g. at the WebSocket upgrade) instead of on every request, matching Lotus. Note that token expiry is no longer re-checked for the lifetime of an established connection.

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -12,6 +12,7 @@ use prometheus_client::{
     metrics::{
         counter::Counter,
         family::Family,
+        gauge::Gauge,
         histogram::{Histogram, exponential_buckets},
     },
 };
@@ -49,6 +50,16 @@ pub static RPC_METHOD_FAILURE: LazyLock<Family<RpcMethodLabel, Counter>> = LazyL
     DEFAULT_REGISTRY.write().register(
         "rpc_method_failure",
         "Number of failed RPC calls",
+        metric.clone(),
+    );
+    metric
+});
+
+pub static RPC_IN_FLIGHT: LazyLock<Gauge> = LazyLock::new(|| {
+    let metric = Gauge::default();
+    DEFAULT_REGISTRY.write().register(
+        "rpc_in_flight_requests",
+        "Number of RPC requests currently being processed",
         metric.clone(),
     );
     metric
@@ -188,5 +199,31 @@ impl HistogramTimerExt for Histogram {
             histogram: self,
             start: Instant::now(),
         }
+    }
+}
+
+/// RAII guard that increments a gauge on creation and decrements it on drop,
+/// keeping the count balanced even if the guarded scope ends via cancellation
+/// (its future is dropped) or panic-unwind. Created via [`GaugeGuardExt::inc_guard`].
+pub struct GaugeGuard<'a> {
+    gauge: &'a Gauge,
+}
+
+impl Drop for GaugeGuard<'_> {
+    fn drop(&mut self) {
+        self.gauge.dec();
+    }
+}
+
+pub trait GaugeGuardExt {
+    /// Increments the gauge and returns a [`GaugeGuard`] that decrements it on drop.
+    #[must_use = "dropping the guard immediately makes the increment a no-op; bind it to a variable"]
+    fn inc_guard(&self) -> GaugeGuard<'_>;
+}
+
+impl GaugeGuardExt for Gauge {
+    fn inc_guard(&self) -> GaugeGuard<'_> {
+        self.inc();
+        GaugeGuard { gauge: self }
     }
 }

--- a/src/rpc/metrics_layer.rs
+++ b/src/rpc/metrics_layer.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::metrics;
+use crate::metrics::GaugeGuardExt as _;
 use crate::{for_each_rpc_method, rpc::reflect::RpcMethod as _};
 use ahash::HashMap;
 use futures::future::Either;
@@ -117,6 +118,9 @@ impl<S> RecordMetrics<S> {
     where
         F: Future<Output = MethodResponse>,
     {
+        // Held across the `.await` below, so the in-flight gauge is decremented on
+        // normal completion, cancellation (future dropped), or panic-unwind alike.
+        let _in_flight = metrics::RPC_IN_FLIGHT.inc_guard();
         let start_time = std::time::Instant::now();
         let resp = future.await;
         // Observe the elapsed time in milliseconds.


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- added in-flight RPC metric

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new JSON-RPC metric (`rpc_in_flight_requests`) to track the number of in-flight requests being processed simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->