### PR TITLE
fix(wallet): support explicit --encrypt false for forest-wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 ### Fixed
 
+- [#7211](https://github.com/ChainSafe/forest/pull/7211): Fixed `forest-wallet` to allow using the unencrypted keystore with `--encrypt false` when an encrypted keystore also exists.
+
 - [#7129](https://github.com/ChainSafe/forest/pull/7129): Fixed a few inaccurate cache size metrics.
 
 - [#6974](https://github.com/ChainSafe/forest/issues/6974): Fixed the message pool reporting a still-pending nonce as the next nonce after an applied message was removed.

--- a/src/wallet/subcommands/mod.rs
+++ b/src/wallet/subcommands/mod.rs
@@ -22,9 +22,11 @@ pub struct Cli {
     #[arg(long)]
     pub remote_wallet: bool,
 
-    /// Encrypt local wallet
+    /// Use encrypted keystore.
+    ///
+    /// Note: When an encrypted keystore exists, it is used by default if `--encrypt` is omitted.
     #[arg(long)]
-    pub encrypt: bool,
+    pub encrypt: Option<bool>,
 
     #[command(subcommand)]
     pub cmd: wallet_cmd::WalletCommands,

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -61,18 +61,15 @@ impl WalletBackend {
         }
     }
 
-    fn new_local(client: rpc::Client, want_encryption: bool) -> anyhow::Result<Self> {
+    fn new_local(client: rpc::Client, want_encryption: Option<bool>) -> anyhow::Result<Self> {
         let Some(dir) = ProjectDirs::from("com", "ChainSafe", "Forest-Wallet") else {
             bail!("Failed to find wallet directory");
         };
-
         let wallet_dir = dir.data_dir().to_path_buf();
-
         let is_encrypted = wallet_dir.join(ENCRYPTED_KEYSTORE_NAME).exists();
-
-        // Always use the encrypted keystore if it exists. It it does not exist,
-        // only use encryption when explicitly asked for it.
-        let keystore = if is_encrypted || want_encryption {
+        // Default to an encrypted keystore if it exist.
+        let use_encryption = want_encryption.unwrap_or(is_encrypted);
+        let keystore = if use_encryption {
             input_password_to_load_encrypted_keystore(wallet_dir)?
         } else {
             KeyStore::new(KeyStoreConfig::Persistent(wallet_dir.to_path_buf()))?
@@ -311,7 +308,7 @@ impl WalletCommands {
         self,
         client: rpc::Client,
         remote_wallet: bool,
-        encrypt: bool,
+        encrypt: Option<bool>,
     ) -> anyhow::Result<()> {
         let mut backend = if remote_wallet {
             WalletBackend::new_remote(client)


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- As reported when an encrypted keystore existed, `forest-wallet` always used it with no way to select the unencrypted keystore. This PR adds `--encrypt false` to allow that when both exist.

```
--encrypt <ENCRYPT>
    Use encrypted keystore.
          
    Note: When an encrypted keystore exists, it is used by default if `--encrypt` is omitted.
          
   [possible values: true, false]
```

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #5209 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--encrypt` flag is now optional. When omitted, the wallet automatically uses an encrypted keystore if available; otherwise, it uses the unencrypted keystore.
  * Users can explicitly use `--encrypt false` to force the unencrypted keystore, even when an encrypted keystore exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->