### PR TITLE
fix: datacap actor should be counted in get_state_circulating_supply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 
 - [#6975](https://github.com/ChainSafe/forest/issues/6975): Fixed `Filecoin.MpoolSelect` to not remove the messages from the live pool, only simulate the head change.
 
+- [#7217](https://github.com/ChainSafe/forest/pull/7217): Fixed a bug that `Filecoin.StateCirculatingSupply` returns error on mainnet.
+
 ## Forest v0.33.6 "Ebb"
 
 Non-mandatory release for all node operators. It fixes a critical memory leak in `v0.33.5`. (Earlier releases are not affected)

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1926,10 +1926,8 @@ impl RpcMethod<1> for StateCirculatingSupply {
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
         let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
-        let height = ts.epoch();
-        let root = ts.parent_state();
-        let genesis_info = GenesisInfo::from_chain_config(ctx.chain_config().clone());
-        let supply = genesis_info.get_state_circulating_supply(height - 1, ctx.db(), root)?;
+        let genesis_info = GenesisInfo::from_chain_config(ctx.chain_config().shallow_clone());
+        let supply = genesis_info.get_state_circulating_supply_with_cache(ctx.db(), &ts)?;
         Ok(supply)
     }
 }

--- a/src/state_manager/circulating_supply.rs
+++ b/src/state_manager/circulating_supply.rs
@@ -181,7 +181,7 @@ impl GenesisInfo {
                         circ += avail_balance.max(TokenAmount::zero());
                         un_circ += actor_balance.min(locked_balance);
                     }
-                    _ => bail!("unexpected actor: {:?}", actor),
+                    _ => bail!("unexpected actor at epoch {height}: {actor:?}"),
                 }
             } else {
                 // Do nothing for zero-balance actors

--- a/src/state_manager/circulating_supply.rs
+++ b/src/state_manager/circulating_supply.rs
@@ -124,7 +124,7 @@ impl GenesisInfo {
         ts: &Tipset,
     ) -> anyhow::Result<TokenAmount> {
         static CACHE: LazyLock<quick_cache::sync::Cache<TipsetKey, Result<TokenAmount, String>>> =
-            LazyLock::new(|| quick_cache::sync::Cache::new(8));
+            LazyLock::new(|| quick_cache::sync::Cache::new(120)); // 120 for 1h-worth epochs
 
         let height = ts.epoch() - 1;
         let root = ts.parent_state();

--- a/src/state_manager/circulating_supply.rs
+++ b/src/state_manager/circulating_supply.rs
@@ -1,6 +1,9 @@
 // Copyright 2019-2026 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use std::sync::LazyLock;
+
+use crate::blocks::{Tipset, TipsetKey};
 use crate::chain::*;
 use crate::networks::{ChainConfig, Height};
 use crate::prelude::*;
@@ -111,11 +114,37 @@ impl GenesisInfo {
     }
 
     /// Calculate total FIL circulating supply based on state, traversing the state tree and
+    /// checking Actor types. This can be a lengthy operation so cache it's used.
+    ///
+    /// IMPORTANT: Easy to mistake for [`GenesisInfo::get_vm_circulating_supply`], that's being
+    /// calculated differently.
+    pub fn get_state_circulating_supply_with_cache(
+        &self,
+        db: &(impl Blockstore + ShallowClone),
+        ts: &Tipset,
+    ) -> anyhow::Result<TokenAmount> {
+        static CACHE: LazyLock<quick_cache::sync::Cache<TipsetKey, Result<TokenAmount, String>>> =
+            LazyLock::new(|| quick_cache::sync::Cache::new(8));
+
+        let height = ts.epoch() - 1;
+        let root = ts.parent_state();
+
+        CACHE
+            .get_or_insert_with(ts.key(), || {
+                anyhow::Ok(
+                    self.get_state_circulating_supply_raw(height, db, root)
+                        .map_err(|e| e.to_string()),
+                )
+            })?
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    /// Calculate total FIL circulating supply based on state, traversing the state tree and
     /// checking Actor types. This can be a lengthy operation.
     ///
     /// IMPORTANT: Easy to mistake for [`GenesisInfo::get_vm_circulating_supply`], that's being
     /// calculated differently.
-    pub fn get_state_circulating_supply(
+    pub fn get_state_circulating_supply_raw(
         &self,
         height: ChainEpoch,
         db: &(impl Blockstore + ShallowClone),
@@ -141,8 +170,7 @@ impl GenesisInfo {
                     | Address::SAFT_ACTOR
                     | Address::RESERVE_ACTOR
                     | Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR
-                    | Address::DATACAP_TOKEN_ACTOR
-                     => {
+                    | Address::DATACAP_TOKEN_ACTOR => {
                         un_circ += actor_balance;
                     }
                     Address::MARKET_ACTOR => {

--- a/src/state_manager/circulating_supply.rs
+++ b/src/state_manager/circulating_supply.rs
@@ -133,7 +133,11 @@ impl GenesisInfo {
             .get_or_insert_with(ts.key(), || {
                 anyhow::Ok(
                     self.get_state_circulating_supply_raw(height, db, root)
-                        .map_err(|e| e.to_string()),
+                        .map_err(|e| {
+                            let mut e = e.to_string();
+                            e.truncate(100); // To make error size bounded
+                            e
+                        }),
                 )
             })?
             .map_err(|e| anyhow::anyhow!(e))

--- a/src/state_manager/circulating_supply.rs
+++ b/src/state_manager/circulating_supply.rs
@@ -140,7 +140,9 @@ impl GenesisInfo {
                     | Address::BURNT_FUNDS_ACTOR
                     | Address::SAFT_ACTOR
                     | Address::RESERVE_ACTOR
-                    | Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR => {
+                    | Address::ETHEREUM_ACCOUNT_MANAGER_ACTOR
+                    | Address::DATACAP_TOKEN_ACTOR
+                     => {
                         un_circ += actor_balance;
                     }
                     Address::MARKET_ACTOR => {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance / Chores**
  * Circulating supply queries now use cached state derived from the current tipset, improving consistency and efficiency.
* **Bug Fixes**
  * Fixed a mainnet issue where `StateCirculatingSupply` could fail with an error.
  * Updated circulating supply accounting so the DataCap token actor is treated as uncirculating.
  * Improved error messages for state supply queries, including height context and clearer actor details.
* **Documentation**
  * Added an unreleased changelog entry describing the mainnet fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->