### PR TITLE
fix: avoid sorting height_infos on the fly

### DIFF
--- a/src/networks/butterflynet/mod.rs
+++ b/src/networks/butterflynet/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2019-2026 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use ahash::HashMap;
 use cid::Cid;
+use indexmap::IndexMap;
 use libp2p::Multiaddr;
 use std::str::FromStr;
 use std::sync::LazyLock;
@@ -74,8 +74,8 @@ pub const ETH_CHAIN_ID: EthChainId = 3141592;
 pub const BREEZE_GAS_TAMPING_DURATION: i64 = 120;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|| {
-    HashMap::from_iter([
+pub static HEIGHT_INFOS: LazyLock<IndexMap<Height, HeightInfo>> = LazyLock::new(|| {
+    IndexMap::from_iter([
         make_height!(Breeze, -50),
         make_height!(Smoke, -2),
         make_height!(Ignition, -3),

--- a/src/networks/calibnet/mod.rs
+++ b/src/networks/calibnet/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2019-2026 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use ahash::HashMap;
 use cid::Cid;
+use indexmap::IndexMap;
 use libp2p::Multiaddr;
 use std::str::FromStr;
 use std::sync::LazyLock;
@@ -51,8 +51,8 @@ pub const ETH_CHAIN_ID: EthChainId = 314159;
 pub const BREEZE_GAS_TAMPING_DURATION: i64 = 120;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|| {
-    HashMap::from_iter([
+pub static HEIGHT_INFOS: LazyLock<IndexMap<Height, HeightInfo>> = LazyLock::new(|| {
+    IndexMap::from_iter([
         make_height!(Breeze, -1),
         make_height!(Smoke, -2),
         make_height!(Ignition, -3),

--- a/src/networks/devnet/mod.rs
+++ b/src/networks/devnet/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2019-2026 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use ahash::HashMap;
 use cid::Cid;
+use indexmap::IndexMap;
 use std::sync::LazyLock;
 
 use crate::{eth::EthChainId, make_height, shim::version::NetworkVersion};
@@ -32,8 +32,8 @@ pub static GENESIS_NETWORK_VERSION: LazyLock<NetworkVersion> = LazyLock::new(|| 
 /// Height epochs.
 /// Environment variable names follow
 /// <https://github.com/filecoin-project/lotus/blob/8f73f157933435f5020d7b8f23bee9e4ab71cb1c/build/params_2k.go#L108>
-pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|| {
-    HashMap::from_iter([
+pub static HEIGHT_INFOS: LazyLock<IndexMap<Height, HeightInfo>> = LazyLock::new(|| {
+    IndexMap::from_iter([
         make_height!(
             Breeze,
             get_upgrade_height_from_env("FOREST_BREEZE_HEIGHT").unwrap_or(-50)

--- a/src/networks/mainnet/mod.rs
+++ b/src/networks/mainnet/mod.rs
@@ -9,8 +9,8 @@ use crate::{
         version::NetworkVersion,
     },
 };
-use ahash::HashMap;
 use cid::Cid;
+use indexmap::IndexMap;
 use libp2p::Multiaddr;
 use std::str::FromStr;
 use std::sync::LazyLock;
@@ -52,8 +52,8 @@ pub const ETH_CHAIN_ID: EthChainId = 314;
 pub const BREEZE_GAS_TAMPING_DURATION: i64 = 120;
 
 /// Height epochs.
-pub static HEIGHT_INFOS: LazyLock<HashMap<Height, HeightInfo>> = LazyLock::new(|| {
-    HashMap::from_iter([
+pub static HEIGHT_INFOS: LazyLock<IndexMap<Height, HeightInfo>> = LazyLock::new(|| {
+    IndexMap::from_iter([
         make_height!(Breeze, 41_280),
         make_height!(Smoke, SMOKE_HEIGHT),
         make_height!(Ignition, 94_000),

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -332,7 +332,6 @@ impl ChainConfig {
             height_infos: HEIGHT_INFOS
                 .clone()
                 .into_iter()
-                .filter(|(_, v)| v.epoch >= 0)
                 .sorted_by_key(|(_, v)| v.epoch)
                 .collect(),
             policy: make_calibnet_policy!(v13).into(),
@@ -370,7 +369,6 @@ impl ChainConfig {
             height_infos: HEIGHT_INFOS
                 .clone()
                 .into_iter()
-                .filter(|(_, v)| v.epoch >= 0)
                 .sorted_by_key(|(_, v)| v.epoch)
                 .collect(),
             policy: make_devnet_policy!(v13).into(),
@@ -404,7 +402,6 @@ impl ChainConfig {
             height_infos: HEIGHT_INFOS
                 .clone()
                 .into_iter()
-                .filter(|(_, v)| v.epoch >= 0)
                 .sorted_by_key(|(_, v)| v.epoch)
                 .collect(),
             policy: make_butterfly_policy!(v13).into(),

--- a/src/networks/mod.rs
+++ b/src/networks/mod.rs
@@ -4,10 +4,7 @@
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use ahash::HashMap;
-use cid::Cid;
-use fvm_ipld_blockstore::Blockstore;
-use itertools::Itertools;
+use indexmap::IndexMap;
 use libp2p::Multiaddr;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
@@ -17,6 +14,7 @@ use tracing::warn;
 use crate::beacon::{BeaconPoint, BeaconSchedule, DrandBeacon, DrandConfig};
 use crate::db::SettingsStore;
 use crate::eth::EthChainId;
+use crate::prelude::*;
 use crate::shim::{
     clock::{ChainEpoch, EPOCH_DURATION_SECONDS, EPOCHS_IN_DAY},
     econ::TokenAmount,
@@ -266,7 +264,8 @@ pub struct ChainConfig {
     pub block_delay_secs: u32,
     pub propagation_delay_secs: u32,
     pub genesis_network: NetworkVersion,
-    pub height_infos: HashMap<Height, HeightInfo>,
+    #[cfg_attr(test, arbitrary(gen(|_g| devnet::HEIGHT_INFOS.clone())))]
+    pub height_infos: IndexMap<Height, HeightInfo>,
     #[cfg_attr(test, arbitrary(gen(|_g| Policy::default())))]
     pub policy: Policy,
     pub eth_chain_id: EthChainId,
@@ -330,7 +329,12 @@ impl ChainConfig {
             ),
             propagation_delay_secs: env_or_default(ENV_FOREST_PROPAGATION_DELAY_SECS, 10),
             genesis_network: GENESIS_NETWORK_VERSION,
-            height_infos: HEIGHT_INFOS.clone(),
+            height_infos: HEIGHT_INFOS
+                .clone()
+                .into_iter()
+                .filter(|(_, v)| v.epoch >= 0)
+                .sorted_by_key(|(_, v)| v.epoch)
+                .collect(),
             policy: make_calibnet_policy!(v13).into(),
             eth_chain_id: ETH_CHAIN_ID,
             breeze_gas_tamping_duration: BREEZE_GAS_TAMPING_DURATION,
@@ -363,7 +367,12 @@ impl ChainConfig {
             block_delay_secs: env_or_default(ENV_FOREST_BLOCK_DELAY_SECS, 4),
             propagation_delay_secs: env_or_default(ENV_FOREST_PROPAGATION_DELAY_SECS, 1),
             genesis_network: *GENESIS_NETWORK_VERSION,
-            height_infos: HEIGHT_INFOS.clone(),
+            height_infos: HEIGHT_INFOS
+                .clone()
+                .into_iter()
+                .filter(|(_, v)| v.epoch >= 0)
+                .sorted_by_key(|(_, v)| v.epoch)
+                .collect(),
             policy: make_devnet_policy!(v13).into(),
             eth_chain_id: ETH_CHAIN_ID,
             breeze_gas_tamping_duration: BREEZE_GAS_TAMPING_DURATION,
@@ -392,7 +401,12 @@ impl ChainConfig {
             ),
             propagation_delay_secs: env_or_default(ENV_FOREST_PROPAGATION_DELAY_SECS, 6),
             genesis_network: GENESIS_NETWORK_VERSION,
-            height_infos: HEIGHT_INFOS.clone(),
+            height_infos: HEIGHT_INFOS
+                .clone()
+                .into_iter()
+                .filter(|(_, v)| v.epoch >= 0)
+                .sorted_by_key(|(_, v)| v.epoch)
+                .collect(),
             policy: make_butterfly_policy!(v13).into(),
             eth_chain_id: ETH_CHAIN_ID,
             breeze_gas_tamping_duration: BREEZE_GAS_TAMPING_DURATION,
@@ -427,7 +441,6 @@ impl ChainConfig {
     fn network_height(&self, epoch: ChainEpoch) -> Option<Height> {
         self.height_infos
             .iter()
-            .sorted_by_key(|(_, info)| info.epoch)
             .rev()
             .find(|(_, info)| epoch > info.epoch)
             .map(|(height, _)| *height)
@@ -441,7 +454,6 @@ impl ChainConfig {
         if let Some((height, info, manifest_cid)) = self
             .height_infos
             .iter()
-            .sorted_by_key(|(_, info)| info.epoch)
             .rev()
             .filter_map(|(height, info)| info.bundle.map(|bundle| (*height, info, bundle)))
             .find(|(_, info, _)| epoch > info.epoch)
@@ -500,7 +512,6 @@ impl ChainConfig {
     pub fn epoch(&self, height: Height) -> ChainEpoch {
         self.height_infos
             .iter()
-            .sorted_by_key(|(_, info)| info.epoch)
             .rev()
             .find_map(|(infos_height, info)| {
                 if *infos_height == height {
@@ -646,8 +657,9 @@ pub fn calculate_expected_epoch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    fn heights_are_present(height_infos: &HashMap<Height, HeightInfo>) {
+    fn heights_are_present(height_infos: &IndexMap<Height, HeightInfo>) {
         /// These are required heights that need to be defined for all networks, for, e.g., conformance
         /// with `Filecoin.StateGetNetworkParams` RPC method.
         const REQUIRED_HEIGHTS: [Height; 31] = [
@@ -823,5 +835,18 @@ mod tests {
         assert_eq!(info.height, Height::Teep);
         assert!(cfg.network_height_with_actor_bundle(1).is_none());
         assert!(cfg.network_height_with_actor_bundle(0).is_none());
+    }
+
+    #[rstest]
+    #[case(ChainConfig::mainnet())]
+    #[case(ChainConfig::calibnet())]
+    #[case(ChainConfig::butterflynet())]
+    #[case(ChainConfig::devnet())]
+    fn ensure_height_info_sorted(#[case] cfg: ChainConfig) {
+        assert!(
+            cfg.height_infos.is_sorted_by_key(|_, v| v.epoch),
+            "height_infos should be sorted in {} config",
+            cfg.network
+        )
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

I see no difference in `oha` benchmark though

```
# command
oha -n 100000 -c 1 -m POST http://127.0.0.1:3456/rpc/v1 -H 'Content-Type: application/json' -D network_version.json

# payload
{
        "method": "Filecoin.StateNetworkVersion",
        "params": [[]],
        "id": 1,
        "jsonrpc": "2.0"
}

# pr (via gateway)
  Success rate: 100.00%   30s     40s     50s     60s      ││0.0001  0.0008  0.0015  0.0022  0.0029  0.0037  0.0044    │
  Total:────────21003.5260 ms──────────────────────────────┘└──────────────────────────────────────────────────────────┘
  Slowest:      4.3950 ms
  Fastest:      0.0596 ms
  Average:      0.2076 ms
  Requests/sec: 4761.1053

  Total data:   3.53 MiB
  Size/request: 37 B
  Size/sec:     172.03 KiB

Response time histogram:
  0.060 ms [1]     |
  0.493 ms [87892] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.927 ms [10409] |■■■
  1.360 ms [1562]  |
  1.794 ms [107]   |
  2.227 ms [12]    |
  2.661 ms [3]     |
  3.094 ms [2]     |
  3.528 ms [2]     |
  3.961 ms [6]     |
  4.395 ms [4]     |

Response time distribution:
  10.00% in 0.0671 ms
  25.00% in 0.0706 ms
  50.00% in 0.0926 ms
  75.00% in 0.2512 ms
  90.00% in 0.5452 ms
  95.00% in 0.7356 ms
  99.00% in 0.9859 ms
  99.90% in 1.4352 ms
  99.99% in 3.4901 ms

# main (via gateway)
  Success rate: 100.00%   30s     40s     50s     60s      ││0.0001  0.0010  0.0019  0.0028  0.0037  0.0046  0.0055    │
  Total:────────22412.7319 ms──────────────────────────────┘└──────────────────────────────────────────────────────────┘
  Slowest:      14.1129 ms
  Fastest:      0.0594 ms
  Average:      0.2216 ms
  Requests/sec: 4461.7497

  Total data:   3.53 MiB
  Size/request: 37 B
  Size/sec:     161.21 KiB

Response time histogram:
   0.059 ms [1]     |
   1.465 ms [99903] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   2.870 ms [76]    |
   4.275 ms [14]    |
   5.681 ms [3]     |
   7.086 ms [0]     |
   8.492 ms [1]     |
   9.897 ms [0]     |
  11.302 ms [0]     |
  12.708 ms [0]     |
  14.113 ms [2]     |

Response time distribution:
  10.00% in 0.0686 ms
  25.00% in 0.0728 ms
  50.00% in 0.1118 ms
  75.00% in 0.2860 ms
  90.00% in 0.5720 ms
  95.00% in 0.7665 ms
  99.00% in 0.9934 ms
  99.90% in 1.4534 ms
  99.99% in 3.9229 ms
  
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated network height information to use an ordered collection, ensuring consistent ordering by epoch across mainnet, devnet, calibnet, and butterflynet.
  * Configuration building now preserves this ordering, reducing the need for repeated runtime sorting during height/epoch lookups.
* **Tests**
  * Added coverage to verify height information remains correctly sorted by epoch across multiple network configurations.
  * Updated test helpers to work with the new ordered height information structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->