### PR TITLE
fix: prefer `StateTree::for_each_cacheless` over `StateTree::for_each`

### DIFF
--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -2026,13 +2026,18 @@ impl RpcMethod<1> for StateListActors {
         (ApiTipsetKey(tsk),): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        let mut actors = vec![];
         let ts = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
         let state_tree = ctx.state_manager.get_state_tree(ts.parent_state())?;
-        state_tree.for_each(|addr, _state| {
-            actors.push(addr);
-            Ok(())
-        })?;
+        // `spawn_blocking` as state tree iteration is expensive
+        let actors = tokio::task::spawn_blocking(move || {
+            let mut actors = vec![];
+            state_tree.for_each_cacheless(|addr, _state| {
+                actors.push(addr);
+                anyhow::Ok(())
+            })?;
+            anyhow::Ok(actors)
+        })
+        .await??;
         Ok(actors)
     }
 }

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -291,7 +291,7 @@ where
     }
 
     /// Use [`Self::for_each_cacheless`] instead unless cache is really needed.
-    /// Note that this method caches all hamt node and can be memory-intensive.
+    /// Note that this method caches all HAMT nodes and can be memory-intensive.
     pub fn for_each<F>(&self, mut f: F) -> anyhow::Result<()>
     where
         F: FnMut(Address, &ActorState) -> anyhow::Result<()>,
@@ -325,7 +325,9 @@ where
             StateTree::FvmV4(st) => {
                 st.for_each_cacheless(|address, actor_state| f(address.into(), &actor_state.into()))
             }
-            StateTree::V0(_) => bail!("StateTree::for_each not supported on old state trees"),
+            StateTree::V0(_) => {
+                bail!("StateTree::for_each_cacheless not supported on old state trees")
+            }
         }
     }
 

--- a/src/shim/state_tree.rs
+++ b/src/shim/state_tree.rs
@@ -290,6 +290,8 @@ where
             .with_context(|| format!("actor id not found for address {addr}"))
     }
 
+    /// Use [`Self::for_each_cacheless`] instead unless cache is really needed.
+    /// Note that this method caches all hamt node and can be memory-intensive.
     pub fn for_each<F>(&self, mut f: F) -> anyhow::Result<()>
     where
         F: FnMut(Address, &ActorState) -> anyhow::Result<()>,
@@ -303,6 +305,25 @@ where
             }
             StateTree::FvmV4(st) => {
                 st.for_each(|address, actor_state| f(address.into(), &actor_state.into()))
+            }
+            StateTree::V0(_) => bail!("StateTree::for_each not supported on old state trees"),
+        }
+    }
+
+    /// Iterate on all actors
+    pub fn for_each_cacheless<F>(&self, mut f: F) -> anyhow::Result<()>
+    where
+        F: FnMut(Address, &ActorState) -> anyhow::Result<()>,
+    {
+        match self {
+            StateTree::FvmV2(st) => {
+                st.for_each(|address, actor_state| f(address.into(), &actor_state.into()))
+            }
+            StateTree::FvmV3(st) => {
+                st.for_each(|address, actor_state| f(address.into(), &actor_state.into()))
+            }
+            StateTree::FvmV4(st) => {
+                st.for_each_cacheless(|address, actor_state| f(address.into(), &actor_state.into()))
             }
             StateTree::V0(_) => bail!("StateTree::for_each not supported on old state trees"),
         }

--- a/src/state_manager/circulating_supply.rs
+++ b/src/state_manager/circulating_supply.rs
@@ -159,7 +159,7 @@ impl GenesisInfo {
 
         let state_tree = StateTree::new_from_root(db, root)?;
 
-        state_tree.for_each(|addr: Address, actor: &ActorState| {
+        state_tree.for_each_cacheless(|addr: Address, actor: &ActorState| {
             let actor_balance = TokenAmount::from(actor.balance.clone());
             if !actor_balance.is_zero() {
                 match addr {

--- a/src/statediff/mod.rs
+++ b/src/statediff/mod.rs
@@ -64,7 +64,7 @@ fn root_to_state_map<BS: Blockstore + ShallowClone>(
 ) -> anyhow::Result<HashMap<Address, ActorState>> {
     let mut actors = HashMap::default();
     let state_tree = StateTree::new_from_root(bs, root)?;
-    state_tree.for_each(|addr: Address, actor: &ActorState| {
+    state_tree.for_each_cacheless(|addr: Address, actor: &ActorState| {
         actors.insert(addr, actor.clone());
         Ok(())
     })?;
@@ -89,7 +89,7 @@ fn try_print_actor_states<BS: Blockstore + ShallowClone>(
     // Compare state with expected
     let state_tree = StateTree::new_from_root(bs, root)?;
 
-    state_tree.for_each(|addr: Address, actor| {
+    state_tree.for_each_cacheless(|addr: Address, actor| {
         if let Some(other) = e_state.remove(&addr) {
             if &other != actor {
                 const COMMA: &str = ",";


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved actor traversal for state listing by moving iteration into a background blocking task and using cache-free enumeration.
  - Updated circulating-supply and state-diff computations to enumerate actors via cache-free traversal, improving behavior on larger states.
- **New Features**
  - Added a cache-free state-tree iteration helper (`for_each_cacheless`) and aligned traversal to it where appropriate.
- **Documentation**
  - Documented the preferred iteration path and noted that cached traversal can be memory-intensive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->