### PR TITLE
chore: add test to ensure links in return data are not followed

### DIFF
--- a/src/ipld/util.rs
+++ b/src/ipld/util.rs
@@ -501,3 +501,77 @@ fn ipld_to_cid(ipld: Ipld) -> Option<Cid> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::{Chain4U, HeaderBuilder, chain4u};
+    use crate::db::MemoryDB;
+    use crate::utils::db::CborStoreExt as _;
+    use fil_actors_shared::fvm_ipld_amt::Amtv0;
+    use futures::TryStreamExt as _;
+    use fvm_ipld_encoding::RawBytes;
+    use ipld_core::ipld::Ipld;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn return_data_links_are_not_followed_by_the_walk() -> anyhow::Result<()> {
+        let db = Arc::new(MemoryDB::default());
+
+        // A fetchable dag-cbor block, reached only if the walk follows links inside `Return`.
+        let embedded = db.put_cbor_default(&Ipld::String("embedded".into()))?;
+
+        // A link in the receipt (positive control): the walk does reach tag-42 links
+        // structurally embedded in the receipts AMT.
+        let events_root = db.put_cbor_default(&Ipld::String("events-root".into()))?;
+
+        // Build the receipt: `Return` is itself valid dag-cbor encoding a tag-42 link to the
+        // `embedded` block.
+        let receipt = fvm_shared4::receipt::Receipt {
+            exit_code: fvm_shared4::error::ExitCode::OK,
+            return_data: RawBytes::new(serde_ipld_dagcbor::to_vec(&Ipld::Link(embedded))?),
+            gas_used: 0,
+            events_root: Some(events_root),
+        };
+
+        let receipts_root = Amtv0::new_from_iter(&db, std::iter::once(receipt))?;
+
+        // One-block tipset whose `message_receipts` points at the AMT. Epoch 1 (> the stateroot
+        // limit below) so the receipts branch is reached.
+        let c4u = Chain4U::with_blockstore(db.clone());
+        chain4u! {
+            in c4u;
+            [_genesis]
+            -> head @ [_header = HeaderBuilder::new().with_message_receipts(receipts_root)]
+        };
+
+        let mut stream = stream_chain(&db, std::iter::once(head), 0, CidHashSet::default())
+            .with_message_receipts(true)
+            // The embedded target is present; other roots (e.g. default state roots) are not, and a
+            // missing root must not stall the walk.
+            .fail_on_dead_links(false);
+
+        let mut seen = Vec::new();
+        while let Some(block) = stream.try_next().await? {
+            seen.push(block.cid);
+        }
+
+        // Receipts walking is active and reaches the AMT root...
+        assert!(
+            seen.contains(&receipts_root),
+            "receipts AMT root must be reachable with receipts enabled"
+        );
+        // ...and follows the EventsRoot link inside it.
+        assert!(
+            seen.contains(&events_root),
+            "EventsRoot link inside the receipt must be followed"
+        );
+        // But the link inside the opaque `Return` byte string is never followed.
+        assert!(
+            !seen.contains(&embedded),
+            "link embedded in Return must not be followed by the walk"
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- nothing changed, just adding a test to ensure this behavior is exercised and stays.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for blockchain/IPLD traversal when receipts and event links are present.
  * Verified that traversal follows the receipts and events roots, while ignoring links hidden inside opaque return data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->