### PR TITLE
fix: yield to runtime on every 128 ChainStream polls

### DIFF
--- a/src/ipld/util.rs
+++ b/src/ipld/util.rs
@@ -183,6 +183,7 @@ pin_project! {
         events: bool,
         tipset_keys:bool,
         track_progress: bool,
+        n_polled: usize,
     }
 }
 
@@ -254,6 +255,7 @@ pub fn stream_chain<
         events: false,
         tipset_keys: false,
         track_progress: false,
+        n_polled: 0,
     }
 }
 
@@ -278,13 +280,22 @@ impl<DB: Blockstore, T: Borrow<Tipset>, ITER: Iterator<Item = T> + Unpin, S: Cid
 {
     type Item = anyhow::Result<CarBlock>;
 
-    fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         use Task::*;
 
         let export_tipset_keys = self.tipset_keys;
         let fail_on_dead_links = self.fail_on_dead_links;
         let stateroot_limit_exclusive = self.stateroot_limit_exclusive;
         let this = self.project();
+
+        // Yield to the runtime every 128 polls to allow cancellation
+        {
+            *this.n_polled += 1;
+            if this.n_polled.is_multiple_of(128) {
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+        }
 
         loop {
             while let Some(task) = this.dfs.front_mut() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Alternative fix to https://github.com/ChainSafe/forest/pull/7253
Tested with https://github.com/ChainSafe/forest/pull/7252

Bug: when the chain stream is consumed in a tight loop with no yield point inside, the task cannot be cancelled or rescheduled by tokio.
https://github.com/ChainSafe/forest/blob/0ba9a6b15f723664215fc464b83c673c203db7f6/src/tool/subcommands/archive_cmd.rs#L601
```rust
let mut stream = stream_chain(...);
while stream.try_next().await?.is_some() {}
stream.into_seen()
```

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of long-running chain stream processing by periodically yielding control back to the runtime. This helps cancellation take effect sooner and improves overall scheduling progress during extended operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->