### PR TITLE
fix: don't allow Bearer in `AuthVerify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 
 - [#4645](https://github.com/ChainSafe/forest/issues/4645): An invalid RPC `Authorization` header (malformed header or unverifiable JWT) is now rejected with an HTTP `401 Unauthorized` instead of the misleading `-32600 Invalid request` JSON-RPC error. A call that authenticates but lacks the permission its method requires now returns a JSON-RPC error with code `-32003` and a `missing permission to invoke '<method>' (need '<perm>')` message.
 
+- [#7256](https://github.com/ChainSafe/forest/pull/7256): `Filecoin.AuthVerify` now verifies its argument as a raw JWT, matching Lotus, instead of stripping a leading `Bearer ` prefix.
+
 - [#7214](https://github.com/ChainSafe/forest/pull/7214): Aligned the `eth` transaction `accessList` field with go-ethereum/reth (typed: `[]`, legacy: omitted, never `null`).
 
 - [#7227](https://github.com/ChainSafe/forest/issues/7227): Fixed invalid `Filecoin.GasEstimateGasPremium` and `Filecoin.GasEstimateFeeCap` responses that were returning a fraction instead of an integer.

--- a/src/rpc/methods/auth.rs
+++ b/src/rpc/methods/auth.rs
@@ -59,7 +59,7 @@ impl RpcMethod<2> for AuthNew {
 pub enum AuthVerify {}
 impl RpcMethod<1> for AuthVerify {
     const NAME: &'static str = "Filecoin.AuthVerify";
-    const PARAM_NAMES: [&'static str; 1] = ["headerRaw"];
+    const PARAM_NAMES: [&'static str; 1] = ["token"];
     const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
     const PERMISSION: Permission = Permission::Read;
     const DESCRIPTION: Option<&'static str> =
@@ -68,13 +68,12 @@ impl RpcMethod<1> for AuthVerify {
     type Ok = Vec<String>;
     async fn handle(
         ctx: Ctx,
-        (header_raw,): Self::Params,
+        (token,): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
         let ks = ctx.keystore.read();
-        let token = header_raw.trim_start_matches("Bearer ");
         let ki = ks.get(JWT_IDENTIFIER)?;
-        let perms = verify_token(token, ki.private_key())?;
+        let perms = verify_token(&token, ki.private_key())?;
         Ok(perms)
     }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -910,10 +910,14 @@ mod tests {
             .unwrap();
         assert_eq!(response, jwt_read_permissions);
 
+        // `AuthVerify` verifies a raw JWT; a `Bearer `-prefixed argument must fail.
+        super::methods::auth::AuthVerify::call(&client, (format!("Bearer {jwt_read}"),))
+            .await
+            .unwrap_err();
+
         drop(client);
 
-        // Raw HTTP: token-level auth failures are rejected at the transport layer
-        // with a bare HTTP 401 (not a JSON-RPC error body), matching Lotus.
+        // A bad token is rejected with a bare HTTP 401, before JSON-RPC dispatch.
         let http = reqwest::Client::new();
         let rpc_url = format!("http://{}:{}/rpc/v1", rpc_address.ip(), rpc_address.port());
         let jsonrpc_body = serde_json::json!({

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
@@ -34,7 +34,7 @@ methods:
   - name: Filecoin.AuthVerify
     description: Verifies a JWT authentication token and returns its permissions.
     params:
-      - name: headerRaw
+      - name: token
         required: true
         schema:
           type: string

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
@@ -34,7 +34,7 @@ methods:
   - name: Filecoin.AuthVerify
     description: Verifies a JWT authentication token and returns its permissions.
     params:
-      - name: headerRaw
+      - name: token
         required: true
         schema:
           type: string


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `Filecoin.AuthVerify` operates on raw tokens, don't allow stripping the `Bearer` - this is the current Lotus behavior.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Filecoin.AuthVerify` now expects a raw JWT token and no longer accepts tokens with a leading `Bearer ` prefix.
  * Requests using the `Bearer `-prefixed format now fail at the method level, matching the updated behavior.
* **Documentation**
  * Updated the changelog to reflect the authentication token handling change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->