### PR TITLE
fix: cancel CancellationToken on error path

### DIFF
--- a/src/tool/subcommands/api_cmd/stateful_tests.rs
+++ b/src/tool/subcommands/api_cmd/stateful_tests.rs
@@ -820,6 +820,8 @@ fn eth_subscribe_logs(tx: TestTransaction) -> RpcTestScenario {
             // All subs receive the same logs at once, so the coordinator just waits for the mint to execute,
             // and then we wait for some `SETTLE` time and then stop as soon as the logs are delivered.
             let stop = CancellationToken::new();
+            // Make sure token is cancelled on error path
+            let _cancellation_token_drop_guard = stop.drop_guard_ref();
             let coordinator = async {
                 let executed = wait_pending_message(&client, cid).await;
                 tokio::time::sleep(SETTLE).await;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html#method.drop_guard_ref

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved subscription log test reliability by ensuring cleanup happens automatically if a test exits early due to an error.
  * Reduced the risk of lingering test state when cancellation is not triggered explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->