### PR TITLE
fix: bugs in `StateManager::wait_for_message`

### DIFF
--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -11,6 +11,7 @@ pub(crate) mod trace;
 pub mod types;
 mod utils;
 pub use tipset_resolver::TipsetResolver;
+use tokio_util::sync::CancellationToken;
 
 use self::eth_tx::*;
 use self::filter::hex_str_to_epoch;
@@ -2629,7 +2630,9 @@ impl RpcMethod<1> for EthGetTransactionByHash {
         (tx_hash,): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        get_eth_transaction_by_hash(&ctx, &tx_hash, None).await
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
+        get_eth_transaction_by_hash(&ctx, &tx_hash, None, &cancellation_token).await
     }
 }
 
@@ -2652,7 +2655,9 @@ impl RpcMethod<2> for EthGetTransactionByHashLimited {
         (tx_hash, limit): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        get_eth_transaction_by_hash(&ctx, &tx_hash, Some(limit)).await
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
+        get_eth_transaction_by_hash(&ctx, &tx_hash, Some(limit), &cancellation_token).await
     }
 }
 
@@ -2660,6 +2665,7 @@ async fn get_eth_transaction_by_hash(
     ctx: &Ctx,
     tx_hash: &EthHash,
     limit: Option<ChainEpoch>,
+    cancellation_token: &CancellationToken,
 ) -> Result<Option<ApiEthTx>, ServerError> {
     let message_cid = ctx.chain_store().get_mapping(tx_hash)?.unwrap_or_else(|| {
         tracing::debug!(
@@ -2673,7 +2679,7 @@ async fn get_eth_transaction_by_hash(
     // First, try to get the cid from mined transactions
     if let Ok(Some((tipset, receipt))) = ctx
         .state_manager
-        .search_for_message(None, message_cid, limit, Some(true))
+        .search_for_message(None, message_cid, limit, Some(true), cancellation_token)
         .await
     {
         let ipld = receipt.return_data().deserialize().unwrap_or(Ipld::Null);
@@ -3011,6 +3017,7 @@ async fn get_eth_transaction_receipt(
     ctx: Ctx,
     tx_hash: EthHash,
     limit: Option<ChainEpoch>,
+    cancellation_token: &CancellationToken,
 ) -> Result<Option<EthTxReceipt>, ServerError> {
     let msg_cid = ctx.chain_store().get_mapping(&tx_hash)?.unwrap_or_else(|| {
         tracing::debug!(
@@ -3023,7 +3030,7 @@ async fn get_eth_transaction_receipt(
 
     let option = ctx
         .state_manager
-        .search_for_message(None, msg_cid, limit, Some(true))
+        .search_for_message(None, msg_cid, limit, Some(true), cancellation_token)
         .await
         .with_context(|| format!("failed to lookup Eth Txn {tx_hash} as {msg_cid}"));
 
@@ -3088,7 +3095,9 @@ impl RpcMethod<1> for EthGetTransactionReceipt {
         (tx_hash,): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        get_eth_transaction_receipt(ctx, tx_hash, None).await
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
+        get_eth_transaction_receipt(ctx, tx_hash, None, &cancellation_token).await
     }
 }
 
@@ -3110,7 +3119,9 @@ impl RpcMethod<2> for EthGetTransactionReceiptLimited {
         (tx_hash, limit): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        get_eth_transaction_receipt(ctx, tx_hash, Some(limit)).await
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
+        get_eth_transaction_receipt(ctx, tx_hash, Some(limit), &cancellation_token).await
     }
 }
 
@@ -3758,7 +3769,16 @@ impl RpcMethod<2> for EthDebugTraceTransaction {
         ext: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
         let opts = opts.unwrap_or_default();
-        debug_trace_transaction(ctx, Self::api_path(ext)?, tx_hash, opts).await
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
+        debug_trace_transaction(
+            ctx,
+            Self::api_path(ext)?,
+            tx_hash,
+            opts,
+            &cancellation_token,
+        )
+        .await
     }
 }
 
@@ -3767,6 +3787,7 @@ async fn debug_trace_transaction(
     api_path: ApiPaths,
     tx_hash: String,
     opts: GethDebugTracingOptions,
+    cancellation_token: &CancellationToken,
 ) -> Result<GethTrace, ServerError> {
     let tracer = match &opts.tracer {
         Some(t) => t.clone(),
@@ -3779,7 +3800,7 @@ async fn debug_trace_transaction(
     };
 
     let eth_hash = EthHash::from_str(&tx_hash).context("invalid transaction hash")?;
-    let eth_txn = get_eth_transaction_by_hash(&ctx, &eth_hash, None)
+    let eth_txn = get_eth_transaction_by_hash(&ctx, &eth_hash, None, cancellation_token)
         .await?
         .ok_or(ServerError::internal_error("transaction not found", None))?;
 
@@ -4036,8 +4057,10 @@ impl RpcMethod<1> for EthTraceTransaction {
         (tx_hash,): Self::Params,
         ext: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
         let eth_hash = EthHash::from_str(&tx_hash).context("invalid transaction hash")?;
-        let eth_txn = get_eth_transaction_by_hash(&ctx, &eth_hash, None)
+        let eth_txn = get_eth_transaction_by_hash(&ctx, &eth_hash, None, &cancellation_token)
             .await?
             .ok_or(ServerError::internal_error("transaction not found", None))?;
 

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod types;
-use futures::stream::FuturesOrdered;
 pub use types::*;
 
 use super::chain::ChainGetTipSetV2;
@@ -58,6 +57,7 @@ use fil_actor_miner_state::v10::{qa_power_for_weight, qa_power_max};
 use fil_actor_verifreg_state::v13::ClaimID;
 use fil_actors_shared::fvm_ipld_amt::Amt;
 use fil_actors_shared::fvm_ipld_bitfield::BitField;
+use futures::stream::FuturesOrdered;
 use futures::{StreamExt as _, TryStreamExt as _};
 use fvm_ipld_encoding::{CborStore, DAG_CBOR};
 pub use fvm_shared3::sector::StoragePower;
@@ -77,6 +77,7 @@ use tokio::task::JoinSet;
 
 const INITIAL_PLEDGE_NUM: u64 = 110;
 const INITIAL_PLEDGE_DEN: u64 = 100;
+const WAIT_FOR_MSG_TIMEOUT: Duration = Duration::from_mins(10);
 
 pub enum StateCall {}
 
@@ -1245,10 +1246,14 @@ impl RpcMethod<2> for StateWaitMsgV0 {
     ) -> Result<Self::Ok, ServerError> {
         let (tipset, receipt) = ctx
             .state_manager
-            .wait_for_message(message_cid, confidence, None, None)
+            .wait_for_message_with_timeout(
+                message_cid,
+                confidence,
+                None,
+                None,
+                WAIT_FOR_MSG_TIMEOUT,
+            )
             .await?;
-        let tipset = tipset.context("wait for msg returned empty tuple")?;
-        let receipt = receipt.context("wait for msg returned empty receipt")?;
         let ipld = receipt.return_data().deserialize().unwrap_or(Ipld::Null);
         Ok(MessageLookup {
             receipt,
@@ -1284,15 +1289,14 @@ impl RpcMethod<4> for StateWaitMsg {
     ) -> Result<Self::Ok, ServerError> {
         let (tipset, receipt) = ctx
             .state_manager
-            .wait_for_message(
+            .wait_for_message_with_timeout(
                 message_cid,
                 confidence,
                 Some(look_back_limit),
                 Some(allow_replaced),
+                WAIT_FOR_MSG_TIMEOUT,
             )
             .await?;
-        let tipset = tipset.context("wait for msg returned empty tuple")?;
-        let receipt = receipt.context("wait for msg returned empty receipt")?;
         let ipld = receipt.return_data().deserialize().unwrap_or(Ipld::Null);
         Ok(MessageLookup {
             receipt,

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -74,10 +74,12 @@ use std::ops::Mul;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 
 const INITIAL_PLEDGE_NUM: u64 = 110;
 const INITIAL_PLEDGE_DEN: u64 = 100;
 const WAIT_FOR_MSG_TIMEOUT: Duration = Duration::from_mins(10);
+const SEARCH_FOR_MSG_TIMEOUT: Duration = Duration::from_mins(10);
 
 pub enum StateCall {}
 
@@ -1217,9 +1219,18 @@ impl RpcMethod<2> for StateGetReceipt {
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
         let tipset = ctx.chain_store().load_required_tipset_or_heaviest(&tsk)?;
-        ctx.state_manager
-            .get_receipt(tipset, cid)
-            .map_err(From::from)
+        let sm = ctx.state_manager.shallow_clone();
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
+        Ok(tokio::time::timeout(
+            SEARCH_FOR_MSG_TIMEOUT,
+            tokio::task::spawn_blocking({
+                let cancellation_token = cancellation_token.clone();
+                move || sm.get_receipt_blocking(tipset, cid, &cancellation_token)
+            }),
+        )
+        .await
+        .context("timed out")???)
     }
 }
 
@@ -1330,18 +1341,23 @@ impl RpcMethod<4> for StateSearchMsg {
         (ApiTipsetKey(tsk), message_cid, look_back_limit, allow_replaced): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
         let from = tsk
             .map(|k| ctx.chain_index().load_required_tipset(&k))
             .transpose()?;
-        let Some((tipset, receipt)) = ctx
-            .state_manager
-            .search_for_message(
+        let Some((tipset, receipt)) = tokio::time::timeout(
+            SEARCH_FOR_MSG_TIMEOUT,
+            ctx.state_manager.search_for_message(
                 from,
                 message_cid,
                 Some(look_back_limit),
                 Some(allow_replaced),
-            )
-            .await?
+                &cancellation_token,
+            ),
+        )
+        .await
+        .context("timed out")??
         else {
             return Ok(None);
         };
@@ -1375,10 +1391,20 @@ impl RpcMethod<2> for StateSearchMsgLimited {
         (message_cid, look_back_limit): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        let Some((tipset, receipt)) = ctx
-            .state_manager
-            .search_for_message(None, message_cid, Some(look_back_limit), None)
-            .await?
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.drop_guard_ref();
+        let Some((tipset, receipt)) = tokio::time::timeout(
+            SEARCH_FOR_MSG_TIMEOUT,
+            ctx.state_manager.search_for_message(
+                None,
+                message_cid,
+                Some(look_back_limit),
+                None,
+                &cancellation_token,
+            ),
+        )
+        .await
+        .context("timed out")??
         else {
             return Ok(None);
         };

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -1199,6 +1199,7 @@ impl RpcMethod<3> for StateMinerPreCommitDepositForPower {
 }
 
 /// returns the message receipt for the given message
+/// This method times out in [`SEARCH_FOR_MSG_TIMEOUT`]
 pub enum StateGetReceipt {}
 
 impl RpcMethod<2> for StateGetReceipt {
@@ -1278,6 +1279,7 @@ impl RpcMethod<2> for StateWaitMsgV0 {
 
 /// looks back in the chain for a message. If not found, it blocks until the
 /// message arrives on chain, and gets to the indicated confidence depth.
+/// This method times out in [`WAIT_FOR_MSG_TIMEOUT`]
 pub enum StateWaitMsg {}
 
 impl RpcMethod<4> for StateWaitMsg {
@@ -1321,6 +1323,7 @@ impl RpcMethod<4> for StateWaitMsg {
 
 /// Searches for a message in the chain, and returns its receipt and the tipset where it was executed.
 /// See <https://github.com/filecoin-project/lotus/blob/master/documentation/en/api-methods-v1-stable.md#StateSearchMsg>
+/// This method times out in [`SEARCH_FOR_MSG_TIMEOUT`]
 pub enum StateSearchMsg {}
 
 impl RpcMethod<4> for StateSearchMsg {
@@ -1373,6 +1376,7 @@ impl RpcMethod<4> for StateSearchMsg {
 }
 
 /// See <https://github.com/filecoin-project/lotus/blob/master/documentation/en/api-methods-v0-deprecated.md#StateSearchMsgLimited>
+/// This method times out in [`SEARCH_FOR_MSG_TIMEOUT`]
 pub enum StateSearchMsgLimited {}
 
 impl RpcMethod<2> for StateSearchMsgLimited {

--- a/src/state_manager/message_search.rs
+++ b/src/state_manager/message_search.rs
@@ -244,13 +244,18 @@ impl StateManager {
             let reverted = reverted.shallow_clone();
             let cancellation_token = cancellation_token.clone();
             move || {
-                if let Ok(Some((ts, receipt))) = sm.search_back_for_message_blocking(
-                    current_ts,
-                    &message,
-                    look_back_limit,
-                    allow_replaced,
-                    &cancellation_token,
-                ) && !reverted.read().contains(ts.key())
+                if let Ok(Some((ts, receipt))) = sm
+                    .search_back_for_message_blocking(
+                        current_ts,
+                        &message,
+                        look_back_limit,
+                        allow_replaced,
+                        &cancellation_token,
+                    )
+                    .inspect_err(|e| {
+                        tracing::warn!("failed to search back for message: {e}");
+                    })
+                    && !reverted.read().contains(ts.key())
                 {
                     if sm.heaviest_tipset().epoch() >= ts.epoch() + confidence {
                         _ = search_back_tx.send((ts, receipt)).inspect_err(|e| {

--- a/src/state_manager/message_search.rs
+++ b/src/state_manager/message_search.rs
@@ -4,9 +4,12 @@
 use super::*;
 use crate::blocks::TipsetKey;
 use crate::message::MessageRead as _;
-use ahash::HashMap;
-use futures::{FutureExt, channel::oneshot, select};
-use tokio::sync::{RwLock, broadcast::error::RecvError};
+use ahash::HashSet;
+use parking_lot::RwLock;
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::broadcast::error::RecvError;
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 impl StateManager {
@@ -161,138 +164,177 @@ impl StateManager {
         Ok(message_receipt)
     }
 
+    pub async fn wait_for_message_with_timeout(
+        &self,
+        msg_cid: Cid,
+        confidence: i64,
+        look_back_limit: Option<ChainEpoch>,
+        allow_replaced: Option<bool>,
+        timeout: Duration,
+    ) -> Result<(Tipset, Receipt), Error> {
+        let cancellation_token = CancellationToken::new();
+        let _cancellation_token_drop_guard = cancellation_token.drop_guard_ref();
+        tokio::time::timeout(
+            timeout,
+            self.wait_for_message(
+                msg_cid,
+                confidence,
+                look_back_limit,
+                allow_replaced,
+                &cancellation_token,
+            ),
+        )
+        .await
+        .map_err(|_| {
+            Error::other(format!(
+                "wait_for_message timed out after {}",
+                humantime::format_duration(timeout)
+            ))
+        })?
+    }
+
     /// `WaitForMessage` blocks until a message appears on chain. It looks
     /// backwards in the chain to see if this has already happened. It
     /// guarantees that the message has been on chain for at least
     /// confidence epochs without being reverted before returning.
+    /// Returns an error when cancelled.
     pub async fn wait_for_message(
         &self,
         msg_cid: Cid,
         confidence: i64,
         look_back_limit: Option<ChainEpoch>,
         allow_replaced: Option<bool>,
-    ) -> Result<(Option<Tipset>, Option<Receipt>), Error> {
-        let mut head_changes_rx = self.cs.subscribe_head_changes();
-        let (sender, mut receiver) = oneshot::channel::<()>();
-        let message = crate::chain::get_chain_message(self.db(), &msg_cid)
-            .map_err(|err| Error::Other(format!("failed to load message {err:}")))?;
-        let current_tipset = self.heaviest_tipset();
-        let maybe_message_receipt =
-            self.tipset_executed_message(&current_tipset, &message, true)?;
-        if let Some(r) = maybe_message_receipt {
-            return Ok((Some(current_tipset.shallow_clone()), Some(r)));
+        cancellation_token: &CancellationToken,
+    ) -> Result<(Tipset, Receipt), Error> {
+        let message = Arc::new(
+            crate::chain::get_chain_message(self.db(), &msg_cid)
+                .map_err(|err| Error::Other(format!("failed to load message {err:}")))?,
+        );
+        let current_ts = self.heaviest_tipset();
+        let maybe_message_receipt = self.tipset_executed_message(&current_ts, &message, true)?;
+        if let Some(receipt) = maybe_message_receipt {
+            return Ok((current_ts, receipt));
         }
 
-        let mut candidate_tipset: Option<Tipset> = None;
-        let mut candidate_receipt: Option<Receipt> = None;
-
-        let sm_cloned = self.shallow_clone();
-
-        let message_for_task = message.clone();
-        let height_of_head = current_tipset.epoch();
-        let task = tokio::task::spawn(async move {
-            let back_tuple = sm_cloned.search_back_for_message(
-                current_tipset,
-                &message_for_task,
-                look_back_limit,
-                allow_replaced,
-            )?;
-            sender
-                .send(())
-                .map_err(|e| Error::Other(format!("Could not send to channel {e:?}")))?;
-            Ok::<_, Error>(back_tuple)
+        // For immediate search back response
+        let (search_back_tx, search_back_rx) = flume::bounded(1);
+        let search_back_candidate: Arc<OnceLock<(Tipset, Receipt)>> = Default::default();
+        let reverted: Arc<RwLock<HashSet<TipsetKey>>> = Arc::new(RwLock::new(HashSet::default()));
+        // Search back task
+        tokio::task::spawn_blocking({
+            let sm = self.shallow_clone();
+            let message = message.shallow_clone();
+            // Cloning tx to avoid all senders being dropped to make `search_back_rx.recv_async()` wait
+            let search_back_tx = search_back_tx.clone();
+            let search_back_candidate = search_back_candidate.shallow_clone();
+            let reverted = reverted.shallow_clone();
+            move || {
+                if let Ok(Some((ts, receipt))) = sm.search_back_for_message(
+                    current_ts,
+                    &message,
+                    look_back_limit,
+                    allow_replaced,
+                ) && !reverted.read().contains(ts.key())
+                {
+                    if sm.heaviest_tipset().epoch() >= ts.epoch() + confidence {
+                        _ = search_back_tx.send((ts, receipt)).inspect_err(|e| {
+                            tracing::warn!("failed to send to search_back_tx: {e}");
+                        });
+                    } else {
+                        _ = search_back_candidate.set((ts, receipt)).inspect_err(|_| {
+                            tracing::warn!("failed to send to set search_back_candidate");
+                        });
+                    }
+                }
+            }
         });
 
-        let reverts: Arc<RwLock<HashMap<TipsetKey, bool>>> = Arc::new(RwLock::new(HashMap::new()));
-        let block_revert = reverts.clone();
-        let sm_cloned = self.shallow_clone();
-
         // Wait for message to be included in head change.
-        let mut subscriber_poll = tokio::task::spawn(async move {
-            loop {
-                match head_changes_rx.recv().await {
-                    Ok(head_changes) => {
-                        for tipset in head_changes.reverts {
-                            if candidate_tipset
-                                .as_ref()
-                                .is_some_and(|candidate| candidate.key() == tipset.key())
-                            {
-                                candidate_tipset = None;
-                                candidate_receipt = None;
-                            }
-                        }
-                        for tipset in head_changes.applies {
-                            if candidate_tipset
-                                .as_ref()
-                                .map(|s| tipset.epoch() >= s.epoch() + confidence)
-                                .unwrap_or_default()
-                            {
-                                return Ok((candidate_tipset, candidate_receipt));
-                            }
-                            let poll_receiver = receiver.try_recv();
-                            if let Ok(Some(_)) = poll_receiver {
-                                block_revert
-                                    .write()
-                                    .await
-                                    .insert(tipset.key().to_owned(), true);
-                            }
-
-                            let maybe_receipt =
-                                sm_cloned.tipset_executed_message(&tipset, &message, true)?;
-                            if let Some(receipt) = maybe_receipt {
-                                if confidence == 0 {
-                                    return Ok((Some(tipset), Some(receipt)));
+        let subscriber_poll = tokio::task::spawn({
+            let cancellation_token = cancellation_token.clone();
+            let search_back_candidate = search_back_candidate.shallow_clone();
+            let reverted = reverted.shallow_clone();
+            let sm = self.shallow_clone();
+            async move {
+                let mut head_changes_rx = sm.cs.subscribe_head_changes();
+                let mut candidate: Option<(Tipset, Receipt)> = None;
+                while !cancellation_token.is_cancelled() {
+                    match head_changes_rx.recv().await {
+                        Ok(head_changes) => {
+                            for reverted_ts in head_changes.reverts {
+                                // No need to update reverted set when search back task is done
+                                if search_back_candidate.get().is_none() {
+                                    reverted.write().insert(reverted_ts.key().clone());
                                 }
-                                candidate_tipset = Some(tipset);
-                                candidate_receipt = Some(receipt)
+
+                                if candidate
+                                    .as_ref()
+                                    .is_some_and(|(ts, _)| ts.key() == reverted_ts.key())
+                                {
+                                    candidate = None;
+                                }
+                            }
+                            for applied_ts in head_changes.applies {
+                                // Return if `search_back_candidate` meets confidence requirement
+                                if let Some((candidate_ts, candidate_receipt)) =
+                                    search_back_candidate.get()
+                                    && applied_ts.epoch() >= candidate_ts.epoch() + confidence
+                                {
+                                    return Ok((
+                                        candidate_ts.shallow_clone(),
+                                        candidate_receipt.clone(),
+                                    ));
+                                }
+
+                                // No need to update reverted set when search back task is done
+                                if search_back_candidate.get().is_none() {
+                                    reverted.write().remove(applied_ts.key());
+                                }
+
+                                // Return if the candidate meets confidence requirement
+                                if let Some((candidate_ts, _)) = &candidate
+                                    && applied_ts.epoch() >= candidate_ts.epoch() + confidence
+                                    && let Some(candidate) = candidate
+                                {
+                                    return Ok(candidate);
+                                }
+
+                                let maybe_receipt =
+                                    sm.tipset_executed_message(&applied_ts, &message, true)?;
+                                if let Some(receipt) = maybe_receipt {
+                                    if confidence == 0 {
+                                        // Return if there's no confidence requirement
+                                        return Ok((applied_ts, receipt));
+                                    } else {
+                                        // Otherwise set it as candidate
+                                        candidate = Some((applied_ts, receipt));
+                                    }
+                                }
                             }
                         }
+                        Err(RecvError::Lagged(i)) => {
+                            warn!(
+                                "wait for message head change subscriber lagged, skipped {} events",
+                                i
+                            );
+                        }
+                        Err(RecvError::Closed) => break,
                     }
-                    Err(RecvError::Lagged(i)) => {
-                        warn!(
-                            "wait for message head change subscriber lagged, skipped {} events",
-                            i
-                        );
-                    }
-                    Err(RecvError::Closed) => break,
                 }
+                Err(Error::other("cancelled"))
             }
-            Ok((None, None))
-        })
-        .fuse();
-
-        // Search backwards for message.
-        let mut search_back_poll = tokio::task::spawn(async move {
-            let back_tuple = task.await.map_err(|e| {
-                Error::Other(format!("Could not search backwards for message {e}"))
-            })??;
-            if let Some((back_tipset, back_receipt)) = back_tuple {
-                let should_revert = *reverts
-                    .read()
-                    .await
-                    .get(back_tipset.key())
-                    .unwrap_or(&false);
-                let larger_height_of_head = height_of_head >= back_tipset.epoch() + confidence;
-                if !should_revert && larger_height_of_head {
-                    return Ok::<_, Error>((Some(back_tipset), Some(back_receipt)));
-                }
-                return Ok((None, None));
-            }
-            Ok((None, None))
-        })
-        .fuse();
+        });
 
         // Await on first future to finish.
-        loop {
-            select! {
-                res = subscriber_poll => {
-                    return res?
-                }
-                res = search_back_poll => {
-                    if let Ok((Some(ts), Some(rct))) = res? {
-                        return Ok((Some(ts), Some(rct)));
-                    }
-                }
+        tokio::select! {
+            res = subscriber_poll => {
+                res.context("tokio join error")?
+            }
+            res = search_back_rx.recv_async()  => {
+                Ok(res.context("channel receive error")?)
+            }
+            _ = cancellation_token.cancelled() => {
+                Err(Error::other("cancelled"))
             }
         }
     }

--- a/src/state_manager/message_search.rs
+++ b/src/state_manager/message_search.rs
@@ -71,12 +71,13 @@ impl StateManager {
             .unwrap_or(Ok(None))
     }
 
-    fn check_search(
+    fn check_search_blocking(
         &self,
         mut current: Tipset,
         message: &ChainMessage,
         lookback_max_epoch: ChainEpoch,
         allow_replaced: bool,
+        cancellation_token: &CancellationToken,
     ) -> Result<Option<(Tipset, Receipt)>, Error> {
         let message_from_address = message.from();
         let message_sequence = message.sequence();
@@ -85,7 +86,7 @@ impl StateManager {
             .map_err(Error::state)?;
         let message_from_id = self.lookup_required_id(&message_from_address, &current)?;
 
-        while current.epoch() >= lookback_max_epoch {
+        while !cancellation_token.is_cancelled() && current.epoch() >= lookback_max_epoch {
             let parent_tipset = self
                 .chain_index()
                 .load_required_tipset(current.parents())
@@ -121,12 +122,13 @@ impl StateManager {
     }
 
     /// Searches backwards through the chain for a message receipt.
-    fn search_back_for_message(
+    fn search_back_for_message_blocking(
         &self,
         current: Tipset,
         message: &ChainMessage,
         look_back_limit: Option<i64>,
         allow_replaced: Option<bool>,
+        cancellation_token: &CancellationToken,
     ) -> Result<Option<(Tipset, Receipt)>, Error> {
         let current_epoch = current.epoch();
         let allow_replaced = allow_replaced.unwrap_or(true);
@@ -143,11 +145,22 @@ impl StateManager {
             _ => 0,
         };
 
-        self.check_search(current, message, lookback_max_epoch, allow_replaced)
+        self.check_search_blocking(
+            current,
+            message,
+            lookback_max_epoch,
+            allow_replaced,
+            cancellation_token,
+        )
     }
 
     /// Returns a message receipt from a given tipset and message CID.
-    pub fn get_receipt(&self, tipset: Tipset, msg: Cid) -> Result<Receipt, Error> {
+    pub fn get_receipt_blocking(
+        &self,
+        tipset: Tipset,
+        msg: Cid,
+        cancellation_token: &CancellationToken,
+    ) -> Result<Receipt, Error> {
         let m = crate::chain::get_chain_message(self.db(), &msg)
             .map_err(|e| Error::Other(e.to_string()))?;
         let message_receipt = self.tipset_executed_message(&tipset, &m, true)?;
@@ -155,7 +168,8 @@ impl StateManager {
             return Ok(receipt);
         }
 
-        let maybe_tuple = self.search_back_for_message(tipset, &m, None, None)?;
+        let maybe_tuple =
+            self.search_back_for_message_blocking(tipset, &m, None, None, cancellation_token)?;
         let message_receipt = maybe_tuple
             .ok_or_else(|| {
                 Error::Other("Could not get receipt from search back message".to_string())
@@ -228,12 +242,14 @@ impl StateManager {
             let search_back_tx = search_back_tx.clone();
             let search_back_candidate = search_back_candidate.shallow_clone();
             let reverted = reverted.shallow_clone();
+            let cancellation_token = cancellation_token.clone();
             move || {
-                if let Ok(Some((ts, receipt))) = sm.search_back_for_message(
+                if let Ok(Some((ts, receipt))) = sm.search_back_for_message_blocking(
                     current_ts,
                     &message,
                     look_back_limit,
                     allow_replaced,
+                    &cancellation_token,
                 ) && !reverted.read().contains(ts.key())
                 {
                     if sm.heaviest_tipset().epoch() >= ts.epoch() + confidence {
@@ -262,10 +278,7 @@ impl StateManager {
                     match head_changes_rx.recv().await {
                         Ok(head_changes) => {
                             for reverted_ts in head_changes.reverts {
-                                // No need to update reverted set when search back task is done
-                                if search_back_candidate.get().is_none() {
-                                    reverted.write().insert(reverted_ts.key().clone());
-                                }
+                                reverted.write().insert(reverted_ts.key().clone());
 
                                 if candidate
                                     .as_ref()
@@ -275,20 +288,18 @@ impl StateManager {
                                 }
                             }
                             for applied_ts in head_changes.applies {
+                                reverted.write().remove(applied_ts.key());
+
                                 // Return if `search_back_candidate` meets confidence requirement
                                 if let Some((candidate_ts, candidate_receipt)) =
                                     search_back_candidate.get()
                                     && applied_ts.epoch() >= candidate_ts.epoch() + confidence
+                                    && !reverted.read().contains(candidate_ts.key())
                                 {
                                     return Ok((
                                         candidate_ts.shallow_clone(),
                                         candidate_receipt.clone(),
                                     ));
-                                }
-
-                                // No need to update reverted set when search back task is done
-                                if search_back_candidate.get().is_none() {
-                                    reverted.write().remove(applied_ts.key());
                                 }
 
                                 // Return if the candidate meets confidence requirement
@@ -345,6 +356,7 @@ impl StateManager {
         msg_cid: Cid,
         look_back_limit: Option<i64>,
         allow_replaced: Option<bool>,
+        cancellation_token: &CancellationToken,
     ) -> Result<Option<(Tipset, Receipt)>, Error> {
         let from = from.unwrap_or_else(|| self.heaviest_tipset());
         let message = crate::chain::get_chain_message(self.db(), &msg_cid)
@@ -355,7 +367,20 @@ impl StateManager {
         if let Some(r) = maybe_message_receipt {
             Ok(Some((from, r)))
         } else {
-            self.search_back_for_message(current_tipset, &message, look_back_limit, allow_replaced)
+            tokio::task::spawn_blocking({
+                let this = self.shallow_clone();
+                let cancellation_token = cancellation_token.clone();
+                move || {
+                    this.search_back_for_message_blocking(
+                        current_tipset,
+                        &message,
+                        look_back_limit,
+                        allow_replaced,
+                        &cancellation_token,
+                    )
+                }
+            })
+            .await?
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

This PR added cancellation to tokio tasks in `wait_for_message`. It also fixes bugs described below.

(co-authored by Claude Code)
# Bugs in (pre-fix) `StateManager::wait_for_message`

Verified against the pre-fix Forest code (left/old side of PR #7266's diff)
and the Lotus reference implementation `StateManager.WaitForMessage` in
`chain/stmgr/searchwait.go`.

## Bug 1: `block_revert` recorded applied tipsets instead of reverted ones

**Old Forest code** (`message_search.rs`, inside the head-change subscriber
task):

```rust
for tipset in head_changes.applies {
    if candidate_tipset
        .as_ref()
        .map(|s| tipset.epoch() >= s.epoch() + confidence)
        .unwrap_or_default()
    {
        return Ok((candidate_tipset, candidate_receipt));
    }
    let poll_receiver = receiver.try_recv();
    if let Ok(Some(_)) = poll_receiver {
        block_revert
            .write()
            .await
            .insert(tipset.key().to_owned(), true);
    }
    let maybe_receipt = sm_cloned.tipset_executed_message(&tipset, &message, true)?;
    ...
}
```

`block_revert` (an alias for the shared `reverts: Arc<RwLock<HashMap<TipsetKey,
bool>>>` map) is inserted into from within the `head_changes.applies` loop —
i.e. it records *applied* tipsets as if they were reverted. There is no
corresponding insertion anywhere in the `head_changes.reverts` loop above it,
so the `reverts` map never actually reflects real chain reverts; instead it
fills up with applied tipsets whenever the search-back task has already
signaled completion via `receiver.try_recv()`.

This map is later consumed by `search_back_poll` to decide whether the
backward-search result should be discarded:

```rust
let should_revert = *reverts.read().await.get(back_tipset.key()).unwrap_or(&false);
...
if !should_revert && larger_height_of_head {
    return Ok::<_, Error>((Some(back_tipset), Some(back_receipt)));
}
```

Since `reverts` is populated with *applied* tipset keys rather than reverted
ones, `should_revert` can spuriously become `true` for a tipset that was
never reverted (if it happens to match an applied tipset's key), or fail to
become `true` for a tipset that genuinely was reverted (since reverts are
never recorded). Either way the revert check is checking the wrong set.

**Go reference** (`searchwait.go`):

```go
case store.HCRevert:
    if val.Val.Equals(candidateTs) {
        candidateTs = nil
        candidateRcp = nil
        candidateFm = cid.Undef
    }
    if backSearchWait != nil {
        reverts[val.Val.Key()] = true
    }
case store.HCApply:
    ...
```

In Go, `reverts[val.Val.Key()] = true` is set in the `HCRevert` branch —
i.e. genuinely reverted tipsets — not in the `HCApply` branch. This confirms
the Forest bug: the old code had the equivalent insertion in the wrong
branch (`applies` instead of `reverts`), inverting the intended tracking.

## Bug 2: `height_of_head` was computed once and never updated

**Old Forest code:**

```rust
let height_of_head = current_tipset.epoch();
let task = tokio::task::spawn(async move {
    let back_tuple = sm_cloned.search_back_for_message(...)?;
    ...
});
...
let mut search_back_poll = tokio::task::spawn(async move {
    let back_tuple = task.await...??;
    if let Some((back_tipset, back_receipt)) = back_tuple {
        let should_revert = ...;
        let larger_height_of_head = height_of_head >= back_tipset.epoch() + confidence;
        if !should_revert && larger_height_of_head {
            return Ok::<_, Error>((Some(back_tipset), Some(back_receipt)));
        }
        return Ok((None, None));
    }
    Ok((None, None))
})
.fuse();
```

`height_of_head` is captured by value into the `search_back_poll` async
block at the moment the function starts (`current_tipset.epoch()`), and is
never reassigned afterward. As the chain progresses while the search-back
task is still running, new tipsets arrive via `head_changes.applies` in the
separate `subscriber_poll` task, but `height_of_head` inside
`search_back_poll` stays frozen at its initial value. This means the
confidence check `larger_height_of_head = height_of_head >= back_tipset.epoch()
+ confidence` is evaluated against a stale head height instead of the
current one, which can cause the function to incorrectly decide the
confidence interval hasn't been met (or, less likely, has been met) based on
outdated chain state.

**Go reference:**

```go
heightOfHead := head[0].Val.Height()
...
for {
    select {
    case notif, ok := <-tsub:
        ...
        case store.HCApply:
            ...
            heightOfHead = val.Val.Height()
        }
    case <-backSearchWait:
        if backTs != nil && !reverts[backTs.Key()] {
            if heightOfHead >= backTs.Height()+abi.ChainEpoch(confidence) {
                return backTs, backRcp, backFm, nil
            }
            ...
        }
    ...
    }
}
```

In Go, `heightOfHead` is declared once before the loop but is reassigned on
every `HCApply` event (`heightOfHead = val.Val.Height()`), so by the time the
`backSearchWait` channel closes and the backward-search result is checked,
`heightOfHead` reflects the *current* chain head rather than the head at
function-start time. This confirms the Forest bug: the old code never
updated `height_of_head` after computing it once, so it did not track chain
progress the way the Go implementation does.

## Summary

| # | Bug | Effect | Confirmed against Go? |
|---|-----|--------|------------------------|
| 1 | `block_revert` (the `reverts` map) was populated from `head_changes.applies` instead of `head_changes.reverts` | The revert-tracking map recorded the wrong tipsets, so the backward-search result's revert check (`should_revert`) was unreliable — it could ignore real reverts and/or be tripped by unrelated applied tipsets | Yes — Go sets `reverts[val.Val.Key()] = true` in the `HCRevert` case, not `HCApply` |
| 2 | `height_of_head` was computed once before the search-back task ran and never updated | The confidence check against the backward-search result (`larger_height_of_head`) compared against a stale chain height instead of the current one as the chain progressed | Yes — Go reassigns `heightOfHead = val.Val.Height()` inside the `HCApply` case on every loop iteration |


Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message-wait and message-search RPCs now include built-in timeouts and return clearer “timed out” errors when lookups exceed the limit.
  * Message lookups became more cancellation-responsive, improving responsiveness during long-running receipt searches.

* **Bug Fixes**
  * More consistent receipt retrieval behavior when waiting/searching for message receipts.
  * Ethereum transaction lookup, receipt, and transaction tracing now share the same timeout/cancellation behavior to reduce delays and inconsistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->