### PR TITLE
feat: add --wait-confidence to forest-wallet send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Added
 
+- [#7269](https://github.com/ChainSafe/forest/pull/7269): Added `--wait-confidence` and `--wait-timeout` to `forest-wallet send` command.
+
 ### Changed
 
 - [#6442](https://github.com/ChainSafe/forest/issues/6442): `forest-wallet sign` and `forest-wallet verify` now apply the FRC-0102 signing envelope to the message by default. Pass `--raw` on both sides to reproduce the previous raw-bytes behaviour.

--- a/src/dev/subcommands/tests_cmd/calibnet/helpers.rs
+++ b/src/dev/subcommands/tests_cmd/calibnet/helpers.rs
@@ -120,7 +120,7 @@ pub fn send_from(from: &str, to: &str, amount: &str, backend: Backend) -> anyhow
         "--from",
         from,
         "--wait-confidence",
-        "1",
+        "0",
         "--wait-timeout",
         "1m",
         to,
@@ -130,9 +130,9 @@ pub fn send_from(from: &str, to: &str, amount: &str, backend: Backend) -> anyhow
     loop {
         match wallet(backend, &args) {
             Ok(out) => return Ok(out),
-            Err(e) if attempt < SEND_RETRIES && is_min_gas_price_error(&e) => {
+            Err(_) if attempt < SEND_RETRIES => {
                 eprintln!(
-                    "send {from} -> {to} hit min-gas-price floor on attempt {attempt}/{SEND_RETRIES}, retrying"
+                    "send {from} -> {to} failed on attempt {attempt}/{SEND_RETRIES}, retrying"
                 );
                 std::thread::sleep(SEND_RETRY_DELAY);
                 attempt += 1;
@@ -147,13 +147,6 @@ const SEND_RETRIES: usize = 3;
 /// Delay between [`send_from`] retries; one block-time at calibnet cadence
 /// is enough for the daemon's gas-price snapshot to refresh.
 const SEND_RETRY_DELAY: Duration = Duration::from_secs(15);
-
-fn is_min_gas_price_error(err: &anyhow::Error) -> bool {
-    err.chain().any(|e| {
-        e.to_string()
-            .contains("gas price is lower than min gas price")
-    })
-}
 
 /// Poll until `try_check` returns `Some` or [`POLL_TIMEOUT`] elapses, sleeping
 /// [`POLL_WAIT_TIME`] between attempts.

--- a/src/dev/subcommands/tests_cmd/calibnet/helpers.rs
+++ b/src/dev/subcommands/tests_cmd/calibnet/helpers.rs
@@ -115,17 +115,29 @@ pub fn balance(address: &str, backend: Backend) -> anyhow::Result<String> {
 /// fee estimation so gas fields match whatever minimum gas price applies
 /// at the next submission.
 pub fn send_from(from: &str, to: &str, amount: &str, backend: Backend) -> anyhow::Result<String> {
-    let args = [
-        "send",
-        "--from",
-        from,
-        "--wait-confidence",
-        "0",
-        "--wait-timeout",
-        "1m",
-        to,
-        amount,
-    ];
+    send_from_and_maybe_wait(from, to, amount, backend, true)
+}
+
+pub fn send_from_no_wait(
+    from: &str,
+    to: &str,
+    amount: &str,
+    backend: Backend,
+) -> anyhow::Result<String> {
+    send_from_and_maybe_wait(from, to, amount, backend, false)
+}
+
+fn send_from_and_maybe_wait(
+    from: &str,
+    to: &str,
+    amount: &str,
+    backend: Backend,
+    wait: bool,
+) -> anyhow::Result<String> {
+    let mut args = vec!["send", to, amount, "--from", from];
+    if wait {
+        args.extend(["--wait-confidence", "0", "--wait-timeout", "1m"]);
+    }
     let mut attempt = 1;
     loop {
         match wallet(backend, &args) {

--- a/src/dev/subcommands/tests_cmd/calibnet/helpers.rs
+++ b/src/dev/subcommands/tests_cmd/calibnet/helpers.rs
@@ -115,7 +115,7 @@ pub fn balance(address: &str, backend: Backend) -> anyhow::Result<String> {
 /// fee estimation so gas fields match whatever minimum gas price applies
 /// at the next submission.
 pub fn send_from(from: &str, to: &str, amount: &str, backend: Backend) -> anyhow::Result<String> {
-    let args = ["send", "--from", from, to, amount];
+    let args = ["send", "--from", from, "--wait-confidence", "1", to, amount];
     let mut attempt = 1;
     loop {
         match wallet(backend, &args) {

--- a/src/dev/subcommands/tests_cmd/calibnet/helpers.rs
+++ b/src/dev/subcommands/tests_cmd/calibnet/helpers.rs
@@ -115,7 +115,17 @@ pub fn balance(address: &str, backend: Backend) -> anyhow::Result<String> {
 /// fee estimation so gas fields match whatever minimum gas price applies
 /// at the next submission.
 pub fn send_from(from: &str, to: &str, amount: &str, backend: Backend) -> anyhow::Result<String> {
-    let args = ["send", "--from", from, "--wait-confidence", "1", to, amount];
+    let args = [
+        "send",
+        "--from",
+        from,
+        "--wait-confidence",
+        "1",
+        "--wait-timeout",
+        "1m",
+        to,
+        amount,
+    ];
     let mut attempt = 1;
     loop {
         match wallet(backend, &args) {

--- a/src/dev/subcommands/tests_cmd/calibnet/mpool.rs
+++ b/src/dev/subcommands/tests_cmd/calibnet/mpool.rs
@@ -55,7 +55,7 @@ async fn mpool_replace_auto_unblocks_pending_async() {
     let addr = FOREST_TEST_PRELOADED_ADDRESS.as_str();
     let nonce = mpool_nonce(addr).unwrap();
 
-    let cid = send_from(addr, addr, FIL_AMT, Backend::Local).unwrap();
+    let cid = send_from_no_wait(addr, addr, FIL_AMT, Backend::Local).unwrap();
     poll_until_pending_nonce(addr, nonce).await.unwrap();
 
     forest_cli(&[

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -316,6 +316,9 @@ pub enum WalletCommands {
         /// The command waits until the message has been on chain for at least `confidence` epochs.
         #[arg(long)]
         wait_confidence: Option<u32>,
+        /// Timeout duration for `--wait-confidence`, e.g. `30s`, `5m`. If not set, the timeout will be `confidence + 5` epochs.
+        #[arg(long, requires = "wait_confidence", value_parser = humantime::parse_duration)]
+        wait_timeout: Option<Duration>,
     },
 }
 impl WalletCommands {
@@ -500,6 +503,7 @@ impl WalletCommands {
                 gas_limit,
                 gas_premium,
                 wait_confidence,
+                wait_timeout,
             } => {
                 let from: Address = match from {
                     Some(a) => a.into(),
@@ -570,6 +574,9 @@ impl WalletCommands {
                 if let Some(confidence) = wait_confidence {
                     let start = Instant::now();
                     let version = Version::call(&backend.remote, ()).await?;
+                    let timeout = wait_timeout.unwrap_or_else(|| {
+                        Duration::from_secs(u64::from((confidence + 5) * version.block_delay))
+                    });
                     backend
                         .remote
                         .call(
@@ -579,10 +586,7 @@ impl WalletCommands {
                                 10,
                                 true,
                             ))?
-                            .with_timeout(Duration::from_secs(
-                                // Give it 5 epochs buffer
-                                u64::from((confidence + 5) * version.block_delay),
-                            )),
+                            .with_timeout(timeout),
                         )
                         .await
                         .with_context(||format!("timed out waiting for the message {msg_cid} with confidence {confidence}, took {}", humantime::format_duration(start.elapsed())))?;

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -5,6 +5,7 @@ use std::{
     cell::RefCell,
     path::PathBuf,
     str::{self, FromStr},
+    time::{Duration, Instant},
 };
 
 use crate::cli::humantoken::TokenAmountPretty as _;
@@ -311,6 +312,10 @@ pub enum WalletCommands {
         gas_limit: i64,
         #[arg(long, value_parser = humantoken::parse, default_value_t = TokenAmount::zero())]
         gas_premium: TokenAmount,
+        /// Wait for the message to be on chain with the given confidence by calling`StateWaitMsg`.
+        /// The command waits until the message has been on chain for at least `confidence` epochs.
+        #[arg(long)]
+        wait_confidence: Option<u32>,
     },
 }
 impl WalletCommands {
@@ -494,6 +499,7 @@ impl WalletCommands {
                 gas_feecap,
                 gas_limit,
                 gas_premium,
+                wait_confidence,
             } => {
                 let from: Address = match from {
                     Some(a) => a.into(),
@@ -558,7 +564,29 @@ impl WalletCommands {
                     MpoolPushMessage::call(&backend.remote, (message, None)).await?
                 };
 
-                println!("{}", signed_msg.cid());
+                let msg_cid = signed_msg.cid();
+                println!("{msg_cid}");
+
+                if let Some(confidence) = wait_confidence {
+                    let start = Instant::now();
+                    let version = Version::call(&backend.remote, ()).await?;
+                    backend
+                        .remote
+                        .call(
+                            StateWaitMsg::request((
+                                msg_cid,
+                                i64::from(confidence),
+                                10,
+                                true,
+                            ))?
+                            .with_timeout(Duration::from_secs(
+                                // Give it 5 epochs buffer
+                                u64::from((confidence + 5) * version.block_delay),
+                            )),
+                        )
+                        .await
+                        .with_context(||format!("timed out waiting for the message {msg_cid} with confidence {confidence}, took {}", humantime::format_duration(start.elapsed())))?;
+                }
 
                 Ok(())
             }

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -24,23 +24,21 @@ use crate::{
         message::{METHOD_SEND, Message},
     },
 };
-use crate::{KeyStore, lotus_json::LotusJson};
 use crate::{
-    KeyStoreConfig,
+    KeyStore, KeyStoreConfig,
+    lotus_json::{HasLotusJson as _, LotusJson},
+    rpc::{self, prelude::*},
     shim::{
         address::StrictAddress,
         crypto::{Signature, SignatureType},
         econ::TokenAmount,
     },
 };
-use crate::{
-    lotus_json::HasLotusJson as _,
-    rpc::{self, prelude::*},
-};
 use anyhow::{Context as _, bail};
 use clap::Subcommand;
 use dialoguer::{Password, console::Term, theme::ColorfulTheme};
 use directories::ProjectDirs;
+use jsonrpsee::core::ClientError;
 use num::Zero as _;
 use tabled::{builder::Builder, settings::Style};
 
@@ -589,7 +587,17 @@ impl WalletCommands {
                             .with_timeout(timeout),
                         )
                         .await
-                        .with_context(||format!("timed out waiting for the message {msg_cid} with confidence {confidence}, took {}", humantime::format_duration(start.elapsed())))?;
+                        .map_err(|e|
+                        {
+                            match e {
+                                ClientError::RequestTimeout => {
+                                    anyhow::anyhow!("timed out waiting for the message {msg_cid} with confidence {confidence}, took {}", humantime::format_duration(start.elapsed()))
+                                }
+                                e => {
+                                    anyhow::anyhow!("failed to wait for the message {msg_cid} with confidence {confidence}: {e}")
+                                }
+                            }
+                        })?;
                 }
 
                 Ok(())

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -312,7 +312,7 @@ pub enum WalletCommands {
         gas_limit: i64,
         #[arg(long, value_parser = humantoken::parse, default_value_t = TokenAmount::zero())]
         gas_premium: TokenAmount,
-        /// Wait for the message to be on chain with the given confidence by calling`StateWaitMsg`.
+        /// Wait for the message to be on chain with the given confidence by calling `StateWaitMsg`.
         /// The command waits until the message has been on chain for at least `confidence` epochs.
         #[arg(long)]
         wait_confidence: Option<u32>,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- add `--wait-confidence` and `--wait-timeout` to `forest-wallet send`
- try to make CI wallet tests less flaky

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `wallet send` can now optionally wait for a transaction to reach a chosen on-chain confidence level.
  * Added `--wait-timeout` to cap this wait (only valid with `--wait-confidence`), with improved timeout/error messages that include the message CID and timing details.
* **Tests**
  * Updated internal test tooling to support sending without waiting for confirmation where needed.
* **Documentation**
  * Updated `CHANGELOG.md` to document the new `forest-wallet send` options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->