### PR TITLE
feat(api-compare): report tested API versions in conformance report

### DIFF
--- a/src/rpc/reflect/mod.rs
+++ b/src/rpc/reflect/mod.rs
@@ -128,6 +128,7 @@ pub enum Permission {
     PartialOrd,
     clap::ValueEnum,
     EnumString,
+    strum::Display,
     Deserialize,
     Serialize,
 )]

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -2871,6 +2871,7 @@ pub(super) async fn run_tests(
                     success,
                     &test_result,
                     &test.request.params,
+                    test.request.api_path,
                 );
 
                 // Dump test data if configured

--- a/src/tool/subcommands/api_cmd/report.rs
+++ b/src/tool/subcommands/api_cmd/report.rs
@@ -3,13 +3,14 @@
 
 use super::ReportMode;
 use crate::prelude::*;
-use crate::rpc::{self, FilterList, Permission};
+use crate::rpc::{self, ApiPaths, FilterList, Permission};
 use crate::tool::subcommands::api_cmd::api_compare_tests::TestSummary;
 use ahash::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, DurationMilliSeconds, DurationSeconds, serde_as};
 use similar::{ChangeTag, TextDiff};
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tabled::{builder::Builder, settings::Style};
@@ -123,6 +124,10 @@ struct MethodReport {
     /// Current testing status
     status: MethodTestStatus,
 
+    /// API versions this method was exercised under
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    api_versions: BTreeSet<ApiPaths>,
+
     // Performance metrics (always included)
     #[serde(skip_serializing_if = "Option::is_none")]
     performance: Option<PerformanceMetrics>,
@@ -177,6 +182,7 @@ impl ReportBuilder {
                     } else {
                         MethodTestStatus::NotTested
                     },
+                    api_versions: BTreeSet::new(),
                     performance: None,
                     success_test_params: vec![],
                     failed_test_params: vec![],
@@ -200,8 +206,11 @@ impl ReportBuilder {
         success: bool,
         test_result: &super::api_compare_tests::TestResult,
         test_params: &serde_json::Value,
+        api_path: ApiPaths,
     ) {
         if let Some(report) = self.method_reports.get_mut(method_name) {
+            report.api_versions.insert(api_path);
+
             // Update test status
             match &mut report.status {
                 MethodTestStatus::NotTested | MethodTestStatus::Filtered => {
@@ -294,7 +303,7 @@ impl ReportBuilder {
         }
 
         let mut builder = Builder::default();
-        builder.push_record(["RPC Method", "Forest", "Lotus", "Status"]);
+        builder.push_record(["RPC Method", "Forest", "Lotus", "API Versions", "Status"]);
 
         let mut methods: Vec<&MethodReport> = self.method_reports.values().collect();
         methods.sort_by(|a, b| a.name.cmp(&b.name));
@@ -339,6 +348,7 @@ impl ReportBuilder {
                         method_name.as_str(),
                         &format!("{success_count}/{total_count}"),
                         &format!("{success_count}/{total_count}"),
+                        &report.api_versions.iter().join(", "),
                         &status,
                     ]);
                 }
@@ -458,6 +468,19 @@ mod tests {
         let durations: Vec<Duration> = vec![];
         let metrics = PerformanceMetrics::from_durations(&durations);
         assert!(metrics.is_none());
+    }
+
+    #[test]
+    fn test_api_versions_render() {
+        assert_eq!(BTreeSet::<ApiPaths>::new().iter().join(", "), "");
+        assert_eq!(BTreeSet::from([ApiPaths::V1]).iter().join(", "), "V1");
+        // Ordering is deterministic regardless of insertion order.
+        assert_eq!(
+            BTreeSet::from([ApiPaths::V2, ApiPaths::V0, ApiPaths::V1])
+                .iter()
+                .join(", "),
+            "V0, V1, V2"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary of changes

The conformance/`api compare` report gave no indication of which API version (`v0`/`v1`/`v2`) a method was tested under. This adds that information.

Changes introduced in this pull request:

- Track the API path of every executed test per method in `ReportBuilder`.
- Expose it as a `tested_api_versions` field in the JSON report (omitted when empty, so existing consumers stay compatible).
- Add an "API Versions" column to the printed summary table.

I went with both the JSON field and the summary column to cover the two options mentioned in the issue.

## Reference issue to close (if applicable)

Closes #6509

## Other information and links

The version set is a `BTreeSet<ApiPaths>` so the output is deterministic (`v0, v1, v2`) regardless of test execution order. Added a unit test for the formatting.

I didn't add a CHANGELOG entry since `forest-tool api compare` is a developer/CI conformance tool rather than a node-operator-facing feature, but happy to add one if you'd prefer.

## Change checklist

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's documentation standards,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the CHANGELOG is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [x] I have read and agree to the CONTRIBUTING document.
- [x] I have read and agree to the AI Policy document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API test reports now show which API versions were used for each RPC method.
  * The summary output includes a new “API Versions” column for easier review.
  * Saved report data now preserves API version usage per method for later inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->