### PR TITLE
fix: don't omit `to` field for contract creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 
 - [#7214](https://github.com/ChainSafe/forest/pull/7214): Aligned the `eth` transaction `accessList` field with go-ethereum/reth (typed: `[]`, legacy: omitted, never `null`).
 
+- [#7270](https://github.com/ChainSafe/forest/issues/7270): `eth` transactions now serialize `"to": null` for contract-creation transactions instead of omitting the field, matching go-ethereum/reth/Lotus and the execution-apis transaction schema.
+
 - [#7227](https://github.com/ChainSafe/forest/issues/7227): Fixed invalid `Filecoin.GasEstimateGasPremium` and `Filecoin.GasEstimateFeeCap` responses that were returning a fraction instead of an integer.
 
 - [#7096](https://github.com/ChainSafe/forest/issues/7096): `eth_subscribe` `logs` now re-emits the logs of reorg-reverted tipsets with `removed: true`, ahead of the logs of the replacing tipsets.

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -4223,8 +4223,14 @@ mod test {
     // Normal tx → `"to"` is the recipient address.
     #[case::normal(Some(EthAddress::default()))]
     fn to_is_always_serialized(#[case] to: Option<EthAddress>) {
-        let json = serde_json::to_value(ApiEthTx { to, ..Default::default() }.into_lotus_json())
-            .unwrap();
+        let json = serde_json::to_value(
+            ApiEthTx {
+                to,
+                ..Default::default()
+            }
+            .into_lotus_json(),
+        )
+        .unwrap();
         assert!(
             json.as_object().unwrap().contains_key("to"),
             "`to` key must always be present"

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -634,7 +634,9 @@ pub struct ApiEthTx {
     pub block_number: EthInt64,
     pub transaction_index: EthUint64,
     pub from: EthAddress,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    // No `skip_serializing_if` (unlike the other `Option` fields): contract-creation txs must
+    // emit `"to": null` rather than drop the key.
+    #[serde(default)]
     pub to: Option<EthAddress>,
     pub value: EthBigInt,
     pub r#type: EthUint64,
@@ -4213,6 +4215,21 @@ mod test {
             ),
             None => assert!(!json.as_object().unwrap().contains_key("accessList")),
         }
+    }
+
+    #[rstest]
+    // Contract creation → `"to": null` present, not omitted.
+    #[case::contract_creation(None)]
+    // Normal tx → `"to"` is the recipient address.
+    #[case::normal(Some(EthAddress::default()))]
+    fn to_is_always_serialized(#[case] to: Option<EthAddress>) {
+        let json = serde_json::to_value(ApiEthTx { to, ..Default::default() }.into_lotus_json())
+            .unwrap();
+        assert!(
+            json.as_object().unwrap().contains_key("to"),
+            "`to` key must always be present"
+        );
+        assert_eq!(json["to"], serde_json::to_value(to).unwrap());
     }
 
     #[rstest]

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
@@ -4817,6 +4817,7 @@ components:
           anyOf:
             - $ref: "#/components/schemas/EthAddress"
             - type: "null"
+          default: ~
         transactionIndex:
           $ref: "#/components/schemas/EthUint64"
         type:

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
@@ -4886,6 +4886,7 @@ components:
           anyOf:
             - $ref: "#/components/schemas/EthAddress"
             - type: "null"
+          default: ~
         transactionIndex:
           $ref: "#/components/schemas/EthUint64"
         type:

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v2.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v2.snap
@@ -1701,6 +1701,7 @@ components:
           anyOf:
             - $ref: "#/components/schemas/EthAddress"
             - type: "null"
+          default: ~
         transactionIndex:
           $ref: "#/components/schemas/EthUint64"
         type:


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- see, e.g., https://github.com/ethereum/go-ethereum/blob/6eae868a95d082a522e86eb391263aa7539f3e96/internal/ethapi/api.go#L1079
- Forest was omitting `to` when it was set to null for contract creation, which is not correct.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Part of https://github.com/ChainSafe/forest/issues/7293

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contract-creation transactions now consistently include `"to": null` in JSON output instead of omitting the field.
  * Regular transactions continue to serialize the recipient address as expected.
* **Documentation**
  * Updated the changelog to note the JSON serialization behavior fix for `eth` transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->