### PR TITLE
fix(test): flaky null round tests

### DIFF
--- a/scripts/devnet/.env
+++ b/scripts/devnet/.env
@@ -1,4 +1,4 @@
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.36.1-2k
+LOTUS_IMAGE=filecoin/lotus-all-in-one:c4e3b46b1-2k
 FOREST_DATA_DIR=/forest_data
 LOTUS_DATA_DIR=/lotus_data
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters

--- a/scripts/tests/api_compare/.env
+++ b/scripts/tests/api_compare/.env
@@ -1,6 +1,6 @@
 # Note: this should be a `fat` image so that it contains the pre-downloaded filecoin proof parameters
 FOREST_IMAGE=ghcr.io/chainsafe/forest:edge-fat
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.36.1-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:c4e3b46b1-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 LOTUS_VIA_GATEWAY_RPC_PORT=4568

--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -44,7 +44,6 @@ services:
       - FOREST_CHAIN_INDEXER_ENABLED=1
       # Legacy null-round receipts for parity with the pre-lotus#13694 Lotus image; remove once it has the fix.
       - FOREST_ETH_GET_BLOCK_RECEIPTS_LEGACY_NULL_ROUND=1
-      - FOREST_ETH_RPC_COMPUTE_STATE_ON_INDEX_MISS=1
     entrypoint: ["/bin/bash", "-c"]
     user: 0:0
     command:

--- a/scripts/tests/api_compare/docker-compose.yml
+++ b/scripts/tests/api_compare/docker-compose.yml
@@ -42,8 +42,6 @@ services:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
       - FULLNODE_API_INFO=/dns/forest/tcp/${FOREST_RPC_PORT}/http
       - FOREST_CHAIN_INDEXER_ENABLED=1
-      # Legacy null-round receipts for parity with the pre-lotus#13694 Lotus image; remove once it has the fix.
-      - FOREST_ETH_GET_BLOCK_RECEIPTS_LEGACY_NULL_ROUND=1
     entrypoint: ["/bin/bash", "-c"]
     user: 0:0
     command:
@@ -127,8 +125,6 @@ services:
     environment:
       - FIL_PROOFS_PARAMETER_CACHE=${FIL_PROOFS_PARAMETER_CACHE}
       - FULLNODE_API_INFO=/dns/api-serve/tcp/${FOREST_OFFLINE_RPC_PORT}/http
-      # See `forest`: legacy null-round receipts for pre-lotus#13694 parity.
-      - FOREST_ETH_GET_BLOCK_RECEIPTS_LEGACY_NULL_ROUND=1
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |

--- a/scripts/tests/bootstrapper/.env
+++ b/scripts/tests/bootstrapper/.env
@@ -1,5 +1,5 @@
 # Note: this should be a `fat` image so that it contains the pre-downloaded filecoin proof parameters
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.36.1-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:c4e3b46b1-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/scripts/tests/snapshot_parity/.env
+++ b/scripts/tests/snapshot_parity/.env
@@ -1,4 +1,4 @@
-LOTUS_IMAGE=filecoin/lotus-all-in-one:v1.36.1-calibnet
+LOTUS_IMAGE=filecoin/lotus-all-in-one:c4e3b46b1-calibnet
 FIL_PROOFS_PARAMETER_CACHE=/var/tmp/filecoin-proof-parameters
 LOTUS_RPC_PORT=1234
 FOREST_RPC_PORT=2345

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -2266,14 +2266,11 @@ fn eth_tests_with_tipset<DB: Blockstore + ShallowClone>(
 }
 
 /// Returns the highest null-round epoch in the first chain gap at or below `shared_tipset`,
-/// or `None`. Bounded to where state is present, since the chosen round gets executed.
+/// or `None`. Bounded to where state is present.
 fn first_null_round_epoch<DB: Blockstore>(
     store: &DB,
     shared_tipset: &Tipset,
 ) -> Option<ChainEpoch> {
-    // Keep the chosen null round at least `SAFE_EPOCH_DELAY_FOR_TESTING` below `shared_tipset`, so
-    // the tipset the legacy `eth_getBlockReceipts*` fallback resolves it to has materialized state.
-    let safe_ceiling = shared_tipset.epoch() - SAFE_EPOCH_DELAY_FOR_TESTING;
     let mut child_epoch: Option<ChainEpoch> = None;
     for ts in shared_tipset.clone().chain(store) {
         // Stop once we leave the snapshot's state window.
@@ -2283,11 +2280,9 @@ fn first_null_round_epoch<DB: Blockstore>(
         let epoch = ts.epoch();
         if let Some(child) = child_epoch
             && child - epoch > 1
-            // The gap must contain a null round at or below the safe ceiling.
-            && epoch + 1 <= safe_ceiling
         {
-            // Highest null round in the gap that is still safely below head.
-            return Some((child - 1).min(safe_ceiling));
+            // `child - 1` is the highest null round in the gap.
+            return Some(child - 1);
         }
         child_epoch = Some(epoch);
     }

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -2271,6 +2271,9 @@ fn first_null_round_epoch<DB: Blockstore>(
     store: &DB,
     shared_tipset: &Tipset,
 ) -> Option<ChainEpoch> {
+    // Keep the chosen null round at least `SAFE_EPOCH_DELAY_FOR_TESTING` below `shared_tipset`, so
+    // the tipset the legacy `eth_getBlockReceipts*` fallback resolves it to has materialized state.
+    let safe_ceiling = shared_tipset.epoch() - SAFE_EPOCH_DELAY_FOR_TESTING;
     let mut child_epoch: Option<ChainEpoch> = None;
     for ts in shared_tipset.clone().chain(store) {
         // Stop once we leave the snapshot's state window.
@@ -2280,9 +2283,11 @@ fn first_null_round_epoch<DB: Blockstore>(
         let epoch = ts.epoch();
         if let Some(child) = child_epoch
             && child - epoch > 1
+            // The gap must contain a null round at or below the safe ceiling.
+            && epoch + 1 <= safe_ceiling
         {
-            // `child - 1` is the highest null round in the gap.
-            return Some(child - 1);
+            // Highest null round in the gap that is still safely below head.
+            return Some((child - 1).min(safe_ceiling));
         }
         child_epoch = Some(epoch);
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- previous attempt doesn't seem to have helped https://github.com/ChainSafe/forest/pull/7295, so reverting it and pinning to latest Lotus master so that we don't have to deal with workaround behavior

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/7297

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image used by devnet and test environments to a newer build.
  * Removed outdated test configuration related to legacy receipt handling and state-computation settings.

* **Documentation**
  * Clarified wording in a test-related comment to better reflect when state is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->