### PR TITLE
docs: let wide tables use full width on large screens

### DIFF
--- a/docs/src/css/index.css
+++ b/docs/src/css/index.css
@@ -51,3 +51,16 @@
 #interactive-box {
   display: none;
 }
+
+/*
+ * Infima renders Markdown tables as `display: block`, so wide tables shrink to
+ * their content and get a horizontal scrollbar even when there is plenty of
+ * horizontal space (e.g. on 21:9 screens). On larger viewports, let tables use
+ * the full available width; narrow viewports keep the scrollable block layout.
+ */
+@media screen and (min-width: 997px) {
+  .markdown table {
+    display: table;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary of changes

Markdown tables (e.g. the [environment variables reference](https://docs.forest.chainsafe.io/reference/env_variables)) were shrinking to their content width and showing a horizontal scrollbar even on wide screens with plenty of room.

Changes introduced in this pull request:

- Override `.markdown table` to `display: table; width: 100%` on viewports ≥997px in `docs/src/css/index.css`. This is needed because Infima renders tables as `display: block` by default, which collapses them to content width. Narrow viewports keep the scrollable block layout untouched.

## Reference issue to close (if applicable)

Closes #5194

## Other information and links

Scoped to the `min-width: 997px` breakpoint (the same one already used in this file) so mobile keeps horizontal scrolling for tables that are genuinely wider than the screen.

## Change checklist

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's documentation standards,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the CHANGELOG is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [x] I have read and agree to the CONTRIBUTING document.
- [x] I have read and agree to the AI Policy document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Markdown table layout on wider screens so tables now use the full available width instead of shrinking.
  * Updated table rendering to keep large tables more readable in desktop viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->