### PR TITLE
fix(rpc): null rounds handling on trace filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 ### Fixed
 
+- [#7314](https://github.com/ChainSafe/forest/issues/7314): `eth_traceFilter` now skips null rounds within its `[fromBlock, toBlock]` range instead of failing with an `ErrNullRound` error when the range spans one, matching Lotus.
+
 - [#7276](https://github.com/ChainSafe/forest/issues/7276): `eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber`, `eth_getTransactionByBlockNumberAndIndex`, `eth_traceBlock`, and `eth_traceReplayBlockTransactions` now return an `ErrNullRound` error (JSON-RPC code `12`) when the requested block number is a null round, matching Lotus, instead of silently returning the previous tipset. Thanks to the `chain.data.riba.plus` dataset, which surfaced this discrepancy; see [#7270](https://github.com/ChainSafe/forest/issues/7270) for the broader effort to reconcile remaining Eth RPC discrepancies against it.
 
 - [#4645](https://github.com/ChainSafe/forest/issues/4645): An invalid RPC `Authorization` header (malformed header or unverifiable JWT) is now rejected with an HTTP `401 Unauthorized` instead of the misleading `-32600 Invalid request` JSON-RPC error. A call that authenticates but lacks the permission its method requires now returns a JSON-RPC error with code `-32003` and a `missing permission to invoke '<method>' (need '<perm>')` message.

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -35,7 +35,7 @@ use crate::rpc::{
     ApiPaths, Ctx, EthEventHandler, LOOKBACK_NO_LIMIT, Permission, RpcMethod, RpcMethodExt as _,
     error::ServerError,
     eth::{
-        errors::EthErrors,
+        errors::{EthErrors, NULL_ROUND_CODE},
         filter::{
             EventRevertStatus, SkipEvent, event::EventFilter, mempool::MempoolFilter,
             tipset::TipSetFilter,
@@ -4186,12 +4186,17 @@ async fn trace_filter(
     let mut trace_counter = 0;
     'blocks: for blk_num in from_block.0..=to_block.0 {
         // For BlockNumber, EthTraceBlock and EthTraceBlockV2 are equivalent.
-        let block_traces = EthTraceBlock::handle(
+        let block_traces = match EthTraceBlock::handle(
             ctx.clone(),
             (BlockNumberOrHash::from_block_number(blk_num as i64),),
             ext,
         )
-        .await?;
+        .await
+        {
+            Ok(block_traces) => block_traces,
+            Err(e) if e.code() == NULL_ROUND_CODE => continue 'blocks,
+            Err(e) => return Err(e.into()),
+        };
         for block_trace in block_traces.0 {
             if block_trace
                 .trace


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fix null round handling for `eth_traceFilter`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/7314

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `eth_traceFilter` now handles ranges that include a single null round more gracefully, skipping the empty round instead of returning an error.
  * This improves compatibility with Lotus-style behavior and helps trace requests succeed in more edge cases.

* **Chores**
  * Updated the changelog with the latest fix entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->