### PR TITLE
docs: group JSON-RPC overview and JWT auth in one section

### DIFF
--- a/docs/docs/users/guides/methods_filtering.md
+++ b/docs/docs/users/guides/methods_filtering.md
@@ -10,7 +10,7 @@ sidebar_position: 4
 When running a Filecoin node, you might want to restrict the RPC methods that are available to the clients. This can be useful for security reasons, to limit the exposure of the node to the internet, or to reduce the load on the node by disabling unnecessary methods.
 
 :::note
-[JWT authentication](../knowledge_base/jwt_handling) is a different way to restrict access to the node. It allows you to authorize certain operations on the node using JWTs. However, JWT restrictions are hard-coded in the node and cannot be changed dynamically. If you want to make sure that a certain read-only method is not available to the clients, you can use the method filtering feature.
+[JWT authentication](../reference/json-rpc/authentication) is a different way to restrict access to the node. It allows you to authorize certain operations on the node using JWTs. However, JWT restrictions are hard-coded in the node and cannot be changed dynamically. If you want to make sure that a certain read-only method is not available to the clients, you can use the method filtering feature.
 
 The methods are first filtered by the method filtering feature, and then the JWT authentication is applied. If a method is disallowed by the method filtering, the JWT token will not be checked for this method.
 :::

--- a/docs/docs/users/reference/json-rpc/authentication.md
+++ b/docs/docs/users/reference/json-rpc/authentication.md
@@ -1,5 +1,6 @@
 ---
-title: JWT Authentication
+title: Authentication
+sidebar_position: 1
 ---
 
 # JWT Authentication :key:

--- a/docs/docs/users/reference/json-rpc/overview.md
+++ b/docs/docs/users/reference/json-rpc/overview.md
@@ -43,6 +43,6 @@ Access control is implemented for certain methods. Levels of access include:
 - Write
 - Admin
 
-Authentication is performed via [JWT Tokens](../../knowledge_base/jwt_handling). When starting Forest use `--save-token <FILE>` to store an `Admin` token,
+Authentication is performed via [JWT Tokens](./authentication). When starting Forest use `--save-token <FILE>` to store an `Admin` token,
 otherwise the token will be printed in the logs during startup. With this token you can call the methods `AuthNew`
 to generate additional tokens as needed.


### PR DESCRIPTION
## Summary of changes

The JWT authentication guide was under "Knowledge Base", separate from the JSON-RPC reference it describes. This groups them together.

Changes introduced in this pull request:

- Moved `knowledge_base/jwt_handling.md` → `reference/json-rpc/authentication.md` (retitled "Authentication", `sidebar_position: 1`), so it sits right after the Overview in the JSON-RPC reference section.
- Repointed the two links that referenced the old page (the Overview's Authentication paragraph and the method-filtering guide).

The move preserves the page content as-is; only its location and the two inbound links change.

## Reference issue to close (if applicable)

Closes #5211

## Other information and links

Part of ChainSafe/forest-docs-v2#87. Kept it as a sibling page under the JSON-RPC section rather than inlining everything into the Overview, since the auth guide is fairly long — happy to fold it directly into the Overview instead if you'd prefer a single page.

## Change checklist

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's documentation standards,
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the CHANGELOG is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [x] I have read and agree to the CONTRIBUTING document.
- [x] I have read and agree to the AI Policy document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication-related links to point to the current reference page.
  * Renamed the authentication reference page title to a simpler “Authentication” label.
  * Improved sidebar ordering for the authentication docs section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->