### PR TITLE
fix(ci): ignore paths in merge queue (lints-only)

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -25,7 +25,26 @@ on:
       - "mise.toml"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the job when nothing relevant changed.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - '.github/workflows/**'
+              - '.github/actionlint.yaml'
+              - 'mise.toml'
   actions-lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -29,7 +29,28 @@ on:
       - ".github/workflows/docker-lint.yml"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the job when nothing relevant changed.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - '**/Dockerfile*'
+              - '**/*.dockerfile'
+              - 'monitored-stack/docker-compose.yml'
+              - 'monitored-stack/.env.example'
+              - '.github/workflows/docker-lint.yml'
   docker-lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -29,7 +29,28 @@ on:
       - ".github/workflows/docs-check.yml"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the job when nothing relevant changed.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - '**.md'
+              - 'docs/**'
+              - '.config/forest.dic'
+              - '.config/spellcheck.toml'
+              - '.github/workflows/docs-check.yml'
   docs-check:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
     name: Check
     runs-on: ubuntu-24.04-arm
     defaults:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -30,8 +30,29 @@ on:
       - "interop-tests/src/tests/**"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the lint job when nothing Go-related changed.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - '.github/workflows/go-lint.yml'
+              - 'go.work'
+              - 'mise.toml'
+              - 'f3-sidecar/**'
+              - 'interop-tests/src/tests/**'
   lint-go:
     name: Go lint checks
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,7 +25,28 @@ on:
       - ".github/workflows/link-check.yml"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the job when nothing relevant changed. Scheduled and
+  # manual runs always proceed since they have no diff to filter on.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - '**.md'
+              - '**.mdx'
+              - '**.html'
+              - '.github/workflows/link-check.yml'
   link-check:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     name: Link Check
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/lists-lint.yml
+++ b/.github/workflows/lists-lint.yml
@@ -25,7 +25,26 @@ on:
       - ".github/workflows/lists-lint.yml"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the job when nothing relevant changed.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - 'src/tool/subcommands/api_cmd/test_snapshots_ignored.txt'
+              - 'src/tool/subcommands/api_cmd/test_snapshots.txt'
+              - '.github/workflows/lists-lint.yml'
   lists-lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -23,7 +23,25 @@ on:
       - ".github/workflows/rubocop.yml"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the job when nothing relevant changed.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - '**/*.rb'
+              - '.github/workflows/rubocop.yml'
   rubocop:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,7 +23,25 @@ on:
       - ".github/workflows/shellcheck.yml"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the job when nothing relevant changed.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - '**/*.sh'
+              - '.github/workflows/shellcheck.yml'
   shellcheck:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -25,7 +25,26 @@ on:
       - ".github/workflows/yaml-lint.yml"
 
 jobs:
+  # Merge groups don't support path filters, so detect the relevant changes
+  # explicitly and skip the job when nothing relevant changed.
+  # https://github.com/community/community/discussions/45899
+  changes:
+    runs-on: ubuntu-slim
+    outputs:
+      changesFound: ${{ steps.filter.outputs.changesFound }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            changesFound:
+              - '**/*.yml'
+              - '**/*.yaml'
+              - '.github/workflows/yaml-lint.yml'
   yaml-lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- this should save some minutes, I was pretty surprised to learn merge queues are exempt from filtering, see https://github.com/orgs/community/discussions/45899

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several automated checks to run only when relevant files change.
  * This reduces unnecessary CI work and avoids issues with merge-group events that don’t support path filters.
  * Affected checks include Actions lint, Docker lint, docs, Go lint, link validation, list lint, Ruby lint, ShellCheck, and YAML lint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->