### PR TITLE
test(lotus_json): assert LotusJson<Option<T>> is nullable in schema

### DIFF
--- a/src/lotus_json/opt.rs
+++ b/src/lotus_json/opt.rs
@@ -37,3 +37,41 @@ fn shapshots() {
 fn quickcheck(val: Option<::cid::Cid>) {
     assert_unchanged_via_json(val)
 }
+
+/// Regression test for <https://github.com/ChainSafe/forest/issues/4331>.
+///
+/// `LotusJson<Option<T>>` must be rendered as an optional value that permits
+/// `null` in the generated JSON/OpenRPC schema, so consumers know the field
+/// may be absent. The non-optional `LotusJson<T>` counterpart must not permit
+/// `null`.
+#[test]
+fn optional_is_nullable_in_schema() {
+    let optional = schemars::schema_for!(LotusJson<Option<::cid::Cid>>);
+    assert!(
+        schema_allows_null(optional.as_value()),
+        "LotusJson<Option<T>> schema must permit null: {optional:?}"
+    );
+
+    let required = schemars::schema_for!(LotusJson<::cid::Cid>);
+    assert!(
+        !schema_allows_null(required.as_value()),
+        "LotusJson<T> schema must not permit null: {required:?}"
+    );
+}
+
+/// Returns `true` if `schema` accepts a JSON `null`, whether expressed as a
+/// `"type": "null"` / `"type": [.., "null"]` union or as a `null` branch of an
+/// `anyOf`/`oneOf`.
+#[cfg(test)]
+fn schema_allows_null(schema: &serde_json::Value) -> bool {
+    let type_allows_null = match schema.get("type") {
+        Some(serde_json::Value::String(s)) => s == "null",
+        Some(serde_json::Value::Array(types)) => types.iter().any(|t| t.as_str() == Some("null")),
+        _ => false,
+    };
+    type_allows_null
+        || ["anyOf", "oneOf"].iter().any(|key| {
+            matches!(schema.get(key), Some(serde_json::Value::Array(variants))
+                if variants.iter().any(schema_allows_null))
+        })
+}


### PR DESCRIPTION
## Summary

Closes #4331.

`LotusJson<Option<T>>` delegates its schema to `Option<T::LotusJson>`, which `schemars` already renders as nullable (`"type": [..., "null"]` / a `null` branch in `anyOf`). This adds a small regression test locking that behaviour in, as suggested in the issue — verifying that:

- `LotusJson<Option<T>>` produces a schema that permits `null` (i.e. is optional in the OpenRPC spec), and
- the non-optional `LotusJson<T>` counterpart does **not** permit `null`.

The helper `schema_allows_null` accepts both the `"type"` union form (used for primitives/arrays) and the `anyOf`/`oneOf` form (used for `$ref` object types), so the test stays robust across inner types.

No production code changes — test only.

## Reference tests

`cargo test -p forest-filecoin --lib lotus_json::opt::` — 3 passed (existing snapshot + quickcheck, plus the new `optional_is_nullable_in_schema`).

## Other information and links

Issue originally raised by @ruseinov in https://github.com/ChainSafe/forest/issues/4330#issuecomment-2113427560.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to ensure optional Lotus JSON values accept `null` in generated JSON/OpenRPC schemas.
  * Verified non-optional Lotus JSON values do not permit `null` in the corresponding schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->