### PR TITLE
fix: prevent snapshot export from hanging forever on a stalled writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 - [#7329](https://github.com/ChainSafe/forest/issues/7329): `Filecoin.NodeStatus` now matches Lotus: `SyncStatus.Behind` is reported in epochs (not seconds), and the method takes an `inclChainStatus` boolean parameter that gates the chain-status computation. Also fixed casing in output JSON to match Lotus `PascalCase` convention.
 
+- [#7348](https://github.com/ChainSafe/forest/pull/7348): In case of snapshot export getting stuck, Forest will now error after a timeout of 5 minutes of no progress.
+
 ## Forest v0.33.8 "Amiga 1200"
 
 Non-mandatory release for all node operators. It includes mostly fixes and performance improvements for the RPC methods.

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -228,12 +228,24 @@ async fn export_to_forest_car<D: Digest, S: CidHashSetLike + Send + Sync + 'stat
     forest::Encoder::write(&mut writer, roots, frames).await?;
 
     // Flush to ensure everything has been successfully written
-    writer.flush().await.context("failed to flush")?;
+    tokio::time::timeout(forest::ASYNC_OPS_TIMEOUT, writer.flush())
+        .await
+        .context("`writer.flush` timed out")??;
 
     let digest = writer.finalize().map_err(|e| Error::Other(e.to_string()))?;
 
     let tipset_lookup = if let Some(ts_lookup_handle) = ts_lookup_handle {
-        Some(ts_lookup_handle.await?)
+        // This join is not I/O-bound: the task finishes once the `par_buffer` producer
+        // exits and drops `ts_lookup_tx`, which `Encoder::write` guarantees by exhausting
+        // the frame stream. The timeout guards against a pipeline lifecycle bug keeping a
+        // sender alive, not against slowness.
+        Some(
+            tokio::time::timeout(forest::ASYNC_OPS_TIMEOUT, ts_lookup_handle)
+                .await
+                .context(
+                    "tipset-lookup task did not finish; is a `ts_lookup_tx` sender still alive?",
+                )??,
+        )
     } else {
         None
     };

--- a/src/chain/tests.rs
+++ b/src/chain/tests.rs
@@ -12,6 +12,7 @@ use rstest::rstest;
 use sha2::{Digest as _, Sha256};
 use std::fs::File;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[test]
 fn test_snapshot_version_cbor_serde() {
@@ -155,4 +156,129 @@ async fn test_export_inner(
     }
 
     Ok(())
+}
+
+/// Regression tests for the "snapshot export stuck at `Exporting: 100.0%`" incidents:
+/// once the DAG walk reaches genesis (`epoch == 0`, progress pins at 100%), the remaining
+/// pipeline steps must not be able to wait forever on a stalled writer.
+mod export_stuckness {
+    use super::*;
+    use crate::shim::crypto::IPLD_RAW;
+    use crate::utils::db::car_stream::CarBlock;
+    use crate::utils::rand::forest_rng;
+    use rand::RngCore as _;
+    use std::io;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::AsyncWrite;
+
+    /// Accepts and discards up to `write_budget` bytes, then stalls forever.
+    struct StallingWriter {
+        write_budget: usize,
+        stall_on_flush: bool,
+    }
+
+    impl AsyncWrite for StallingWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let this = self.get_mut();
+            if this.write_budget == 0 {
+                Poll::Pending
+            } else {
+                let n = buf.len().min(this.write_budget);
+                this.write_budget -= n;
+                Poll::Ready(Ok(n))
+            }
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            if self.stall_on_flush {
+                Poll::Pending
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.poll_flush(cx)
+        }
+    }
+
+    /// A stalled final flush must surface as an error instead of hanging the export
+    /// forever while `Forest.ChainExportStatus` keeps reporting an in-progress export
+    /// at 100%.
+    #[tokio::test(start_paused = true)]
+    async fn export_stalled_final_flush_errors_instead_of_hanging() -> anyhow::Result<()> {
+        let db = Arc::new(MemoryDB::default());
+        let c4u = Chain4U::with_blockstore(db.clone());
+        chain4u! {
+            in c4u;
+            [_genesis_header]
+            -> [_b1] -> [_b2] -> [_b3] -> [_b4] -> [b5]
+        };
+        let head = Tipset::load_required(&db, &TipsetKey::from(nunny::vec![b5.cid()]))?;
+
+        let export = export::<Sha256, _>(
+            &db,
+            &head,
+            0,
+            StallingWriter {
+                write_budget: usize::MAX,
+                stall_on_flush: true,
+            },
+            ExportOptions::<CidHashSet>::default(),
+        );
+
+        // Give the export a virtual eternity, far beyond any internal timeout.
+        let result = tokio::time::timeout(Duration::from_hours(24), export)
+            .await
+            .expect("export wedged forever in the untimed `writer.flush()`");
+        let err = result.err().expect("a stalled writer must fail the export");
+        assert!(
+            err.downcast_ref::<tokio::time::error::Elapsed>().is_some(),
+            "expected an internal export timeout, got: {err:#}"
+        );
+        Ok(())
+    }
+
+    /// Control: a stall in the middle of the frame stream is already covered by
+    /// `ASYNC_OPS_TIMEOUT` and errors out instead of hanging.
+    #[tokio::test(start_paused = true)]
+    async fn export_stalled_frame_write_times_out() {
+        let raw_cid = |data: &[u8]| Cid::new_v1(IPLD_RAW, MultihashCode::Blake2b256.digest(data));
+        // Incompressible random blocks so the first zstd frame exceeds the writer budget.
+        let blocks = futures::stream::iter((0..64).map(|_| {
+            let mut data = vec![0_u8; 4096];
+            forest_rng().fill_bytes(&mut data);
+            anyhow::Ok(CarBlock {
+                cid: raw_cid(&data),
+                data: data.into(),
+            })
+        }));
+        let frames = forest::Encoder::compress_stream_default(blocks);
+        let roots = nunny::vec![raw_cid(b"root")];
+
+        let mut sink = StallingWriter {
+            write_budget: 1024,
+            stall_on_flush: false,
+        };
+        let err = tokio::time::timeout(
+            Duration::from_hours(24),
+            forest::Encoder::write(&mut sink, roots, frames),
+        )
+        .await
+        .expect("frame writes are timed and must not hang")
+        .expect_err("a stalled writer must fail the export");
+        assert!(
+            err.downcast_ref::<tokio::time::error::Elapsed>().is_some(),
+            "expected an internal export timeout, got: {err:#}"
+        );
+        // An exhausted write budget pins the stall to a frame write: the header alone
+        // fits the budget, and a producer or index stall would leave budget unspent.
+        assert_eq!(
+            sink.write_budget, 0,
+            "the writer must have stalled mid-write"
+        );
+    }
 }

--- a/src/db/car/forest.rs
+++ b/src/db/car/forest.rs
@@ -309,6 +309,11 @@ fn decode_zstd_single_frame<ReaderT: Read>(reader: ReaderT) -> io::Result<Bytes>
     Ok(zstd_frame.into())
 }
 
+/// Timeout applied to each async I/O operation of the snapshot export pipeline so that a
+/// stalled reader or writer surfaces as an error instead of wedging the export forever
+/// while `Forest.ChainExportStatus` keeps reporting it as in progress.
+pub(crate) const ASYNC_OPS_TIMEOUT: Duration = Duration::from_mins(5);
+
 pub struct Encoder {}
 
 impl Encoder {
@@ -317,9 +322,6 @@ impl Encoder {
         roots: NonEmpty<Cid>,
         mut stream: impl Stream<Item = anyhow::Result<ForestCarFrame>> + Unpin,
     ) -> anyhow::Result<()> {
-        // For troubleshooting stuck-ness issue
-        const ASYNC_OPS_TIMEOUT: Duration = Duration::from_mins(5);
-
         let mut offset = 0;
 
         // Write CARv1 header
@@ -334,7 +336,9 @@ impl Encoder {
         header_encoder.write_all(&header_uvi_frame)?;
         let header_bytes = header_encoder.finish()?.into_inner().freeze();
 
-        sink.write_all(&header_bytes).await?;
+        tokio::time::timeout(ASYNC_OPS_TIMEOUT, sink.write_all(&header_bytes))
+            .await
+            .context("header `sink.write_all` timed out")??;
         let header_len = header_bytes.len();
 
         offset += header_len;
@@ -372,7 +376,9 @@ impl Encoder {
         let footer = ForestCarFooter {
             index: offset as u64 + ZSTD_SKIP_FRAME_LEN,
         };
-        sink.write_all(&footer.to_le_bytes()).await?;
+        tokio::time::timeout(ASYNC_OPS_TIMEOUT, sink.write_all(&footer.to_le_bytes()))
+            .await
+            .context("footer `sink.write_all` timed out")??;
         tracing::info!("Finished writing zstd CAR footer frame");
         Ok(())
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- workaround for snapshot export getting stuck - this does NOT fix stuckness on its own, it just makes the entire export process fail and not hang forever.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot export now fails with a clear error after five minutes without progress instead of hanging.
  * Added timeout handling across the export pipeline, including initial CAR header writing, writer flushing, footer finalization, and tipset lookup completion.
  * Improved error context and hints when export steps stall.
* **Tests**
  * Added regression tests for “stuck at 100%” export scenarios, covering stalls during writing and flushing to ensure failures time out rather than hang.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->