### PR TITLE
fix: `allow_replaced` handling in `wait_for_message`

### DIFF
--- a/src/state_manager/message_search.rs
+++ b/src/state_manager/message_search.rs
@@ -240,7 +240,8 @@ impl StateManager {
                 .map_err(|err| Error::Other(format!("failed to load message {err:}")))?,
         );
         let current_ts = self.heaviest_tipset();
-        let maybe_message_receipt = self.tipset_executed_message(&current_ts, &message, true)?;
+        let maybe_message_receipt =
+            self.tipset_executed_message(&current_ts, &message, allow_replaced.unwrap_or(true))?;
         if let Some(receipt) = maybe_message_receipt {
             return Ok((current_ts, receipt));
         }
@@ -330,8 +331,11 @@ impl StateManager {
                                     return Ok(candidate);
                                 }
 
-                                let maybe_receipt =
-                                    sm.tipset_executed_message(&applied_ts, &message, true)?;
+                                let maybe_receipt = sm.tipset_executed_message(
+                                    &applied_ts,
+                                    &message,
+                                    allow_replaced.unwrap_or(true),
+                                )?;
                                 if let Some(receipt) = maybe_receipt {
                                     if confidence == 0 {
                                         // Return if there's no confidence requirement

--- a/src/state_manager/message_search.rs
+++ b/src/state_manager/message_search.rs
@@ -473,6 +473,34 @@ mod tests {
         }
     }
 
+    fn state_manager_with_replaced_message_at_head(db: &Arc<MemoryDB>) -> (StateManager, Cid) {
+        let message = message_with_nonce(5);
+        let msg_cid = db.put_cbor_default(&message).unwrap();
+        let replacement = Message {
+            gas_limit: 1,
+            ..message
+        };
+        let replacement_cid = db.put_cbor_default(&replacement).unwrap();
+
+        let root_before = state_root_with_sender_nonce(db, 5);
+        let root_after = state_root_with_sender_nonce(db, 6);
+        let messages = tx_meta(db, replacement_cid);
+        let receipts = receipts_root(db);
+        let c4u = Chain4U::with_blockstore(db.clone());
+        chain4u! {
+            in c4u;
+            [genesis = HeaderBuilder::new().with_timestamp(7777)]
+            -> [_e1 = HeaderBuilder::new().with_state_root(root_before)]
+            -> [_e2 = HeaderBuilder::new()
+                    .with_state_root(root_before)
+                    .with_messages(messages)]
+            -> head @ [_e3 = HeaderBuilder::new()
+                    .with_state_root(root_after)
+                    .with_message_receipts(receipts)]
+        };
+        (state_manager_with_head(db.clone(), genesis, head), msg_cid)
+    }
+
     fn state_manager_with_head(
         db: Arc<MemoryDB>,
         genesis: &RawBlockHeader,
@@ -634,5 +662,36 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_none());
+    }
+
+    /// A replacing message executed on chain. When replacements are
+    /// disallowed, `wait_for_message` must forward `allow_replaced = false`
+    /// and surface an error instead of silently returning the replacement's
+    /// receipt.
+    #[tokio::test]
+    async fn wait_for_message_rejects_replaced_when_disallowed() {
+        let db = Arc::new(MemoryDB::default());
+        let (state_manager, msg_cid) = state_manager_with_replaced_message_at_head(&db);
+
+        let result = state_manager
+            .wait_for_message(msg_cid, 0, None, Some(false), &CancellationToken::new())
+            .await;
+        let err = result.expect_err("replaced message should be rejected");
+        assert!(err.to_string().contains("different CID"), "{err}");
+    }
+
+    /// The same replacing message is accepted when replacements are allowed,
+    /// returning the receipt at the head tipset.
+    #[tokio::test]
+    async fn wait_for_message_accepts_replaced_when_allowed() {
+        let db = Arc::new(MemoryDB::default());
+        let (state_manager, msg_cid) = state_manager_with_replaced_message_at_head(&db);
+
+        let (tipset, receipt) = state_manager
+            .wait_for_message(msg_cid, 0, None, Some(true), &CancellationToken::new())
+            .await
+            .expect("replaced message should be accepted");
+        assert_eq!(tipset.epoch(), 3);
+        assert!(receipt.exit_code().is_success());
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Use `allow_replaced` in `wait_for_message` instead of hard-coding `true`, matching Lotus's `WaitForMessage`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Part of #7267  

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message waiting now consistently respects the option to allow or reject replaced-message receipts.
  * Requests configured to reject replaced messages no longer return receipts for those messages.
  * Requests configured to allow replaced messages continue to return the expected receipts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->