### PR TITLE
chore: update the chain follower logs to report validation

### DIFF
--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -401,9 +401,17 @@ async fn chain_follower(
                 }
 
                 let (_, forks) = state_machine.lock().tasks();
+                let is_validating = forks
+                    .iter()
+                    .any(|fork| fork.stage == ForkSyncStage::ValidatingTipsets);
+                let is_fetching = forks
+                    .iter()
+                    .any(|fork| fork.stage == ForkSyncStage::FetchingHeaders);
                 // The fork closest to the validated head connects first, so its
-                // gap is how many epochs remain before tipset validation can start.
-                let until_validation = forks
+                // gap is roughly how many header fetches remain before tipset
+                // validation can start. Forks fetching at or below the validated
+                // head (fork-point search) have no meaningful gap.
+                let remaining_headers = forks
                     .iter()
                     .filter(|fork| fork.stage == ForkSyncStage::FetchingHeaders)
                     .filter_map(|fork| {
@@ -411,16 +419,20 @@ async fn chain_follower(
                         (gap > 0).then_some(gap)
                     })
                     .min();
-                let is_validating = forks
-                    .iter()
-                    .any(|fork| fork.stage == ForkSyncStage::ValidatingTipsets);
 
                 let status = if is_validating {
                     ", validating tipsets".to_string()
-                } else if let Some(gap) = until_validation {
-                    format!(", validation starts in ~{gap} epochs")
+                } else if let Some(remaining) = remaining_headers {
+                    format!(", fetching headers (~{remaining})")
+                } else if is_fetching {
+                    // All live fetches are at or below the validated head:
+                    // fork-point searches, fetching a competing branch's
+                    // ancestry down to where it forked off our chain.
+                    ", fetching headers".to_string()
                 } else {
-                    String::new()
+                    // waiting for peers to (re)seed tipsets (startup, no usable peers, or the buffer
+                    // was just cleared after a failed validation).
+                    ", waiting for tipsets".to_string()
                 };
                 info!(
                     "Catching up to HEAD: {heaviest_epoch}{} -> {expected_head} (diff: {diff}){status}",

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -376,52 +376,56 @@ async fn chain_follower(
         }
     });
 
-    // Periodically report progress if there are any tipsets left to be fetched.
-    // Once we're in steady-state (i.e. caught up to HEAD) and there are no
-    // active forks, this will not report anything.
+    // Periodically report progress while catching up to HEAD. Once we're in
+    // steady-state (i.e. caught up to HEAD), and there are
+    // no active forks, this will not report anything.
     set.spawn({
         let state_manager = state_manager.shallow_clone();
         let state_machine = state_machine.clone();
         async move {
             loop {
                 tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-                let (tasks_set, _) = state_machine.lock().tasks();
                 let heaviest_tipset = state_manager.chain_store().heaviest_tipset();
                 let heaviest_epoch = heaviest_tipset.epoch();
-
-                let to_download = tasks_set
-                    .iter()
-                    .filter_map(|task| match task {
-                        SyncTask::FetchTipset(_, epoch) => Some(epoch - heaviest_epoch),
-                        _ => None,
-                    })
-                    .max()
-                    .unwrap_or(0);
-
                 let expected_head = calculate_expected_epoch(
                     Utc::now().timestamp() as u64,
                     state_manager.chain_store().genesis_block_header().timestamp,
                     state_manager.chain_config().block_delay_secs,
                 );
+                let diff = expected_head - heaviest_epoch;
 
                 // Only print 'Catching up to HEAD' if we're more than 10 epochs
                 // behind. Otherwise it can be too spammy.
-                match (expected_head - heaviest_epoch > 10, to_download > 0) {
-                    (true, true) => info!(
-                        "Catching up to HEAD: {heaviest_epoch}{} -> {expected_head} (diff: {}), downloading {to_download} tipsets"
-                        , heaviest_tipset.key(),
-                        expected_head - heaviest_epoch
-                    ),
-                    (true, false) => info!(
-                        "Catching up to HEAD: {heaviest_epoch}{} -> {expected_head} (diff: {})"
-                        ,heaviest_tipset.key(),
-                        expected_head - heaviest_epoch
-                    ),
-                    (false, true) => {
-                        info!("Downloading {to_download} tipsets")
-                    }
-                    (false, false) => {}
+                if diff <= 10 {
+                    continue;
                 }
+
+                let (_, forks) = state_machine.lock().tasks();
+                // The fork closest to the validated head connects first, so its
+                // gap is how many epochs remain before tipset validation can start.
+                let until_validation = forks
+                    .iter()
+                    .filter(|fork| fork.stage == ForkSyncStage::FetchingHeaders)
+                    .filter_map(|fork| {
+                        let gap = fork.target_sync_epoch_start - fork.validated_chain_head_epoch;
+                        (gap > 0).then_some(gap)
+                    })
+                    .min();
+                let is_validating = forks
+                    .iter()
+                    .any(|fork| fork.stage == ForkSyncStage::ValidatingTipsets);
+
+                let status = if is_validating {
+                    ", validating tipsets".to_string()
+                } else if let Some(gap) = until_validation {
+                    format!(", validation starts in ~{gap} epochs")
+                } else {
+                    String::new()
+                };
+                info!(
+                    "Catching up to HEAD: {heaviest_epoch}{} -> {expected_head} (diff: {diff}){status}",
+                    heaviest_tipset.key()
+                );
             }
         }
     });

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -39,7 +39,10 @@ use chrono::Utc;
 use hashbrown::{HashMap, HashSet};
 use libp2p::PeerId;
 use parking_lot::Mutex;
-use std::time::{Duration, Instant};
+use std::{
+    borrow::Cow,
+    time::{Duration, Instant},
+};
 use tokio::{sync::Notify, task::JoinSet};
 use tokio_util::sync::CancellationToken;
 
@@ -381,7 +384,7 @@ async fn chain_follower(
     // no active forks, this will not report anything.
     set.spawn({
         let state_manager = state_manager.shallow_clone();
-        let state_machine = state_machine.clone();
+        let sync_status = sync_status.shallow_clone();
         async move {
             loop {
                 tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
@@ -400,39 +403,42 @@ async fn chain_follower(
                     continue;
                 }
 
-                let (_, forks) = state_machine.lock().tasks();
-                let is_validating = forks
+                // The event loop refreshes this report on every state change,
+                // so it is never staler than the state machine itself.
+                let report = sync_status.load();
+                let forks = &report.active_forks;
+                // Once the nearest fork is validating, the remaining fetch
+                // gaps belong to freshly gossiped forks near the clock head
+                // and their min would mislead.
+                let status: Cow<'static, str> = if forks
                     .iter()
-                    .any(|fork| fork.stage == ForkSyncStage::ValidatingTipsets);
-                let is_fetching = forks
+                    .any(|fork| fork.stage == ForkSyncStage::ValidatingTipsets)
+                {
+                    ", validating tipsets".into()
+                } else if forks
                     .iter()
-                    .any(|fork| fork.stage == ForkSyncStage::FetchingHeaders);
-                // The fork closest to the validated head connects first, so its
-                // gap is roughly how many header fetches remain before tipset
-                // validation can start. Forks fetching at or below the validated
-                // head (fork-point search) have no meaningful gap.
-                let remaining_headers = forks
-                    .iter()
-                    .filter(|fork| fork.stage == ForkSyncStage::FetchingHeaders)
-                    .filter_map(|fork| {
-                        let gap = fork.target_sync_epoch_start - fork.validated_chain_head_epoch;
-                        (gap > 0).then_some(gap)
-                    })
-                    .min();
-
-                let status = if is_validating {
-                    ", validating tipsets".to_string()
-                } else if let Some(remaining) = remaining_headers {
-                    format!(", fetching headers (~{remaining})")
-                } else if is_fetching {
-                    // All live fetches are at or below the validated head:
-                    // fork-point searches, fetching a competing branch's
-                    // ancestry down to where it forked off our chain.
-                    ", fetching headers".to_string()
+                    .any(|fork| fork.stage == ForkSyncStage::FetchingHeaders)
+                {
+                    // The fork closest to the validated head connects first, so
+                    // its gap approximates the header fetches left before
+                    // validation can start.
+                    let remaining = forks
+                        .iter()
+                        .filter(|fork| fork.stage == ForkSyncStage::FetchingHeaders)
+                        .map(|fork| fork.target_sync_epoch_start - fork.validated_chain_head_epoch)
+                        .filter(|gap| *gap > 0)
+                        .min();
+                    match remaining {
+                        Some(remaining) => format!(", fetching headers (~{remaining})").into(),
+                        // All fetches are at or below the validated head:
+                        // fork-point searches, fetching a competing branch's
+                        // ancestry down to where it forked off our chain.
+                        None => ", fetching headers".into(),
+                    }
                 } else {
                     // waiting for peers to (re)seed tipsets (startup, no usable peers, or the buffer
                     // was just cleared after a failed validation).
-                    ", waiting for tipsets".to_string()
+                    ", waiting for tipsets".into()
                 };
                 info!(
                     "Catching up to HEAD: {heaviest_epoch}{} -> {expected_head} (diff: {diff}){status}",


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Instead of the `max` forks epoch remaining to start validation, now log shows `min` epochs remaining to start validation
- Update the  chain follower logs to report the remaining tipset to start validation instead of remaining downloads

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/5499

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [ ] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain synchronization progress reporting while catching up to the latest chain head by showing the heaviest epoch, expected head, and the computed difference.
  * Progress messages now include clearer stage-based status (e.g., validating tipsets, remaining header fetches, or waiting for tipsets).
  * Log updates are emitted only when the node is significantly behind, reducing unnecessary log noise during normal operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->