### PR TITLE
chore(test): add regression test for paritydb deadlock

### DIFF
--- a/src/cid_collections/hash_set.rs
+++ b/src/cid_collections/hash_set.rs
@@ -161,6 +161,60 @@ mod tests {
     use super::*;
     use ahash::HashSet;
 
+    /// Stress-regression test for the parity-db commit pipeline behind [`FileBackedCidHashSet`].
+    /// Fixed in `parity-db v0.5.6` via <https://github.com/paritytech/parity-db/pull/252>.
+    #[test]
+    #[ignore = "manual stress test; takes minutes"]
+    fn file_backed_insert_hammer() {
+        use crate::utils::multihash::prelude::*;
+        use std::sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        };
+
+        const TARGET: u64 = 60_000_000;
+        const STALL_LIMIT_SECS: u64 = 60;
+
+        let progress = Arc::new(AtomicU64::new(0));
+        let worker = std::thread::spawn({
+            let progress = progress.clone();
+            move || -> anyhow::Result<()> {
+                let mut set = FileBackedCidHashSet::new_in_temp_dir()?;
+                for i in 0..TARGET {
+                    let cid = Cid::new_v1(
+                        fvm_ipld_encoding::DAG_CBOR,
+                        MultihashCode::Blake2b256.digest(&i.to_le_bytes()),
+                    );
+                    anyhow::ensure!(set.insert(cid)?, "cid {i} was not newly inserted");
+                    progress.store(i + 1, Ordering::Relaxed);
+                }
+                Ok(())
+            }
+        });
+
+        let mut last = 0;
+        let mut stalled_for = 0;
+        loop {
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            if worker.is_finished() {
+                worker.join().unwrap().unwrap();
+                return;
+            }
+            let current = progress.load(Ordering::Relaxed);
+            if current == last {
+                stalled_for += 5;
+                assert!(
+                    stalled_for < STALL_LIMIT_SECS,
+                    "insert wedged at {current} inserts for {STALL_LIMIT_SECS}s"
+                );
+            } else {
+                stalled_for = 0;
+                eprintln!("{current} inserts");
+            }
+            last = current;
+        }
+    }
+
     #[quickcheck_macros::quickcheck]
     fn test_cid_hashset(cids: HashSet<Cid>) {
         let mut set = CidHashSet::default();


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- added a regression test for parity db deadlock fixed via https://github.com/ChainSafe/forest/pull/7389
- ignored because it takes a lot of time but could be triggered manually in case of future issues

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an optional stress test to detect hangs or stalls during repeated file-backed CID insertions.
  * The test reports progress and fails when operations appear to stop responding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->