### PR TITLE
fix: `eth` new block filter stateful test

### DIFF
--- a/src/tool/subcommands/api_cmd/stateful_tests.rs
+++ b/src/tool/subcommands/api_cmd/stateful_tests.rs
@@ -199,7 +199,7 @@ async fn wait_next_epoch(client: &rpc::Client) -> anyhow::Result<()> {
     let base = client.call(ChainHead::request(())?).await?.epoch();
     tokio::time::timeout(Duration::from_secs(180), async {
         loop {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
             if client.call(ChainHead::request(())?).await?.epoch() > base {
                 break Ok(());
             }

--- a/src/tool/subcommands/api_cmd/stateful_tests.rs
+++ b/src/tool/subcommands/api_cmd/stateful_tests.rs
@@ -902,12 +902,18 @@ fn eth_new_block_filter() -> RpcTestScenario {
         let result = process_filter(&client, &filter_id).await;
 
         // Cleanup
-        let removed = client
-            .call(EthUninstallFilter::request((filter_id,))?)
-            .await?;
-        anyhow::ensure!(removed);
+        let cleanup: anyhow::Result<()> = async {
+            let removed = client
+                .call(EthUninstallFilter::request((filter_id,))?)
+                .await
+                .context("failed to uninstall filter")?;
+            anyhow::ensure!(removed, "filter was not removed");
+            Ok(())
+        }
+        .await;
 
-        result
+        // A cleanup failure must not mask the original test failure.
+        result.and(cleanup)
     })
 }
 

--- a/src/tool/subcommands/api_cmd/stateful_tests.rs
+++ b/src/tool/subcommands/api_cmd/stateful_tests.rs
@@ -195,119 +195,18 @@ async fn connect_ws(client: &rpc::Client) -> anyhow::Result<EthSubStream> {
     Ok(ws_stream)
 }
 
-#[allow(unreachable_code)]
-async fn next_tipset(client: &rpc::Client) -> anyhow::Result<()> {
-    async fn close_channel(
-        stream: &mut EthSubStream,
-        id: &serde_json::Value,
-    ) -> anyhow::Result<()> {
-        let request = json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "xrpc.cancel",
-            "params": [id]
-        });
-
-        stream
-            .send(WsMessage::Text(request.to_string().into()))
-            .await
-            .context("failed to send close channel request")?;
-
-        Ok(())
-    }
-
-    let mut ws_stream = connect_ws(client).await?;
-
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "Filecoin.ChainNotify",
-        "params": []
-    });
-    ws_stream
-        .send(WsMessage::Text(request.to_string().into()))
-        .await?;
-
-    let mut channel_id: Option<serde_json::Value> = None;
-
-    // The goal of this loop is to wait for a new tipset to arrive without using a busy loop or sleep.
-    // It processes incoming WebSocket messages until it encounters an "apply" or "revert" change type.
-    // If an "apply" change is found, it closes the channel and exits. If a "revert" change is found,
-    // it closes the channel and raises an error. Any channel protocol or parameter validation issues result in an error.
-    loop {
-        let msg = match tokio::time::timeout(Duration::from_secs(180), ws_stream.next()).await {
-            Ok(Some(msg)) => msg,
-            Ok(None) => anyhow::bail!("WebSocket stream closed"),
-            Err(_) => {
-                if let Some(id) = channel_id.as_ref() {
-                    let _ = close_channel(&mut ws_stream, id).await;
-                }
-                let _ = ws_stream.close(None).await;
-                anyhow::bail!("timeout waiting for tipset");
-            }
-        };
-        match msg {
-            Ok(WsMessage::Text(text)) => {
-                let json: serde_json::Value = serde_json::from_str(&text)?;
-
-                if let Some(id) = json.get("result") {
-                    channel_id = Some(id.clone());
-                } else {
-                    let method = json!("xrpc.ch.val");
-                    anyhow::ensure!(json.get("method") == Some(&method));
-
-                    if let Some(params) = json.get("params").and_then(|v| v.as_array()) {
-                        if let Some(id) = params.first() {
-                            anyhow::ensure!(Some(id) == channel_id.as_ref());
-                        } else {
-                            anyhow::bail!("expecting an open channel");
-                        }
-                        if let Some(changes) = params.get(1).and_then(|v| v.as_array()) {
-                            for change in changes {
-                                if let Some(type_) = change.get("Type").and_then(|v| v.as_str()) {
-                                    if type_ == "apply" {
-                                        let id = channel_id.as_ref().ok_or_else(|| {
-                                            anyhow::anyhow!("subscription not opened")
-                                        })?;
-                                        close_channel(&mut ws_stream, id).await?;
-                                        ws_stream.close(None).await?;
-                                        return Ok(());
-                                    } else if type_ == "revert" {
-                                        let id = channel_id.as_ref().ok_or_else(|| {
-                                            anyhow::anyhow!("subscription not opened")
-                                        })?;
-                                        close_channel(&mut ws_stream, id).await?;
-                                        ws_stream.close(None).await?;
-                                        anyhow::bail!("revert");
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        let id = channel_id
-                            .as_ref()
-                            .ok_or_else(|| anyhow::anyhow!("subscription not opened"))?;
-                        close_channel(&mut ws_stream, id).await?;
-                        ws_stream.close(None).await?;
-                        anyhow::bail!("expecting params");
-                    }
-                }
-            }
-            Err(..) | Ok(WsMessage::Close(..)) => {
-                let id = channel_id
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("subscription not opened"))?;
-                close_channel(&mut ws_stream, id).await?;
-                ws_stream.close(None).await?;
-                anyhow::bail!("unexpected error or close message");
-            }
-            _ => {
-                // Ignore other message types
+async fn wait_next_epoch(client: &rpc::Client) -> anyhow::Result<()> {
+    let base = client.call(ChainHead::request(())?).await?.epoch();
+    tokio::time::timeout(Duration::from_secs(180), async {
+        loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            if client.call(ChainHead::request(())?).await?.epoch() > base {
+                break Ok(());
             }
         }
-    }
-
-    unreachable!("loop always returns within the branches above")
+    })
+    .await
+    .context("timeout waiting for the next epoch")?
 }
 
 /// Poll `MpoolPending` until `message_cid` is visible. Returns while the message
@@ -959,71 +858,56 @@ fn create_eth_new_filter_limit_test(count: usize) -> RpcTestScenario {
 fn eth_new_block_filter() -> RpcTestScenario {
     RpcTestScenario::basic(move |client| async move {
         async fn process_filter(client: &rpc::Client, filter_id: &FilterID) -> anyhow::Result<()> {
-            let filter_result = client
-                .call(EthGetFilterChanges::request((filter_id.clone(),))?)
-                .await?;
-
-            if let EthFilterResult::Hashes(prev_hashes) = filter_result {
-                let verify_hashes = async |hashes: &[EthHash]| -> anyhow::Result<()> {
-                    for hash in hashes {
-                        let _block = client
-                            .call(EthGetBlockByHash::request((*hash, false))?)
-                            .await?;
-                    }
-                    Ok(())
-                };
-                verify_hashes(&prev_hashes).await?;
-
-                // Wait for the next block to arrive
-                next_tipset(client).await?;
-
-                let filter_result = client
+            let poll = async || -> anyhow::Result<Vec<EthHash>> {
+                match client
                     .call(EthGetFilterChanges::request((filter_id.clone(),))?)
-                    .await?;
-
-                if let EthFilterResult::Hashes(hashes) = filter_result {
-                    verify_hashes(&hashes).await?;
-                    anyhow::ensure!(
-                        (prev_hashes.is_empty() && hashes.is_empty()) || prev_hashes != hashes,
-                    );
-
-                    Ok(())
-                } else {
-                    Err(anyhow::anyhow!("expecting blocks"))
+                    .await?
+                {
+                    EthFilterResult::Hashes(hashes) => Ok(hashes),
+                    _ => Err(anyhow::anyhow!("expecting block hashes")),
                 }
-            } else {
-                Err(anyhow::anyhow!("expecting blocks"))
-            }
-        }
-
-        let mut retries = 5;
-        loop {
-            // Create the filter
-            let filter_id = client.call(EthNewBlockFilter::request(())?).await?;
-
-            let result = match process_filter(&client, &filter_id).await {
-                Ok(()) => Ok(()),
-                Err(e) if retries != 0 && e.to_string().contains("revert") => {
-                    // Cleanup
-                    let removed = client
-                        .call(EthUninstallFilter::request((filter_id,))?)
+            };
+            let verify_hashes = async |hashes: &[EthHash]| -> anyhow::Result<()> {
+                for hash in hashes {
+                    let _block = client
+                        .call(EthGetBlockByHash::request((*hash, false))?)
                         .await?;
-                    anyhow::ensure!(removed);
-
-                    retries -= 1;
-                    continue;
                 }
-                Err(e) => Err(e),
+                Ok(())
             };
 
-            // Cleanup
-            let removed = client
-                .call(EthUninstallFilter::request((filter_id,))?)
-                .await?;
-            anyhow::ensure!(removed);
+            let prev_hashes = poll().await?;
+            verify_hashes(&prev_hashes).await?;
 
-            break result;
+            // The filter derives its hashes from executed events, so an epoch
+            // without events legitimately leaves the poll unchanged, allow a
+            // few more epochs before declaring the filter stuck.
+            let mut hashes = Vec::new();
+            for _ in 0..3 {
+                wait_next_epoch(client).await?;
+                hashes = poll().await?;
+                verify_hashes(&hashes).await?;
+                if hashes != prev_hashes {
+                    break;
+                }
+            }
+            anyhow::ensure!((prev_hashes.is_empty() && hashes.is_empty()) || prev_hashes != hashes);
+
+            Ok(())
         }
+
+        // Create the filter
+        let filter_id = client.call(EthNewBlockFilter::request(())?).await?;
+
+        let result = process_filter(&client, &filter_id).await;
+
+        // Cleanup
+        let removed = client
+            .call(EthUninstallFilter::request((filter_id,))?)
+            .await?;
+        anyhow::ensure!(removed);
+
+        result
     })
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Earlier the `EthNewBlockFilter` relied on the `ChainNotify` and was failing if the tipset reverted was returned in the Chain Notify response
- Now it simply waits for the `ChainHead` to report a new head

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/7385

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved reliability of Ethereum block filter testing by adding bounded polling to wait for chain head progress (with a defined timeout) before re-verifying results.
  * Reduced flaky outcomes by re-polling and re-checking returned block hashes across multiple epoch advances, and by simplifying cleanup to avoid obscuring the original test failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->