### PR TITLE
feat(eth): allow eth_call and eth_estimateGas from contract and non-existent senders

### DIFF
--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1875,6 +1875,15 @@ async fn eth_estimate_gas(
     // gas estimation actually run.
     msg.gas_limit = 0;
 
+    // Geth allows eth_estimateGas from senders that Filecoin's explicit path rejects. An
+    // EVM-contract sender fails the FVM's account-type check, and a sender that does not
+    // exist on chain has no nonce to read. Detect both up front and estimate on the
+    // skip-sender-validation path, which applies the message implicitly (contract sender)
+    // or creates an ephemeral placeholder first (non-existent sender).
+    if sender_needs_skip_validation(ctx, msg.from, &tipset).await {
+        return eth_estimate_gas_skip_sender(ctx, msg, tipset).await;
+    }
+
     match gas::estimate_message_gas(ctx, msg.clone(), None, tipset.key().clone().into()).await {
         Err(server_err) => {
             // On failure, GasEstimateMessageGas doesn't actually return the invocation result,
@@ -1899,10 +1908,46 @@ async fn eth_estimate_gas(
             Err(err.context("failed to estimate gas").into())
         }
         Ok(gassed_msg) => {
-            let expected_gas = eth_gas_search(ctx, gassed_msg, &tipset.key().into()).await?;
+            let expected_gas = eth_gas_search(ctx, gassed_msg, &tipset.key().into(), false).await?;
             Ok(expected_gas.into())
         }
     }
+}
+
+/// Returns `true` if the sender is an EVM contract or does not exist on chain, in which case
+/// `eth_call`/`eth_estimateGas` must run with sender validation skipped (matching Geth).
+async fn sender_needs_skip_validation(ctx: &Ctx, from: FilecoinAddress, tipset: &Tipset) -> bool {
+    let Ok(TipsetState { state_root, .. }) = ctx.state_manager.load_tipset_state(tipset).await
+    else {
+        return false;
+    };
+    match ctx.state_manager.get_actor(&from, state_root) {
+        // Sender exists but is an EVM contract: not a valid explicit sender.
+        Ok(Some(actor)) => is_evm_actor(&actor.code),
+        // Sender does not exist on chain: no nonce to read on the explicit path.
+        Ok(None) => true,
+        // Could not resolve the sender; let the strict path decide.
+        Err(_) => false,
+    }
+}
+
+/// Estimates gas for a message whose sender is a contract or does not exist on chain,
+/// mirroring the normal path: an initial estimate on the skip-sender-validation path, the
+/// overestimation multiplier, then a gas search so nested calls get the limit they need.
+async fn eth_estimate_gas_skip_sender(
+    ctx: &Ctx,
+    mut msg: Message,
+    tipset: Tipset,
+) -> Result<EthUint64, ServerError> {
+    let tsk: ApiTipsetKey = tipset.key().clone().into();
+    let gas_limit =
+        gas::GasEstimateGasLimit::estimate_gas_limit_skip_sender_validation(ctx, msg.clone(), &tsk)
+            .await?;
+    let gas_limit = ((gas_limit as f64) * ctx.mpool.gas_limit_overestimation()) as u64;
+    msg.set_gas_limit(gas_limit.min(BLOCK_GAS_LIMIT));
+
+    let expected_gas = eth_gas_search(ctx, msg, &tsk, true).await?;
+    Ok(expected_gas.into())
 }
 
 async fn apply_message(
@@ -1919,11 +1964,34 @@ async fn apply_message(
         return Err(crate::state_manager::Error::ExpensiveFork { epoch: ts.epoch() }.into());
     }
 
-    let (invoc_res, _) = ctx
+    let apply = ctx
         .state_manager
-        .apply_on_state_with_gas(tipset, msg, VMFlush::Skip)
-        .await
-        .context("failed to apply on state with gas")?;
+        .apply_on_state_with_gas(tipset.clone(), msg.clone(), VMFlush::Skip)
+        .await;
+
+    // Geth allows eth_call/eth_estimateGas from senders that Filecoin's explicit path
+    // rejects. A sender that is an EVM contract surfaces as a `SysErrSenderInvalid` receipt;
+    // a sender that does not exist on chain surfaces as a `SenderValidationFailed` error.
+    // In either case, retry with sender validation skipped.
+    let sender_invalid: ExitCode = fvm_shared4::error::ExitCode::SYS_SENDER_INVALID.into();
+    let needs_skip = match &apply {
+        Ok((invoc_res, _)) => invoc_res
+            .msg_rct
+            .as_ref()
+            .is_some_and(|receipt| ExitCode::from(receipt.exit_code()) == sender_invalid),
+        Err(e) => e
+            .downcast_ref::<crate::state_manager::Error>()
+            .is_some_and(|e| matches!(e, crate::state_manager::Error::SenderValidationFailed(_))),
+    };
+
+    let (invoc_res, _) = if needs_skip {
+        ctx.state_manager
+            .apply_on_state_with_gas_skip_sender_validation(tipset, msg, VMFlush::Skip)
+            .await
+            .context("failed to apply on state with gas (skip sender validation)")?
+    } else {
+        apply.context("failed to apply on state with gas")?
+    };
 
     // Extract receipt or return early if none
     match &invoc_res.msg_rct {
@@ -1946,9 +2014,22 @@ async fn apply_message(
     Ok(invoc_res)
 }
 
-pub async fn eth_gas_search(data: &Ctx, msg: Message, tsk: &ApiTipsetKey) -> anyhow::Result<u64> {
-    let (_invoc_res, apply_ret, prior_messages, ts) =
-        gas::GasEstimateGasLimit::estimate_call_with_gas(data, msg.clone(), tsk).await?;
+pub async fn eth_gas_search(
+    data: &Ctx,
+    msg: Message,
+    tsk: &ApiTipsetKey,
+    skip_sender_validation: bool,
+) -> anyhow::Result<u64> {
+    let (_invoc_res, apply_ret, prior_messages, ts) = if skip_sender_validation {
+        gas::GasEstimateGasLimit::estimate_call_with_gas_skip_sender_validation(
+            data,
+            msg.clone(),
+            tsk,
+        )
+        .await?
+    } else {
+        gas::GasEstimateGasLimit::estimate_call_with_gas(data, msg.clone(), tsk).await?
+    };
     if apply_ret.msg_receipt().exit_code().is_success() {
         return Ok(msg.gas_limit());
     }
@@ -1964,7 +2045,7 @@ pub async fn eth_gas_search(data: &Ctx, msg: Message, tsk: &ApiTipsetKey) -> any
             })
         )
     }) {
-        let ret = gas_search(data, &msg, prior_messages, ts).await?;
+        let ret = gas_search(data, &msg, prior_messages, ts, skip_sender_validation).await?;
         Ok(((ret as f64) * data.mpool.gas_limit_overestimation()) as u64)
     } else {
         anyhow::bail!(
@@ -1984,6 +2065,7 @@ async fn gas_search(
     msg: &Message,
     prior_messages: Arc<Vec<ChainMessage>>,
     ts: Tipset,
+    skip_sender_validation: bool,
 ) -> anyhow::Result<u64> {
     let mut high = msg.gas_limit;
     let mut low = msg.gas_limit;
@@ -1994,12 +2076,23 @@ async fn gas_search(
         prior_messages: Arc<Vec<ChainMessage>>,
         ts: Tipset,
         limit: u64,
+        skip_sender_validation: bool,
     ) -> anyhow::Result<bool> {
         msg.gas_limit = limit;
-        let (_invoc_res, apply_ret, _, _) = data
-            .state_manager
-            .call_with_gas(msg.into(), prior_messages, Some(ts), VMFlush::Skip)
-            .await?;
+        let (_invoc_res, apply_ret, _, _) = if skip_sender_validation {
+            data.state_manager
+                .call_with_gas_skip_sender_validation(
+                    msg.into(),
+                    prior_messages,
+                    Some(ts),
+                    VMFlush::Skip,
+                )
+                .await?
+        } else {
+            data.state_manager
+                .call_with_gas(msg.into(), prior_messages, Some(ts), VMFlush::Skip)
+                .await?
+        };
         Ok(apply_ret.msg_receipt().exit_code().is_success())
     }
 
@@ -2010,6 +2103,7 @@ async fn gas_search(
             prior_messages.shallow_clone(),
             ts.shallow_clone(),
             high,
+            skip_sender_validation,
         )
         .await?
         {
@@ -2028,6 +2122,7 @@ async fn gas_search(
             prior_messages.shallow_clone(),
             ts.shallow_clone(),
             median,
+            skip_sender_validation,
         )
         .await?
         {

--- a/src/rpc/methods/gas.rs
+++ b/src/rpc/methods/gas.rs
@@ -208,8 +208,29 @@ impl RpcMethod<2> for GasEstimateGasLimit {
 impl GasEstimateGasLimit {
     pub async fn estimate_call_with_gas(
         data: &Ctx,
+        msg: Message,
+        tsk: &ApiTipsetKey,
+    ) -> anyhow::Result<(InvocResult, ApplyRet, Arc<Vec<ChainMessage>>, Tipset)> {
+        Self::estimate_call_with_gas_inner(data, msg, tsk, false).await
+    }
+
+    /// Same as [`Self::estimate_call_with_gas`] but skips sender validation, so
+    /// `eth_estimateGas` can estimate calls from EVM-contract senders or from addresses
+    /// that do not yet exist on chain. See
+    /// [`crate::state_manager::StateManager::call_with_gas_skip_sender_validation`].
+    pub async fn estimate_call_with_gas_skip_sender_validation(
+        data: &Ctx,
+        msg: Message,
+        tsk: &ApiTipsetKey,
+    ) -> anyhow::Result<(InvocResult, ApplyRet, Arc<Vec<ChainMessage>>, Tipset)> {
+        Self::estimate_call_with_gas_inner(data, msg, tsk, true).await
+    }
+
+    async fn estimate_call_with_gas_inner(
+        data: &Ctx,
         mut msg: Message,
         ApiTipsetKey(tsk): &ApiTipsetKey,
+        skip_sender_validation: bool,
     ) -> anyhow::Result<(InvocResult, ApplyRet, Arc<Vec<ChainMessage>>, Tipset)> {
         msg.set_gas_limit(BLOCK_GAS_LIMIT);
         msg.set_gas_fee_cap(TokenAmount::from_atto(0));
@@ -246,22 +267,54 @@ impl GasEstimateGasLimit {
             _ => msg.into(),
         };
 
-        let (invoc_res, apply_ret, _, _) = data
-            .state_manager
-            .call_with_gas(
-                chain_msg,
-                prior_messages.shallow_clone(),
-                Some(ts.shallow_clone()),
-                VMFlush::Skip,
-            )
-            .await?;
+        let (invoc_res, apply_ret, _, _) = if skip_sender_validation {
+            data.state_manager
+                .call_with_gas_skip_sender_validation(
+                    chain_msg,
+                    prior_messages.shallow_clone(),
+                    Some(ts.shallow_clone()),
+                    VMFlush::Skip,
+                )
+                .await?
+        } else {
+            data.state_manager
+                .call_with_gas(
+                    chain_msg,
+                    prior_messages.shallow_clone(),
+                    Some(ts.shallow_clone()),
+                    VMFlush::Skip,
+                )
+                .await?
+        };
         Ok((invoc_res, apply_ret, prior_messages, ts))
     }
 
     pub async fn estimate_gas_limit(data: &Ctx, msg: Message, tsk: &ApiTipsetKey) -> Result<i64> {
-        let (res, ..) = Self::estimate_call_with_gas(data, msg, tsk)
-            .await
-            .context("gas estimation failed")?;
+        Self::estimate_gas_limit_inner(data, msg, tsk, false).await
+    }
+
+    /// Same as [`Self::estimate_gas_limit`] but skips sender validation. Used by
+    /// `eth_estimateGas` for EVM-contract or non-existent senders.
+    pub async fn estimate_gas_limit_skip_sender_validation(
+        data: &Ctx,
+        msg: Message,
+        tsk: &ApiTipsetKey,
+    ) -> Result<i64> {
+        Self::estimate_gas_limit_inner(data, msg, tsk, true).await
+    }
+
+    async fn estimate_gas_limit_inner(
+        data: &Ctx,
+        msg: Message,
+        tsk: &ApiTipsetKey,
+        skip_sender_validation: bool,
+    ) -> Result<i64> {
+        let (res, ..) = if skip_sender_validation {
+            Self::estimate_call_with_gas_skip_sender_validation(data, msg, tsk).await
+        } else {
+            Self::estimate_call_with_gas(data, msg, tsk).await
+        }
+        .context("gas estimation failed")?;
         match res.msg_rct {
             Some(rct) => {
                 anyhow::ensure!(

--- a/src/state_manager/errors.rs
+++ b/src/state_manager/errors.rs
@@ -18,6 +18,10 @@ pub enum Error {
         "required historical state unavailable: refusing explicit call due to state fork at epoch {epoch}"
     )]
     ExpensiveFork { epoch: ChainEpoch },
+    /// The sender actor does not exist on chain or is not a valid sender type. Control flow
+    /// only: `eth_call`/`eth_estimateGas` use it to retry with sender validation skipped.
+    #[error("sender validation failed: {0}")]
+    SenderValidationFailed(String),
     /// Other state manager error
     #[error("{0}")]
     Other(String),

--- a/src/state_manager/message_simulation.rs
+++ b/src/state_manager/message_simulation.rs
@@ -7,8 +7,9 @@ use super::*;
 use crate::interpreter::{ExecutionContext, IMPLICIT_MESSAGE_GAS_LIMIT, VM, VMTrace};
 use crate::message::{MessageRead as _, MessageReadWrite as _};
 use crate::rpc::state::{ApiInvocResult, InvocResult, MessageGasCost};
+use crate::shim::address::Address;
 use crate::shim::executor::ApplyRet;
-use crate::shim::message::Message;
+use crate::shim::message::{METHOD_SEND, Message};
 use crate::state_migration::run_state_migrations;
 use std::time::Duration;
 use tracing::instrument;
@@ -188,13 +189,44 @@ impl StateManager {
         msg: Message,
         vm_flush: VMFlush,
     ) -> anyhow::Result<(ApiInvocResult, Option<Cid>)> {
+        self.apply_on_state_with_gas_inner(tipset, msg, vm_flush, false)
+            .await
+    }
+
+    /// Same as [`Self::apply_on_state_with_gas`] but skips sender validation, letting
+    /// `eth_call`/`eth_estimateGas` simulate calls from EVM-contract senders or from
+    /// addresses that do not yet exist on chain. See
+    /// [`Self::call_with_gas_skip_sender_validation`].
+    pub async fn apply_on_state_with_gas_skip_sender_validation(
+        &self,
+        tipset: Option<Tipset>,
+        msg: Message,
+        vm_flush: VMFlush,
+    ) -> anyhow::Result<(ApiInvocResult, Option<Cid>)> {
+        self.apply_on_state_with_gas_inner(tipset, msg, vm_flush, true)
+            .await
+    }
+
+    async fn apply_on_state_with_gas_inner(
+        &self,
+        tipset: Option<Tipset>,
+        msg: Message,
+        vm_flush: VMFlush,
+        skip_sender_validation: bool,
+    ) -> anyhow::Result<(ApiInvocResult, Option<Cid>)> {
         let ts = tipset.unwrap_or_else(|| self.heaviest_tipset());
 
         let from_a = self.resolve_to_deterministic_address(msg.from, &ts).await?;
         let chain_msg = ChainMessage::for_gas_estimation(msg.clone(), from_a.protocol());
 
         let (_invoc_res, apply_ret, duration, state_root) = self
-            .call_with_gas(chain_msg, Default::default(), Some(ts), vm_flush)
+            .call_with_gas_inner(
+                chain_msg,
+                Default::default(),
+                Some(ts),
+                vm_flush,
+                skip_sender_validation,
+            )
             .await?;
 
         Ok((
@@ -216,10 +248,44 @@ impl StateManager {
     /// messages and returns the values computed in the VM.
     pub async fn call_with_gas(
         &self,
+        message: ChainMessage,
+        prior_messages: Arc<Vec<ChainMessage>>,
+        tipset: Option<Tipset>,
+        vm_flush: VMFlush,
+    ) -> Result<(InvocResult, ApplyRet, Duration, Option<Cid>), Error> {
+        self.call_with_gas_inner(message, prior_messages, tipset, vm_flush, false)
+            .await
+    }
+
+    /// Same as [`Self::call_with_gas`] but skips sender validation, mirroring Geth's
+    /// behavior so `eth_call`/`eth_estimateGas` can simulate calls from EVM-contract
+    /// senders or from addresses that do not yet exist on chain.
+    ///
+    /// - Sender missing: apply an implicit zero-value send so the FVM instantiates an
+    ///   ephemeral placeholder actor for the address, then run the message on the explicit
+    ///   path so gas accounting matches a real first send from a fresh account.
+    /// - Sender present but not a valid sender type (e.g. an EVM contract): run the message
+    ///   on the implicit path, which skips the account-type, nonce and balance checks.
+    ///
+    /// Nothing is persisted; this operates on the VM's in-memory buffered state.
+    pub async fn call_with_gas_skip_sender_validation(
+        &self,
+        message: ChainMessage,
+        prior_messages: Arc<Vec<ChainMessage>>,
+        tipset: Option<Tipset>,
+        vm_flush: VMFlush,
+    ) -> Result<(InvocResult, ApplyRet, Duration, Option<Cid>), Error> {
+        self.call_with_gas_inner(message, prior_messages, tipset, vm_flush, true)
+            .await
+    }
+
+    async fn call_with_gas_inner(
+        &self,
         mut message: ChainMessage,
         prior_messages: Arc<Vec<ChainMessage>>,
         tipset: Option<Tipset>,
         vm_flush: VMFlush,
+        skip_sender_validation: bool,
     ) -> Result<(InvocResult, ApplyRet, Duration, Option<Cid>), Error> {
         let ts = tipset.unwrap_or_else(|| self.heaviest_tipset());
         let TipsetState { state_root, .. } = self
@@ -236,7 +302,7 @@ impl StateManager {
         tokio::task::spawn_blocking(move || {
             // FVM requires a stack size of 64MiB. The alternative is to use `ThreadedExecutor` from
             // FVM, but that introduces some constraints, and possible deadlocks.
-            let (ret, duration, state_cid) = stacker::grow(64 << 20, || -> anyhow::Result<_> {
+            let applied = stacker::grow(64 << 20, || -> anyhow::Result<_> {
                 let mut vm = VM::new(
                     ExecutionContext {
                         heaviest_tipset: ts.clone(),
@@ -261,19 +327,75 @@ impl StateManager {
                     vm.apply_message(msg)?;
                 }
 
-                let from_actor = vm
+                let maybe_from_actor = vm
                     .get_actor(&message.from())
-                    .map_err(|e| Error::Other(format!("Could not get actor from state: {e:#}")))?
-                    .ok_or_else(|| Error::Other("cant find actor in state tree".to_string()))?;
+                    .map_err(|e| Error::Other(format!("Could not get actor from state: {e:#}")))?;
+
+                let (from_actor, sender_created) = match maybe_from_actor {
+                    Some(actor) => (actor, false),
+                    None if skip_sender_validation => {
+                        // The sender does not exist on chain. Apply an implicit zero-value send
+                        // to the address: the FVM assigns it an ID address and instantiates a
+                        // placeholder actor, exactly as a real first transfer would. A nonce-0
+                        // placeholder is a valid message sender, so the message itself is then
+                        // applied on the explicit path, keeping gas accounting identical to a
+                        // real first send from a fresh account.
+                        let placeholder_send = Message {
+                            from: Address::SYSTEM_ACTOR,
+                            to: message.from(),
+                            method_num: METHOD_SEND,
+                            gas_limit: IMPLICIT_MESSAGE_GAS_LIMIT as u64,
+                            ..Default::default()
+                        };
+                        let (create_ret, _) = vm.apply_implicit_message(&placeholder_send)?;
+                        let exit_code = create_ret.msg_receipt().exit_code();
+                        if !exit_code.is_success() {
+                            anyhow::bail!(
+                                "creating ephemeral sender placeholder for {} failed with exit code {exit_code:?}",
+                                message.from()
+                            );
+                        }
+                        let actor = vm
+                            .get_actor(&message.from())
+                            .map_err(|e| Error::Other(format!("Could not get actor from state: {e:#}")))?
+                            .ok_or_else(|| {
+                                Error::Other(
+                                    "ephemeral sender placeholder missing after creation".to_string(),
+                                )
+                            })?;
+                        (actor, true)
+                    }
+                    // Sender missing under strict validation. Signal to the caller via `None`
+                    // so the typed `SenderValidationFailed` error survives (it would otherwise
+                    // be flattened by the anyhow -> Error conversion below).
+                    None => return Ok(None),
+                };
 
                 message.set_sequence(from_actor.sequence);
-                let (ret, duration) = vm.apply_message(&message)?;
+                let (ret, duration) = if skip_sender_validation && !sender_created {
+                    // The sender exists but is not a valid message sender (e.g. an EVM
+                    // contract): apply on the implicit path, which skips the account-type,
+                    // nonce and balance checks.
+                    vm.apply_implicit_message(message.message())?
+                } else {
+                    vm.apply_message(&message)?
+                };
                 let state_root = match vm_flush {
                     VMFlush::Flush => Some(vm.flush()?),
                     VMFlush::Skip => None,
                 };
-                Ok((ret, duration, state_root))
+                Ok(Some((ret, duration, state_root)))
             })?;
+
+            let (ret, duration, state_cid) = match applied {
+                Some(applied) => applied,
+                None => {
+                    return Err(Error::SenderValidationFailed(format!(
+                        "sender {} not found on chain",
+                        message.from()
+                    )));
+                }
+            };
 
             Ok((
                 InvocResult::new(message.message().clone(), &ret),

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -2498,7 +2498,49 @@ fn eth_state_tests_with_tipset<DB: Blockstore + ShallowClone>(
     // Test eth_call API errors
     tests.extend(eth_call_api_err_tests(shared_tipset.epoch()));
 
+    // Test eth_call / eth_estimateGas from a non-existent sender (#7394)
+    tests.extend(eth_call_estimate_skip_sender_tests(shared_tipset.epoch()));
+
     Ok(tests)
+}
+
+/// Regression tests for <https://github.com/ChainSafe/forest/issues/7394>: `eth_call` and
+/// `eth_estimateGas` must work when the sender is not a valid Filecoin message sender. A
+/// fresh Ethereum address that has never transacted has no actor on chain, yet
+/// Geth-compatible tooling still expects these calls to succeed (an ephemeral placeholder
+/// sender is created for them).
+fn eth_call_estimate_skip_sender_tests(epoch: ChainEpoch) -> Vec<RpcTest> {
+    // A deterministic address that is overwhelmingly unlikely to exist on chain.
+    let nonexistent = EthAddress::from_str("0x00000000000000000000000000000000dead0000")
+        .expect("valid eth address");
+
+    let mut tests = Vec::new();
+    for api_path in [ApiPaths::V1, ApiPaths::V2] {
+        let msg = EthCallMessage {
+            from: Some(nonexistent),
+            to: Some(nonexistent),
+            ..EthCallMessage::default()
+        };
+
+        let eth_call_request =
+            EthCall::request((msg.clone(), BlockNumberOrHash::from_block_number(epoch)))
+                .unwrap()
+                .with_api_path(api_path);
+        tests.push(
+            RpcTest::identity(eth_call_request)
+                .policy_on_rejected(PolicyOnRejected::PassWithIdenticalError),
+        );
+
+        let eth_estimate_gas_request =
+            EthEstimateGas::request((msg, Some(BlockNumberOrHash::BlockNumber(epoch.into()))))
+                .unwrap()
+                .with_api_path(api_path);
+        tests.push(
+            RpcTest::identity(eth_estimate_gas_request)
+                .policy_on_rejected(PolicyOnRejected::PassWithIdenticalError),
+        );
+    }
+    tests
 }
 
 fn gas_tests_with_tipset(shared_tipset: &Tipset) -> Vec<RpcTest> {


### PR DESCRIPTION
## Summary

Ports filecoin-project/lotus#13724 to Forest. Closes #7394.

Ethereum tooling assumes `eth_call` and `eth_estimateGas` work from senders that Filecoin's explicit path rejects: Safe's protocol-kit issues `eth_call` with `from == to` for EIP-1271 checks, dApps estimate gas before an account is funded, and viem defaults `from` to the connected wallet even for reads. Forest ran both methods on the FVM's explicit path, which requires the sender to be an existing account-type actor, so all of the above failed.

This mirrors Geth (and Lotus) by skipping sender validation for these two methods only:

- **Sender does not exist on chain:** apply an implicit zero-value send to the address so the FVM instantiates an ephemeral placeholder actor, then run the message on the explicit path so gas accounting matches a real first send.
- **Sender exists but is an EVM contract:** run the message on the implicit path, which skips the account-type / nonce / balance checks.

Everything runs on the VM's in-memory buffered state; nothing is persisted.

## Design notes (Forest specifics)

- Forest routes both `eth_call` and `eth_estimateGas` through `StateManager::call_with_gas` (explicit apply), so both cases are gated there behind a new `skip_sender_validation` flag. The strict public API is unchanged (thin wrappers), and `Filecoin.GasEstimateGasLimit` / the other Filecoin RPCs keep strict validation — the skip path is scoped to the two eth methods.
- `eth_call` tries the strict path first and retries on the skip path when the receipt is `SysErrSenderInvalid` (contract sender) or the call returns the new typed `Error::SenderValidationFailed` (missing sender).
- `eth_estimateGas` detects a contract or missing sender up front (via the sender actor's code) and estimates on the skip path: initial estimate, overestimation multiplier, then the usual gas search.

## Known deficiency (inherited from Lotus)

As documented in the upstream PR, estimates from *contract* senders miss the on-chain inclusion cost on the implicit path; the 1.25x overestimation multiplier covers it for realistic calls. The proper fix needs a new FVM `ApplyKind` and a ref-fvm/ffi release.

## Tests

Added RPC conformance cases (`eth_call` / `eth_estimateGas` from a non-existent sender, V1 + V2). Rejections are tolerated identically across nodes so the cases stay stable against a Lotus that predates the equivalent change.

## Validation status

- `cargo check` / `clippy --all-targets -D warnings` (modulo the pre-existing generated `_go_bindings.rs` cast lints) / `cargo fmt` all clean.
- The completion criteria call for a gas benchmark against Lotus. That needs the RPC conformance harness against a Lotus build carrying lotus#13724, which is why this is a **draft** — I would like the conformance CI to run before I call the parity guaranteed. Happy to add contract-sender fixtures or adjust the approach based on what you would prefer to see benchmarked.