### PR TITLE
fix(rpc): require non-empty tipset key in MinerGetBaseInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Breaking
 
+- [#7422](https://github.com/ChainSafe/forest/issues/7422): `Filecoin.MinerGetBaseInfo` now requires a non-empty tipset key and rejects a `null` or empty one, matching Lotus. Previously it silently fell back to the heaviest tipset.
+
 - [#7339](https://github.com/ChainSafe/forest/issues/7339): Forest-owned RPC methods now use `camelCase` field names consistently in requests and responses: `Forest.SyncStatus`, `Forest.NetInfo`, `Forest.ChainExport`, `Forest.ChainExportDiff`, `Forest.ChainExportStatus`, `Forest.StateActorInfo`, `Forest.StateCompute` and `Filecoin.ChainExport` (e.g. `num_peers` → `numPeers`, `start_epoch` → `startEpoch`, `StateRoot` → `stateRoot`). The named parameters of `Filecoin.StateMinerInitialPledgeForSector` are now `sectorDuration`, `sectorSize`, `verifiedSize` and `tipsetKey` (positional calls are unaffected). The generated OpenRPC document is now tested for casing regressions.
 
 ### Added

--- a/src/rpc/methods/miner.rs
+++ b/src/rpc/methods/miner.rs
@@ -311,6 +311,13 @@ impl RpcMethod<3> for MinerGetBaseInfo {
         (miner_address, epoch, ApiTipsetKey(tipset_key)): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
+        // Lotus requires an explicit tipset key for this method and rejects an
+        // empty one (`NewTipSet called with zero length array of blocks`), so we
+        // reject `null`/`[]` here instead of silently falling back to the
+        // heaviest tipset.
+        let tipset_key = tipset_key.ok_or_else(|| {
+            ServerError::invalid_params("MinerGetBaseInfo requires a non-empty tipset key", None)
+        })?;
         let tipset = ctx
             .chain_store()
             .load_required_tipset_or_heaviest(&tipset_key)?;

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -1131,6 +1131,14 @@ fn state_tests_with_tipset<DB: Blockstore + ShallowClone>(
                 block.epoch,
                 tipset.key().into(),
             ))?),
+            // An empty tipset key must be rejected by both nodes, matching Lotus
+            // which requires an explicit tipset key for this method.
+            RpcTest::identity(MinerGetBaseInfo::request((
+                block.miner_address,
+                block.epoch,
+                ApiTipsetKey(None),
+            ))?)
+            .policy_on_rejected(PolicyOnRejected::Pass),
             RpcTest::identity(StateMinerRecoveries::request((
                 block.miner_address,
                 tipset.key().into(),


### PR DESCRIPTION
## Summary of changes

`Filecoin.MinerGetBaseInfo` accepted a `null` or empty tipset key and silently fell back to the heaviest tipset. Lotus instead treats the tipset key as required and rejects an empty one with `failed to load tipset for mining base: NewTipSet called with zero length array of blocks`. This aligns Forest with Lotus.

Changes introduced in this pull request:

- `MinerGetBaseInfo` now returns an invalid params error when the tipset key is `null` or empty, instead of defaulting to the heaviest tipset.
- Added an RPC conformance test asserting both Forest and Lotus reject the empty tipset key case.
- Added a CHANGELOG entry under Breaking.

## Reference issue to close (if applicable)

Closes #7422

## Other information and links

Behaviour mapped against Lotus, where `MinerGetBaseInfo` takes a required `types.TipSetKey` and errors on an empty key rather than defaulting to the chain head.

## Change checklist

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [x] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [x] I have read and agree to the [CONTRIBUTING][2] document.
- [x] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `MinerGetBaseInfo` now rejects requests with missing or empty tipset keys instead of defaulting to the heaviest tipset.
  * Invalid requests consistently return an invalid-parameters error.

* **Documentation**
  * Added a changelog entry documenting this breaking behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->