### PR TITLE
fix: improve blocking task usage

### DIFF
--- a/src/chain_sync/network_context.rs
+++ b/src/chain_sync/network_context.rs
@@ -373,10 +373,12 @@ impl SyncNetworkContext {
 
         // Add timeout to receiving response from p2p service to avoid stalling.
         // There is also a timeout inside the request-response calls, but this ensures
-        // this.
-        let res = tokio::task::spawn_blocking(move || {
-            rx.recv_timeout(Duration::from_millis(CHAIN_EXCHANGE_TIMEOUT_MILLIS.get()))
-        })
+        // this. Awaited rather than `spawn_blocking`d so a slow peer doesn't pin a
+        // blocking-pool thread for the whole timeout.
+        let res = tokio::time::timeout(
+            Duration::from_millis(CHAIN_EXCHANGE_TIMEOUT_MILLIS.get()),
+            rx.recv_async(),
+        )
         .await;
         let res_duration = Instant::now().duration_since(req_pre_time);
         match res {
@@ -445,9 +447,10 @@ impl SyncNetworkContext {
 
         const HELLO_TIMEOUT: Duration = Duration::from_secs(30);
         let sent = Instant::now();
-        let res = tokio::task::spawn_blocking(move || rx.recv_timeout(HELLO_TIMEOUT))
-            .await?
-            .ok();
+        let res = tokio::time::timeout(HELLO_TIMEOUT, rx.recv_async())
+            .await
+            .ok()
+            .and_then(Result::ok);
         Ok((peer_id, sent, res))
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- blocking tasks is a limited resource so we should limit its usage if possible. One way is to have an async timeout instead of timeout in a blocking task.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness while waiting for chain synchronization messages.
  * Preserved existing timeout behavior and peer-failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->