### PR TITLE
chore: bitswap async block

### DIFF
--- a/src/libp2p_bitswap/request_manager.rs
+++ b/src/libp2p_bitswap/request_manager.rs
@@ -11,7 +11,6 @@ use crate::cid_collections::CidHashMap;
 use crate::prelude::*;
 use crate::utils::misc::env::env_or_default_logged;
 use ahash::HashSet;
-use flume::TryRecvError;
 use futures::StreamExt;
 use libp2p::PeerId;
 use nonzero_ext::nonzero;
@@ -226,13 +225,10 @@ impl BitswapRequestManager {
             let mut success = store.contains(&cid).unwrap_or_default();
             if !success {
                 let deadline = start.checked_add(timeout).expect("Infallible");
-                success = task::spawn_blocking({
-                    let store = store.shallow_clone();
-                    move || self.get_block_sync(&store, cid, deadline, validate_peer)
-                })
-                .await
-                .unwrap_or_default();
-                // Spin check db when `get_block_sync` fails fast,
+                success = self
+                    .get_block_inner(&store, cid, deadline, validate_peer)
+                    .await;
+                // Spin check db when `get_block_inner` fails fast,
                 // which means there is other task actually processing the same `cid`
                 while !success && Instant::now() < deadline {
                     task::sleep(BITSWAP_BLOCK_REQUEST_INTERVAL).await;
@@ -256,9 +252,9 @@ impl BitswapRequestManager {
         });
     }
 
-    fn get_block_sync(
+    async fn get_block_inner(
         &self,
-        store: &impl BitswapStoreReadWrite,
+        store: &(impl BitswapStoreReadWrite + ShallowClone),
         cid: Cid,
         deadline: Instant,
         validate_peer: Option<Arc<ValidatePeerCallback>>,
@@ -299,52 +295,62 @@ impl BitswapRequestManager {
             }
         }
 
-        let mut success = false;
-        let mut block_data = None;
-        while !success && Instant::now() < deadline {
-            match block_have_rx.try_recv() {
-                Ok(peer) => {
-                    _ = self.outbound_block_request_tx.send((peer, cid));
-                }
-                Err(TryRecvError::Empty) => {}
-                Err(TryRecvError::Disconnected) => {
-                    break;
-                }
-            }
-
-            if let Ok(data) = block_saved_rx.recv_timeout(BITSWAP_BLOCK_REQUEST_INTERVAL) {
-                success = true;
-                block_data = data;
-            }
-        }
-
-        if !success && let Ok(data) = block_saved_rx.recv_deadline(deadline) {
-            success = true;
-            block_data = data;
-        }
-
-        if let Some(data) = block_data {
-            success = match Block::new(cid, data) {
-                Ok(block) => match store.insert(&block) {
-                    Ok(()) => {
-                        metrics::message_counter_inbound_response_block_update_db().inc();
-                        true
+        // Wait for the block off the blocking pool: react to `have` offers by
+        // requesting the block, and take the first saved response, bounded by the
+        // deadline. `have_open` stops polling the `have` channel once it closes
+        // while still awaiting a saved response. `biased` keeps a saved response
+        // that arrives right at the deadline from being dropped by a tie.
+        let timeout = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline));
+        tokio::pin!(timeout);
+        let mut have_open = true;
+        let response = loop {
+            tokio::select! {
+                biased;
+                saved = block_saved_rx.recv_async() => break saved.ok(),
+                () = &mut timeout => break None,
+                have = block_have_rx.recv_async(), if have_open => match have {
+                    Ok(peer) => {
+                        _ = self.outbound_block_request_tx.send((peer, cid));
                     }
+                    Err(_) => have_open = false,
+                },
+            }
+        };
+
+        let success = match response {
+            // Block already in the db, nothing to insert.
+            Some(None) => true,
+            // Timed out or channel closed.
+            None => false,
+            // Inserting is blocking db IO with an unbounded tail (lock, commit,
+            // compaction), so it stays off the async runtime.
+            Some(Some(data)) => {
+                let store = store.shallow_clone();
+                task::spawn_blocking(move || match Block::new(cid, data) {
+                    Ok(block) => match store.insert(&block) {
+                        Ok(()) => {
+                            metrics::message_counter_inbound_response_block_update_db().inc();
+                            true
+                        }
+                        Err(e) => {
+                            metrics::message_counter_inbound_response_block_update_db_failure()
+                                .inc();
+                            warn!(
+                                "Failed to update db, cid: {cid}, data: {:?}, error: {e:#}",
+                                block.data()
+                            );
+                            false
+                        }
+                    },
                     Err(e) => {
-                        metrics::message_counter_inbound_response_block_update_db_failure().inc();
-                        warn!(
-                            "Failed to update db, cid: {cid}, data: {:?}, error: {e:#}",
-                            block.data()
-                        );
+                        warn!("Failed to construct block, cid: {cid}, error: {e:#}");
                         false
                     }
-                },
-                Err(e) => {
-                    warn!("Failed to construct block, cid: {cid}, error: {e:#}");
-                    false
-                }
-            };
-        }
+                })
+                .await
+                .unwrap_or(false)
+            }
+        };
 
         // Cleanup
         {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- asyncify getting blocks via bitswap to save up some blocking tasks
- this also fixes a couple of things, i.e., we should get a block faster (current main - we're waiting unnecessarily up to interval), more deterministic at exact time (biased).

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved block retrieval responsiveness by handling requests asynchronously.
  * Added concurrent handling for block responses, availability notifications, and request timeouts.
  * Preserved existing success, failure, cleanup, and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->