### PR TITLE
docs: fix incorrect CLI help and a garbled doc comment

### DIFF
--- a/src/cli/subcommands/healthcheck_cmd.rs
+++ b/src/cli/subcommands/healthcheck_cmd.rs
@@ -24,7 +24,7 @@ pub enum HealthcheckCommand {
     },
     /// Display liveness status
     Live {
-        /// Don't exit until node is ready
+        /// Don't exit until node is live
         #[arg(long)]
         wait: bool,
         /// Healthcheck port
@@ -33,7 +33,7 @@ pub enum HealthcheckCommand {
     },
     /// Display health status
     Healthy {
-        /// Don't exit until node is ready
+        /// Don't exit until node is healthy
         #[arg(long)]
         wait: bool,
         /// Healthcheck port

--- a/src/rpc/methods/eth/filter/mod.rs
+++ b/src/rpc/methods/eth/filter/mod.rs
@@ -414,7 +414,7 @@ impl EthEventHandler {
 
     /// Collects the tipset's events from already-loaded executed messages, keeping those that
     /// match `spec` and tagging each with `revert_status`. Use [`Self::collect_events`] instead
-    /// wages sthen the executed messill need to be loaded.
+    /// when the executed messages still need to be loaded.
     pub async fn collect_events_from_messages(
         state_manager: &StateManager,
         tipset: &Tipset,

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -306,7 +306,7 @@ pub enum WalletCommands {
         amount: TokenAmount,
         #[arg(long, value_parser = humantoken::parse, default_value_t = TokenAmount::zero())]
         gas_feecap: TokenAmount,
-        /// In milliGas
+        /// The gas limit in gas units. `0` lets the node estimate it.
         #[arg(long, default_value_t = 0)]
         gas_limit: i64,
         #[arg(long, value_parser = humantoken::parse, default_value_t = TokenAmount::zero())]


### PR DESCRIPTION
## Summary of changes

Three small, self-contained documentation fixes found while reading through the CLI and RPC code. No behaviour changes.

Changes introduced in this pull request:

- `wallet send --gas-limit` help said `In milliGas`, but the value is passed straight into `Message.gas_limit` (a count of gas units) with no milligas conversion anywhere on the path, so a user trusting the help would set a limit 1000x too small. Reworded to say gas units and note that `0` lets the node estimate it.
- `healthcheck live` and `healthcheck healthy` both described their `--wait` flag as `Don't exit until node is ready`, copied from the `ready` subcommand, even though they poll the `livez` and `healthz` endpoints. Each help string now points at the probe the command actually waits on.
- The doc comment on `EthEventHandler::collect_events_from_messages` had a garbled last line (`wages sthen the executed messill need to be loaded`). Restored the intended sentence.

## Reference issue to close (if applicable)

Closes

## Other information and links

Pure documentation and CLI help text. No functional change, so no CHANGELOG entry.

## Change checklist

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [x] I have read and agree to the [CONTRIBUTING][2] document.
- [x] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that health-check wait options wait for a node to become live or healthy.
  * Corrected event collection guidance for messages that still need loading.
  * Updated wallet send help text to explain gas units and automatic estimation when set to `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->