### PR TITLE
fix(build): rerun build on f3 sidecar opt out env change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() {
 
     // Do not build f3-sidecar on docs.rs publishing
     // No proper version of Go compiler is available.
+    println!("cargo:rerun-if-env-changed=FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT");
     if !is_docs_rs() && !is_env_truthy("FOREST_F3_SIDECAR_FFI_BUILD_OPT_OUT") {
         println!("cargo:rustc-cfg=f3sidecar");
         println!("cargo::rerun-if-changed=f3-sidecar");


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- the build script only tracks envs with `rerun-if-env` - so even though we check a variable, if it's not tracked, it won't trigger the build. which will end up with, e.g., `2026-08-07T15:21:33.806712Z  INFO forest::f3: Failed to enable F3 sidecar, the Forest binary is not compiled with f3-sidecar Go lib
`

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration handling so changes to the sidecar FFI build opt-out setting are detected automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->