### PR TITLE
fix(build): wasteful go ffi tests rebuild

### DIFF
--- a/interop-tests/build.rs
+++ b/interop-tests/build.rs
@@ -9,10 +9,12 @@ fn main() {
     }
     rust2go::Builder::default()
         .with_go_src("./src/tests/go_app")
-        .with_regen_arg(rust2go::RegenArgs {
-            src: "./src/tests/go_ffi.rs".into(),
-            dst: "./src/tests/go_app/ffi_gen.go".into(),
-            ..Default::default()
-        })
+        // the generated Go file has been committed to the git repository,
+        // uncomment to regenerate the code locally
+        // .with_regen_arg(rust2go::RegenArgs {
+        //     src: "./src/tests/go_ffi.rs".into(),
+        //     dst: "./src/tests/go_app/ffi_gen.go".into(),
+        //     ..Default::default()
+        // })
         .build();
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- don't regenerate some Go test files on every test build (effectively just bumping the mtime...)
- this reduces the test re-runs A LOT - right now each consecutive `cargo nextest...` takes around a minute to rebuild (most likely linking) even though NOTHING changed. With this change, consecutive `cargo nextest...` runs just run the tests without any hold-up.
- the fix is not super nice but the precedence is in the root already https://github.com/ChainSafe/forest/blob/9199a822c02c6ab993d8a80fecae740f7d7087c9/build.rs#L37-L44 and the files themselves don't change a lot (last change in 2025). I also don't expect them to change anytime soon.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration to prevent automatic regeneration of generated integration files.
  * Retained local regeneration instructions for developers when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->