### PR TITLE
chore: improve decode revert reason handling and logging

### DIFF
--- a/src/rpc/methods/eth/utils.rs
+++ b/src/rpc/methods/eth/utils.rs
@@ -588,7 +588,7 @@ mod test {
 
     // Undecodable input is the expected non-Ethereum case; Lotus returns empty data and reason.
     #[rstest]
-    #[case(RawBytes::default(), vec![], "")]
+    #[case(RawBytes::new(vec![0x18]), vec![], "")]
     #[case(cbor_bytes(vec![]), vec![], "none")]
     #[case(
         cbor_bytes(create_error_data("boom")),

--- a/src/rpc/methods/eth/utils.rs
+++ b/src/rpc/methods/eth/utils.rs
@@ -18,7 +18,6 @@ use cbor4ii::core::dec::Decode as _;
 use fvm_ipld_encoding::{CBOR, DAG_CBOR, IPLD_RAW, RawBytes};
 use serde::de;
 use std::sync::LazyLock;
-use tracing::log;
 
 pub fn lookup_eth_address<DB: Blockstore>(
     addr: &FilecoinAddress,
@@ -143,16 +142,14 @@ where
 
 /// Extract and decode Ethereum revert reason from receipt return data
 pub fn decode_revert_reason(return_data: RawBytes) -> (Vec<u8>, String) {
-    let (data, reason) = match decode_payload(&return_data, CBOR) {
-        Err(e) => {
-            log::warn!("failed to unmarshal cbor bytes from message receipt return error: {e}");
-            (EthBytes::default(), String::default())
+    match decode_payload(&return_data, CBOR) {
+        Err(_) => (Vec::new(), String::new()),
+        Ok(data) if !data.is_empty() => {
+            let reason = parse_eth_revert(data.as_slice());
+            (data.0, reason)
         }
-        Ok(data) if !data.is_empty() => (data.clone(), parse_eth_revert(data.as_slice())),
-        Ok(data) => (data.clone(), "none".to_string()),
-    };
-
-    (data.0, reason)
+        Ok(data) => (data.0, "none".to_string()),
+    }
 }
 
 const ERROR_FUNCTION_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0]; // keccak256("Error(string)") [first 4 bytes]
@@ -274,8 +271,7 @@ fn parse_panic_revert(data: &[u8]) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
-    use cbor4ii::core::{enc::Encode, utils::BufWriter};
-    use cbor4ii::serde::Serializer;
+    use rstest::rstest;
 
     fn create_error_data(msg: &str) -> Vec<u8> {
         let mut encoded = Vec::new();
@@ -550,16 +546,13 @@ mod test {
         assert!(result.is_err());
 
         // valid cbor bytes
-        let mut writer = BufWriter::new(Vec::new());
-        Value::Bytes(vec![1]).encode(&mut writer).unwrap();
-        let serializer = Serializer::new(writer);
-        let encoded = serializer.into_inner().into_inner();
+        let encoded = cbor_bytes(vec![1]);
 
-        let result = decode_payload(&RawBytes::new(encoded.clone()), DAG_CBOR);
+        let result = decode_payload(&encoded, DAG_CBOR);
         assert_eq!(result.unwrap(), EthBytes(vec![1]));
 
         // regular cbor also works
-        let result = decode_payload(&RawBytes::new(encoded), CBOR);
+        let result = decode_payload(&encoded, CBOR);
         assert_eq!(result.unwrap(), EthBytes(vec![1]));
 
         // random codec should fail
@@ -587,5 +580,35 @@ mod test {
         // identity
         let result = decode_payload(&RawBytes::new(vec![1]), IDENTITY_HASH);
         assert!(result.unwrap().0.is_empty());
+    }
+
+    fn cbor_bytes(inner: Vec<u8>) -> RawBytes {
+        RawBytes::new(cbor4ii::serde::to_vec(Vec::new(), &Value::Bytes(inner)).unwrap())
+    }
+
+    // Undecodable input is the expected non-Ethereum case; Lotus returns empty data and reason.
+    #[rstest]
+    #[case(RawBytes::default(), vec![], "")]
+    #[case(cbor_bytes(vec![]), vec![], "none")]
+    #[case(
+        cbor_bytes(create_error_data("boom")),
+        create_error_data("boom"),
+        "Error(boom)"
+    )]
+    #[case(
+        cbor_bytes(create_panic_data(0x01)),
+        create_panic_data(0x01),
+        "Assert()"
+    )]
+    // Too short for a selector+word, so the reason is the raw hex passthrough.
+    #[case(cbor_bytes(vec![0xde, 0xad, 0xbe, 0xef]), vec![0xde, 0xad, 0xbe, 0xef], "0xdeadbeef")]
+    fn test_decode_revert_reason(
+        #[case] input: RawBytes,
+        #[case] expected_data: Vec<u8>,
+        #[case] expected_reason: &str,
+    ) {
+        let (data, reason) = decode_revert_reason(input);
+        assert_eq!(data, expected_data);
+        assert_eq!(reason, expected_reason);
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- removed annoying `failed to unmarshal cbor bytes from message receipt return error` log line; it's not a genuine warning, it's expected and node operators shouldn't get warned about it. Lotus also doesn't log it.
- rm needless `data` clone
- 0% -> 100% coverage for this method for good measure

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of undecodable and malformed revert payloads.
  * Preserved returned data and reason behavior across supported revert formats.

* **Tests**
  * Added coverage for empty, short, undecodable, `Error`, and `Panic` revert payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->