### PR TITLE
feat: improve `eth_getBlockReceipts` perf

### DIFF
--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1608,10 +1608,13 @@ async fn get_block_receipts(
     let mut eth_receipts = Vec::with_capacity(executed_messages.len());
     for (
         i,
-        ExecutedMessage {
-            message, receipt, ..
-        },
-    ) in executed_messages.iter().enumerate()
+        (
+            ExecutedMessage {
+                message, receipt, ..
+            },
+            logs,
+        ),
+    ) in executed_messages.iter().zip(logs_by_msg).enumerate()
     {
         let tx = new_eth_tx(
             ctx,
@@ -1622,10 +1625,6 @@ async fn get_block_receipts(
             i as u64,
         )?;
 
-        let logs = logs_by_msg
-            .get_mut(i)
-            .map(std::mem::take)
-            .unwrap_or_default();
         let receipt = new_eth_tx_receipt(&ts_ref, &tx, receipt, logs)?;
         eth_receipts.push(receipt);
     }

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1606,16 +1606,10 @@ async fn get_block_receipts(
 
     let block_cid = ts_key.cid()?;
     let mut eth_receipts = Vec::with_capacity(executed_messages.len());
-    for (
-        i,
-        (
-            ExecutedMessage {
-                message, receipt, ..
-            },
-            logs,
-        ),
-    ) in executed_messages.iter().zip(logs_by_msg).enumerate()
-    {
+    for (i, (executed, logs)) in executed_messages.iter().zip(logs_by_msg).enumerate() {
+        let ExecutedMessage {
+            message, receipt, ..
+        } = executed;
         let tx = new_eth_tx(
             ctx,
             &state_tree,

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1353,12 +1353,11 @@ fn new_eth_tx(
     })
 }
 
-async fn new_eth_tx_receipt(
-    ctx: &Ctx,
+fn new_eth_tx_receipt(
     tipset: &Tipset,
     tx: &ApiEthTx,
-    msg_cid: Cid,
     msg_receipt: &Receipt,
+    logs: Vec<EthLog>,
 ) -> anyhow::Result<EthTxReceipt> {
     let mut tx_receipt = EthTxReceipt {
         transaction_hash: tx.hash,
@@ -1401,13 +1400,7 @@ async fn new_eth_tx_receipt(
         tx_receipt.contract_address = Some(ret.eth_address.0.into());
     }
 
-    if msg_receipt.events_root().is_some() {
-        let logs =
-            eth_logs_for_block_and_transaction(ctx, tipset, &tx.block_hash, &msg_cid).await?;
-        if !logs.is_empty() {
-            tx_receipt.logs = logs;
-        }
-    }
+    tx_receipt.logs = logs;
 
     let mut bloom = Bloom::default();
     for log in tx_receipt.logs.iter() {
@@ -1446,6 +1439,27 @@ pub async fn eth_logs_for_block_and_transaction(
     eth_filter_logs_from_events(ctx, &events)
 }
 
+/// Collects all Ethereum logs produced by a tipset's already-executed messages, in tipset order.
+async fn collect_block_logs(
+    ctx: &Ctx,
+    tipset: &Tipset,
+    executed_messages: &[ExecutedMessage],
+    revert_status: EventRevertStatus,
+) -> anyhow::Result<Vec<EthLog>> {
+    let mut events = vec![];
+    EthEventHandler::collect_events_from_messages(
+        &ctx.state_manager,
+        tipset,
+        executed_messages,
+        None::<&ParsedFilter>,
+        SkipEvent::OnUnresolvedAddress,
+        revert_status,
+        &mut events,
+    )
+    .await?;
+    eth_filter_logs_from_events(ctx, &events)
+}
+
 /// Collects the logs produced by a single chain head change, for the logs
 /// subscription.
 pub(in crate::rpc) async fn eth_logs_for_head_change(
@@ -1467,18 +1481,7 @@ pub(in crate::rpc) async fn eth_logs_for_head_change(
         .state_manager
         .load_executed_tipset_with_receipt(&msg_ts, receipt_ts)
         .await?;
-    let mut events = vec![];
-    EthEventHandler::collect_events_from_messages(
-        &ctx.state_manager,
-        &msg_ts,
-        &executed_ts.executed_messages,
-        None::<&ParsedFilter>,
-        SkipEvent::OnUnresolvedAddress,
-        revert_status,
-        &mut events,
-    )
-    .await?;
-    eth_filter_logs_from_events(ctx, &events)
+    collect_block_logs(ctx, &msg_ts, &executed_ts.executed_messages, revert_status).await
 }
 
 fn get_signed_message(ctx: &Ctx, message_cid: Cid) -> Result<SignedMessage> {
@@ -1581,6 +1584,27 @@ async fn get_block_receipts(
     // Load the state tree
     let state_tree = ctx.state_manager.get_state_tree(&state_root)?;
 
+    // Collect the whole tipset's logs in a single pass and scatter them back to their messages.
+    let heaviest_epoch = ctx.chain_store().heaviest_tipset().epoch();
+    if ts_ref.epoch() >= heaviest_epoch
+        && executed_messages
+            .iter()
+            .any(|em| em.receipt.events_root().is_some())
+    {
+        return Err(EthErrors::EventsNotYetAvailable.into());
+    }
+
+    let mut logs_by_msg: Vec<Vec<EthLog>> = vec![Vec::new(); executed_messages.len()];
+    for log in
+        collect_block_logs(ctx, &ts_ref, &executed_messages, EventRevertStatus::Applied).await?
+    {
+        // `transaction_index` is the message's index in `executed_messages` (this loop's slice), always a valid bucket.
+        if let Some(bucket) = logs_by_msg.get_mut(log.transaction_index.0 as usize) {
+            bucket.push(log);
+        }
+    }
+
+    let block_cid = ts_key.cid()?;
     let mut eth_receipts = Vec::with_capacity(executed_messages.len());
     for (
         i,
@@ -1593,12 +1617,16 @@ async fn get_block_receipts(
             ctx,
             &state_tree,
             ts_ref.epoch(),
-            &ts_key.cid()?,
+            &block_cid,
             &message.cid(),
             i as u64,
         )?;
 
-        let receipt = new_eth_tx_receipt(ctx, &ts_ref, &tx, message.cid(), receipt).await?;
+        let logs = logs_by_msg
+            .get_mut(i)
+            .map(std::mem::take)
+            .unwrap_or_default();
+        let receipt = new_eth_tx_receipt(&ts_ref, &tx, receipt, logs)?;
         eth_receipts.push(receipt);
     }
     Ok(eth_receipts)
@@ -3108,8 +3136,12 @@ async fn get_eth_transaction_receipt(
             )
         })?;
 
-    let tx_receipt =
-        new_eth_tx_receipt(&ctx, &parent_ts, &tx, msg_cid, &message_lookup.receipt).await?;
+    let logs = if message_lookup.receipt.events_root().is_some() {
+        eth_logs_for_block_and_transaction(&ctx, &parent_ts, &tx.block_hash, &msg_cid).await?
+    } else {
+        vec![]
+    };
+    let tx_receipt = new_eth_tx_receipt(&parent_ts, &tx, &message_lookup.receipt, logs)?;
 
     Ok(Some(tx_receipt))
 }

--- a/src/rpc/methods/eth/filter/mod.rs
+++ b/src/rpc/methods/eth/filter/mod.rs
@@ -1711,15 +1711,13 @@ mod tests {
         assert!(ensure_filter_cap(100, 3, 101).is_err());
     }
 
-    #[tokio::test]
-    async fn test_collect_events_from_messages_sets_revert_status() {
+    /// Minimal `StateManager` over an in-memory store plus its (genesis) heaviest tipset, for
+    /// event-collection tests.
+    fn test_state_manager() -> (StateManager, Tipset) {
         use crate::blocks::{CachingBlockHeader, RawBlockHeader};
         use crate::chain::ChainStore;
         use crate::db::MemoryDB;
-        use crate::message::ChainMessage;
         use crate::networks::ChainConfig;
-        use crate::shim::executor::Receipt;
-        use crate::shim::message::Message;
 
         let db = Arc::new(MemoryDB::default());
         let genesis_header = CachingBlockHeader::new(RawBlockHeader {
@@ -1732,26 +1730,21 @@ mod tests {
             ChainStore::new(db, Arc::new(ChainConfig::default()), genesis_header).unwrap();
         let tipset = chain_store.heaviest_tipset();
         let state_manager = StateManager::new(chain_store).unwrap();
+        (state_manager, tipset)
+    }
 
-        let event = StampedEvent::V4(fvm_shared4::event::StampedEvent::new(
-            1234,
-            fvm_shared4::event::ActorEvent {
-                entries: vec![fvm_shared4::event::Entry {
-                    flags: Flags::FLAG_INDEXED_ALL,
-                    key: "t1".into(),
-                    codec: IPLD_RAW,
-                    value: vec![0xab; 32],
-                }],
-            },
-        ));
+    #[tokio::test]
+    async fn test_collect_events_from_messages_sets_revert_status() {
+        use crate::message::ChainMessage;
+        use crate::shim::executor::Receipt;
+        use crate::shim::message::Message;
+
+        let (state_manager, tipset) = test_state_manager();
+
+        let event = StampedEvent::new_indexed(1234, "t1");
         let executed_messages = vec![ExecutedMessage {
             message: ChainMessage::Unsigned(Message::default().into()),
-            receipt: Receipt::V4(fvm_shared4::receipt::Receipt {
-                exit_code: fvm_shared4::error::ExitCode::OK,
-                return_data: Default::default(),
-                gas_used: 0,
-                events_root: None,
-            }),
+            receipt: Receipt::empty_success(),
             events: Some(vec![event]),
         }];
 
@@ -1778,5 +1771,71 @@ mod tests {
             assert_eq!(event.reverted, expected_reverted);
             assert_eq!(event.emitter_addr, Address::new_id(1234));
         }
+    }
+
+    /// `eth_getBlockReceipts` relies on `CollectedEvent::msg_idx` (and hence the derived
+    /// `EthLog::transaction_index`) being the event's message index within `executed_messages`.
+    /// This locks that invariant, plus the globally-monotonic `event_idx` across the tipset.
+    #[tokio::test]
+    async fn test_collect_events_from_messages_indexing() {
+        use crate::message::ChainMessage;
+        use crate::shim::executor::Receipt;
+        use crate::shim::message::Message;
+
+        let (state_manager, tipset) = test_state_manager();
+
+        // Emitter id encodes the message index (1000 + idx) so a collected event can be traced
+        // back to the message it came from.
+        let exec_msg = |idx: u64, n_events: usize| ExecutedMessage {
+            message: ChainMessage::Unsigned(Message::default().into()),
+            receipt: Receipt::empty_success(),
+            events: (n_events > 0).then(|| {
+                (0..n_events)
+                    .map(|_| StampedEvent::new_indexed(1000 + idx, "t1"))
+                    .collect()
+            }),
+        };
+
+        // Message 1 emits nothing (and, having no events, must not perturb the indices of later
+        // messages' events).
+        let events_per_msg = [2usize, 0, 3, 1];
+        let executed_messages: Vec<_> = events_per_msg
+            .iter()
+            .enumerate()
+            .map(|(idx, &n)| exec_msg(idx as u64, n))
+            .collect();
+
+        let mut events = vec![];
+        EthEventHandler::collect_events_from_messages(
+            &state_manager,
+            &tipset,
+            &executed_messages,
+            None::<&ParsedFilter>,
+            SkipEvent::Never,
+            EventRevertStatus::Applied,
+            &mut events,
+        )
+        .await
+        .unwrap();
+
+        // The collected events must be exactly this sequence: each message contributes `n` events
+        // tagged with its own index, `event_idx` runs gap-free across the whole tipset (so the
+        // zero-event message must not shift later indices), and `emitter_addr` traces back to the
+        // source message via the `1000 + idx` encoding.
+        let expected = events_per_msg
+            .iter()
+            .enumerate()
+            .flat_map(|(msg_idx, &n)| std::iter::repeat_n(msg_idx as u64, n))
+            .enumerate()
+            .map(|(event_idx, msg_idx)| {
+                (msg_idx, event_idx as u64, Address::new_id(1000 + msg_idx))
+            });
+
+        itertools::assert_equal(
+            events
+                .iter()
+                .map(|e| (e.msg_idx, e.event_idx, e.emitter_addr)),
+            expected,
+        );
     }
 }

--- a/src/shim/executor.rs
+++ b/src/shim/executor.rs
@@ -157,6 +157,18 @@ impl PartialEq for Receipt {
 }
 
 impl Receipt {
+    /// Test-only constructor: a successful, empty receipt at the latest supported FVM version.
+    /// Lets tests build receipts without naming a concrete FVM version.
+    #[cfg(test)]
+    pub fn empty_success() -> Self {
+        Receipt::V4(Receipt_v4 {
+            exit_code: fvm_shared4::error::ExitCode::OK,
+            return_data: Default::default(),
+            gas_used: 0,
+            events_root: None,
+        })
+    }
+
     pub fn exit_code(&self) -> ExitCode {
         match self {
             Receipt::V2(v2) => ExitCode::new(v2.exit_code.value()),
@@ -289,6 +301,14 @@ impl GetSize for StampedEvent {
 }
 
 impl StampedEvent {
+    /// Test-only constructor: a stamped event at the latest supported FVM version with a single
+    /// `FLAG_INDEXED_ALL` entry whose key and value are `key`. Lets tests build events without
+    /// naming a concrete FVM version.
+    #[cfg(test)]
+    pub fn new_indexed(emitter: ActorID, key: &str) -> Self {
+        Self::V4(create_raw_event_v4(emitter, key))
+    }
+
     /// Returns the ID of the actor that emitted this event.
     pub fn emitter(&self) -> ActorID {
         delegate_stamped_event!(self.emitter)
@@ -329,6 +349,40 @@ impl StampedEvent {
         }
 
         Ok(events)
+    }
+}
+
+/// Builds a raw FVM4 stamped event with a single indexed entry whose key and value are `key`.
+/// Wrap in [`StampedEvent::V4`] for the shim-level type.
+#[cfg(test)]
+pub(crate) fn create_raw_event_v4(emitter: u64, key: &str) -> fvm_shared4::event::StampedEvent {
+    fvm_shared4::event::StampedEvent {
+        emitter,
+        event: fvm_shared4::event::ActorEvent {
+            entries: vec![fvm_shared4::event::Entry {
+                flags: fvm_shared4::event::Flags::FLAG_INDEXED_ALL,
+                key: key.to_string(),
+                codec: fvm_ipld_encoding::IPLD_RAW,
+                value: key.as_bytes().to_vec(),
+            }],
+        },
+    }
+}
+
+/// Builds a raw FVM3 stamped event with a single indexed entry whose key and value are `key`.
+/// Wrap in [`StampedEvent::V3`] for the shim-level type.
+#[cfg(test)]
+pub(crate) fn create_raw_event_v3(emitter: u64, key: &str) -> fvm_shared3::event::StampedEvent {
+    fvm_shared3::event::StampedEvent {
+        emitter,
+        event: fvm_shared3::event::ActorEvent {
+            entries: vec![fvm_shared3::event::Entry {
+                flags: fvm_shared3::event::Flags::FLAG_INDEXED_ALL,
+                key: key.to_string(),
+                codec: fvm_ipld_encoding::IPLD_RAW,
+                value: key.as_bytes().to_vec(),
+            }],
+        },
     }
 }
 

--- a/src/state_manager/tests.rs
+++ b/src/state_manager/tests.rs
@@ -4,37 +4,9 @@
 use super::*;
 use crate::db::MemoryDB;
 use crate::rpc::eth::types::CallSource;
-use crate::shim::executor::StampedEvent;
+use crate::shim::executor::{StampedEvent, create_raw_event_v3, create_raw_event_v4};
 use fil_actors_shared::fvm_ipld_amt::Amt;
 use rstest::rstest;
-
-fn create_raw_event_v4(emitter: u64, key: &str) -> fvm_shared4::event::StampedEvent {
-    fvm_shared4::event::StampedEvent {
-        emitter,
-        event: fvm_shared4::event::ActorEvent {
-            entries: vec![fvm_shared4::event::Entry {
-                flags: fvm_shared4::event::Flags::FLAG_INDEXED_ALL,
-                key: key.to_string(),
-                codec: fvm_ipld_encoding::IPLD_RAW,
-                value: key.as_bytes().to_vec(),
-            }],
-        },
-    }
-}
-
-fn create_raw_event_v3(emitter: u64, key: &str) -> fvm_shared3::event::StampedEvent {
-    fvm_shared3::event::StampedEvent {
-        emitter,
-        event: fvm_shared3::event::ActorEvent {
-            entries: vec![fvm_shared3::event::Entry {
-                flags: fvm_shared3::event::Flags::FLAG_INDEXED_ALL,
-                key: key.to_string(),
-                codec: fvm_ipld_encoding::IPLD_RAW,
-                value: key.as_bytes().to_vec(),
-            }],
-        },
-    }
-}
 
 #[test]
 fn test_events_store_and_retrieve_basic() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- improves event collection from quadratic to linear
- less message re-hashing
- checked correctness against riba dataset manually (mainnet 6277900–6279799 (~1900 epochs, 2026-08-14))

```
┌──────────┬─────────────────┬────────┬────────┬───────────┬────────────────┬─────────┬─────────┬──────────┐
│   net    │      range      │ blocks │ max rx │ NEW total │ BASELINE total │ speedup │ new/blk │ base/blk │
├──────────┼─────────────────┼────────┼────────┼───────────┼────────────────┼─────────┼─────────┼──────────┤
│ calibnet │ 3986400–3986637 │ 235    │ 73     │ 773 ms    │ 1303 ms        │ 1.69×   │ 3.29 ms │ 5.54 ms  │
├──────────┼─────────────────┼────────┼────────┼───────────┼────────────────┼─────────┼─────────┼──────────┤
│ mainnet  │ 6279600–6279838 │ 237    │ 27     │ 15 898 ms │ 30 611 ms      │ 1.93×   │ 67.1 ms │ 129.2 ms │
└──────────┴─────────────────┴────────┴────────┴───────────┴────────────────┴─────────┴─────────┴──────────┘

Per-large-block hot path (calibnet, 65–73 rx, warm 50 iters): new 2.7 ms vs baseline ~11 ms ≈ 4×.
```
so on average almost 2x improvement, bad case 4x (and in case of bigger blocks it only gets better).

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Ethereum transaction receipts to include event logs more reliably.
  - Corrected event-log handling for reverted transactions.
  - Improved consistency of logs across block receipts and individual transaction lookups.
  - Improved receipt accuracy when multiple transactions emit logs within the same block.
  - Added clearer handling when event data is unavailable for the current chain head.
  - Improved event ordering and transaction association across messages, including messages without events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->