### PR TITLE
feat: `Filecoin.NetBandwidthStats` stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 - [#7494](https://github.com/ChainSafe/forest/issues/7494): Implemented the `Filecoin.StateMinerCreationDeposit` RPC method, matching Lotus. It returns the deposit required to create a new miner actor.
 
+- [#7505](https://github.com/ChainSafe/forest/pull/7505): Implemented the `Filecoin.NetBandwidthStats` RPC method for Lotus API compatibility. It is currently a stub that returns zeros, which is enough to unblock Curio's dashboard when pointed at a Forest node.
+
 ### Changed
 
 ### Removed

--- a/scripts/tests/api_compare/filter-list-gateway
+++ b/scripts/tests/api_compare/filter-list-gateway
@@ -19,6 +19,7 @@
 !Filecoin.NetAddrsListen
 !Filecoin.NetAgentVersion
 !Filecoin.NetAutoNatStatus
+!Filecoin.NetBandwidthStats
 !Filecoin.NetPeers
 !Filecoin.NetProtectAdd
 !Filecoin.NetProtectList

--- a/scripts/tests/api_compare/filter-list-offline
+++ b/scripts/tests/api_compare/filter-list-offline
@@ -5,6 +5,7 @@
 !Filecoin.NetAddrsListen
 !Filecoin.NetAgentVersion
 !Filecoin.NetAutoNatStatus
+!Filecoin.NetBandwidthStats
 !Filecoin.NetPeers
 !Filecoin.NetFindPeer
 !Filecoin.NetProtectAdd

--- a/src/rpc/methods/net.rs
+++ b/src/rpc/methods/net.rs
@@ -160,6 +160,28 @@ impl RpcMethod<0> for NetInfo {
     }
 }
 
+pub enum NetBandwidthStats {}
+impl RpcMethod<0> for NetBandwidthStats {
+    const NAME: &'static str = "Filecoin.NetBandwidthStats";
+    const PARAM_NAMES: [&'static str; 0] = [];
+    const API_PATHS: BitFlags<ApiPaths> = ApiPaths::all();
+    const PERMISSION: Permission = Permission::Read;
+    const DESCRIPTION: &'static str = "Returns statistics about the node's total bandwidth. Currently a stub that always returns zeros.";
+
+    type Params = ();
+    type Ok = BandwidthStats;
+
+    // Forest feeds libp2p bandwidth into a Prometheus registry that exposes no
+    // queryable totals, so report zeros. See <https://github.com/ChainSafe/forest/issues/7370>.
+    async fn handle(
+        _: Ctx,
+        (): Self::Params,
+        _: &http::Extensions,
+    ) -> Result<Self::Ok, ServerError> {
+        Ok(BandwidthStats::default())
+    }
+}
+
 pub enum NetConnect {}
 impl RpcMethod<1> for NetConnect {
     const NAME: &'static str = "Filecoin.NetConnect";

--- a/src/rpc/methods/net/types.rs
+++ b/src/rpc/methods/net/types.rs
@@ -90,3 +90,14 @@ impl From<libp2p::autonat::NatStatus> for NatStatusResult {
         }
     }
 }
+
+/// Mirrors go-libp2p's `metrics.Stats`, the return type of Lotus `NetBandwidthStats`.
+#[derive(Debug, Default, Serialize, Deserialize, Clone, JsonSchema, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub struct BandwidthStats {
+    pub total_in: i64,
+    pub total_out: i64,
+    pub rate_in: f64,
+    pub rate_out: f64,
+}
+lotus_json_with_self!(BandwidthStats);

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -195,6 +195,7 @@ macro_rules! for_each_rpc_method {
         $callback!($crate::rpc::net::NetAddrsListen);
         $callback!($crate::rpc::net::NetAgentVersion);
         $callback!($crate::rpc::net::NetAutoNatStatus);
+        $callback!($crate::rpc::net::NetBandwidthStats);
         $callback!($crate::rpc::net::NetConnect);
         $callback!($crate::rpc::net::NetDisconnect);
         $callback!($crate::rpc::net::NetFindPeer);

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v0.snap
@@ -2307,6 +2307,15 @@ methods:
       schema:
         $ref: "#/components/schemas/NatStatusResult"
     paramStructure: by-position
+  - name: Filecoin.NetBandwidthStats
+    description: "Returns statistics about the node's total bandwidth. Currently a stub that always returns zeros."
+    params: []
+    result:
+      name: Filecoin.NetBandwidthStats.Result
+      required: true
+      schema:
+        $ref: "#/components/schemas/BandwidthStats"
+    paramStructure: by-position
   - name: Filecoin.NetConnect
     description: Connects to a specified peer.
     params:
@@ -5080,6 +5089,27 @@ components:
         - Return
         - GasUsed
         - EventsRoot
+    BandwidthStats:
+      description: "Mirrors go-libp2p's `metrics.Stats`, the return type of Lotus `NetBandwidthStats`."
+      type: object
+      properties:
+        RateIn:
+          type: number
+          format: double
+        RateOut:
+          type: number
+          format: double
+        TotalIn:
+          type: integer
+          format: int64
+        TotalOut:
+          type: integer
+          format: int64
+      required:
+        - TotalIn
+        - TotalOut
+        - RateIn
+        - RateOut
     Base64String:
       type:
         - string

--- a/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
+++ b/src/rpc/snapshots/forest__rpc__tests__rpc__v1.snap
@@ -2386,6 +2386,15 @@ methods:
       schema:
         $ref: "#/components/schemas/NatStatusResult"
     paramStructure: by-position
+  - name: Filecoin.NetBandwidthStats
+    description: "Returns statistics about the node's total bandwidth. Currently a stub that always returns zeros."
+    params: []
+    result:
+      name: Filecoin.NetBandwidthStats.Result
+      required: true
+      schema:
+        $ref: "#/components/schemas/BandwidthStats"
+    paramStructure: by-position
   - name: Filecoin.NetConnect
     description: Connects to a specified peer.
     params:
@@ -5166,6 +5175,27 @@ components:
         - Return
         - GasUsed
         - EventsRoot
+    BandwidthStats:
+      description: "Mirrors go-libp2p's `metrics.Stats`, the return type of Lotus `NetBandwidthStats`."
+      type: object
+      properties:
+        RateIn:
+          type: number
+          format: double
+        RateOut:
+          type: number
+          format: double
+        TotalIn:
+          type: integer
+          format: int64
+        TotalOut:
+          type: integer
+          format: int64
+      required:
+        - TotalIn
+        - TotalOut
+        - RateIn
+        - RateOut
     Base64String:
       type:
         - string

--- a/src/tool/subcommands/api_cmd/api_compare_tests.rs
+++ b/src/tool/subcommands/api_cmd/api_compare_tests.rs
@@ -731,6 +731,7 @@ fn net_tests() -> Vec<RpcTest> {
         RpcTest::basic(NetInfo::request(()).unwrap())
             .ignore("Not implemented in Lotus. Why do we even have this method?"),
         RpcTest::basic(NetAutoNatStatus::request(()).unwrap()),
+        RpcTest::basic(NetBandwidthStats::request(()).unwrap()),
         RpcTest::identity(NetVersion::request(()).unwrap()),
         RpcTest::identity(NetProtectAdd::request((vec![PeerId::random().to_string()],)).unwrap()),
         RpcTest::identity(

--- a/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
+++ b/src/tool/subcommands/api_cmd/test_snapshots_ignored.txt
@@ -49,6 +49,7 @@ Filecoin.MpoolSelect
 Filecoin.NetAddrsListen
 Filecoin.NetAgentVersion
 Filecoin.NetAutoNatStatus
+Filecoin.NetBandwidthStats
 Filecoin.NetConnect
 Filecoin.NetDisconnect
 Filecoin.NetFindPeer


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- implemented `Filecoin.NetBandwidthStats` stub to unblock some Curio dashboard widget integration.
- follow-up in https://github.com/ChainSafe/forest/issues/7504

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `Filecoin.NetBandwidthStats` RPC method.
  - Added bandwidth statistics output for inbound and outbound traffic, including totals and rates. The current implementation returns zeroed statistics.

- **Tests**
  - Added API schema comparison coverage for the new method.

- **Documentation**
  - Documented the new method in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->