### PR TITLE
fix: forward fetch drand rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 
 ### Fixed
 
+- [#7508](https://github.com/ChainSafe/forest/pull/7508): `Filecoin.StateGetBeaconEntry` and `Filecoin.BeaconGetEntry` no longer over-wait for a beacon entry: past and current epochs are read from on-chain block headers (no drand round-trip, matching Lotus) and future epochs wait only until the drand round itself is produced rather than until the later Filecoin epoch. This lets a storage provider (e.g. Curio) using Forest as its node fetch the beacon in time to produce blocks that get included.
+
 - [#7473](https://github.com/ChainSafe/forest/pull/7473): Fixed `eth_estimateGas` under-estimating gas for nested contract calls (EIP-150's 63/64 rule), which could make transactions fail on chain with `SYS_OUT_OF_GAS`; the estimate is now raised until the message succeeds. Genuine reverts return an `execution reverted` error (JSON-RPC code `3`) with the decoded reason and data, matching Lotus.
 
 - [#7412](https://github.com/ChainSafe/forest/issues/7412): Fixes quicknet "unchained" logic to fetch the `max_beacon_round` for all covered epochs

--- a/src/beacon/drand.rs
+++ b/src/beacon/drand.rs
@@ -188,6 +188,31 @@ pub trait Beacon {
         network_version: NetworkVersion,
         fil_epoch: ChainEpoch,
     ) -> anyhow::Result<u64>;
+
+    /// Unix timestamp (seconds) at which the given `drand` round is produced, or `None`
+    /// (the default) if not derivable - meaning callers should not wait.
+    fn beacon_round_timestamp(&self, _round: u64) -> Option<u64> {
+        None
+    }
+
+    /// Fetches `round`, waiting only until that `drand` round is produced (per
+    /// [`Self::beacon_round_timestamp`]) rather than until the later Filecoin epoch.
+    async fn entry_when_available(&self, round: u64) -> anyhow::Result<BeaconEntry> {
+        if let Some(round_ts) = self.beacon_round_timestamp(round) {
+            let wait = beacon_round_wait(round_ts, chrono::Utc::now().timestamp());
+            if !wait.is_zero() {
+                tokio::time::sleep(wait).await;
+            }
+        }
+        self.entry(round).await
+    }
+}
+
+/// How long to wait until the `drand` round produced at `round_ts` (Unix seconds) is
+/// available, given the current time `now`. Includes a 1s publish-latency buffer.
+pub(crate) fn beacon_round_wait(round_ts: u64, now: i64) -> Duration {
+    let now = now.max(0) as u64;
+    Duration::from_secs(round_ts.saturating_add(1).saturating_sub(now))
 }
 
 #[derive(SerdeDeserialize, SerdeSerialize, Debug, Clone, PartialEq, Eq, Default)]
@@ -252,6 +277,23 @@ impl DrandBeacon {
 
     fn is_verified(&self, entry: &BeaconEntry) -> bool {
         self.verified_beacons.get(&entry.round()).as_deref() == Some(entry)
+    }
+
+    /// Verify-and-cache a freshly fetched entry: `verify_entries` inserts verified rounds
+    /// into `verified_beacons`. Only unchained rounds verify standalone, so chained ones are skipped.
+    fn cache_fetched_entry(&self, entry: &BeaconEntry) {
+        if !self.network.is_unchained() {
+            return;
+        }
+        if !matches!(
+            self.verify_entries(std::slice::from_ref(entry), entry),
+            Ok(true)
+        ) {
+            debug!(
+                round = entry.round(),
+                "fetched drand entry failed verification"
+            );
+        }
     }
 }
 
@@ -328,68 +370,63 @@ impl Beacon for DrandBeacon {
     }
 
     async fn entry(&self, round: u64) -> anyhow::Result<BeaconEntry> {
-        let cached = self.verified_beacons.get(&round);
-        match cached {
-            Some(cached_entry) => Ok(Arc::unwrap_or_clone(cached_entry)),
-            None => {
-                async fn fetch_entry_from_url(
-                    url: impl reqwest::IntoUrl,
-                ) -> anyhow::Result<BeaconEntry> {
-                    let resp: BeaconEntryJson = global_http_client()
-                        .get(url)
-                        // More tolerance on slow networks
-                        .timeout(Duration::from_secs(15))
-                        .send()
-                        .await?
-                        .error_for_status()?
-                        .json()
-                        .await?;
-                    anyhow::Ok(BeaconEntry::new(resp.round, hex::decode(resp.signature)?))
-                }
-
-                async fn fetch_entry(
-                    urls: impl Iterator<Item = impl reqwest::IntoUrl>,
-                ) -> anyhow::Result<BeaconEntry> {
-                    let mut errors = vec![];
-                    for url in urls {
-                        match fetch_entry_from_url(url).await {
-                            Ok(e) => return Ok(e),
-                            Err(e) => errors.push(e),
-                        }
-                    }
-                    anyhow::bail!(
-                        "Aggregated errors:\n{}",
-                        errors.into_iter().map(|e| e.to_string()).join("\n\n")
-                    );
-                }
-
-                let urls: Vec<_> = self
-                    .servers
-                    .iter()
-                    .map(|server| {
-                        anyhow::Ok(server.join(&format!("{}/public/{round}", self.hash))?)
-                    })
-                    .try_collect()?;
-                let entry = (|| fetch_entry(urls.iter().cloned()))
-                    .retry(ExponentialBuilder::default())
-                    .notify(|err, dur| {
-                        debug!(
-                            "retrying fetch_entry after {}: {err:#}",
-                            humantime::format_duration(dur)
-                        );
-                    })
-                    .await?;
-                // Callers assume the entry is for the round they asked for. Round 0 is served
-                // as "latest", so it answers with a different round by design:
-                // <https://github.com/drand/drand/blob/v2.1.6/handler/http/server.go#L367>
-                anyhow::ensure!(
-                    round == 0 || entry.round() == round,
-                    "drand returned round {} for round {round}",
-                    entry.round()
-                );
-                Ok(entry)
-            }
+        if let Some(cached_entry) = self.verified_beacons.get(&round) {
+            return Ok(Arc::unwrap_or_clone(cached_entry));
         }
+
+        async fn fetch_entry_from_url(url: impl reqwest::IntoUrl) -> anyhow::Result<BeaconEntry> {
+            let resp: BeaconEntryJson = global_http_client()
+                .get(url)
+                // More tolerance on slow networks
+                .timeout(Duration::from_secs(15))
+                .send()
+                .await?
+                .error_for_status()?
+                .json()
+                .await?;
+            anyhow::Ok(BeaconEntry::new(resp.round, hex::decode(resp.signature)?))
+        }
+
+        async fn fetch_entry(
+            urls: impl Iterator<Item = impl reqwest::IntoUrl>,
+        ) -> anyhow::Result<BeaconEntry> {
+            let mut errors = vec![];
+            for url in urls {
+                match fetch_entry_from_url(url).await {
+                    Ok(e) => return Ok(e),
+                    Err(e) => errors.push(e),
+                }
+            }
+            anyhow::bail!(
+                "Aggregated errors:\n{}",
+                errors.into_iter().map(|e| e.to_string()).join("\n\n")
+            );
+        }
+
+        let urls: Vec<_> = self
+            .servers
+            .iter()
+            .map(|server| anyhow::Ok(server.join(&format!("{}/public/{round}", self.hash))?))
+            .try_collect()?;
+        let entry = (|| fetch_entry(urls.iter().cloned()))
+            .retry(ExponentialBuilder::default())
+            .notify(|err, dur| {
+                debug!(
+                    "retrying fetch_entry after {}: {err:#}",
+                    humantime::format_duration(dur)
+                );
+            })
+            .await?;
+        // Callers assume the entry is for the round they asked for. Round 0 is served
+        // as "latest", so it answers with a different round by design:
+        // <https://github.com/drand/drand/blob/v2.1.6/handler/http/server.go#L367>
+        anyhow::ensure!(
+            round == 0 || entry.round() == round,
+            "drand returned round {} for round {round}",
+            entry.round()
+        );
+        self.cache_fetched_entry(&entry);
+        Ok(entry)
     }
 
     fn max_beacon_round_for_epoch(
@@ -424,5 +461,13 @@ impl Beacon for DrandBeacon {
             // round 1 starts at genesis time.
             Ok(from_genesis / self.interval + 1)
         }
+    }
+
+    fn beacon_round_timestamp(&self, round: u64) -> Option<u64> {
+        // Round 1 is produced at drand genesis; round n at genesis + (n-1)*period.
+        Some(
+            self.drand_gen_time
+                .saturating_add(round.saturating_sub(1).saturating_mul(self.interval)),
+        )
     }
 }

--- a/src/beacon/tests/drand.rs
+++ b/src/beacon/tests/drand.rs
@@ -3,6 +3,7 @@
 
 use itertools::Itertools;
 
+use crate::beacon::drand::beacon_round_wait;
 use crate::{
     beacon::mock_beacon::MockBeacon,
     beacon::{
@@ -15,6 +16,7 @@ use quickcheck_macros::quickcheck;
 use rstest::rstest;
 use std::borrow::Cow;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 fn new_beacon_mainnet() -> DrandBeacon {
     DrandBeacon::new(
@@ -91,6 +93,53 @@ fn construct_drand_beacon_mainnet() {
 #[test]
 fn construct_drand_beacon_quicknet() {
     new_beacon_quicknet();
+}
+
+#[test]
+fn beacon_round_timestamp_quicknet() {
+    // quicknet: genesis 1692803367, period 3s; round 1 is produced at genesis.
+    let beacon = &*QUICKNET;
+    assert_eq!(beacon.beacon_round_timestamp(1), Some(1_692_803_367));
+    assert_eq!(beacon.beacon_round_timestamp(2), Some(1_692_803_370));
+    assert_eq!(
+        beacon.beacon_round_timestamp(100),
+        Some(1_692_803_367 + 99 * 3)
+    );
+    // Round 0 saturates instead of underflowing.
+    assert_eq!(beacon.beacon_round_timestamp(0), Some(1_692_803_367));
+}
+
+#[test]
+fn beacon_round_timestamp_default_is_none() {
+    // Non-drand beacons (e.g. the mock) fall back to the trait default, which signals
+    // "no wait derivable" to callers.
+    assert_eq!(MockBeacon::default().beacon_round_timestamp(42), None);
+}
+
+#[quickcheck]
+fn beacon_round_timestamp_no_panic(round: u64) {
+    // Must not overflow-panic for any round, including u64::MAX.
+    let _ = QUICKNET.beacon_round_timestamp(round);
+}
+
+#[rstest]
+// Round produced in the future: wait until then, plus the 1s publish buffer.
+#[case(1_000, 900, Duration::from_secs(101))]
+// `now` exactly at the round's production time: only the 1s buffer remains.
+#[case(1_000, 1_000, Duration::from_secs(1))]
+// Buffer already elapsed: no wait.
+#[case(1_000, 1_001, Duration::ZERO)]
+// Round long past: no wait.
+#[case(1_000, 5_000, Duration::ZERO)]
+// Negative clock is clamped to 0, never panics or under-waits.
+#[case(1_000, -5, Duration::from_secs(1_001))]
+fn beacon_round_wait_cases(#[case] round_ts: u64, #[case] now: i64, #[case] expected: Duration) {
+    assert_eq!(beacon_round_wait(round_ts, now), expected);
+}
+
+#[quickcheck]
+fn beacon_round_wait_no_panic(round_ts: u64, now: i64) {
+    let _ = beacon_round_wait(round_ts, now);
 }
 
 #[tokio::test]

--- a/src/rpc/methods/beacon.rs
+++ b/src/rpc/methods/beacon.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2026 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::beacon::Beacon as _;
 use crate::rpc::{ApiPaths, Ctx, Permission, RpcMethod, ServerError};
 use crate::{beacon::BeaconEntry, shim::clock::ChainEpoch};
 use anyhow::Result;
@@ -25,12 +24,8 @@ impl RpcMethod<1> for BeaconGetEntry {
     async fn handle(
         ctx: Ctx,
         (first,): Self::Params,
-        _: &http::Extensions,
+        ext: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        let (_, beacon) = ctx.beacon().beacon_for_epoch(first)?;
-        let rr = beacon
-            .max_beacon_round_for_epoch(ctx.state_manager.get_network_version(first), first)?;
-        let e = beacon.entry(rr).await?;
-        Ok(e)
+        crate::rpc::state::StateGetBeaconEntry::handle(ctx, (first,), ext).await
     }
 }

--- a/src/rpc/methods/state.rs
+++ b/src/rpc/methods/state.rs
@@ -2205,22 +2205,6 @@ impl RpcMethod<3> for StateDealProviderCollateralBounds {
     }
 }
 
-/// How long to wait for `epoch`'s beacon entry, with a 1s clock drift buffer.
-fn beacon_entry_wait(
-    genesis_timestamp: i64,
-    block_delay: i64,
-    epoch: ChainEpoch,
-    now_timestamp: i64,
-) -> anyhow::Result<Duration> {
-    let epoch_timestamp = epoch
-        .checked_mul(block_delay)
-        .and_then(|ts| ts.checked_add(genesis_timestamp))
-        .and_then(|ts| ts.checked_add(1))
-        .with_context(|| format!("epoch {epoch} has no representable timestamp"))?;
-    let seconds = epoch_timestamp.saturating_sub(now_timestamp).max(0);
-    Ok(Duration::from_secs(seconds as u64))
-}
-
 pub enum StateGetBeaconEntry {}
 
 impl RpcMethod<1> for StateGetBeaconEntry {
@@ -2238,20 +2222,26 @@ impl RpcMethod<1> for StateGetBeaconEntry {
         (epoch,): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        let genesis_timestamp = i64::try_from(ctx.chain_store().genesis_block_header().timestamp)
-            .context("genesis timestamp is out of range")?;
-        tokio::time::sleep(beacon_entry_wait(
-            genesis_timestamp,
-            i64::from(ctx.chain_config().block_delay_secs),
-            epoch,
-            chrono::Utc::now().timestamp(),
-        )?)
-        .await;
+        let epoch = epoch.max(0); // negative epochs read genesis (Lotus parity)
+        // Read the entry from on-chain headers (no drand round-trip, like Lotus). Falls
+        // through to the beacon path when the tipset isn't stored locally (partial snapshot).
+        let heaviest = ctx.chain_store().heaviest_tipset();
+        if epoch <= heaviest.epoch() {
+            let chain_rand = ctx.state_manager.chain_rand(heaviest);
+            if let Ok(entry) = tokio::task::spawn_blocking(move || {
+                chain_rand.extract_beacon_entry_for_epoch(epoch)
+            })
+            .await?
+            {
+                return Ok(entry);
+            }
+        }
 
+        // Future epoch (or missing locally): wait only until the drand round is produced.
         let (_, beacon) = ctx.beacon().beacon_for_epoch(epoch)?;
         let network_version = ctx.state_manager.get_network_version(epoch);
         let round = beacon.max_beacon_round_for_epoch(network_version, epoch)?;
-        let entry = beacon.entry(round).await?;
+        let entry = beacon.entry_when_available(round).await?;
         Ok(entry)
     }
 }
@@ -3553,35 +3543,6 @@ mod tests {
     use super::*;
     use quickcheck_macros::quickcheck;
     use rstest::rstest;
-
-    const GENESIS: i64 = 1598306400;
-    const BLOCK_DELAY: i64 = crate::shim::clock::EPOCH_DURATION_SECONDS;
-    /// Wall clock at epoch 100.
-    const NOW: i64 = GENESIS + 100 * BLOCK_DELAY;
-
-    #[rstest]
-    #[case(99, Duration::ZERO)]
-    // The 1s clock drift buffer puts the current epoch 1s in the future.
-    #[case(100, Duration::from_secs(1))]
-    #[case(102, Duration::from_secs(61))]
-    fn beacon_entry_wait_until_epoch(#[case] epoch: ChainEpoch, #[case] expected: Duration) {
-        assert_eq!(
-            beacon_entry_wait(GENESIS, BLOCK_DELAY, epoch, NOW).unwrap(),
-            expected
-        );
-    }
-
-    #[rstest]
-    #[case(i64::MIN)]
-    #[case(i64::MAX)]
-    fn beacon_entry_wait_rejects_unrepresentable_epochs(#[case] epoch: ChainEpoch) {
-        assert!(beacon_entry_wait(GENESIS, BLOCK_DELAY, epoch, NOW).is_err());
-    }
-
-    #[quickcheck]
-    fn beacon_entry_wait_no_panic(epoch: ChainEpoch, now_timestamp: i64) {
-        let _ = beacon_entry_wait(GENESIS, BLOCK_DELAY, epoch, now_timestamp);
-    }
 
     #[rstest]
     #[case(1_000, Some(600))]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- the current logic for drand works well when just validating the chain, when working with Curio the beacon round needs to be fetched well in advance (especially on a devnet) - this adds necessary logic for this + caching to limit relay calls
- made legacy v0 `Filecoin.BeaconGetEntry` an alias of v1 `Filecoin.StateBeaconGetEntry`, same as in Lotus https://github.com/filecoin-project/lotus/blob/27abf0f16a7f2a83305910f3c2a1844764d20b75/api/v0api/v1_wrapper.go#L212-L214

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `StateMinerCreationDeposit` RPC, with network-version-aware deposit calculations.
  - Improved beacon entry retrieval for current, past, and future epochs.
  - Historical requests can resolve entries from on-chain randomness data.

- **Bug Fixes**
  - Future requests now wait efficiently until beacon rounds are available.
  - Reuses verified beacon entries to reduce unnecessary network requests.
  - Improved endpoint fallback, retries, response validation, and error reporting.
  - Added safeguards for extreme round and timestamp values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->