### PR TITLE
coreos-k3s: pin hostname so k3s node name survives reboots

### DIFF
--- a/deployment/coreos-k3s/config.bu.in
+++ b/deployment/coreos-k3s/config.bu.in
@@ -76,6 +76,10 @@ storage:
         inline: |
           #!/bin/bash
           set -euo pipefail
+          # pin the hostname so k3s's node name is stable across reboots -- a transient
+          # DHCP/rDNS hostname can revert to localhost.localdomain on a later boot, k3s
+          # then registers a new node and the node-affine local-path PVCs strand the data
+          hostnamectl set-hostname "$(hostname)"
           curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable traefik" sh -
           # on ostree the installer only *enables* k3s: it queues k3s-selinux via
           # rpm-ostree and skips the start, so start it ourselves and wait for the API


### PR DESCRIPTION
follow-up to #7363.

found this upgrading the box this deploy came from (FCOS 43 -> 44): on a major-version reboot the transient DHCP/rDNS hostname reverted to `localhost.localdomain`, so k3s registered a brand-new node. the local-path PVCs are node-affine to the old node name, so every pod got stuck with `didn't match PersistentVolume's node affinity` and the data was stranded. an unattended auto-update reboot would strand a node the same way.

fix: persist the hostname at first-boot k3s install (`hostnamectl set-hostname "$(hostname)"`) before installing k3s, so the node name stays stable across reboots. one line in `install-k3s.sh`.

validated: the mechanism (persisting the hostname -> stable k3s node name) fixed a live production box's reboot -- once persisted, subsequent reboots came up on the same node with pods scheduling cleanly. render still builds. happy to run a full VM boot+reboot cycle on the package itself if you'd like the first-boot path confirmed too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unexpected hostname changes during k3s installation.
  * Improved node registration stability and reduced the risk of stranded local storage data after reboots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->