### PR TITLE
chore: improve `StateAccountKey` perf for bad queries

### DIFF
--- a/src/state_manager/address_resolution.rs
+++ b/src/state_manager/address_resolution.rs
@@ -103,15 +103,38 @@ impl StateManager {
         ts: &Tipset,
     ) -> anyhow::Result<Address> {
         // First try to resolve the actor in the parent state, so we don't have to compute anything.
-        if let Ok(state) = self.get_state_tree(ts.parent_state())
-            && let Ok(address) = state.resolve_to_deterministic_address(self.db(), address)
-        {
-            return Ok(address);
+        if let Ok(state) = self.get_state_tree(ts.parent_state()) {
+            match state.resolve_to_deterministic_address(self.db(), address) {
+                Ok(resolved) => return Ok(resolved),
+                // Re-executing the tipset can only change this for an actor absent
+                // from the parent state, or one a migration rewrites
+                // while `ts` is computed (e.g. FIP-0085). No point in doing it for
+                // keyless actors.
+                Err(e)
+                    if matches!(state.get_actor(&address), Ok(Some(_)))
+                        && !self.computes_across_migration(ts) =>
+                {
+                    return Err(e);
+                }
+                Err(_) => {}
+            }
         }
         // If that fails, compute the tip-set and try again.
         let TipsetState { state_root, .. } = self.load_tipset_state(ts).await?;
         let state = self.get_state_tree(&state_root)?;
         state.resolve_to_deterministic_address(self.db(), address)
+    }
+
+    /// Whether computing `ts`'s state runs a network-upgrade migration. Such a
+    /// migration can rewrite an actor's code, so the pre-migration parent state
+    /// is not authoritative for a present actor across that boundary. Errs on
+    /// the side of `true` when the parent tipset cannot be loaded.
+    fn computes_across_migration(&self, ts: &Tipset) -> bool {
+        let Ok(parent) = self.chain_index().load_required_tipset(ts.parents()) else {
+            return true;
+        };
+        self.chain_config()
+            .has_expensive_fork_between(parent.epoch(), ts.epoch())
     }
 }
 
@@ -131,6 +154,10 @@ mod tests {
     const OLD_ACTOR: u64 = 300;
     /// Present only in the head's parent state — younger than finality.
     const YOUNG_ACTOR: u64 = 400;
+    /// Present from genesis but with a non-account code and no delegated
+    /// address, so it exists yet has no resolvable key address (a miner, a
+    /// singleton, ...).
+    const NON_ACCOUNT_ACTOR: u64 = 500;
 
     /// Builds a 3-tipset chain (genesis, ts1, head at epoch 2). Genesis and
     /// ts1 carry `root_a` (contains f0300 -> bls_a); head carries `root_b`,
@@ -150,6 +177,11 @@ mod tests {
         st_a.set_actor(
             &Address::new_id(OLD_ACTOR),
             ActorState::new_empty(Cid::default(), Some(bls_a)),
+        )
+        .unwrap();
+        st_a.set_actor(
+            &Address::new_id(NON_ACCOUNT_ACTOR),
+            ActorState::new_empty(Cid::default(), None),
         )
         .unwrap();
         let root_a = st_a.flush().unwrap();
@@ -270,6 +302,23 @@ mod tests {
             sm.id_to_deterministic_address_cache().unwrap().len(),
             0,
             "epoch == chain_finality is not finality-deep and must not be cached"
+        );
+    }
+
+    #[tokio::test]
+    async fn present_non_account_actor_errors_without_caching() {
+        let (sm, head, _bls_a, _bls_b) = setup_with_finality(1);
+        let resolved = sm
+            .resolve_to_deterministic_address(Address::new_id(NON_ACCOUNT_ACTOR), &head)
+            .await;
+        assert!(
+            resolved.is_err(),
+            "an actor that is present but is not an account has no key address"
+        );
+        assert_eq!(
+            sm.id_to_deterministic_address_cache().unwrap().len(),
+            0,
+            "an unresolvable actor must not be cached"
         );
     }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- we do some wasteful computations for `StateAccountKey` which is mostly called... with kind of bad params (that'd return `unknown actor`). A keyless actor won't suddenly get a key address (unless through some network migration which we guard).

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

```
┌───────────────┬──────────────────────┬──────┐
│               │ cold (head uncached) │ warm │
├───────────────┼──────────────────────┼──────┤
│ OLD (pre-fix) │ 4.056s               │ 28ms │
├───────────────┼──────────────────────┼──────┤
│ NEW (fix)     │ 0.024s               │ 24ms │
└───────────────┴──────────────────────┴──────┘
```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved state resolution across actor migrations by retrying tipset computation when parent actors are temporarily unavailable.
  - Preserved immediate errors for existing actors outside migration boundaries.
  - Prevented failed resolutions for present non-account actors from being cached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->