### PR TITLE
chore: fast-track `eth_getCode`

### DIFF
--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -66,7 +66,6 @@ use crate::shim::message::Message;
 use crate::shim::{clock::ChainEpoch, state_tree::StateTree};
 use crate::state_manager::{ExecutedMessage, ExecutedTipset, StateManager, TipsetState, VMFlush};
 use crate::utils::cache::SizeTrackingCache;
-use crate::utils::db::BlockstoreExt as _;
 use crate::utils::encoding::from_slice_with_fallback;
 use crate::utils::misc::env::env_or_default;
 use crate::utils::multihash::prelude::*;
@@ -86,7 +85,7 @@ use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 use std::sync::{LazyLock, OnceLock};
-use utils::{decode_payload, lookup_eth_address};
+use utils::{ActorStateEthExt as _, decode_payload, lookup_eth_address};
 
 static FOREST_TRACE_FILTER_MAX_RESULT: LazyLock<u64> =
     LazyLock::new(|| env_or_default("FOREST_TRACE_FILTER_MAX_RESULT", 500));
@@ -2258,71 +2257,15 @@ async fn eth_get_code(
 ) -> Result<EthBytes, ServerError> {
     let to_address = FilecoinAddress::try_from(eth_address)?;
     let TipsetState { state_root, .. } = ctx.state_manager.load_tipset_state(ts).await?;
-    let state_tree = ctx.state_manager.get_state_tree(&state_root)?;
-    let Some(actor) = state_tree
-        .get_actor(&to_address)
+    let Some(actor) = ctx
+        .state_manager
+        .get_actor(&to_address, state_root)
         .with_context(|| format!("failed to lookup contract {}", eth_address.0))?
     else {
         return Ok(Default::default());
     };
 
-    // Not a contract. We could try to distinguish between accounts and "native" contracts here,
-    // but it's not worth it.
-    if !is_evm_actor(&actor.code) {
-        return Ok(Default::default());
-    }
-
-    let message = Arc::new(Message {
-        from: FilecoinAddress::SYSTEM_ACTOR,
-        to: to_address,
-        method_num: METHOD_GET_BYTE_CODE,
-        gas_limit: BLOCK_GAS_LIMIT,
-        ..Default::default()
-    });
-
-    // Rewind ts to escape the fork guard, but keep state_root fixed to the requested epoch: the
-    // result comes from state_root (ts only supplies execution context), so recomputing it for the
-    // parent would read an earlier epoch's bytecode.
-    let mut ts = ts.shallow_clone();
-    let api_invoc_result = loop {
-        match ctx
-            .state_manager
-            .call_on_state(
-                state_root,
-                message.shallow_clone(),
-                Some(ts.shallow_clone()),
-            )
-            .await
-        {
-            Ok(res) => break res,
-            Err(crate::state_manager::Error::ExpensiveFork { .. }) => {
-                ts = ctx
-                    .chain_index()
-                    .load_required_tipset(ts.parents())
-                    .map_err(|e| anyhow::anyhow!("getting parent tipset: {e}"))?;
-            }
-            Err(e) => return Err(e.into()),
-        }
-    };
-    let Some(msg_rct) = api_invoc_result.msg_rct else {
-        return Err(anyhow::anyhow!("no message receipt").into());
-    };
-    if !msg_rct.exit_code().is_success() || !api_invoc_result.error.is_empty() {
-        return Err(anyhow::anyhow!(
-            "GetBytecode failed: exit={} error={}",
-            msg_rct.exit_code(),
-            api_invoc_result.error
-        )
-        .into());
-    }
-
-    let get_bytecode_return: GetBytecodeReturn =
-        fvm_ipld_encoding::from_slice(msg_rct.return_data().as_slice())?;
-    if let Some(cid) = get_bytecode_return.0 {
-        Ok(EthBytes(ctx.db().get_required(&cid)?))
-    } else {
-        Ok(Default::default())
-    }
+    Ok(actor.eth_bytecode(ctx.db())?.unwrap_or_default())
 }
 
 pub enum EthGetStorageAt {}

--- a/src/rpc/methods/eth/trace/state_diff.rs
+++ b/src/rpc/methods/eth/trace/state_diff.rs
@@ -738,6 +738,16 @@ mod tests {
     }
 
     #[test]
+    fn test_actor_bytecode_evm_tombstoned() {
+        let store = Arc::new(MemoryDB::default());
+        let actor = create_tombstoned_evm_actor(&store, &[0x60, 0x80, 0x60, 0x40, 0x52])
+            .expect("failed to create tombstoned EVM actor fixture");
+        // A self-destructed contract reports no code even though its bytecode is present,
+        // matching the EVM actor's GetBytecode.
+        assert!(actor.eth_bytecode(store.as_ref()).unwrap().is_none());
+    }
+
+    #[test]
     fn test_diff_entry_keys_both_empty() {
         let pre = HashMap::default();
         let post = HashMap::default();

--- a/src/rpc/methods/eth/trace/test_helpers.rs
+++ b/src/rpc/methods/eth/trace/test_helpers.rs
@@ -88,6 +88,40 @@ pub fn create_evm_actor_with_bytecode(
     ))
 }
 
+/// Like [`create_evm_actor_with_bytecode`] but marks the actor self-destructed via a
+/// tombstone, so it must report no bytecode even though the code block is present.
+pub fn create_tombstoned_evm_actor(store: &MemoryDB, bytecode: &[u8]) -> Option<ActorState> {
+    use fvm_ipld_blockstore::Blockstore as _;
+    use multihash_codetable::MultihashDigest as _;
+
+    let evm_code_cid = get_evm_actor_code_cid()?;
+    let mh = multihash_codetable::Code::Blake2b256.digest(bytecode);
+    let bytecode_cid = Cid::new_v1(fvm_ipld_encoding::IPLD_RAW, mh);
+    store.put_keyed(&bytecode_cid, bytecode).ok()?;
+
+    let evm_state = fil_actor_evm_state::v17::State {
+        bytecode: bytecode_cid,
+        bytecode_hash: fil_actor_evm_state::v17::BytecodeHash::from(
+            keccak_hash::keccak(bytecode).0,
+        ),
+        contract_state: Cid::default(),
+        transient_data: None,
+        nonce: 0,
+        tombstone: Some(fil_actor_evm_state::v17::Tombstone {
+            origin: 0,
+            nonce: 0,
+        }),
+    };
+    let state_cid = store.put_cbor_default(&evm_state).ok()?;
+    Some(ActorState::new(
+        evm_code_cid,
+        state_cid,
+        TokenAmount::from_atto(0),
+        0,
+        None,
+    ))
+}
+
 pub fn create_masked_id_eth_address(actor_id: u64) -> EthAddress {
     EthAddress::from_actor_id(actor_id)
 }

--- a/src/rpc/methods/eth/types.rs
+++ b/src/rpc/methods/eth/types.rs
@@ -12,7 +12,6 @@ use rand::Rng;
 use serde::de::{IntoDeserializer, value::StringDeserializer};
 use std::{hash::Hash, ops::Deref};
 
-pub const METHOD_GET_BYTE_CODE: u64 = 3;
 pub const METHOD_GET_STORAGE_AT: u64 = 5;
 
 const UNCOMPRESSED_PUBLIC_KEY_SIZE: usize = 65;
@@ -67,9 +66,6 @@ impl FromStr for EthBytes {
         Ok(Self(bytes))
     }
 }
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct GetBytecodeReturn(pub Option<Cid>);
 
 const GET_STORAGE_AT_PARAMS_ARRAY_LENGTH: usize = 32;
 const LENGTH_BUF_GET_STORAGE_AT_PARAMS: u8 = 129;
@@ -627,18 +623,6 @@ mod tests {
     #[quickcheck_macros::quickcheck]
     fn get_storage_at_deserialize_params_no_panic(bz: Vec<u8>) {
         let _ = GetStorageAtParams::deserialize_params(&bz);
-    }
-
-    #[test]
-    fn get_bytecode_return_roundtrip() {
-        let bytes = hex::decode("d82a5827000155a0e40220fa0b7a54007ba2e76d5818b6e60793fb0b8bdbe177995e1b20dcfb6873d69779").unwrap();
-        let des: GetBytecodeReturn = fvm_ipld_encoding::from_slice(&bytes).unwrap();
-        assert_eq!(
-            des.0.unwrap().to_string(),
-            "bafk2bzaced5aw6suab52fz3nlamlnzqhsp5qxc634f3zsxq3edopw2dt22lxs"
-        );
-        let ser = fvm_ipld_encoding::to_vec(&des).unwrap();
-        assert_eq!(ser, bytes);
     }
 
     #[test]

--- a/src/rpc/methods/eth/utils.rs
+++ b/src/rpc/methods/eth/utils.rs
@@ -64,7 +64,7 @@ pub fn lookup_eth_address<DB: Blockstore>(
 pub(crate) trait ActorStateEthExt {
     /// Returns the effective nonce: EVM nonce for EVM actors, sequence otherwise.
     fn eth_nonce<DB: Blockstore>(&self, store: &DB) -> anyhow::Result<EthUint64>;
-    /// Returns the deployed bytecode of an EVM actor, or `None` for non-EVM actors.
+    /// Returns the deployed bytecode of an EVM actor, or `None` for non-EVM or self-destructed actors.
     fn eth_bytecode<DB: Blockstore>(&self, store: &DB) -> anyhow::Result<Option<EthBytes>>;
 }
 
@@ -85,6 +85,10 @@ impl ActorStateEthExt for ActorState {
         }
         let evm_state = evm::State::load(store, self.code, self.state)
             .context("failed to load EVM state for bytecode")?;
+        // A self-destructed contract reports no code, matching the actor's GetBytecode.
+        if !evm_state.is_alive() {
+            return Ok(None);
+        }
         let bytecode = store
             .get(&evm_state.bytecode())
             .context("failed to read EVM bytecode")?;

--- a/src/utils/db/mod.rs
+++ b/src/utils/db/mod.rs
@@ -43,12 +43,6 @@ pub trait BlockstoreExt: Blockstore {
 
         Ok(cids)
     }
-
-    /// Gets the block from the blockstore. Return an error when not found.
-    fn get_required(&self, cid: &Cid) -> anyhow::Result<Vec<u8>> {
-        self.get(cid)?
-            .with_context(|| format!("Entry not found in block store: cid={cid}"))
-    }
 }
 
 impl<T: fvm_ipld_blockstore::Blockstore> BlockstoreExt for T {}


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- right now, to get the bytecode, we invoke all the FVM machinery to extract it - a lot of effort for mostly just reading the field in state. Lotus does the same and I assume the code was just translated from it but this can be done cheaper - same as done in the actors code https://github.com/filecoin-project/builtin-actors/blob/47e5b87a76b9e2e4f3d1c5ee695f126ffcbcb38e/actors/evm/src/lib.rs#L288-L298
- the caveat is that if the code there changes, we would need to port the logic across different versions or re-introduce the current behavior. That said, I think it's safe and gives a big win in terms of performance. Since its conception in builtin-actors, this was never changed.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

```
┌────────────┬────────┬────────┬─────────────┐
│            │  p50   │  p99   │ throughput  │
├────────────┼────────┼────────┼─────────────┤
│ OLD (VM)   │ 1.22ms │ 12.6ms │ 13.9k req/s │
├────────────┼────────┼────────┼─────────────┤
│ NEW (read) │ 0.20ms │ 0.97ms │ 47.9k req/s │
└────────────┴────────┴────────┴─────────────┘
```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `eth_getCode` to retrieve contract bytecode directly and consistently.
  * Self-destructed EVM actors now correctly report no bytecode, even if old bytecode data remains stored.
* **Tests**
  * Added regression coverage for bytecode lookup on tombstoned actors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->