### PR TITLE
chore: fast-path mpool pending

### DIFF
--- a/src/lotus_json/vec.rs
+++ b/src/lotus_json/vec.rs
@@ -38,7 +38,7 @@ where
 // while an empty `NotNullVec<T>` serializes into `[]`
 // this is a temporary workaround and will likely be deprecated once
 // other issues on serde of `Vec<T>` are resolved.
-#[derive(Debug, Clone, Default, PartialEq, JsonSchema, GetSize)]
+#[derive(Debug, Clone, Default, PartialEq, JsonSchema, GetSize, derive_more::From)]
 pub struct NotNullVec<T>(pub Vec<T>);
 
 impl<T> HasLotusJson for NotNullVec<T>

--- a/src/rpc/methods/mpool.rs
+++ b/src/rpc/methods/mpool.rs
@@ -111,13 +111,14 @@ impl RpcMethod<1> for MpoolPending {
 
         let (mut pending, mpts) = ctx.mpool.pending();
 
+        // The mpool is already at or past `ts`, so its pending set needs no on-chain merge.
+        if mpts.epoch() > ts.epoch() || mpts == ts {
+            return Ok(NotNullVec(pending.into_iter().collect()));
+        }
+
         let mut have_cids = HashSet::new();
         for item in pending.iter() {
             have_cids.insert(item.cid());
-        }
-
-        if mpts.epoch() > ts.epoch() {
-            return Ok(NotNullVec(pending.into_iter().collect()));
         }
 
         loop {

--- a/src/rpc/methods/mpool.rs
+++ b/src/rpc/methods/mpool.rs
@@ -113,7 +113,7 @@ impl RpcMethod<1> for MpoolPending {
 
         // The mpool is already at or past `ts`, so its pending set needs no on-chain merge.
         if mpts.epoch() > ts.epoch() || mpts == ts {
-            return Ok(NotNullVec(pending.into_iter().collect()));
+            return Ok(pending.into());
         }
 
         let mut have_cids = HashSet::new();
@@ -152,7 +152,7 @@ impl RpcMethod<1> for MpoolPending {
 
             ts = ctx.chain_index().load_required_tipset(ts.parents())?;
         }
-        Ok(NotNullVec(pending.into_iter().collect()))
+        Ok(pending.into())
     }
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- there's no need to build that hashset since it won't be used under these conditions; I'm kind of surprised the compiler didn't mark it as unused. In any case, saves some allocations and computation on the hot path (not that much to be very visible in benchmarks, though, likely in microseconds maaybe millisecond land in typical mainnet tipset).
- avoid some redundant hand-crafted clone on a vec :monocle_face: 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending message retrieval by promptly returning current results when the requested tipset is up to date.
  * Preserved historical message merging for requests targeting older tipsets.
  * Improved consistency when converting pending messages into response results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->