### PR TITLE
chore(perf): optimize `eth_feeHistory`

### DIFF
--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -2127,26 +2127,27 @@ async fn eth_fee_history(
     )];
     let mut rewards_array = vec![];
     let mut gas_used_ratio_array = vec![];
+    // The walk goes newest -> oldest, so each tipset is the child of the next. Carry the current
+    // tipset's `parent_message_receipts` forward: it is exactly the next (older) tipset's receipt
+    // root, so only the newest tipset needs a `load_child_tipset` lookup (`None` on the first pass).
+    let mut receipt_root = None;
     for ts in tipset
         .chain(ctx.db())
         .filter(|i| i.epoch() > 0)
         .take(block_count as _)
     {
         let base_fee = &ts.block_headers().first().parent_base_fee;
-        let ExecutedTipset {
-            executed_messages, ..
-        } = ctx.state_manager.load_executed_tipset_for_rpc(&ts).await?;
-        let mut tx_gas_rewards = Vec::with_capacity(executed_messages.len());
-        for ExecutedMessage {
-            message, receipt, ..
-        } in executed_messages.iter()
-        {
-            let premium = message.effective_gas_premium(base_fee);
-            tx_gas_rewards.push(GasReward {
+        let message_receipts = ctx
+            .state_manager
+            .tipset_message_receipts(&ts, receipt_root)
+            .await?;
+        let tx_gas_rewards = message_receipts
+            .iter()
+            .map(|(message, receipt)| GasReward {
                 gas_used: receipt.gas_used(),
-                premium,
-            });
-        }
+                premium: message.effective_gas_premium(base_fee),
+            })
+            .collect_vec();
         let (rewards, total_gas_used) =
             calculate_rewards_and_gas_used(&reward_percentiles, tx_gas_rewards);
         let max_gas = BLOCK_GAS_LIMIT * (ts.block_headers().len() as u64);
@@ -2157,6 +2158,8 @@ async fn eth_fee_history(
         rewards_array.push(rewards);
 
         oldest_block_height = ts.epoch();
+        // Child root for the next (older) tipset.
+        receipt_root = Some(*ts.parent_message_receipts());
     }
 
     // Reverse the arrays; we collected them newest to oldest; the client expects oldest to newest.

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -2127,10 +2127,10 @@ async fn eth_fee_history(
     )];
     let mut rewards_array = vec![];
     let mut gas_used_ratio_array = vec![];
-    // The walk goes newest -> oldest, so each tipset is the child of the next. Carry the current
-    // tipset's `parent_message_receipts` forward: it is exactly the next (older) tipset's receipt
-    // root, so only the newest tipset needs a `load_child_tipset` lookup (`None` on the first pass).
-    let mut receipt_root = None;
+    // The walk goes newest -> oldest, so each tipset is the child of the next. Carry it forward as the
+    // receipt source for the next (older) tipset, so only the newest needs a `load_child_tipset` lookup
+    // (`None` on the first pass).
+    let mut child: Option<Tipset> = None;
     for ts in tipset
         .chain(ctx.db())
         .filter(|i| i.epoch() > 0)
@@ -2139,7 +2139,7 @@ async fn eth_fee_history(
         let base_fee = &ts.block_headers().first().parent_base_fee;
         let message_receipts = ctx
             .state_manager
-            .tipset_message_receipts(&ts, receipt_root)
+            .tipset_message_receipts(&ts, child.as_ref())
             .await?;
         let tx_gas_rewards = message_receipts
             .iter()
@@ -2158,8 +2158,8 @@ async fn eth_fee_history(
         rewards_array.push(rewards);
 
         oldest_block_height = ts.epoch();
-        // Child root for the next (older) tipset.
-        receipt_root = Some(*ts.parent_message_receipts());
+        // This tipset is the receipt source (child) of the next (older) one.
+        child = Some(ts);
     }
 
     // Reverse the arrays; we collected them newest to oldest; the client expects oldest to newest.

--- a/src/shim/executor.rs
+++ b/src/shim/executor.rs
@@ -157,25 +157,6 @@ impl PartialEq for Receipt {
 }
 
 impl Receipt {
-    /// Test-only constructor: a successful, empty receipt at the latest supported FVM version.
-    /// Lets tests build receipts without naming a concrete FVM version.
-    #[cfg(test)]
-    pub fn empty_success() -> Self {
-        Self::with_gas_used(0)
-    }
-
-    /// Test-only constructor: a successful receipt with the given `gas_used` at the latest
-    /// supported FVM version.
-    #[cfg(test)]
-    pub fn with_gas_used(gas_used: u64) -> Self {
-        Receipt::V4(Receipt_v4 {
-            exit_code: fvm_shared4::error::ExitCode::OK,
-            return_data: Default::default(),
-            gas_used,
-            events_root: None,
-        })
-    }
-
     pub fn exit_code(&self) -> ExitCode {
         match self {
             Receipt::V2(v2) => ExitCode::new(v2.exit_code.value()),
@@ -251,21 +232,6 @@ pub enum Entry {
 }
 
 impl Entry {
-    #[cfg(test)]
-    pub fn new(
-        flags: crate::shim::fvm_shared_latest::event::Flags,
-        key: String,
-        codec: u64,
-        value: Vec<u8>,
-    ) -> Self {
-        Entry::V4(Entry_v4 {
-            flags,
-            key,
-            codec,
-            value,
-        })
-    }
-
     pub fn into_parts(self) -> (u64, String, u64, Vec<u8>) {
         delegate_entry!(self => |e| (e.flags.bits(), e.key, e.codec, e.value))
     }
@@ -308,14 +274,6 @@ impl GetSize for StampedEvent {
 }
 
 impl StampedEvent {
-    /// Test-only constructor: a stamped event at the latest supported FVM version with a single
-    /// `FLAG_INDEXED_ALL` entry whose key and value are `key`. Lets tests build events without
-    /// naming a concrete FVM version.
-    #[cfg(test)]
-    pub fn new_indexed(emitter: ActorID, key: &str) -> Self {
-        Self::V4(create_raw_event_v4(emitter, key))
-    }
-
     /// Returns the ID of the actor that emitted this event.
     pub fn emitter(&self) -> ActorID {
         delegate_stamped_event!(self.emitter)
@@ -359,98 +317,10 @@ impl StampedEvent {
     }
 }
 
-/// Builds a raw FVM4 stamped event with a single indexed entry whose key and value are `key`.
-/// Wrap in [`StampedEvent::V4`] for the shim-level type.
 #[cfg(test)]
-pub(crate) fn create_raw_event_v4(emitter: u64, key: &str) -> fvm_shared4::event::StampedEvent {
-    fvm_shared4::event::StampedEvent {
-        emitter,
-        event: fvm_shared4::event::ActorEvent {
-            entries: vec![fvm_shared4::event::Entry {
-                flags: fvm_shared4::event::Flags::FLAG_INDEXED_ALL,
-                key: key.to_string(),
-                codec: fvm_ipld_encoding::IPLD_RAW,
-                value: key.as_bytes().to_vec(),
-            }],
-        },
-    }
-}
-
-/// Builds a raw FVM3 stamped event with a single indexed entry whose key and value are `key`.
-/// Wrap in [`StampedEvent::V3`] for the shim-level type.
+mod test_utils;
 #[cfg(test)]
-pub(crate) fn create_raw_event_v3(emitter: u64, key: &str) -> fvm_shared3::event::StampedEvent {
-    fvm_shared3::event::StampedEvent {
-        emitter,
-        event: fvm_shared3::event::ActorEvent {
-            entries: vec![fvm_shared3::event::Entry {
-                flags: fvm_shared3::event::Flags::FLAG_INDEXED_ALL,
-                key: key.to_string(),
-                codec: fvm_ipld_encoding::IPLD_RAW,
-                value: key.as_bytes().to_vec(),
-            }],
-        },
-    }
-}
-
-#[cfg(test)]
-impl quickcheck::Arbitrary for Receipt {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        #[derive(derive_quickcheck_arbitrary::Arbitrary, Clone)]
-        enum Helper {
-            V2 {
-                exit_code: u32,
-                return_data: Vec<u8>,
-                gas_used: i64,
-            },
-            V3 {
-                exit_code: u32,
-                return_data: Vec<u8>,
-                gas_used: u64,
-                events_root: Option<::cid::Cid>,
-            },
-            V4 {
-                exit_code: u32,
-                return_data: Vec<u8>,
-                gas_used: u64,
-                events_root: Option<::cid::Cid>,
-            },
-        }
-        match Helper::arbitrary(g) {
-            Helper::V2 {
-                exit_code,
-                return_data,
-                gas_used,
-            } => Self::V2(Receipt_v2 {
-                exit_code: exit_code.into(),
-                return_data: return_data.into(),
-                gas_used,
-            }),
-            Helper::V3 {
-                exit_code,
-                return_data,
-                gas_used,
-                events_root,
-            } => Self::V3(Receipt_v3 {
-                exit_code: exit_code.into(),
-                return_data: return_data.into(),
-                gas_used,
-                events_root,
-            }),
-            Helper::V4 {
-                exit_code,
-                return_data,
-                gas_used,
-                events_root,
-            } => Self::V4(Receipt_v4 {
-                exit_code: exit_code.into(),
-                return_data: return_data.into(),
-                gas_used,
-                events_root,
-            }),
-        }
-    }
-}
+pub(crate) use test_utils::{create_raw_event_v3, create_raw_event_v4};
 
 #[cfg(test)]
 mod tests {

--- a/src/shim/executor.rs
+++ b/src/shim/executor.rs
@@ -161,10 +161,17 @@ impl Receipt {
     /// Lets tests build receipts without naming a concrete FVM version.
     #[cfg(test)]
     pub fn empty_success() -> Self {
+        Self::with_gas_used(0)
+    }
+
+    /// Test-only constructor: a successful receipt with the given `gas_used` at the latest
+    /// supported FVM version.
+    #[cfg(test)]
+    pub fn with_gas_used(gas_used: u64) -> Self {
         Receipt::V4(Receipt_v4 {
             exit_code: fvm_shared4::error::ExitCode::OK,
             return_data: Default::default(),
-            gas_used: 0,
+            gas_used,
             events_root: None,
         })
     }

--- a/src/shim/executor/test_utils.rs
+++ b/src/shim/executor/test_utils.rs
@@ -1,0 +1,152 @@
+// Copyright 2019-2026 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+//! Test-only constructors and fixtures for the shim executor types.
+
+use super::*;
+
+impl Receipt {
+    /// A successful, empty receipt at the latest supported FVM version. Lets tests build receipts
+    /// without naming a concrete FVM version.
+    pub fn empty_success() -> Self {
+        Self::with_gas_used(0)
+    }
+
+    /// A successful receipt with the given `gas_used` at the latest supported FVM version.
+    pub fn with_gas_used(gas_used: u64) -> Self {
+        Receipt::V4(Receipt_v4 {
+            exit_code: fvm_shared4::error::ExitCode::OK,
+            return_data: Default::default(),
+            gas_used,
+            events_root: None,
+        })
+    }
+
+    /// Writes `count` successful receipts to a fresh AMT and returns its root, in the same format
+    /// [`Receipt::get_receipts`] reads.
+    pub fn store_receipts(store: &impl Blockstore, count: usize) -> anyhow::Result<Cid> {
+        Ok(Amtv0::new_from_iter(
+            store,
+            (0..count).map(|_| Receipt_v4 {
+                exit_code: fvm_shared4::error::ExitCode::OK,
+                return_data: Default::default(),
+                gas_used: 0,
+                events_root: None,
+            }),
+        )?)
+    }
+}
+
+impl Entry {
+    pub fn new(
+        flags: crate::shim::fvm_shared_latest::event::Flags,
+        key: String,
+        codec: u64,
+        value: Vec<u8>,
+    ) -> Self {
+        Entry::V4(Entry_v4 {
+            flags,
+            key,
+            codec,
+            value,
+        })
+    }
+}
+
+impl StampedEvent {
+    /// A stamped event at the latest supported FVM version with a single `FLAG_INDEXED_ALL` entry
+    /// whose key and value are `key`. Lets tests build events without naming a concrete FVM version.
+    pub fn new_indexed(emitter: ActorID, key: &str) -> Self {
+        Self::V4(create_raw_event_v4(emitter, key))
+    }
+}
+
+/// Builds a raw FVM4 stamped event with a single indexed entry whose key and value are `key`.
+/// Wrap in [`StampedEvent::V4`] for the shim-level type.
+pub(crate) fn create_raw_event_v4(emitter: u64, key: &str) -> fvm_shared4::event::StampedEvent {
+    fvm_shared4::event::StampedEvent {
+        emitter,
+        event: fvm_shared4::event::ActorEvent {
+            entries: vec![fvm_shared4::event::Entry {
+                flags: fvm_shared4::event::Flags::FLAG_INDEXED_ALL,
+                key: key.to_string(),
+                codec: fvm_ipld_encoding::IPLD_RAW,
+                value: key.as_bytes().to_vec(),
+            }],
+        },
+    }
+}
+
+/// Builds a raw FVM3 stamped event with a single indexed entry whose key and value are `key`.
+/// Wrap in [`StampedEvent::V3`] for the shim-level type.
+pub(crate) fn create_raw_event_v3(emitter: u64, key: &str) -> fvm_shared3::event::StampedEvent {
+    fvm_shared3::event::StampedEvent {
+        emitter,
+        event: fvm_shared3::event::ActorEvent {
+            entries: vec![fvm_shared3::event::Entry {
+                flags: fvm_shared3::event::Flags::FLAG_INDEXED_ALL,
+                key: key.to_string(),
+                codec: fvm_ipld_encoding::IPLD_RAW,
+                value: key.as_bytes().to_vec(),
+            }],
+        },
+    }
+}
+
+impl quickcheck::Arbitrary for Receipt {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        #[derive(derive_quickcheck_arbitrary::Arbitrary, Clone)]
+        enum Helper {
+            V2 {
+                exit_code: u32,
+                return_data: Vec<u8>,
+                gas_used: i64,
+            },
+            V3 {
+                exit_code: u32,
+                return_data: Vec<u8>,
+                gas_used: u64,
+                events_root: Option<::cid::Cid>,
+            },
+            V4 {
+                exit_code: u32,
+                return_data: Vec<u8>,
+                gas_used: u64,
+                events_root: Option<::cid::Cid>,
+            },
+        }
+        match Helper::arbitrary(g) {
+            Helper::V2 {
+                exit_code,
+                return_data,
+                gas_used,
+            } => Self::V2(Receipt_v2 {
+                exit_code: exit_code.into(),
+                return_data: return_data.into(),
+                gas_used,
+            }),
+            Helper::V3 {
+                exit_code,
+                return_data,
+                gas_used,
+                events_root,
+            } => Self::V3(Receipt_v3 {
+                exit_code: exit_code.into(),
+                return_data: return_data.into(),
+                gas_used,
+                events_root,
+            }),
+            Helper::V4 {
+                exit_code,
+                return_data,
+                gas_used,
+                events_root,
+            } => Self::V4(Receipt_v4 {
+                exit_code: exit_code.into(),
+                return_data: return_data.into(),
+                gas_used,
+                events_root,
+            }),
+        }
+    }
+}

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -92,7 +92,8 @@ impl GetSize for ExecutedMessage {
     }
 }
 
-/// A tipset's messages paired with their execution receipts.
+/// A tipset's messages paired with their execution receipts. The variants are an internal detail of
+/// how the pairs were loaded; consumers iterate them via [`Self::iter`].
 pub enum TipsetMessageReceipts {
     /// Backed by a full executed tipset (a cache hit, or the fallback loader).
     Executed(Arc<Vec<ExecutedMessage>>),

--- a/src/state_manager/mod.rs
+++ b/src/state_manager/mod.rs
@@ -54,6 +54,7 @@ use crate::utils::cache::SizeTrackingCache;
 use crate::utils::get_size::GetSize;
 use anyhow::Context as _;
 use chain_rand::ChainRand;
+use itertools::Either;
 use nonzero_ext::nonzero;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -88,6 +89,26 @@ impl GetSize for ExecutedMessage {
                 + self.events.get_heap_size_with_tracker(&mut tracker).0,
             tracker,
         )
+    }
+}
+
+/// A tipset's messages paired with their execution receipts.
+pub enum TipsetMessageReceipts {
+    /// Backed by a full executed tipset (a cache hit, or the fallback loader).
+    Executed(Arc<Vec<ExecutedMessage>>),
+    /// Receipts read directly from the child tipset, paired with the tipset's messages (no events).
+    Stored(Arc<Vec<ChainMessage>>, Vec<Receipt>),
+}
+
+impl TipsetMessageReceipts {
+    /// Iterates the (message, receipt) pairs in index order, by reference.
+    pub fn iter(&self) -> impl Iterator<Item = (&ChainMessage, &Receipt)> + '_ {
+        match self {
+            Self::Executed(messages) => {
+                Either::Left(messages.iter().map(|em| (&em.message, &em.receipt)))
+            }
+            Self::Stored(messages, receipts) => Either::Right(messages.iter().zip(receipts.iter())),
+        }
     }
 }
 

--- a/src/state_manager/state_computation.rs
+++ b/src/state_manager/state_computation.rs
@@ -75,6 +75,45 @@ impl StateManager {
             .await
     }
 
+    /// Returns `ts`'s messages paired with their execution receipts, without loading events.
+    /// `receipt_root` is `ts`'s message-receipt root (the child tipset's `parent_message_receipts`)
+    /// when the caller already knows it, avoiding a `load_child_tipset` lookup; `None` resolves it.
+    pub async fn tipset_message_receipts(
+        &self,
+        ts: &Tipset,
+        receipt_root: Option<Cid>,
+    ) -> anyhow::Result<TipsetMessageReceipts> {
+        if let Some(cached) = self.cache.get(ts.key()) {
+            return Ok(TipsetMessageReceipts::Executed(cached.executed_messages));
+        }
+
+        let receipt_root = match receipt_root {
+            Some(root) => Some(root),
+            None => self
+                .chain_store()
+                .load_child_tipset(ts)
+                .await?
+                .map(|child| *child.parent_message_receipts()),
+        };
+        if let Some(root) = receipt_root
+            && let Ok(receipts) = Receipt::get_receipts(self.cs.db(), root)
+        {
+            let messages = self.chain_store().messages_for_tipset(ts)?;
+            anyhow::ensure!(
+                messages.len() == receipts.len(),
+                "mismatching message and receipt counts ({} messages, {} receipts)",
+                messages.len(),
+                receipts.len()
+            );
+            return Ok(TipsetMessageReceipts::Stored(messages, receipts));
+        }
+        Ok(TipsetMessageReceipts::Executed(
+            self.load_executed_tipset_for_rpc(ts)
+                .await?
+                .executed_messages,
+        ))
+    }
+
     /// Load an executed tipset using an explicitly provided receipt (child) tipset instead of
     /// resolving the child on the current heaviest chain. This is required when serving events
     /// for tipsets that are no longer canonical.
@@ -725,4 +764,47 @@ pub(in crate::state_manager) fn compute_state_blocking(
     )?;
 
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tipset_message_receipts_iter_pairs_in_order() {
+        let msg_count = 3u64;
+        let messages = (0..msg_count)
+            .map(|i| {
+                ChainMessage::Unsigned(Arc::new(Message {
+                    sequence: i,
+                    ..Default::default()
+                }))
+            })
+            .collect_vec();
+        let receipts = (0..msg_count)
+            .map(|i| Receipt::with_gas_used((i + 1) * 10))
+            .collect_vec();
+        let expected = (0..msg_count).map(|i| (i, (i + 1) * 10)).collect_vec();
+
+        let executed = TipsetMessageReceipts::Executed(Arc::new(
+            messages
+                .iter()
+                .zip(receipts.iter())
+                .map(|(m, r)| ExecutedMessage {
+                    message: m.clone(),
+                    receipt: r.clone(),
+                    events: None,
+                })
+                .collect(),
+        ));
+        let stored = TipsetMessageReceipts::Stored(Arc::new(messages), receipts);
+
+        for variant in [&executed, &stored] {
+            let got = variant
+                .iter()
+                .map(|(m, r)| (m.message().sequence, r.gas_used()))
+                .collect_vec();
+            assert_eq!(got, expected);
+        }
+    }
 }

--- a/src/state_manager/state_computation.rs
+++ b/src/state_manager/state_computation.rs
@@ -76,36 +76,38 @@ impl StateManager {
     }
 
     /// Returns `ts`'s messages paired with their execution receipts, without loading events.
-    /// `receipt_root` is `ts`'s message-receipt root (the child tipset's `parent_message_receipts`)
-    /// when the caller already knows it, avoiding a `load_child_tipset` lookup; `None` resolves it.
+    /// `receipt_ts` is `ts`'s child (whose `parent_message_receipts` is `ts`'s receipt root) when the
+    /// caller already knows it, avoiding a `load_child_tipset` lookup; `None` resolves it.
     pub async fn tipset_message_receipts(
         &self,
         ts: &Tipset,
-        receipt_root: Option<Cid>,
+        receipt_ts: Option<&Tipset>,
     ) -> anyhow::Result<TipsetMessageReceipts> {
         if let Some(cached) = self.cache.get(ts.key()) {
             return Ok(TipsetMessageReceipts::Executed(cached.executed_messages));
         }
 
-        let receipt_root = match receipt_root {
-            Some(root) => Some(root),
-            None => self
-                .chain_store()
-                .load_child_tipset(ts)
-                .await?
-                .map(|child| *child.parent_message_receipts()),
+        let receipt_ts = match receipt_ts {
+            Some(child) => Some(child.shallow_clone()),
+            None => self.chain_store().load_child_tipset(ts).await?,
         };
-        if let Some(root) = receipt_root
-            && let Ok(receipts) = Receipt::get_receipts(self.cs.db(), root)
-        {
-            let messages = self.chain_store().messages_for_tipset(ts)?;
+        if let Some(child) = &receipt_ts {
             anyhow::ensure!(
-                messages.len() == receipts.len(),
-                "mismatching message and receipt counts ({} messages, {} receipts)",
-                messages.len(),
-                receipts.len()
+                ts.key() == child.parents(),
+                "message tipset should be the parent of message receipt tipset"
             );
-            return Ok(TipsetMessageReceipts::Stored(messages, receipts));
+            if let Ok(receipts) =
+                Receipt::get_receipts(self.cs.db(), *child.parent_message_receipts())
+            {
+                let messages = self.chain_store().messages_for_tipset(ts)?;
+                anyhow::ensure!(
+                    messages.len() == receipts.len(),
+                    "mismatching message and receipt counts ({} messages, {} receipts)",
+                    messages.len(),
+                    receipts.len()
+                );
+                return Ok(TipsetMessageReceipts::Stored(messages, receipts));
+            }
         }
         Ok(TipsetMessageReceipts::Executed(
             self.load_executed_tipset_for_rpc(ts)
@@ -769,6 +771,8 @@ pub(in crate::state_manager) fn compute_state_blocking(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::blocks::{CachingBlockHeader, RawBlockHeader, TipsetKey, TxMeta};
+    use crate::utils::db::CborStoreExt as _;
 
     #[test]
     fn tipset_message_receipts_iter_pairs_in_order() {
@@ -806,5 +810,138 @@ mod tests {
                 .collect_vec();
             assert_eq!(got, expected);
         }
+    }
+
+    /// A `TxMeta` with empty message roots, so `messages_for_tipset` yields zero messages.
+    fn empty_message_meta(db: &impl Blockstore) -> Cid {
+        let empty = Amtv0::<Cid, _>::new(db).flush().unwrap();
+        db.put_cbor_default(&TxMeta {
+            bls_message_root: empty,
+            secp_message_root: empty,
+        })
+        .unwrap()
+    }
+
+    /// A single block with the given epoch, parents, message meta and receipt root. The nonzero
+    /// timestamp lets an epoch-0 block serve as a genesis (which must not be at time 0).
+    fn block(
+        epoch: ChainEpoch,
+        parents: TipsetKey,
+        messages: Cid,
+        receipts: Cid,
+    ) -> CachingBlockHeader {
+        CachingBlockHeader::new(RawBlockHeader {
+            parents,
+            epoch,
+            messages,
+            message_receipts: receipts,
+            timestamp: 1,
+            ..Default::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn tipset_message_receipts_covers_all_paths() {
+        use crate::chain::ChainStore;
+        use crate::db::MemoryDB;
+        use crate::networks::ChainConfig;
+
+        let db = Arc::new(MemoryDB::default());
+        let genesis = block(0, TipsetKey::default(), Cid::default(), Cid::default());
+        db.put_cbor_default(&genesis).unwrap();
+        let cs = ChainStore::new(db.clone(), Arc::new(ChainConfig::default()), genesis).unwrap();
+        let genesis_key = cs.genesis_tipset().key().clone();
+
+        // `ts` (epoch 1, no messages) and `head` (epoch 2), its child and the chain head, so
+        // `load_child_tipset(ts)` resolves `head`.
+        let ts = Tipset::from(block(
+            1,
+            genesis_key.clone(),
+            empty_message_meta(&db),
+            Cid::default(),
+        ));
+        let head = Tipset::from(block(
+            2,
+            ts.key().clone(),
+            Cid::default(),
+            Receipt::store_receipts(&db, 0).unwrap(),
+        ));
+        for b in ts.block_headers().iter().chain(head.block_headers().iter()) {
+            db.put_cbor_default(b).unwrap();
+        }
+        cs.set_heaviest_tipset(head.clone()).unwrap();
+        let sm = StateManager::new(cs).unwrap();
+
+        // Cache hit -> Executed.
+        sm.cache.insert(
+            ts.key().clone(),
+            ExecutedTipset {
+                state_root: Cid::default(),
+                receipt_root: Cid::default(),
+                executed_messages: Arc::new(vec![]),
+            },
+        );
+        assert!(matches!(
+            sm.tipset_message_receipts(&ts, None).await.unwrap(),
+            TipsetMessageReceipts::Executed(_)
+        ));
+        sm.cache.remove(ts.key());
+
+        // Caller-supplied child -> Stored (assertion holds, receipts read, counts match).
+        assert!(matches!(
+            sm.tipset_message_receipts(&ts, Some(&head)).await.unwrap(),
+            TipsetMessageReceipts::Stored(m, r) if m.is_empty() && r.is_empty()
+        ));
+
+        // `None` resolves the child via `load_child_tipset` -> Stored.
+        assert!(matches!(
+            sm.tipset_message_receipts(&ts, None).await.unwrap(),
+            TipsetMessageReceipts::Stored(..)
+        ));
+
+        // `head` has no child, so `None` resolves to nothing and the loader fallback errors.
+        assert!(sm.tipset_message_receipts(&head, None).await.is_err());
+
+        // Receipt tipset that is not `ts`'s child -> parent-mismatch error.
+        let wrong = Tipset::from(block(
+            2,
+            genesis_key,
+            Cid::default(),
+            Receipt::store_receipts(&db, 0).unwrap(),
+        ));
+        assert!(
+            sm.tipset_message_receipts(&ts, Some(&wrong))
+                .await
+                .err()
+                .expect("expected error")
+                .to_string()
+                .contains("should be the parent")
+        );
+
+        // Receipt count != message count -> error.
+        let extra = Tipset::from(block(
+            2,
+            ts.key().clone(),
+            Cid::default(),
+            Receipt::store_receipts(&db, 1).unwrap(),
+        ));
+        assert!(
+            sm.tipset_message_receipts(&ts, Some(&extra))
+                .await
+                .err()
+                .expect("expected error")
+                .to_string()
+                .contains("mismatching message and receipt counts")
+        );
+
+        // Unreadable receipt root -> falls back to the full loader (re-resolves the on-chain child).
+        // Keep last: this populates `ts`'s cache, which would mask the `Stored` cases above.
+        let unreadable = Tipset::from(block(2, ts.key().clone(), Cid::default(), Cid::default()));
+        assert!(matches!(
+            sm.tipset_message_receipts(&ts, Some(&unreadable))
+                .await
+                .unwrap(),
+            TipsetMessageReceipts::Executed(_)
+        ));
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- avoid grabbing event logs for fee history (it's not needed - we only need receipts)
- avoid wasteful `load_child_tipset` - the maximum block walk we allow for this method is 1024, so there would be 1023 completely wasteful blocking tasks just to get message receipt, which we already have, given we walk from newest to oldest.
- this nicely improves the methods questionable performance (especially around P99 - ~500 ms), while doing less work. A naive alternative was to parallelize the entire walk, but it'd just increase resource usage and possibly exhaust blocking task pool.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

```
┌────────────┬──────────────────────┬────────────────────┬───────┐
│ blockCount │ baseline (no-thread) │     threading      │  win  │
├────────────┼──────────────────────┼────────────────────┼───────┤
│ 500        │ 0.221s median        │ 0.024s             │ ~9.2× │
├────────────┼──────────────────────┼────────────────────┼───────┤
│ 1024       │ 0.441s (0.587 max)   │ 0.051s (0.215 max) │ ~8.6× │
└────────────┴──────────────────────┴────────────────────┴───────┘
```

We might be doing similar silly thing elsewhere. To be investigated.

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved fee history retrieval by using available message receipts more efficiently.
  * Reduced unnecessary processing when retrieving contract bytecode and calculating gas reward data.

* **Reliability**
  * Added fallback handling when receipt data is unavailable.
  * Added validation to ensure messages and receipts remain correctly ordered and matched.
  * Improved consistency when retrieving receipts across related tipsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->