### PR TITLE
chore: avoid wasteful loading tipset in `eth_getLogs`

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -474,6 +474,7 @@ async fn prefill_rpc_caches_for_tipset(
                 if let Err(e) = EthEventHandler::collect_events(
                     &state_manager,
                     &ts,
+                    None,
                     Some(&CollectEventsCachePrefillingMatcher),
                     SkipEvent::OnUnresolvedAddress,
                     &mut collected_events,

--- a/src/rpc/methods/eth.rs
+++ b/src/rpc/methods/eth.rs
@@ -1431,6 +1431,7 @@ pub async fn eth_logs_for_block_and_transaction(
     EthEventHandler::collect_events(
         &ctx.state_manager,
         ts,
+        None,
         Some(&parsed_filter),
         SkipEvent::OnUnresolvedAddress,
         &mut events,

--- a/src/rpc/methods/eth/filter/mod.rs
+++ b/src/rpc/methods/eth/filter/mod.rs
@@ -356,14 +356,17 @@ impl EthEventHandler {
         collected_events: &mut Vec<CollectedEvent>,
     ) -> anyhow::Result<()> {
         let mut tasks = FuturesOrdered::new();
+        let mut child: Option<Tipset> = None;
         for tipset in tipsets {
+            let receipt_ts = child.replace(tipset.shallow_clone());
             let state_manager = ctx.state_manager.shallow_clone();
-            let spec = spec.as_ref().map(|v| v.shallow_clone());
+            let spec = spec.map(|v| v.shallow_clone());
             let task = AbortOnDropHandle::new(tokio::spawn(async move {
                 let mut events = vec![];
                 Self::collect_events(
                     &state_manager,
                     &tipset,
+                    receipt_ts.as_ref(),
                     spec.as_ref(),
                     skip_event,
                     &mut events,
@@ -390,16 +393,26 @@ impl EthEventHandler {
         Ok(())
     }
 
+    /// Collects a single tipset's events. `receipt_ts` is the tipset holding `tipset`'s message
+    /// receipts (its child); pass `None` to resolve it on the current heaviest chain.
     pub async fn collect_events(
         state_manager: &StateManager,
         tipset: &Tipset,
+        receipt_ts: Option<&Tipset>,
         spec: Option<&impl Matcher>,
         skip_event: SkipEvent,
         collected_events: &mut Vec<CollectedEvent>,
     ) -> anyhow::Result<()> {
         let ExecutedTipset {
             executed_messages, ..
-        } = state_manager.load_executed_tipset_for_rpc(tipset).await?;
+        } = match receipt_ts {
+            Some(receipt_ts) => {
+                state_manager
+                    .load_executed_tipset_with_receipt(tipset, receipt_ts)
+                    .await?
+            }
+            None => state_manager.load_executed_tipset_for_rpc(tipset).await?,
+        };
         Self::collect_events_from_messages(
             state_manager,
             tipset,
@@ -538,6 +551,7 @@ impl EthEventHandler {
                 Self::collect_events(
                     &ctx.state_manager,
                     &tipset,
+                    None,
                     Some(pf),
                     skip_event,
                     &mut collected_events,
@@ -549,6 +563,7 @@ impl EthEventHandler {
                 Self::collect_events(
                     &ctx.state_manager,
                     &tipset,
+                    None,
                     Some(pf),
                     skip_event,
                     &mut collected_events,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- similar to https://github.com/ChainSafe/forest/pull/7529
- avoids loading child tipset (further across the call chain)
- meager 13% faster in my test, but it potentially saves a lot of blocking calls so a busy node will have more breathingroom.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ethereum event and log retrieval for deferred execution scenarios.
  * Ensured transaction receipts are loaded from the correct child tipset when processing event ranges.
  * Preserved existing behavior for hash- and key-based queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->