### PR TITLE
fix: block producing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ### Changed
 
+- [#7535](https://github.com/ChainSafe/forest/pull/7535): `Filecoin.Version` now reports the API version of the endpoint being served (`1.5.0` over `/rpc/v0`, `2.3.0` over `/rpc/v1`), matching Lotus, and `Filecoin.SyncSubmitBlock` no longer requires the node to be in the `Synced` state and waits up to one block time for the submitted block to become the chain head. Together these let Forest act as the full node for an external block producer such as `lotus-miner` or `curio` (verified on a local devnet, calibnet/mainnet tests to come).
+
 ### Removed
 
 ### Fixed

--- a/src/chain_sync/chain_follower.rs
+++ b/src/chain_sync/chain_follower.rs
@@ -199,6 +199,11 @@ impl ChainFollower {
             .validated_tipset_broadcast_tx
             .subscribe()
     }
+
+    /// Subscribe-only handle to per-block validation outcomes (see [`BlockValidationOutcome`]).
+    pub fn block_validation_subscriber(&self) -> BlockValidationSubscriber {
+        BlockValidationSubscriber(self.state_machine.lock().block_validation_tx.clone())
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -685,6 +690,35 @@ pub fn load_full_tipset(
     Ok(fts)
 }
 
+/// Per-block validation outcome from the sync state machine. `Filecoin.SyncSubmitBlock`
+/// awaits its block's outcome instead of inferring it from head movement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlockValidationOutcome {
+    Applied,
+    Rejected,
+}
+
+/// Subscribe-only handle to the per-block validation outcome broadcast (keyed by block CID).
+/// `Default` yields a handle wired to no follower, for contexts that never submit blocks (tests,
+/// the offline RPC server).
+#[derive(Clone)]
+pub struct BlockValidationSubscriber(tokio::sync::broadcast::Sender<(Cid, BlockValidationOutcome)>);
+
+impl Default for BlockValidationSubscriber {
+    fn default() -> Self {
+        Self(tokio::sync::broadcast::Sender::new(1))
+    }
+}
+
+impl BlockValidationSubscriber {
+    /// Returns a receiver delivering `(Cid, BlockValidationOutcome)` for each block the follower
+    /// validates or rejects, following Tokio broadcast semantics: only outcomes broadcast after
+    /// this call are delivered, and a slow reader may observe `RecvError::Lagged`.
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<(Cid, BlockValidationOutcome)> {
+        self.0.subscribe()
+    }
+}
+
 enum SyncEvent {
     NewFullTipsets(Vec<FullTipset>),
     BadTipset(FullTipset),
@@ -732,6 +766,8 @@ struct SyncStateMachine {
     stateless_mode: bool,
     /// Broadcast channel for validated tipsets, used to notify other components of new validated tipsets.
     validated_tipset_broadcast_tx: tokio::sync::broadcast::Sender<TipsetKey>,
+    /// Broadcast of each block's validation outcome, keyed by block CID.
+    block_validation_tx: tokio::sync::broadcast::Sender<(Cid, BlockValidationOutcome)>,
 }
 
 impl SyncStateMachine {
@@ -746,6 +782,27 @@ impl SyncStateMachine {
             tipsets: HashMap::default(),
             stateless_mode,
             validated_tipset_broadcast_tx: tokio::sync::broadcast::Sender::new(1024),
+            block_validation_tx: tokio::sync::broadcast::Sender::new(1024),
+        }
+    }
+
+    /// Report `Rejected` for the blocks the validator actually flagged bad. Keyed on
+    /// `bad_block_cache` membership rather than the whole tipset, so a valid block merged into
+    /// the same tipset as a bad sibling (`validate_tipset` fails the tipset on one bad block) is
+    /// not wrongly rejected.
+    fn notify_rejected(&self, tipset: &FullTipset) {
+        if crate::utils::broadcast::has_subscribers(&self.block_validation_tx) {
+            for cid in tipset.key().to_cids() {
+                if self
+                    .bad_block_cache
+                    .as_ref()
+                    .is_some_and(|c| c.get(&cid).is_some())
+                {
+                    let _ = self
+                        .block_validation_tx
+                        .send((cid, BlockValidationOutcome::Rejected));
+                }
+            }
         }
     }
 
@@ -882,6 +939,9 @@ impl SyncStateMachine {
     // Mark all descendants of tipsets as bad.
     // Remove all bad tipsets from the tipset map.
     fn mark_bad_tipset(&mut self, tipset: FullTipset) {
+        // Only the entered tipset can carry a submitted block; descendants are marked bad by
+        // cascade, so reporting the outcome once here avoids flooding the channel.
+        self.notify_rejected(&tipset);
         let mut stack = vec![tipset];
         while let Some(tipset) = stack.pop() {
             self.tipsets.remove(tipset.key());
@@ -951,12 +1011,25 @@ impl SyncStateMachine {
                 tipset,
                 is_proposed_head,
             } => {
-                if self.try_mark_tipset_as_validated(tipset, is_proposed_head)
-                    && crate::utils::broadcast::has_subscribers(&self.validated_tipset_broadcast_tx)
-                    // Sending the actual head key here as it could be expanded from the above tipset when `is_proposed_head` is `true`
-                    && let Err(e) = self.validated_tipset_broadcast_tx.send(self.cs.heaviest_tipset().key().clone())
-                {
-                    warn!("Failed to broadcast validated tipset: {e}");
+                // Capture CIDs before `try_mark` consumes the tipset, but only when a submitter is
+                // waiting, to avoid allocating on the steady-state sync path.
+                let applied_cids =
+                    crate::utils::broadcast::has_subscribers(&self.block_validation_tx)
+                        .then(|| tipset.key().to_cids());
+                if self.try_mark_tipset_as_validated(tipset, is_proposed_head) {
+                    if let Some(cids) = applied_cids {
+                        for cid in cids {
+                            let _ = self
+                                .block_validation_tx
+                                .send((cid, BlockValidationOutcome::Applied));
+                        }
+                    }
+                    if crate::utils::broadcast::has_subscribers(&self.validated_tipset_broadcast_tx)
+                        // Sending the actual head key here as it could be expanded from the above tipset when `is_proposed_head` is `true`
+                        && let Err(e) = self.validated_tipset_broadcast_tx.send(self.cs.heaviest_tipset().key().clone())
+                    {
+                        warn!("Failed to broadcast validated tipset: {e}");
+                    }
                 }
             }
         }
@@ -1254,7 +1327,7 @@ mod metrics_collection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blocks::{Chain4U, HeaderBuilder, chain4u};
+    use crate::blocks::{CachingBlockHeader, Chain4U, HeaderBuilder, chain4u};
     use crate::db::MemoryDB;
     use crate::utils::db::CborStoreExt as _;
     use num_bigint::BigInt;
@@ -1411,5 +1484,63 @@ mod tests {
 
         // Both chains should start at the same tipset
         assert_eq!(chains, vec![vec![1, 3], vec![1, 2]]);
+    }
+
+    fn single_block_tipset(header: CachingBlockHeader) -> FullTipset {
+        FullTipset::new(vec![Block {
+            header,
+            bls_messages: vec![],
+            secp_messages: vec![],
+        }])
+        .unwrap()
+    }
+
+    #[test]
+    fn notify_rejected_reports_only_bad_block_cache_members() {
+        let (cs, c4u) = setup();
+        let db = cs.db_owned();
+        chain4u! { from [genesis_header] in c4u; [a = dummy_node(&db, 1)] };
+
+        let bad_blocks = BadBlockCache::default();
+        let state_machine =
+            SyncStateMachine::new(cs.shallow_clone(), Some(bad_blocks.shallow_clone()), true);
+        let mut rx = state_machine.block_validation_tx.subscribe();
+
+        let tipset = single_block_tipset(a.clone().into());
+        let block_cid = *tipset.blocks().first().cid();
+
+        // Not flagged bad: a valid block sharing a tipset with a bad sibling must not be rejected.
+        state_machine.notify_rejected(&tipset);
+        assert!(rx.try_recv().is_err());
+
+        // Flagged bad by the validator: reported as rejected.
+        bad_blocks.push(block_cid);
+        state_machine.notify_rejected(&tipset);
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            (block_cid, BlockValidationOutcome::Rejected)
+        );
+    }
+
+    #[test]
+    fn validated_tipset_reports_applied() {
+        let (cs, c4u) = setup();
+        let db = cs.db_owned();
+        chain4u! { from [genesis_header] in c4u; [a = dummy_node(&db, 1)] };
+
+        let mut state_machine = SyncStateMachine::new(cs.shallow_clone(), Default::default(), true);
+        let mut rx = state_machine.block_validation_tx.subscribe();
+
+        let tipset = single_block_tipset(a.clone().into());
+        let block_cid = *tipset.blocks().first().cid();
+
+        state_machine.update(SyncEvent::ValidatedTipset {
+            tipset,
+            is_proposed_head: false,
+        });
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            (block_cid, BlockValidationOutcome::Applied)
+        );
     }
 }

--- a/src/chain_sync/mod.rs
+++ b/src/chain_sync/mod.rs
@@ -13,7 +13,10 @@ mod validation;
 
 pub use self::{
     bad_block_cache::BadBlockCache,
-    chain_follower::{ChainFollower, get_full_tipset, load_full_tipset},
+    chain_follower::{
+        BlockValidationOutcome, BlockValidationSubscriber, ChainFollower, get_full_tipset,
+        load_full_tipset,
+    },
     chain_muxer::SyncConfig,
     consensus::collect_errs,
     sync_status::{ForkSyncInfo, ForkSyncStage, NodeSyncStatus, SyncStatus, SyncStatusReport},

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -601,6 +601,7 @@ fn maybe_start_rpc_service(
             let sync_status = chain_follower.sync_status.shallow_clone();
             let sync_network_context = chain_follower.network.shallow_clone();
             let tipset_send = chain_follower.tipset_sender.clone();
+            let block_validation_subscriber = chain_follower.block_validation_subscriber();
             let keystore = ctx.keystore.shallow_clone();
             let snapshot_progress_tracker = ctx.snapshot_progress_tracker.clone();
             let nonce_tracker = NonceTracker::new();
@@ -625,6 +626,7 @@ fn maybe_start_rpc_service(
                         start_time,
                         shutdown,
                         tipset_send,
+                        block_validation_subscriber,
                         snapshot_progress_tracker,
                         mpool_locker,
                         nonce_tracker,

--- a/src/rpc/methods/common.rs
+++ b/src/rpc/methods/common.rs
@@ -44,13 +44,18 @@ impl RpcMethod<0> for Version {
     async fn handle(
         ctx: Ctx,
         (): Self::Params,
-        _: &http::Extensions,
+        ext: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
+        // Report the API version for the endpoint actually being served, so V0
+        // clients (e.g. lotus-miner over `/rpc/v0`) accept the version handshake.
+        // Values from Lotus `api/version.go`: <https://github.com/filecoin-project/lotus/blob/27abf0f16a7f2a83305910f3c2a1844764d20b75/api/version.go#L57-L58>
+        let api_version = match ext.get::<ApiPaths>() {
+            Some(ApiPaths::V0) => ShiftingVersion::new(1, 5, 0),
+            Some(ApiPaths::V1 | ApiPaths::V2) | None => ShiftingVersion::new(2, 3, 0),
+        };
         Ok(PublicVersion {
             version: crate::utils::version::FOREST_VERSION_STRING.clone(),
-            // This matches Lotus's versioning for the API v1.
-            // For the API v0, we don't support it but it should be `1.5.0`.
-            api_version: ShiftingVersion::new(2, 3, 0),
+            api_version,
             block_delay: ctx.chain_config().block_delay_secs,
             agent: "forest".into(),
         })

--- a/src/rpc/methods/sync.rs
+++ b/src/rpc/methods/sync.rs
@@ -5,13 +5,13 @@ mod types;
 
 use crate::blocks::{Block, FullTipset, GossipBlock};
 use crate::chain;
-use crate::chain_sync::{NodeSyncStatus, SyncStatusReport, TipsetValidator};
+use crate::chain_sync::{SyncStatusReport, TipsetValidator};
 use crate::libp2p::{IdentTopic, NetworkMessage, PUBSUB_BLOCK_STR};
 use crate::prelude::*;
 use crate::rpc::{ApiPaths, Ctx, Permission, RpcMethod, ServerError};
-use anyhow::anyhow;
 use enumflags2::BitFlags;
 use fvm_ipld_encoding::to_vec;
+use std::time::Duration;
 pub use types::*;
 
 pub enum SyncCheckBad {}
@@ -125,9 +125,6 @@ impl RpcMethod<1> for SyncSubmitBlock {
         (block_msg,): Self::Params,
         _: &http::Extensions,
     ) -> Result<Self::Ok, ServerError> {
-        if !matches!(ctx.sync_status.load().status, NodeSyncStatus::Synced) {
-            Err(anyhow!("the node isn't in 'follow' mode"))?
-        }
         let genesis_network_name = ctx.chain_config().network.genesis_name();
         let encoded_message = to_vec(&block_msg)?;
         let pubsub_block_str = format!("{PUBSUB_BLOCK_STR}/{genesis_network_name}");
@@ -150,6 +147,7 @@ impl RpcMethod<1> for SyncSubmitBlock {
             )
             .context("failed to validate the tipset")?;
 
+        let submitted_epoch = ts.epoch();
         ctx.tipset_send
             .try_send(ts)
             .context("tipset queue is full")?;
@@ -158,6 +156,26 @@ impl RpcMethod<1> for SyncSubmitBlock {
             topic: IdentTopic::new(pubsub_block_str),
             message: encoded_message,
         })?;
+
+        // Forest applies the submitted tipset via the async follower, unlike Lotus whose
+        // `Syncer.Sync` sets the head synchronously. Wait (bounded by ~one block time) for the
+        // head to reflect it, else a caller mining on the head re-selects the
+        // same base and stalls a full block time each round.
+        let block_delay_secs = ctx.chain_config().block_delay_secs.into();
+        if tokio::time::timeout(Duration::from_secs(block_delay_secs), async {
+            while ctx.chain_store().heaviest_tipset().epoch() < submitted_epoch {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .is_err()
+        {
+            tracing::warn!(
+                submitted_epoch,
+                block_delay_secs,
+                "SyncSubmitBlock: head did not catch up within one block time"
+            );
+        }
         Ok(())
     }
 }
@@ -171,6 +189,7 @@ mod tests {
     use crate::blocks::RawBlockHeader;
     use crate::blocks::{CachingBlockHeader, Tipset};
     use crate::chain::ChainStore;
+    use crate::chain_sync::NodeSyncStatus;
     use crate::chain_sync::network_context::SyncNetworkContext;
     use crate::db::{Blockstore as _, MemoryDB};
     use crate::key_management::{KeyStore, KeyStoreConfig};

--- a/src/rpc/methods/sync.rs
+++ b/src/rpc/methods/sync.rs
@@ -5,13 +5,14 @@ mod types;
 
 use crate::blocks::{Block, FullTipset, GossipBlock};
 use crate::chain;
-use crate::chain_sync::{SyncStatusReport, TipsetValidator};
+use crate::chain_sync::{BlockValidationOutcome, SyncStatusReport, TipsetValidator};
 use crate::libp2p::{IdentTopic, NetworkMessage, PUBSUB_BLOCK_STR};
 use crate::prelude::*;
 use crate::rpc::{ApiPaths, Ctx, Permission, RpcMethod, ServerError};
 use enumflags2::BitFlags;
 use fvm_ipld_encoding::to_vec;
 use std::time::Duration;
+use tokio::sync::broadcast::error::RecvError;
 pub use types::*;
 
 pub enum SyncCheckBad {}
@@ -130,6 +131,7 @@ impl RpcMethod<1> for SyncSubmitBlock {
         let pubsub_block_str = format!("{PUBSUB_BLOCK_STR}/{genesis_network_name}");
         let (bls_messages, secp_messages) =
             chain::store::block_messages(ctx.db(), &block_msg.header)?;
+        let block_cid = *block_msg.header.cid();
         let block = Block {
             header: block_msg.header,
             bls_messages,
@@ -147,35 +149,50 @@ impl RpcMethod<1> for SyncSubmitBlock {
             )
             .context("failed to validate the tipset")?;
 
-        let submitted_epoch = ts.epoch();
+        // Subscribe before injecting the tipset so the follower's verdict cannot be missed.
+        let mut outcomes = ctx.block_validation_subscriber.subscribe();
         ctx.tipset_send
             .try_send(ts)
             .context("tipset queue is full")?;
 
+        // Forest applies the tipset via the async follower, unlike Lotus whose `Syncer.Sync` is
+        // synchronous. Wait (bounded by ~one block time) for the follower's verdict; for a block
+        // that extends the head (the mining case) an applied verdict means the head has advanced,
+        // so lotus-miner does not re-select the same base.
+        let block_delay_secs = ctx.chain_config().block_delay_secs.into();
+        let verdict = tokio::time::timeout(Duration::from_secs(block_delay_secs), async {
+            loop {
+                match outcomes.recv().await {
+                    Ok((cid, outcome)) if cid == block_cid => return Some(outcome),
+                    Ok(_) | Err(RecvError::Lagged(_)) => {}
+                    Err(RecvError::Closed) => return None,
+                }
+            }
+        })
+        .await;
+
+        // Publish the block unless the follower definitively rejected it: Lotus publishes after a
+        // successful `Syncer.Sync` and errors on failure, and on no verdict within a block time we
+        // still publish best-effort (the block passed the synchronous `TipsetValidator` and is not
+        // known-bad; gossiping an unincluded block is not slashable, peers just reject it).
+        match verdict {
+            Ok(Some(BlockValidationOutcome::Rejected)) => {
+                return Err(anyhow::anyhow!(
+                    "submitted block {block_cid} was rejected during validation"
+                )
+                .into());
+            }
+            Ok(Some(BlockValidationOutcome::Applied)) | Ok(None) => {}
+            Err(_elapsed) => tracing::warn!(
+                %block_cid,
+                block_delay_secs,
+                "SyncSubmitBlock: no validation verdict within one block time; publishing best-effort"
+            ),
+        }
         ctx.network_send().send(NetworkMessage::PubsubMessage {
             topic: IdentTopic::new(pubsub_block_str),
             message: encoded_message,
         })?;
-
-        // Forest applies the submitted tipset via the async follower, unlike Lotus whose
-        // `Syncer.Sync` sets the head synchronously. Wait (bounded by ~one block time) for the
-        // head to reflect it, else a caller mining on the head re-selects the
-        // same base and stalls a full block time each round.
-        let block_delay_secs = ctx.chain_config().block_delay_secs.into();
-        if tokio::time::timeout(Duration::from_secs(block_delay_secs), async {
-            while ctx.chain_store().heaviest_tipset().epoch() < submitted_epoch {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .is_err()
-        {
-            tracing::warn!(
-                submitted_epoch,
-                block_delay_secs,
-                "SyncSubmitBlock: head did not catch up within one block time"
-            );
-        }
         Ok(())
     }
 }
@@ -262,6 +279,7 @@ mod tests {
             start_time,
             shutdown: mpsc::channel(1).0, // dummy for tests
             tipset_send,
+            block_validation_subscriber: Default::default(),
             snapshot_progress_tracker: Default::default(),
             mpool_locker: MpoolLocker::new(),
             nonce_tracker,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -509,6 +509,7 @@ pub struct RPCState {
     pub eth_logs_feed: std::sync::OnceLock<eth::pubsub::LogsFeed>,
     pub sync_network_context: SyncNetworkContext,
     pub tipset_send: flume::Sender<FullTipset>,
+    pub block_validation_subscriber: crate::chain_sync::BlockValidationSubscriber,
     pub start_time: chrono::DateTime<chrono::Utc>,
     pub snapshot_progress_tracker: SnapshotProgressTracker,
     pub shutdown: mpsc::Sender<()>,

--- a/src/tool/offline_server/server.rs
+++ b/src/tool/offline_server/server.rs
@@ -122,6 +122,7 @@ pub async fn offline_rpc_state(
             start_time: chrono::Utc::now(),
             shutdown,
             tipset_send,
+            block_validation_subscriber: Default::default(),
             snapshot_progress_tracker: Default::default(),
             mpool_locker: MpoolLocker::new(),
             nonce_tracker,

--- a/src/tool/subcommands/api_cmd/generate_test_snapshot.rs
+++ b/src/tool/subcommands/api_cmd/generate_test_snapshot.rs
@@ -165,6 +165,7 @@ async fn ctx(
         start_time: chrono::Utc::now(),
         shutdown,
         tipset_send,
+        block_validation_subscriber: Default::default(),
         snapshot_progress_tracker: Default::default(),
         mpool_locker: MpoolLocker::new(),
         nonce_tracker,

--- a/src/tool/subcommands/api_cmd/test_snapshot.rs
+++ b/src/tool/subcommands/api_cmd/test_snapshot.rs
@@ -270,6 +270,7 @@ async fn ctx(
         start_time: chrono::Utc::now(),
         shutdown,
         tipset_send,
+        block_validation_subscriber: Default::default(),
         snapshot_progress_tracker: Default::default(),
         mpool_locker: MpoolLocker::new(),
         nonce_tracker,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `Filecoin.Version` now reports the API version of the endpoint being served (`1.5.0` over `/rpc/v0`, `2.3.0` over `/rpc/v1`), matching Lotus, and `Filecoin.SyncSubmitBlock` no longer requires the node to be in the `Synced` state and waits up to one block time for the submitted block to become the chain head. Together these let Forest act as the full node for an external block producer such as `lotus-miner` or `curio`
- validated that it works on a local devnet backed up lotus-miner + forest; the setup to be submitted in a follow-up PR.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Part of https://github.com/ChainSafe/forest/issues/7370
Closes https://github.com/ChainSafe/forest/issues/7536

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - API version reporting now distinguishes V0, V1, and V2 requests.
  - External block submissions can proceed while the node is syncing.
  - Submitted blocks are monitored for validation results, with rejected blocks refused and delayed results producing a warning.
  - Successfully validated blocks are published automatically.

- **Documentation**
  - Added unreleased changelog notes describing these updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->