### PR TITLE
feat(wallet): support calldata in forest-wallet send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Added
 
+- [#7472](https://github.com/ChainSafe/forest/issues/7472): `forest-wallet send` now accepts `--params-hex` to attach calldata (CBOR-wrapped for contract `InvokeContract` targets, matching `lotus send`), so it can call a method on a contract, and `--method` to set the message method number explicitly for non-contract targets.
+
 ### Changed
 
 ### Removed

--- a/src/dev/subcommands/devnet_cmd/eth_gas.rs
+++ b/src/dev/subcommands/devnet_cmd/eth_gas.rs
@@ -82,6 +82,9 @@ fn tests() -> Vec<Trial> {
         trial("eth_estimate_gas_is_sufficient_on_chain", || {
             block_on(estimate_is_sufficient_on_chain())
         }),
+        trial("forest_wallet_send_calldata_invokes_contract", || {
+            block_on(forest_wallet_send_calldata_invokes_contract())
+        }),
         trial("eth_estimate_gas_reports_a_non_gas_failure", || {
             block_on(estimate_reports_a_non_gas_failure())
         }),
@@ -173,6 +176,77 @@ async fn sender_addr() -> anyhow::Result<&'static Address> {
             Ok(sender)
         })
         .await
+}
+
+/// A delegated (`f4`) sender in Forest's *local* keystore, funded well enough to
+/// afford the nested call. Unlike [`sender_addr`] (Lotus's keystore), the key
+/// lives with Forest so `forest-wallet send` can sign locally.
+async fn forest_wallet_sender() -> anyhow::Result<&'static str> {
+    static SENDER: OnceCell<String> = OnceCell::const_new();
+    SENDER
+        .get_or_try_init(|| async {
+            let addr = wallet(Backend::Local, &["new", "delegated"])?;
+            let msg = send_from(
+                &FOREST_TEST_PRELOADED_ADDRESS,
+                &addr,
+                SENDER_FUND_AMT,
+                Backend::Local,
+            )?;
+            eprintln!("funding forest-wallet sender {addr} with {SENDER_FUND_AMT}, msg: {msg}");
+            let balance = poll_until_funded(&addr, Backend::Local).await?;
+            eprintln!("forest-wallet sender {addr} funded balance: {balance}");
+            // The miner runs on Lotus, so wait until Lotus sees the funded actor
+            // before submitting, or the call could be mined against stale state.
+            let parsed = Address::from_str(&addr).context("parsing forest-wallet sender")?;
+            poll_until_actor_on("lotus", parsed, lotus_client).await?;
+            anyhow::Ok(addr)
+        })
+        .await
+        .map(String::as_str)
+}
+
+/// `forest-wallet send --params-hex` must build a working `InvokeContract`
+/// message: it should CBOR-wrap the calldata, land on chain, and the contract
+/// call must succeed. This exercises the calldata support end to end through the
+/// CLI rather than a raw `MpoolPush`.
+async fn forest_wallet_send_calldata_invokes_contract() -> anyhow::Result<()> {
+    let target = contract().await?.f4.to_string();
+    let sender = forest_wallet_sender().await?;
+    let params = hex::encode(recurse_calldata(NESTED_DEPTH));
+
+    // The `f4` target makes `forest-wallet send` infer `InvokeContract` and
+    // CBOR-wrap the params; it estimates the gas itself, so no `--gas-limit`.
+    let out = wallet(
+        Backend::Local,
+        &[
+            "send",
+            "--from",
+            sender,
+            "--params-hex",
+            &params,
+            &target,
+            "0",
+        ],
+    )?;
+    let cid = Cid::from_str(
+        out.lines()
+            .last()
+            .context("no cid from `forest-wallet send`")?
+            .trim(),
+    )?;
+    eprintln!("forest-wallet submitted contract call: {cid}");
+
+    let forest = forest_client()?;
+    let lookup = forest
+        .call(StateWaitMsg::request((cid, 0, 800, true))?.with_timeout(POLL_TIMEOUT))
+        .await?;
+    let exit = lookup.receipt.exit_code();
+    ensure!(
+        exit.is_success(),
+        "contract call submitted via `forest-wallet send --params-hex` failed on chain \
+         with exit code {exit}"
+    );
+    Ok(())
 }
 
 async fn estimate(

--- a/src/wallet/subcommands/wallet_cmd.rs
+++ b/src/wallet/subcommands/wallet_cmd.rs
@@ -36,9 +36,11 @@ use crate::{
     },
 };
 use anyhow::{Context as _, bail};
+use cbor4ii::core::Value;
 use clap::Subcommand;
 use dialoguer::{Password, console::Term, theme::ColorfulTheme};
 use directories::ProjectDirs;
+use fvm_ipld_encoding::RawBytes;
 use jsonrpsee::core::ClientError;
 use num::Zero as _;
 use tabled::{builder::Builder, settings::Style};
@@ -314,6 +316,15 @@ pub enum WalletCommands {
         gas_limit: i64,
         #[arg(long, value_parser = humantoken::parse, default_value_t = TokenAmount::zero())]
         gas_premium: TokenAmount,
+        /// Hex-encoded calldata for the message params (a leading `0x` is
+        /// accepted). For a contract target it is CBOR-wrapped the way the EVM
+        /// actor expects, matching `lotus send --params-hex`.
+        #[arg(long)]
+        params_hex: Option<String>,
+        /// Explicitly set the message method number. Cannot be combined with a
+        /// contract target, whose method is always `InvokeContract`.
+        #[arg(long)]
+        method: Option<u64>,
         /// Wait for the message to be on chain with the given confidence by calling `StateWaitMsg`.
         /// The command waits until the message has been on chain for at least `confidence` epochs.
         #[arg(long)]
@@ -507,6 +518,8 @@ impl WalletCommands {
                 gas_feecap,
                 gas_limit,
                 gas_premium,
+                params_hex,
+                method,
                 wait_confidence,
                 wait_timeout,
             } => {
@@ -532,13 +545,15 @@ impl WalletCommands {
                             )
                         })?;
                 }
-                let method_num = resolve_method_num(&from, &to, is_0x_recipient);
+                let method_num = resolve_send_method_num(&from, &to, is_0x_recipient, method)?;
+                let params = encode_message_params(params_hex.as_deref(), method_num)?;
 
                 let message = Message {
                     from,
                     to,
                     value: amount,
                     method_num,
+                    params,
                     gas_limit: gas_limit as u64,
                     gas_fee_cap: gas_feecap,
                     gas_premium,
@@ -690,6 +705,48 @@ fn resolve_method_num(from: &Address, to: &Address, is_0x_recipient: bool) -> u6
     }
 }
 
+/// Resolves the method number for a `send`, honoring an explicit `--method`
+/// override. Like `lotus send`, an explicit method is rejected for a contract
+/// target, whose method is always `InvokeContract`.
+fn resolve_send_method_num(
+    from: &Address,
+    to: &Address,
+    is_0x_recipient: bool,
+    explicit: Option<u64>,
+) -> anyhow::Result<u64> {
+    let resolved = resolve_method_num(from, to, is_0x_recipient);
+    match explicit {
+        Some(_) if resolved == EVMMethod::InvokeContract as u64 => bail!(
+            "--method cannot be used with a contract target; the method is always InvokeContract"
+        ),
+        Some(m) => Ok(m),
+        None => Ok(resolved),
+    }
+}
+
+/// Builds the message params from optional hex calldata. For an
+/// `InvokeContract` target the calldata is CBOR-wrapped as a byte string, the
+/// way the EVM actor expects (matching `lotus send --params-hex`); for any
+/// other method the decoded bytes are used verbatim. Empty or absent calldata
+/// yields empty params.
+fn encode_message_params(params_hex: Option<&str>, method_num: u64) -> anyhow::Result<RawBytes> {
+    let Some(hex_str) = params_hex else {
+        return Ok(RawBytes::default());
+    };
+    let bytes =
+        hex::decode(hex_str.trim_start_matches("0x")).context("--params-hex must be valid hex")?;
+    if bytes.is_empty() {
+        return Ok(RawBytes::default());
+    }
+    if method_num == EVMMethod::InvokeContract as u64 {
+        let wrapped = cbor4ii::serde::to_vec(Vec::new(), &Value::Bytes(bytes))
+            .context("failed to CBOR-encode calldata params")?;
+        Ok(RawBytes::new(wrapped))
+    } else {
+        Ok(RawBytes::new(bytes))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -700,7 +757,11 @@ mod tests {
     use crate::shim::message::METHOD_SEND;
     use rstest::rstest;
 
-    use super::{SignatureType, resolve_method_num, resolve_target_address, wrap_frc0102};
+    use super::{
+        SignatureType, encode_message_params, resolve_method_num, resolve_send_method_num,
+        resolve_target_address, wrap_frc0102,
+    };
+    use fvm_ipld_encoding::RawBytes;
 
     #[test]
     fn test_resolve_target_address_id() {
@@ -851,6 +912,78 @@ mod tests {
         assert_eq!(&wrapped[..26], b"\x19Filecoin Signed Message:\n");
         assert_eq!(&wrapped[26..26 + digits.len()], digits.as_bytes());
         assert_eq!(&wrapped[26 + digits.len()..], msg.as_slice());
+    }
+
+    #[test]
+    fn test_resolve_send_method_num_explicit_override() {
+        // A plain send to a native actor may carry an explicit method number.
+        let from = Address::from_str("f01234").unwrap();
+        let to = Address::from_str("f05678").unwrap();
+        assert_eq!(
+            resolve_send_method_num(&from, &to, false, Some(42)).unwrap(),
+            42
+        );
+        // Without an override it falls back to the resolved method.
+        assert_eq!(
+            resolve_send_method_num(&from, &to, false, None).unwrap(),
+            METHOD_SEND
+        );
+    }
+
+    #[test]
+    fn test_resolve_send_method_num_rejects_method_on_contract() {
+        // A contract target resolves to `InvokeContract`; an explicit method is rejected.
+        let from = Address::from_str("f410fvfpyxvy6aqet3g2bfbj6h7nr5kjgyncpaeimgxa").unwrap();
+        let to = Address::from_str("f410fvfpyxvy6aqet3g2bfbj6h7nr5kjgyncpaeimgxa").unwrap();
+        assert_eq!(
+            resolve_send_method_num(&from, &to, false, None).unwrap(),
+            EVMMethod::InvokeContract as u64
+        );
+        let err = resolve_send_method_num(&from, &to, false, Some(7)).unwrap_err();
+        assert!(err.to_string().contains("--method cannot be used"));
+    }
+
+    #[test]
+    fn test_encode_message_params_none_and_empty() {
+        assert_eq!(
+            encode_message_params(None, METHOD_SEND).unwrap(),
+            RawBytes::default()
+        );
+        // Empty calldata yields empty params, even for a contract target.
+        assert_eq!(
+            encode_message_params(Some(""), EVMMethod::InvokeContract as u64).unwrap(),
+            RawBytes::default()
+        );
+    }
+
+    #[test]
+    fn test_encode_message_params_raw_for_non_contract() {
+        // A non-`InvokeContract` method carries the decoded bytes verbatim.
+        assert_eq!(
+            encode_message_params(Some("1234"), METHOD_SEND).unwrap(),
+            RawBytes::new(vec![0x12, 0x34])
+        );
+    }
+
+    #[test]
+    fn test_encode_message_params_cbor_wraps_calldata() {
+        // For `InvokeContract` the calldata is wrapped as a CBOR byte string:
+        // major type 2, length 4 (`0x44`) followed by the 4 calldata bytes.
+        assert_eq!(
+            encode_message_params(Some("12345678"), EVMMethod::InvokeContract as u64).unwrap(),
+            RawBytes::new(vec![0x44, 0x12, 0x34, 0x56, 0x78])
+        );
+        // A leading `0x` is accepted.
+        assert_eq!(
+            encode_message_params(Some("0x12345678"), EVMMethod::InvokeContract as u64).unwrap(),
+            RawBytes::new(vec![0x44, 0x12, 0x34, 0x56, 0x78])
+        );
+    }
+
+    #[test]
+    fn test_encode_message_params_rejects_invalid_hex() {
+        let err = encode_message_params(Some("nothex"), METHOD_SEND).unwrap_err();
+        assert!(err.to_string().contains("must be valid hex"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary of changes

`forest-wallet send` already routes eth targets to `InvokeContract`, but there was no way to attach calldata, so it couldn't actually call a method on a contract (the message params were always empty).

Changes introduced in this pull request:

- Add `--params-hex` to `forest-wallet send`. The hex calldata (a leading `0x` is accepted) is decoded and, for an `InvokeContract` target, CBOR-wrapped as a byte string the way the EVM actor expects, matching what `lotus send --params-hex` produces. For any other method the decoded bytes are used verbatim. Empty or absent calldata yields empty params.
- Add `--method` to set the message method number explicitly. Like `lotus send`, an explicit method is rejected for a contract target, whose method is always `InvokeContract`.
- Factored the method resolution and param encoding into small pure helpers and covered them with unit tests (contract vs non-contract method resolution, the `--method` guard, CBOR-wrapping of calldata, raw passthrough, `0x` prefix handling, and invalid hex).

## Reference issue to close (if applicable)

Closes #7472

## Other information and links

The issue also suggests replacing some `lotus wallet send` usages in the dev tooling with the forest one. I left that for a follow-up: the one obvious call site (`src/dev/subcommands/devnet_cmd/eth_gas.rs`) intentionally submits via Lotus to prove Forest's gas estimate lands on a different node, so swapping it would defeat that test's purpose. Happy to migrate whichever call sites you'd like in a follow-up.

## Change checklist

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [x] I have read and agree to the [CONTRIBUTING][2] document.
- [x] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional hexadecimal calldata support to `forest-wallet send` through `--params-hex`.
  * Added support for specifying explicit method numbers with `--method`.
  * Contract calls now validate method options and encode calldata appropriately.

* **Bug Fixes**
  * Improved handling of empty and invalid hexadecimal calldata input.

* **Documentation**
  * Updated the changelog with the new wallet send options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->