### PR TITLE
chore: remove panic on overflow in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,11 +328,7 @@ panic = "abort"
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip
 strip = true
 panic = "abort"
-overflow-checks = true
 lto = "thin"
-
-[profile.release.package.quinn-proto]
-overflow-checks = false
 
 [profile.release-lto-fat]
 inherits = "release"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- we already fixed most prominent bugs with overflows, see https://github.com/ChainSafe/forest/pull/7459
- this is a non-negligible perf cost in some hot loops (mentioned briefly in https://mara.nl/atomics/)
- allowing overflows is the default anyway, both in Rust and other languages like Go
- we do panic on abort (AFAIR due to some WASM things) so this completely obliterates the node in case it happens
- even if we fix all possible under/overflows in Forest, our dependencies can still have them; most are pretty fast with fixes and releases, but, e.g., `rust-libp2p` had a last release... over a year ago. And we cannot do anything with its pinned versions (except for forking or checking every packet somehow ourselves).
- Some CI checks could still benefit from this, though, to be tackled via https://github.com/ChainSafe/forest/issues/7560

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release build configuration while retaining thin link-time optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->