### PR TITLE
feat(bench): tipset benchmarking over snapshot & ranges

### DIFF
--- a/src/benchmark_private/tipset_validation.rs
+++ b/src/benchmark_private/tipset_validation.rs
@@ -5,15 +5,144 @@
 #![allow(clippy::unwrap_used)]
 
 use crate::{
+    blocks::Tipset,
+    interpreter::VMTrace,
     networks::NetworkChain,
-    state_manager::utils::state_compute::{
-        get_state_compute_snapshot, prepare_state_compute, state_compute,
+    state_manager::{
+        NO_CALLBACK,
+        utils::state_compute::{get_state_compute_snapshot, prepare_state_compute, state_compute},
     },
 };
+use anyhow::Context as _;
 use criterion::Criterion;
 use std::hint::black_box;
+use std::path::Path;
+use std::time::Instant;
 
+// Re-validate a range of tipsets from a local snapshot, timing each, so the cost of tipset
+// validation can be compared across FVM/wasmtime changes on real chain data.
+//
+// Knobs:
+//   FOREST_BENCH_SNAPSHOT  path to a full `.forest.car.zst` snapshot (required to enable this mode)
+//   FOREST_BENCH_CHAIN     network name, e.g. `mainnet` or `calibnet` (default: mainnet)
+//   FOREST_BENCH_EPOCHS    how many tipsets to walk back from the snapshot head (default: 1).
+//                          Must fit inside the snapshot's retained-state window, otherwise the run
+//                          fails rather than reporting a short result.
+fn validate_range(chain: &NetworkChain, snapshot: &Path, epochs: u64) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    anyhow::ensure!(epochs > 0, "FOREST_BENCH_EPOCHS must be greater than 0");
+    rt.block_on(async {
+        let (sm, mut ts, mut child) = prepare_state_compute(chain, snapshot)
+            .await
+            .with_context(|| format!("failed to open snapshot {}", snapshot.display()))?;
+        let head = ts.epoch();
+        // Recomputed state accumulates in the in-memory write layer over the snapshot, so a very
+        // large range against an archival snapshot (which retains every state) can grow unbounded.
+        let mut durations_ms: Vec<f64> = Vec::with_capacity(epochs.min(10_000) as usize);
+        let wall = Instant::now();
+        for i in 0..epochs {
+            let t0 = Instant::now();
+            let executed = match sm
+                .compute_tipset_state(ts.clone(), NO_CALLBACK, VMTrace::NotTraced)
+                .await
+            {
+                Ok(e) => e,
+                Err(e) => {
+                    // Never report a short run as a success: a partial walk is either bad input
+                    // (asking for more tipsets than the snapshot retains) or a real regression, and
+                    // both deserve a non-zero exit.
+                    return Err(anyhow::Error::new(e)).with_context(|| {
+                        format!(
+                            "failed to compute tipset state at epoch {} after validating {} of \
+                             {epochs} tipsets; if the snapshot's retained-state window is shallower \
+                             than the requested range, lower FOREST_BENCH_EPOCHS",
+                            ts.epoch(),
+                            durations_ms.len()
+                        )
+                    });
+                }
+            };
+            durations_ms.push(t0.elapsed().as_secs_f64() * 1e3);
+            anyhow::ensure!(
+                executed.state_root == *child.parent_state(),
+                "state root mismatch at epoch {}: computed {}, expected {}",
+                ts.epoch(),
+                executed.state_root,
+                child.parent_state()
+            );
+            anyhow::ensure!(
+                executed.receipt_root == *child.parent_message_receipts(),
+                "receipt root mismatch at epoch {}: computed {}, expected {}",
+                ts.epoch(),
+                executed.receipt_root,
+                child.parent_message_receipts()
+            );
+            if i + 1 == epochs {
+                break;
+            }
+            let parent = Tipset::load_required(sm.db(), ts.parents())
+                .with_context(|| format!("failed to load parent of epoch {}", ts.epoch()))?;
+            child = ts;
+            ts = parent;
+        }
+
+        let total = wall.elapsed().as_secs_f64();
+        let n = durations_ms.len();
+        anyhow::ensure!(n > 0, "no tipsets were validated");
+        let sum: f64 = durations_ms.iter().sum();
+        let cold = *durations_ms
+            .first()
+            .context("no timing samples were collected")?;
+        durations_ms.sort_unstable_by(f64::total_cmp);
+        let sample = |i: usize| -> anyhow::Result<f64> {
+            durations_ms
+                .get(i)
+                .copied()
+                .with_context(|| format!("timing sample {i} out of range (n = {n})"))
+        };
+        let median = if n.is_multiple_of(2) {
+            (sample(n / 2 - 1)? + sample(n / 2)?) / 2.0
+        } else {
+            sample(n / 2)?
+        };
+        let p95 = sample((n as f64 * 0.95) as usize)?;
+
+        println!("\n==== tipset validation timing ({chain}) ====");
+        println!("tipsets validated (from epoch {head}) : {n}");
+        println!("total wall time            : {total:.2} s");
+        println!("mean per tipset            : {:.2} ms", sum / n as f64);
+        println!("median per tipset          : {median:.2} ms");
+        println!("p95 per tipset             : {p95:.2} ms");
+        println!("first tipset (cold compile): {cold:.1} ms");
+        anyhow::Ok(())
+    })
+}
+
+/// Benchmarks tipset validation.
+///
+/// By default this runs the criterion benchmarks over purpose-built snapshots.
+/// Setting `FOREST_BENCH_SNAPSHOT` instead validates and times a range of tipsets from
+/// a local snapshot; see [`validate_range`] for the accompanying environment variables.
 pub fn bench_tipset_validation(c: &mut Criterion) {
+    if let Ok(path) = std::env::var("FOREST_BENCH_SNAPSHOT") {
+        let chain = match std::env::var("FOREST_BENCH_CHAIN").as_deref() {
+            Ok("mainnet") | Err(_) => NetworkChain::Mainnet,
+            Ok("calibnet") => NetworkChain::Calibnet,
+            Ok(other) => {
+                panic!("FOREST_BENCH_CHAIN must be `mainnet` or `calibnet`, got {other:?}")
+            }
+        };
+        let epochs: u64 = std::env::var("FOREST_BENCH_EPOCHS")
+            .ok()
+            .map(|s| s.parse().expect("invalid FOREST_BENCH_EPOCHS"))
+            .unwrap_or(1);
+        validate_range(&chain, Path::new(&path), epochs).expect("tipset validation failed");
+        return;
+    }
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- added some helpful benchmark for tipset validation against a snapshot; useful for catching regressions (or wins) in, e.g., wasmtime updates in FVM (or some internal Forest logic).
- keeping the env variables out of docs - not Forest, just a dev benchmark.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

Can be run, e.g., like so:
```
❯ FOREST_BENCH_SNAPSHOT=~/prj/snapshots/forest_snapshot_mainnet_2026-08-14_height_6279840.forest.car.zst \
      FOREST_BENCH_CHAIN=mainnet \
      FOREST_BENCH_EPOCHS=1800 \
        cargo bench --features benchmark-private --bench tipset-validation
```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added an optional snapshot-based benchmark for validating historical chain data.
  - Verifies state and receipt roots while traversing historical tipsets.
  - Reports timing statistics with accurate median performance measurements.
  - Provides contextual errors when validation encounters issues.
  - Existing fixed-network benchmarks remain available when snapshot mode is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->