### PR TITLE
fix(cli): `forest-tool` index backfill ensure proof parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Fixed
 
-- [#XXXX](https://github.com/ChainSafe/forest/pull/XXXX): `forest-tool index backfill` now downloads the Filecoin proof parameters before running.
+- [#7579](https://github.com/ChainSafe/forest/issues/7579): `forest-tool index backfill` now downloads the Filecoin proof parameters before running.
 
 ## Forest v0.36.1 "Kaaguy"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,27 @@
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Fixed
+
+- [#XXXX](https://github.com/ChainSafe/forest/pull/XXXX): `forest-tool index backfill` now downloads the Filecoin proof parameters before running.
+
+## Forest v0.36.1 "Kaaguy"
+
+Non-mandatory release for all node operators. Mostly fixes and improvements around RPC methods.
+
+### Added
+
 - [#7555](https://github.com/ChainSafe/forest/issues/7555): Added `--as-default` to `forest-wallet import`.
+
 - [#7414](https://github.com/ChainSafe/forest/issues/7414): New `drand_http_fetch_total` metric, counting the drand rounds that had to be fetched over HTTP rather than served from the in-memory cache.
 
 ### Changed
 
 - [#7535](https://github.com/ChainSafe/forest/pull/7535): `Filecoin.Version` now reports the API version of the endpoint being served (`1.5.0` over `/rpc/v0`, `2.3.0` over `/rpc/v1`), matching Lotus, and `Filecoin.SyncSubmitBlock` no longer requires the node to be in the `Synced` state and waits up to one block time for the submitted block to become the chain head. Together these let Forest act as the full node for an external block producer such as `lotus-miner` or `curio` (verified on a local devnet, calibnet/mainnet tests to come).
-
-### Removed
 
 ### Fixed
 

--- a/scripts/tests/external-rpc-checks/docker-compose.yaml
+++ b/scripts/tests/external-rpc-checks/docker-compose.yaml
@@ -24,7 +24,6 @@ services:
     environment:
       - FOREST_PATH=/data
       - FOREST_CHAIN_INDEXER_ENABLED=1
-      - FOREST_ETH_RPC_COMPUTE_STATE_ON_INDEX_MISS=1
     command:
       - --chain=calibnet
       - --encrypt-keystore=false

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -774,15 +774,12 @@ pub async fn run_backfill(
     let mut processed_since_flush = 0usize;
     let mut lowest_epoch = start_ts.epoch();
 
-    for (count, ts) in start_ts
+    for ts in start_ts
         .shallow_clone()
         .chain(&state_manager.chain_store().db())
-        .enumerate()
     {
-        match spec {
-            RangeSpec::To(to_epoch) if ts.epoch() < to_epoch => break,
-            RangeSpec::NumTipsets(n) if count >= n => break,
-            _ => {}
+        if ts.epoch() < target_epoch {
+            break;
         }
 
         if cancel.is_cancelled() {

--- a/src/daemon/db_util.rs
+++ b/src/daemon/db_util.rs
@@ -774,12 +774,15 @@ pub async fn run_backfill(
     let mut processed_since_flush = 0usize;
     let mut lowest_epoch = start_ts.epoch();
 
-    for ts in start_ts
+    for (count, ts) in start_ts
         .shallow_clone()
         .chain(&state_manager.chain_store().db())
+        .enumerate()
     {
-        if ts.epoch() < target_epoch {
-            break;
+        match spec {
+            RangeSpec::To(to_epoch) if ts.epoch() < to_epoch => break,
+            RangeSpec::NumTipsets(n) if count >= n => break,
+            _ => {}
         }
 
         if cancel.is_cancelled() {

--- a/src/state_manager/state_computation.rs
+++ b/src/state_manager/state_computation.rs
@@ -221,6 +221,26 @@ impl StateManager {
                     .compute_tipset_state(msg_ts.shallow_clone(), NO_CALLBACK, VMTrace::NotTraced)
                     .await?;
                 recomputed = true;
+
+                if let Some(receipt_ts) = receipt_ts {
+                    let expected_receipts = *receipt_ts.parent_message_receipts();
+                    let expected_state = *receipt_ts.parent_state();
+
+                    anyhow::ensure!(
+                        state_output.state_root == expected_state,
+                        "state root mismatch at epoch {}: computed {}, expected {}",
+                        msg_ts.epoch(),
+                        state_output.state_root,
+                        expected_state
+                    );
+                    anyhow::ensure!(
+                        state_output.receipt_root == expected_receipts,
+                        "receipt root mismatch at epoch {}: computed {}, expected {}",
+                        msg_ts.epoch(),
+                        state_output.receipt_root,
+                        expected_receipts
+                    );
+                }
                 (
                     state_output.state_root,
                     state_output.receipt_root,

--- a/src/state_manager/state_computation.rs
+++ b/src/state_manager/state_computation.rs
@@ -16,6 +16,25 @@ enum StateRecomputePolicy {
     Disallowed,
 }
 
+fn ensure_recomputed_state_matches(
+    epoch: ChainEpoch,
+    computed: &ExecutedTipset,
+    expected_state: &Cid,
+    expected_receipts: &Cid,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        computed.state_root == *expected_state,
+        "state root mismatch at epoch {epoch}: computed {}, expected {expected_state}",
+        computed.state_root,
+    );
+    anyhow::ensure!(
+        computed.receipt_root == *expected_receipts,
+        "receipt root mismatch at epoch {epoch}: computed {}, expected {expected_receipts}",
+        computed.receipt_root,
+    );
+    Ok(())
+}
+
 impl StateManager {
     /// Load the state of a tipset, including state root, message receipts
     pub async fn load_tipset_state(&self, ts: &Tipset) -> anyhow::Result<TipsetState> {
@@ -223,23 +242,12 @@ impl StateManager {
                 recomputed = true;
 
                 if let Some(receipt_ts) = receipt_ts {
-                    let expected_receipts = *receipt_ts.parent_message_receipts();
-                    let expected_state = *receipt_ts.parent_state();
-
-                    anyhow::ensure!(
-                        state_output.state_root == expected_state,
-                        "state root mismatch at epoch {}: computed {}, expected {}",
+                    ensure_recomputed_state_matches(
                         msg_ts.epoch(),
-                        state_output.state_root,
-                        expected_state
-                    );
-                    anyhow::ensure!(
-                        state_output.receipt_root == expected_receipts,
-                        "receipt root mismatch at epoch {}: computed {}, expected {}",
-                        msg_ts.epoch(),
-                        state_output.receipt_root,
-                        expected_receipts
-                    );
+                        &state_output,
+                        receipt_ts.parent_state(),
+                        receipt_ts.parent_message_receipts(),
+                    )?;
                 }
                 (
                     state_output.state_root,
@@ -266,12 +274,19 @@ impl StateManager {
                         if !allow_state_compute {
                             anyhow::bail!(state_compute_disallow_error());
                         }
-                        self.compute_tipset_state(
-                            msg_ts.shallow_clone(),
-                            NO_CALLBACK,
-                            VMTrace::NotTraced,
-                        )
-                        .await?;
+                        let state_output = self
+                            .compute_tipset_state(
+                                msg_ts.shallow_clone(),
+                                NO_CALLBACK,
+                                VMTrace::NotTraced,
+                            )
+                            .await?;
+                        ensure_recomputed_state_matches(
+                            msg_ts.epoch(),
+                            &state_output,
+                            &state_root,
+                            &receipt_root,
+                        )?;
                         recomputed = true;
                         StampedEvent::get_events(self.cs.db(), &events_root)?
                     }

--- a/src/tool/subcommands/index_cmd.rs
+++ b/src/tool/subcommands/index_cmd.rs
@@ -19,6 +19,7 @@ use crate::prelude::*;
 use crate::shim::clock::ChainEpoch;
 use crate::state_manager::StateManager;
 use crate::tool::offline_server::server::handle_chain_config;
+use crate::utils::proofs_api::{self, ensure_proof_params_downloaded};
 
 #[derive(Debug, Subcommand)]
 pub enum IndexCommands {
@@ -55,6 +56,9 @@ impl IndexCommands {
                 let spec = RangeSpec::new(*to, *n_tipsets)?;
 
                 let (_, config) = read_config(config.as_ref(), chain.clone())?;
+
+                proofs_api::maybe_set_proofs_parameter_cache_dir_env(&config.client.data_dir);
+                ensure_proof_params_downloaded().await?;
 
                 let chain_data_path = chain_path(&config);
                 let db_root_dir = db_root(&chain_data_path)?;


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `forest-tool index backfill` calls `ensure_proof_params_downloaded()` before proceed with the backfilling
- `load_executed_tipset_inner` now `ensure!`s that a recomputed tipset's receipt root and state root match the child header's `ParentMessageReceipts`/`ParentStateRoot`; a mismatch is an error (the backfill reports the tipset as skipped with the diverging CIDs) instead of passing as a success.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes https://github.com/ChainSafe/forest/issues/7579

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * State and receipt root mismatches are now detected consistently during state recomputation, preventing invalid results from being accepted.
  * Index backfills now ensure required proof parameters are available before processing begins.

* **Documentation**
  * Updated the unreleased changelog entry to reference the correct issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->