### PR TITLE
Drop `--recompute` flag on index backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ### Changed
 
+- [#7594](https://github.com/ChainSafe/forest/pull/7594): `forest-cli index backfill` now defaults `--recompute` to true and exits with an error if any tipsets were skipped.
+
 ### Removed
 
 ### Fixed

--- a/docs/docs/users/reference/cli.md
+++ b/docs/docs/users/reference/cli.md
@@ -835,8 +835,8 @@ Options:
       --n-tipsets <N_TIPSETS>
           Number of tipsets to back-fill
 
-      --recompute
-          Recompute missing tipset state (expensive) instead of skipping it; tipsets that still can't be computed are skipped and reported rather than aborting the run
+      --recompute [<RECOMPUTE>]
+          Recompute missing tipset state (expensive) instead of skipping it; tipsets that still can't be computed are skipped and reported rather than aborting the run [default: true]
 
       --allow-near-head
           Also index revert-prone tipsets newer than the EC-finalized epoch (up to the head). By default the walk is clamped to the EC-finalized epoch

--- a/scripts/tests/external-rpc-checks/docker-compose.yaml
+++ b/scripts/tests/external-rpc-checks/docker-compose.yaml
@@ -24,7 +24,6 @@ services:
     environment:
       - FOREST_PATH=/data
       - FOREST_CHAIN_INDEXER_ENABLED=1
-      - FOREST_ETH_RPC_COMPUTE_STATE_ON_INDEX_MISS=1
     command:
       - --chain=calibnet
       - --encrypt-keystore=false

--- a/src/cli/subcommands/index_cmd.rs
+++ b/src/cli/subcommands/index_cmd.rs
@@ -132,10 +132,13 @@ async fn wait_for_backfill(client: &rpc::Client) -> anyhow::Result<()> {
         tokio::time::sleep(Duration::from_millis(500)).await;
     };
     match last.state {
-        ChainExportState::Succeeded => pb.finish_with_message(format!(
-            "Backfill completed (indexed {}, skipped {})",
-            last.indexed, last.skipped
-        )),
+        ChainExportState::Succeeded => {
+            pb.finish_with_message(format!(
+                "Backfill completed (indexed {}, skipped {})",
+                last.indexed, last.skipped
+            ));
+            anyhow::ensure!(last.skipped == 0);
+        }
         ChainExportState::Cancelled => pb.abandon_with_message(format!(
             "Backfill cancelled (indexed {}, skipped {})",
             last.indexed, last.skipped

--- a/src/cli/subcommands/index_cmd.rs
+++ b/src/cli/subcommands/index_cmd.rs
@@ -32,7 +32,7 @@ pub enum IndexCommands {
         n_tipsets: Option<u64>,
         /// Recompute missing tipset state (expensive) instead of skipping it; tipsets that still
         /// can't be computed are skipped and reported rather than aborting the run.
-        #[arg(long)]
+        #[arg(long, num_args = 0..=1, default_value_t = true, default_missing_value = "true", action = clap::ArgAction::Set)]
         recompute: bool,
         /// Also index revert-prone tipsets newer than the EC-finalized epoch (up to the head). By
         /// default the walk is clamped to the EC-finalized epoch.
@@ -134,7 +134,7 @@ async fn wait_for_backfill(client: &rpc::Client) -> anyhow::Result<()> {
     match last.state {
         ChainExportState::Succeeded => {
             pb.finish_with_message(format!(
-                "Backfill completed (indexed {}, skipped {})",
+                "Backfill finished (indexed {}, skipped {})",
                 last.indexed, last.skipped
             ));
             anyhow::ensure!(last.skipped == 0);

--- a/src/cli/subcommands/index_cmd.rs
+++ b/src/cli/subcommands/index_cmd.rs
@@ -137,7 +137,9 @@ async fn wait_for_backfill(client: &rpc::Client) -> anyhow::Result<()> {
                 "Backfill finished (indexed {}, skipped {})",
                 last.indexed, last.skipped
             ));
-            anyhow::ensure!(last.skipped == 0);
+            if last.skipped != 0 {
+                std::process::exit(1);
+            }
         }
         ChainExportState::Cancelled => pb.abandon_with_message(format!(
             "Backfill cancelled (indexed {}, skipped {})",


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Dropped `--recompute` and always recompute and backfill as much as possible, exiting non-zero on error.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Updated `forest-cli index backfill` so `--recompute` defaults to `true` and can be used without specifying a value.
  - Backfills now report when they finish and exit with an error status if tipsets were skipped.

- **Documentation**
  - Updated the CLI reference to describe the new `--recompute` default and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->