### PR TITLE
Implement `forest-cli evm invoke`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Added
 
 - [#7471](https://github.com/ChainSafe/forest/issues/7471): Implement `forest-cli evm deploy` and `forest-cli evm call`.
+- [#7595](https://github.com/ChainSafe/forest/pull/7595): Implement `forest-cli evm invoke`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Added
 
 - [#7471](https://github.com/ChainSafe/forest/issues/7471): Implement `forest-cli evm deploy` and `forest-cli evm call`.
+
 - [#7595](https://github.com/ChainSafe/forest/pull/7595): Implement `forest-cli evm invoke`.
 
 ### Changed

--- a/docs/docs/developers/guides/rpc_stateful_tests.md
+++ b/docs/docs/developers/guides/rpc_stateful_tests.md
@@ -71,5 +71,3 @@ pub async fn test_eth_method(client: Arc<Client>) -> anyhow::Result<()> {
 ## Notes
 
 The current test framework assumes a running node and a valid wallet.
-
-Consider implementing `forest-tool evm deploy` and `forest-tool evm invoke` subcommands to simplify contract deployment and test invocation.

--- a/docs/docs/users/reference/cli.sh
+++ b/docs/docs/users/reference/cli.sh
@@ -98,6 +98,7 @@ generate_markdown_section "forest-cli" "f3 ready"
 
 generate_markdown_section "forest-cli" "evm"
 generate_markdown_section "forest-cli" "evm deploy"
+generate_markdown_section "forest-cli" "evm invoke"
 generate_markdown_section "forest-cli" "evm call"
 
 generate_markdown_section "forest-tool" ""

--- a/src/cli/subcommands/evm_cmd.rs
+++ b/src/cli/subcommands/evm_cmd.rs
@@ -1,21 +1,25 @@
 // Copyright 2019-2026 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::eth::EAMMethod;
+use crate::eth::{EAMMethod, EVMMethod};
 use crate::rpc::eth::{
     BlockNumberOrHash, Predefined,
     types::{EthAddress, EthBytes, EthCallMessage},
 };
+use crate::rpc::types::MessageLookup;
 use crate::rpc::{self, prelude::*};
 use crate::shim::actors::eam;
 use crate::shim::address::Address;
+use crate::shim::econ::TokenAmount;
 use crate::shim::message::Message;
 use crate::utils::encoding::{from_slice_with_fallback, hex};
 use anyhow::Context as _;
 use base64::Engine as _;
 use base64::prelude::BASE64_STANDARD;
+use cid::Cid;
 use clap::Subcommand;
 use fil_actor_eam_state::v16::CreateExternalParams;
+use fil_actor_evm_state::v16::{InvokeContractParams, InvokeContractReturn};
 use fvm_ipld_encoding::RawBytes;
 use std::path::PathBuf;
 use std::str::FromStr as _;
@@ -41,6 +45,19 @@ pub enum EvmCommands {
         /// Contract init code
         contract: PathBuf,
     },
+    /// Invoke an EVM smart contract using the specified calldata
+    Invoke {
+        /// Optionally specify the account to use for sending the exec message
+        #[arg(long)]
+        from: Option<Address>,
+        /// Value to send with the invocation message, in attoFIL
+        #[arg(long, default_value_t = 0)]
+        value: u64,
+        /// Filecoin address of the contract
+        address: Address,
+        /// Hex-encoded ABI calldata
+        calldata: EthBytes,
+    },
     /// Simulate an eth contract call
     Call {
         /// Ethereum sender address
@@ -61,9 +78,32 @@ impl EvmCommands {
                 wait,
                 contract,
             } => deploy(client, from, hex, wait.unwrap_or(true), contract).await,
+            Self::Invoke {
+                from,
+                value,
+                address,
+                calldata,
+            } => invoke(client, from, value, address, calldata).await,
             Self::Call { from, to, params } => call(client, from, to, params).await,
         }
     }
+}
+
+async fn resolve_from(client: &rpc::Client, from: Option<Address>) -> anyhow::Result<Address> {
+    match from {
+        Some(addr) => Ok(addr),
+        None => WalletDefaultAddress::call(client, ())
+            .await?
+            .context("no default wallet address"),
+    }
+}
+
+async fn wait_for_message(client: &rpc::Client, cid: Cid) -> anyhow::Result<MessageLookup> {
+    println!("waiting for message to execute...");
+    client
+        .call(StateWaitMsg::request((cid, 0, WAIT_LOOKBACK, true))?.with_timeout(WAIT_TIMEOUT))
+        .await
+        .context("error waiting for message")
 }
 
 async fn deploy(
@@ -75,15 +115,12 @@ async fn deploy(
 ) -> anyhow::Result<()> {
     let mut initcode = std::fs::read(&contract).context("failed to read contract")?;
     if is_hex {
-        initcode = decode_hex_contract(&initcode).context("failed to decode contract")?;
+        initcode = EthBytes::from_str(std::str::from_utf8(&initcode)?)
+            .context("failed to decode contract")?
+            .0;
     }
 
-    let from = match from {
-        Some(addr) => addr,
-        None => WalletDefaultAddress::call(&client, ())
-            .await?
-            .context("no default wallet address")?,
-    };
+    let from = resolve_from(&client, from).await?;
 
     let params = RawBytes::serialize(CreateExternalParams(initcode))
         .context("failed to serialize Create params")?;
@@ -106,11 +143,7 @@ async fn deploy(
         return Ok(());
     }
 
-    println!("waiting for message to execute...");
-    let lookup = client
-        .call(StateWaitMsg::request((cid, 0, WAIT_LOOKBACK, true))?.with_timeout(WAIT_TIMEOUT))
-        .await
-        .context("error waiting for message")?;
+    let lookup = wait_for_message(&client, cid).await?;
 
     println!("Exit Code: {}", lookup.receipt.exit_code().value());
     println!("Gas Used: {}", lookup.receipt.gas_used());
@@ -148,6 +181,73 @@ async fn deploy(
     Ok(())
 }
 
+async fn invoke(
+    client: rpc::Client,
+    from: Option<Address>,
+    value: u64,
+    address: Address,
+    calldata: EthBytes,
+) -> anyhow::Result<()> {
+    let from = resolve_from(&client, from).await?;
+    let params = RawBytes::serialize(InvokeContractParams {
+        input_data: calldata.0,
+    })
+    .context("failed to encode evm params as cbor")?;
+
+    let msg = Message {
+        to: address,
+        from,
+        value: TokenAmount::from_atto(value),
+        method_num: EVMMethod::InvokeContract as u64,
+        params,
+        ..Default::default()
+    };
+
+    println!("sending message...");
+    let smsg = MpoolPushMessage::call(&client, (msg, None))
+        .await
+        .context("failed to push message")?;
+    let cid = smsg.cid();
+    println!("Message CID: {cid}");
+
+    let lookup = wait_for_message(&client, cid).await?;
+
+    anyhow::ensure!(
+        lookup.receipt.exit_code().is_success(),
+        "actor execution failed"
+    );
+
+    println!("Gas used: {}", lookup.receipt.gas_used());
+
+    let ret: InvokeContractReturn = from_slice_with_fallback(lookup.receipt.return_data().bytes())
+        .context("evm result not correctly encoded")?;
+    if ret.output_data.is_empty() {
+        println!("OK");
+    } else {
+        println!("{}", hex::encode(&ret.output_data));
+    }
+
+    if let Some(root) = lookup.receipt.events_root() {
+        let events = ChainGetEvents::call(&client, (root,))
+            .await
+            .context("failed to load events")?;
+        println!("Events emitted:");
+        for event in events {
+            println!("\tEmitter ID: {}", event.emitter);
+            for entry in event.entries {
+                println!(
+                    "\t\tKey: {}, Value: 0x{}, Flags: b{:b}",
+                    entry.key,
+                    hex::encode(&entry.value.0),
+                    entry.flags
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 async fn call(
     client: rpc::Client,
     from: EthAddress,
@@ -178,10 +278,4 @@ async fn call(
             Err(e.into())
         }
     }
-}
-
-fn decode_hex_contract(raw: &[u8]) -> anyhow::Result<Vec<u8>> {
-    let s = std::str::from_utf8(raw)?.trim();
-    let s = s.strip_prefix("0X").unwrap_or(s);
-    Ok(EthBytes::from_str(s)?.0)
 }

--- a/src/cli/subcommands/evm_cmd.rs
+++ b/src/cli/subcommands/evm_cmd.rs
@@ -52,7 +52,7 @@ pub enum EvmCommands {
         from: Option<Address>,
         /// Value to send with the invocation message, in attoFIL
         #[arg(long, default_value_t = 0)]
-        value: u64,
+        value: i64,
         /// Filecoin address of the contract
         address: Address,
         /// Hex-encoded ABI calldata
@@ -184,7 +184,7 @@ async fn deploy(
 async fn invoke(
     client: rpc::Client,
     from: Option<Address>,
-    value: u64,
+    value: i64,
     address: Address,
     calldata: EthBytes,
 ) -> anyhow::Result<()> {

--- a/src/cli/subcommands/evm_cmd.rs
+++ b/src/cli/subcommands/evm_cmd.rs
@@ -116,7 +116,7 @@ async fn deploy(
 ) -> anyhow::Result<()> {
     let mut initcode = std::fs::read(&contract).context("failed to read contract")?;
     if is_hex {
-        initcode = EthBytes::from_str(std::str::from_utf8(&initcode)?)
+        initcode = EthBytes::from_str(std::str::from_utf8(&initcode)?.trim())
             .context("failed to decode contract")?
             .0;
     }

--- a/src/cli/subcommands/evm_cmd.rs
+++ b/src/cli/subcommands/evm_cmd.rs
@@ -21,6 +21,7 @@ use clap::Subcommand;
 use fil_actor_eam_state::v16::CreateExternalParams;
 use fil_actor_evm_state::v16::{InvokeContractParams, InvokeContractReturn};
 use fvm_ipld_encoding::RawBytes;
+use num::{BigInt, Signed as _};
 use std::path::PathBuf;
 use std::str::FromStr as _;
 use std::time::Duration;
@@ -50,9 +51,9 @@ pub enum EvmCommands {
         /// Optionally specify the account to use for sending the exec message
         #[arg(long)]
         from: Option<Address>,
-        /// Value to send with the invocation message, in attoFIL
-        #[arg(long, default_value_t = 0)]
-        value: i64,
+        /// Value to send with the invocation message
+        #[arg(long, value_parser = parse_invoke_value, default_value = "0")]
+        value: TokenAmount,
         /// Filecoin address of the contract
         address: Address,
         /// Hex-encoded ABI calldata
@@ -184,7 +185,7 @@ async fn deploy(
 async fn invoke(
     client: rpc::Client,
     from: Option<Address>,
-    value: i64,
+    value: TokenAmount,
     address: Address,
     calldata: EthBytes,
 ) -> anyhow::Result<()> {
@@ -197,7 +198,7 @@ async fn invoke(
     let msg = Message {
         to: address,
         from,
-        value: TokenAmount::from_atto(value),
+        value,
         method_num: EVMMethod::InvokeContract as u64,
         params,
         ..Default::default()
@@ -276,6 +277,35 @@ async fn call(
         Err(e) => {
             println!("Eth call fails, return val: 0x");
             Err(e.into())
+        }
+    }
+}
+
+/// Bare digits are `attoFIL`; otherwise parse a human amount (e.g. `1FIL`) and reject negatives.
+fn parse_invoke_value(s: &str) -> anyhow::Result<TokenAmount> {
+    if !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()) {
+        return Ok(TokenAmount::from_atto(BigInt::from_str(s)?));
+    }
+    let amount = crate::cli::humantoken::parse(s)?;
+    anyhow::ensure!(!amount.is_negative(), "value cannot be negative");
+    Ok(amount)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("1000", Ok(TokenAmount::from_atto(1000)))]
+    #[case("1FIL", Ok(TokenAmount::from_whole(1)))]
+    #[case("1attoFIL", Ok(TokenAmount::from_atto(1)))]
+    #[case("-1", Err("value cannot be negative"))]
+    fn parse_invoke_value_cases(#[case] input: &str, #[case] expected: Result<TokenAmount, &str>) {
+        let result = parse_invoke_value(input).map_err(|e| e.to_string());
+        match expected {
+            Ok(amount) => assert_eq!(result.unwrap(), amount),
+            Err(msg) => assert!(result.unwrap_err().contains(msg)),
         }
     }
 }

--- a/src/cli/subcommands/evm_cmd.rs
+++ b/src/cli/subcommands/evm_cmd.rs
@@ -1,6 +1,7 @@
 // Copyright 2019-2026 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use crate::cli::humantoken;
 use crate::eth::{EAMMethod, EVMMethod};
 use crate::rpc::eth::{
     BlockNumberOrHash, Predefined,
@@ -21,7 +22,6 @@ use clap::Subcommand;
 use fil_actor_eam_state::v16::CreateExternalParams;
 use fil_actor_evm_state::v16::{InvokeContractParams, InvokeContractReturn};
 use fvm_ipld_encoding::RawBytes;
-use num::{BigInt, Signed as _};
 use std::path::PathBuf;
 use std::str::FromStr as _;
 use std::time::Duration;
@@ -51,8 +51,8 @@ pub enum EvmCommands {
         /// Optionally specify the account to use for sending the exec message
         #[arg(long)]
         from: Option<Address>,
-        /// Value to send with the invocation message
-        #[arg(long, value_parser = parse_invoke_value, default_value = "0")]
+        /// Value to send with the invocation message (human FIL amount, e.g. `1FIL`, `1attoFIL`)
+        #[arg(long, value_parser = humantoken::parse, default_value = "0")]
         value: TokenAmount,
         /// Filecoin address of the contract
         address: Address,
@@ -213,12 +213,13 @@ async fn invoke(
 
     let lookup = wait_for_message(&client, cid).await?;
 
+    println!("Exit Code: {}", lookup.receipt.exit_code().value());
+    println!("Gas Used: {}", lookup.receipt.gas_used());
+
     anyhow::ensure!(
         lookup.receipt.exit_code().is_success(),
         "actor execution failed"
     );
-
-    println!("Gas used: {}", lookup.receipt.gas_used());
 
     let ret: InvokeContractReturn = from_slice_with_fallback(lookup.receipt.return_data().bytes())
         .context("evm result not correctly encoded")?;
@@ -277,35 +278,6 @@ async fn call(
         Err(e) => {
             println!("Eth call fails, return val: 0x");
             Err(e.into())
-        }
-    }
-}
-
-/// Bare digits are `attoFIL`; otherwise parse a human amount (e.g. `1FIL`) and reject negatives.
-fn parse_invoke_value(s: &str) -> anyhow::Result<TokenAmount> {
-    if !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()) {
-        return Ok(TokenAmount::from_atto(BigInt::from_str(s)?));
-    }
-    let amount = crate::cli::humantoken::parse(s)?;
-    anyhow::ensure!(!amount.is_negative(), "value cannot be negative");
-    Ok(amount)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case("1000", Ok(TokenAmount::from_atto(1000)))]
-    #[case("1FIL", Ok(TokenAmount::from_whole(1)))]
-    #[case("1attoFIL", Ok(TokenAmount::from_atto(1)))]
-    #[case("-1", Err("value cannot be negative"))]
-    fn parse_invoke_value_cases(#[case] input: &str, #[case] expected: Result<TokenAmount, &str>) {
-        let result = parse_invoke_value(input).map_err(|e| e.to_string());
-        match expected {
-            Ok(amount) => assert_eq!(result.unwrap(), amount),
-            Err(msg) => assert!(result.unwrap_err().contains(msg)),
         }
     }
 }

--- a/src/dev/subcommands/devnet_cmd/eth_skip_sender.rs
+++ b/src/dev/subcommands/devnet_cmd/eth_skip_sender.rs
@@ -362,44 +362,42 @@ async fn lotus_send(
     from: &Address,
     to: &Address,
     calldata: &[u8],
-    gas_limit: Option<u64>,
+    gas_limit: u64,
 ) -> anyhow::Result<Cid> {
     let forest = forest_client()?;
     let from_s = from.to_string();
     let to_s = to.to_string();
     let params = hex::encode(calldata);
-    let gas = gas_limit.map(|g| g.to_string());
-    let mut args = vec![
+    let gas = gas_limit.to_string();
+    let out = lotus_exec_retrying_transient(&[
         "send",
         "--from",
         from_s.as_str(),
         "--params-hex",
         params.as_str(),
-    ];
-    if let Some(gas) = gas.as_deref() {
-        args.extend(["--gas-limit", gas]);
-    }
-    args.extend([to_s.as_str(), "0"]);
-    let out = lotus_exec_retrying_transient(&args).await?;
+        "--gas-limit",
+        gas.as_str(),
+        to_s.as_str(),
+        "0",
+    ])
+    .await?;
     let cid = Cid::from_str(
         out.lines()
             .last()
             .context("no cid from `lotus send`")?
             .trim(),
     )?;
-    if let Some(limit) = gas_limit {
-        eprintln!("submitted at estimate {limit}: {cid}");
-        wait_for_cid(&forest, cid)
-            .await
-            .with_context(|| format!("transaction submitted at eth_estimateGas {limit} failed"))?;
-    } else {
-        wait_for_cid(&forest, cid).await?;
-    }
+    eprintln!("submitted at estimate {gas_limit}: {cid}");
+    wait_for_cid(&forest, cid)
+        .await
+        .with_context(|| format!("transaction submitted at eth_estimateGas {gas_limit} failed"))?;
     Ok(cid)
 }
 
-async fn invoke(to: &Address, calldata: &[u8]) -> anyhow::Result<Cid> {
-    lotus_send(deployer().await?, to, calldata, None).await
+async fn invoke(to: &Address, calldata: &[u8]) -> anyhow::Result<()> {
+    let from = deployer().await?.to_string();
+    forest_evm_invoke(&from, &to.to_string(), &hex::encode(calldata))?;
+    Ok(())
 }
 
 async fn submit_at_gas_limit(
@@ -408,7 +406,7 @@ async fn submit_at_gas_limit(
     calldata: &[u8],
     gas_limit: u64,
 ) -> anyhow::Result<()> {
-    lotus_send(from, to, calldata, Some(gas_limit)).await?;
+    lotus_send(from, to, calldata, gas_limit).await?;
     Ok(())
 }
 

--- a/src/dev/subcommands/devnet_cmd/eth_skip_sender.rs
+++ b/src/dev/subcommands/devnet_cmd/eth_skip_sender.rs
@@ -363,7 +363,7 @@ async fn lotus_send(
     to: &Address,
     calldata: &[u8],
     gas_limit: u64,
-) -> anyhow::Result<Cid> {
+) -> anyhow::Result<()> {
     let forest = forest_client()?;
     let from_s = from.to_string();
     let to_s = to.to_string();
@@ -391,22 +391,12 @@ async fn lotus_send(
     wait_for_cid(&forest, cid)
         .await
         .with_context(|| format!("transaction submitted at eth_estimateGas {gas_limit} failed"))?;
-    Ok(cid)
+    Ok(())
 }
 
 async fn invoke(to: &Address, calldata: &[u8]) -> anyhow::Result<()> {
     let from = deployer().await?.to_string();
     forest_evm_invoke(&from, &to.to_string(), &hex::encode(calldata))?;
-    Ok(())
-}
-
-async fn submit_at_gas_limit(
-    from: &Address,
-    to: &Address,
-    calldata: &[u8],
-    gas_limit: u64,
-) -> anyhow::Result<()> {
-    lotus_send(from, to, calldata, gas_limit).await?;
     Ok(())
 }
 
@@ -912,7 +902,7 @@ async fn round_trip_from_unfunded() -> anyhow::Result<()> {
         actor.sequence
     );
 
-    submit_at_gas_limit(&from.f4, &coin.f4, &calldata, gas).await?;
+    lotus_send(&from.f4, &coin.f4, &calldata, gas).await?;
     let after = get_actor(&forest, from.f4)
         .await?
         .with_context(|| format!("actor {} missing after successful submit", from.f4))?;
@@ -965,7 +955,7 @@ async fn round_trip_recursive() -> anyhow::Result<()> {
     );
 
     fund_on_chain(&from.cli, RECURSIVE_FUND_AMT).await?;
-    submit_at_gas_limit(&from.f4, &nested.f4, &calldata, gas).await
+    lotus_send(&from.f4, &nested.f4, &calldata, gas).await
 }
 
 async fn call_sender_identity() -> anyhow::Result<()> {

--- a/src/dev/subcommands/tests_cmd/helpers.rs
+++ b/src/dev/subcommands/tests_cmd/helpers.rs
@@ -489,6 +489,11 @@ pub fn forest_evm_deploy_hex(from: &str, bytecode_hex: &str) -> anyhow::Result<S
     forest_cli(&["evm", "deploy", "--from", from, "--hex", path])
 }
 
+/// Invoke a contract with `forest-cli evm invoke`.
+pub fn forest_evm_invoke(from: &str, to: &str, calldata_hex: &str) -> anyhow::Result<String> {
+    forest_cli(&["evm", "invoke", "--from", from, to, calldata_hex])
+}
+
 /// Parse the `f4 Address:` line from `forest-cli evm deploy` output.
 pub fn parse_f4_from_evm_deploy(out: &str) -> anyhow::Result<Address> {
     let f4 = out

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -410,8 +410,14 @@ pub mod hexify_vec_bytes {
     where
         D: Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
-        let s = Cow::from(s.strip_prefix("0x").unwrap_or(&s));
+        let raw = String::deserialize(deserializer)?;
+        let trimmed = raw.trim();
+        let s = Cow::from(
+            trimmed
+                .strip_prefix("0x")
+                .or_else(|| trimmed.strip_prefix("0X"))
+                .unwrap_or(trimmed),
+        );
 
         // Pad with 0 if odd length. This is necessary because decoding requires an even
         // number of characters, whereas a valid input is also `0x0`.
@@ -724,6 +730,10 @@ mod tests {
             ("0xF", vec![15]),
             ("0x2a42", vec![42, 66]),
             ("0x2A42", vec![42, 66]),
+            ("0X2a42", vec![42, 66]),
+            ("  0x2a42\n", vec![42, 66]),
+            ("\t0X2A42  ", vec![42, 66]),
+            ("2a42", vec![42, 66]),
         ];
 
         for (input, expected) in cases.into_iter() {
@@ -733,7 +743,7 @@ mod tests {
             self::assert_eq!(deserialized, expected);
         }
 
-        let fail_cases = ["cthulhu", "x", "0xazathoth"];
+        let fail_cases = ["cthulhu", "x", "0xazathoth", "0x2a 42", "0x2a\n42"];
         for input in fail_cases.into_iter() {
             let deserializer: StringDeserializer<SerdeError> =
                 String::from_str(input).unwrap().into_deserializer();

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -410,14 +410,8 @@ pub mod hexify_vec_bytes {
     where
         D: Deserializer<'de>,
     {
-        let raw = String::deserialize(deserializer)?;
-        let trimmed = raw.trim();
-        let s = Cow::from(
-            trimmed
-                .strip_prefix("0x")
-                .or_else(|| trimmed.strip_prefix("0X"))
-                .unwrap_or(trimmed),
-        );
+        let s = String::deserialize(deserializer)?;
+        let s = Cow::from(s.strip_prefix("0x").unwrap_or(&s));
 
         // Pad with 0 if odd length. This is necessary because decoding requires an even
         // number of characters, whereas a valid input is also `0x0`.
@@ -730,10 +724,6 @@ mod tests {
             ("0xF", vec![15]),
             ("0x2a42", vec![42, 66]),
             ("0x2A42", vec![42, 66]),
-            ("0X2a42", vec![42, 66]),
-            ("  0x2a42\n", vec![42, 66]),
-            ("\t0X2A42  ", vec![42, 66]),
-            ("2a42", vec![42, 66]),
         ];
 
         for (input, expected) in cases.into_iter() {
@@ -743,7 +733,7 @@ mod tests {
             self::assert_eq!(deserialized, expected);
         }
 
-        let fail_cases = ["cthulhu", "x", "0xazathoth", "0x2a 42", "0x2a\n42"];
+        let fail_cases = ["cthulhu", "x", "0xazathoth"];
         for input in fail_cases.into_iter() {
             let deserializer: StringDeserializer<SerdeError> =
                 String::from_str(input).unwrap().into_deserializer();

--- a/src/lotus_json/mod.rs
+++ b/src/lotus_json/mod.rs
@@ -411,7 +411,11 @@ pub mod hexify_vec_bytes {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        let s = Cow::from(s.strip_prefix("0x").unwrap_or(&s));
+        let s = Cow::from(
+            s.strip_prefix("0x")
+                .or_else(|| s.strip_prefix("0X"))
+                .unwrap_or(&s),
+        );
 
         // Pad with 0 if odd length. This is necessary because decoding requires an even
         // number of characters, whereas a valid input is also `0x0`.
@@ -724,6 +728,7 @@ mod tests {
             ("0xF", vec![15]),
             ("0x2a42", vec![42, 66]),
             ("0x2A42", vec![42, 66]),
+            ("0X2a42", vec![42, 66]),
         ];
 
         for (input, expected) in cases.into_iter() {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Implement and test `forest-cli evm invoke`.
- Accept `0X` prefixes and whitespace or new line when parsing eth hex byte strings matching Lotus.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #7597 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code adheres to the team's [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes should be reflected in this document.

### Outside contributions

- [ ] This pull request is based on an issue that a maintainer has accepted (see [Before Opening a Pull Request][4]).
- [ ] I have read and agree to the [CONTRIBUTING][2] document.
- [ ] I have read and agree to the [AI Policy][3] document. I understand that failure to comply with the guidelines will lead to rejection of the pull request.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest/blob/main/CHANGELOG.md
[2]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md
[3]: https://github.com/ChainSafe/forest/blob/main/AI_POLICY.md
[4]: https://github.com/ChainSafe/forest/blob/main/CONTRIBUTING.md#before-opening-a-pull-request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `forest-cli evm invoke` now accepts arbitrary-precision amounts in attoFIL or human-readable FIL units.
  - Added support for downloading proof parameters during `forest-tool index backfill`.

- **Bug Fixes**
  - Negative human-readable token amounts are now rejected.
  - EVM invocation workflows now require a gas limit and wait for execution.

- **Documentation**
  - Updated CLI reference generation to include EVM invoke help.
  - Removed outdated EVM deployment guidance from stateful test documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->